### PR TITLE
Ruby Docs: Fix initialize param

### DIFF
--- a/docs/references/ruby/overview.mdx
+++ b/docs/references/ruby/overview.mdx
@@ -44,7 +44,7 @@ This examples shows how to instantiate an instance of `Clerk::SDK` with your sec
 <InjectKeys>
 
 ```ruby
-clerk = Clerk::SDK.new(secret_key: {{secret}})
+clerk = Clerk::SDK.new(api_key: {{secret}})
 
 # List all users
 clerk.users.all
@@ -82,7 +82,7 @@ You can customize each instance of the `Clerk::SDK` object by passing keyword ar
 
 ```ruby
 clerk = Clerk::SDK.new(
-    secret_key: {{secret}},
+    api_key: {{secret}},
     base_url: "Y",
     logger: Logger.new()
 )

--- a/docs/references/ruby/overview.mdx
+++ b/docs/references/ruby/overview.mdx
@@ -96,7 +96,7 @@ If an argument is not provided, the configuration object is looked up, which fal
 
 ```ruby
 Clerk.configure do |c|
-  c.secret_key = {{secret}} # if omitted: ENV["CLERK_SECRET_KEY"] - API calls will fail if unset
+  c.api_key = {{secret}} # if omitted: ENV["CLERK_SECRET_KEY"] - API calls will fail if unset
   c.base_url = "https://..." # if omitted: "https://api.clerk.com/v1/"
   c.logger = Logger.new(STDOUT) # if omitted, no logging
   c.middleware_cache_store = Rails.cache # if omitted: no caching


### PR DESCRIPTION
Client should be initialized with `api_key`, rather than `secret_key`. Check docs -> https://github.com/clerkinc/clerk-sdk-ruby/blob/main/lib/clerk.rb#L19