### PR TITLE
clarify on deprecated content

### DIFF
--- a/docs/advanced-usage/using-proxies.mdx
+++ b/docs/advanced-usage/using-proxies.mdx
@@ -218,8 +218,8 @@ You can configure your proxy setup via environment variables or via properties.
         ```tsx filename="app.tsx"
           import Clerk from '@clerk/clerk-js';
 
-          const clerkFrontendApi = `{{pub_key}}`;
-          const clerk = new Clerk(clerkFrontendApi);
+          const clerkPublishableKey = `{{pub_key}}`;
+          const clerk = new Clerk(clerkPublishableKey);
           await clerk.load({
             proxyUrl: 'https://app.dev/__clerk',
           });

--- a/docs/authentication/social-connections/linkedin.mdx
+++ b/docs/authentication/social-connections/linkedin.mdx
@@ -5,7 +5,9 @@ description: Learn how to set up social connection with LinkedIn.
 
 # LinkedIn (Deprecated)
 
-This page is now deprecated. Please see the new [guide](/docs/authentication/social-connections/linkedin-oidc) on how to set up a social connection with LinkedIn.
+<Callout type="danger">
+  This page is now deprecated. Please see the new [guide](/docs/authentication/social-connections/linkedin-oidc) on how to set up a social connection with LinkedIn.
+</Callout>
 
 ## Overview
 

--- a/docs/custom-flows/magic-links.mdx
+++ b/docs/custom-flows/magic-links.mdx
@@ -280,12 +280,12 @@ import {
   SignedIn,
 } from '@clerk/clerk-react';
 
-const frontendApi = process.env.REACT_APP_CLERK_FRONTEND_API;
+const publishableKey = process.env.REACT_APP_CLERK_PUBLISHABLE_KEY;
 
 function App() {
   return (
     <Router>
-      <ClerkProvider frontendApi={frontendApi}>
+      <ClerkProvider publishableKey={publishableKey}>
         <Switch>
           {/* Root path shows sign up page. */}
           <Route 
@@ -673,12 +673,12 @@ import {
   useSignIn,
 } from "@clerk/clerk-react";
 
-const frontendApi = process.env.REACT_APP_CLERK_FRONTEND_API;
+const publishableKey = process.env.REACT_APP_CLERK_PUBLISHABLE_KEY;
 
 function App() {
   return (
     <Router>
-      <ClerkProvider frontendApi={frontendApi}>
+      <ClerkProvider publishableKey={publishableKey}>
         <Routes>
           {/* Root path shows sign in page. */}
           <Route 

--- a/docs/custom-flows/oauth-connections.mdx
+++ b/docs/custom-flows/oauth-connections.mdx
@@ -35,11 +35,13 @@ import {
   useSignIn,
 } from "@clerk/clerk-react";
 
+const publishableKey = process.env.REACT_APP_CLERK_PUBLISHABLE_KEY;
+
 function App() {
   return (
     //  react-router-dom requires your app to be wrapped with a Router
     <BrowserRouter>
-      <ClerkProvider frontendApi="{{fapi}}">
+      <ClerkProvider publishableKey={publishableKey}>
         <Switch>
           {/* Define a / route that displays the OAuth buttons */}
           <Route path="/">

--- a/docs/custom-flows/saml-connections.mdx
+++ b/docs/custom-flows/saml-connections.mdx
@@ -37,11 +37,13 @@ import {
   SignedOut
 } from "@clerk/clerk-react";
 
+const publishableKey = process.env.REACT_APP_CLERK_PUBLISHABLE_KEY;
+
 function App() {
   return (
     //  react-router-dom requires your app to be wrapped with a Router
     <BrowserRouter>
-      <ClerkProvider frontendApi="{{fapi}}">
+      <ClerkProvider publishableKey={publishableKey}>
         <Switch>
           {/* Define a / route that displays the OAuth buttons */}
           <Route path="/">

--- a/docs/custom-flows/user-impersonation.mdx
+++ b/docs/custom-flows/user-impersonation.mdx
@@ -105,7 +105,7 @@ When working with frontend (client-side) code, you can easily detect impersonate
 <CodeBlockTabs options={["Next.js", "React", "JavaScript"]}>
 ```jsx
 import { useAuth } from "@clerk/nextjs";
-import { withServerSideAuth } from "@clerk/nextjs/ssr";
+import { withServerSideAuth } from "@clerk/nextjs";
 
 // SSR authentication context
 export const getServerSideProps = withServerSideAuth(
@@ -183,7 +183,7 @@ When working with backend code, Clerk provides middleware that can be used in Ne
 <CodeBlockTabs options={["Next.js", "Node"]}>
 ```jsx
 // pages/api/some-handler.js
-import { withAuth } from "@clerk/nextjs/api";
+import { withAuth } from "@clerk/nextjs";
 
 export default withAuth(async (req) => {
   // The request object is augmented with the 

--- a/docs/quickstarts/javascript.mdx
+++ b/docs/quickstarts/javascript.mdx
@@ -78,12 +78,18 @@ CLERK_FRONTEND_API=[your-domain].clerk.accounts.dev
 
 To use the ClerkJS package, you'll need to initialize the Clerk class with your **Publishable key**.
 
+<Callout type="info">
+  Calling the `load()` method initializes ClerkJS. For more information on the `load()` method and what options you can pass to it, check out the [reference documentation](/docs/references/javascript/clerk/clerk#load).
+</Callout>
+
+<InjectKeys>
+
 <CodeBlockTabs options={['npm Package', 'script Tag']}>
 ```js filename="index.js"
 import Clerk from '@clerk/clerk-js';
 
-const clerkFrontendApi = `{{pub_key}}`;
-const clerk = new Clerk(clerkFrontendApi);
+const clerkPublishableKey = `{{pub_key}}`;
+const clerk = new Clerk(clerkPublishableKey);
 await clerk.load({
   // Set load options here...
 });
@@ -91,12 +97,12 @@ await clerk.load({
 
 ```html filename="index.html"
 <script>
-  const clerkFrontendApi = `pk_{{pub_key}}`;
+  const clerkPublishableKey = `{{pub_key}}`;
   const frontendApi = '[your-domain].clerk.accounts.dev';
   const version = '@latest';
   const script = document.createElement('script');
   script.setAttribute('data-clerk-frontend-api', frontendApi);
-  script.setAttribute('data-clerk-publishable-key', clerkFrontendApi);
+  script.setAttribute('data-clerk-publishable-key', clerkPublishableKey);
   script.async = true;
   script.src = `https://${frontendApi}/npm/@clerk/clerk-js${version}/dist/clerk.browser.js`;
 
@@ -111,6 +117,8 @@ await clerk.load({
 </script>
 ```
 </CodeBlockTabs>
+
+</InjectKeys>
 
 > You can configure the options for `Clerk.load` to change the behavior of ClerkJS. See the [ClerkJS reference documentation](/docs/references/javascript/clerk/clerk#load) for more information.
 

--- a/docs/references/javascript/clerk/session-methods.mdx
+++ b/docs/references/javascript/clerk/session-methods.mdx
@@ -16,7 +16,7 @@ function setSession(
 ): Promise<void>;
 ```
 
-<Callout type="info">
+<Callout type="danger">
   Deprecated in favor of [`setActive()`](#set-active).
 </Callout>
 

--- a/docs/references/javascript/organization/invitations.mdx
+++ b/docs/references/javascript/organization/invitations.mdx
@@ -32,7 +32,11 @@ function getInvitations(params?: GetInvitationsParams): Promise<PaginatedResourc
 
 ## `getPendingInvitations()` (deprecated)
 
-Retrieves a list of organization invitations that have not yet been accepted. This method is deprecated in favor of [`getInvitations()`](#get-invitations).
+<Callout type="danger">
+  This method is deprecated in favor of [`getInvitations()`](#get-invitations).
+</Callout>
+
+Retrieves a list of organization invitations that have not yet been accepted. 
 
 ```typescript
 function getPendingInvitations(params?: GetPendingInvitationsParams): Promise<OrganizationInvitation[]>;

--- a/docs/references/javascript/organization/members.mdx
+++ b/docs/references/javascript/organization/members.mdx
@@ -23,7 +23,7 @@ Retrieve the members of the currently active organization.
 | `pageSize?` | `number` | A number that indicates the maximum number of results that should be returned for a specific page. |
 | `role?` | `('admin' \| 'basic_member' \| 'guest_member')[]` | The roles of memberships that will be included in the response. |
 
-<Callout type="info">
+<Callout type="danger">
   `GetMembershipsParams` was recently updated to `GetMembersParams`. The `limit` and `offset` parameters are now deprecated.
 </Callout>
 

--- a/docs/references/javascript/organization/members.mdx
+++ b/docs/references/javascript/organization/members.mdx
@@ -24,7 +24,7 @@ Retrieve the members of the currently active organization.
 | `role?` | `('admin' \| 'basic_member' \| 'guest_member')[]` | The roles of memberships that will be included in the response. |
 
 <Callout type="danger">
-  `GetMembershipsParams` was recently updated to `GetMembersParams`. The `limit` and `offset` parameters are now deprecated.
+  `GetMembershipsParams` was updated to `GetMembersParams` in September, 2023. The `limit` and `offset` parameters are now deprecated.
 </Callout>
 
 

--- a/docs/references/javascript/organization/organization.mdx
+++ b/docs/references/javascript/organization/organization.mdx
@@ -14,7 +14,7 @@ This is a class that represents an organization. It's returned from the [`create
 | `id` | `string` | The unique identifier of the related organization. |
 | `name` | `string` | The name of the related organization. |
 | `slug` | `string \| null` | The organization slug. If supplied, it must be unique for the instance. |
-| `logoUrl` (deprecated) | `string \| null` | The full URL for the organization logo. (deprecated in favor of `imageUrl`) |
+| `logoUrl` (deprecated) | `string \| null` | Deprecated in favor of `imageUrl`. |
 | `imageUrl` | `string` | Holds the organization logo or default logo. |
 | `hasImage` | `boolean` | A getter boolean to check if the organization has an uploaded image. Returns `false` if Clerk is displaying an avatar for the organization. |
 | `membersCount` | `number` | The number of members the associated organization contains. |

--- a/docs/references/javascript/organization/organization.mdx
+++ b/docs/references/javascript/organization/organization.mdx
@@ -14,7 +14,7 @@ This is a class that represents an organization. It's returned from the [`create
 | `id` | `string` | The unique identifier of the related organization. |
 | `name` | `string` | The name of the related organization. |
 | `slug` | `string \| null` | The organization slug. If supplied, it must be unique for the instance. |
-| `logoUrl` | `string \| null` | The full URL for the organization logo. (deprecated in favor of `imageUrl`) |
+| <Badge label="Deprecated">`logoUrl`</Badge> | `string \| null` | The full URL for the organization logo. (deprecated in favor of `imageUrl`) |
 | `imageUrl` | `string` | Holds the organization logo or default logo. |
 | `hasImage` | `boolean` | A getter boolean to check if the organization has an uploaded image. Returns `false` if Clerk is displaying an avatar for the organization. |
 | `membersCount` | `number` | The number of members the associated organization contains. |

--- a/docs/references/javascript/organization/organization.mdx
+++ b/docs/references/javascript/organization/organization.mdx
@@ -14,7 +14,7 @@ This is a class that represents an organization. It's returned from the [`create
 | `id` | `string` | The unique identifier of the related organization. |
 | `name` | `string` | The name of the related organization. |
 | `slug` | `string \| null` | The organization slug. If supplied, it must be unique for the instance. |
-| <Badge label="Deprecated">`logoUrl`</Badge> | `string \| null` | The full URL for the organization logo. (deprecated in favor of `imageUrl`) |
+| `logoUrl` (deprecated) | `string \| null` | The full URL for the organization logo. (deprecated in favor of `imageUrl`) |
 | `imageUrl` | `string` | Holds the organization logo or default logo. |
 | `hasImage` | `boolean` | A getter boolean to check if the organization has an uploaded image. Returns `false` if Clerk is displaying an avatar for the organization. |
 | `membersCount` | `number` | The number of members the associated organization contains. |

--- a/docs/references/javascript/overview.mdx
+++ b/docs/references/javascript/overview.mdx
@@ -38,8 +38,8 @@ Once you have installed the package, you will need to import the ClerkJS object 
 ```js
 import Clerk from '@clerk/clerk-js';
 
-const clerkFrontendApi = {{pub_key}};
-const clerk = new Clerk(clerkFrontendApi);
+const clerkPublishableKey = {{pub_key}};
+const clerk = new Clerk(clerkPublishableKey);
 await clerk.load({
   // Set load options here...
 });
@@ -62,14 +62,14 @@ Add the following script to your site's `<body>` element:
 ```html
 <script>
   // Get this URL and Publishable Key from the Clerk Dashboard
-  const clerkFrontendApi = {{pub_key}};
+  const clerkPublishableKey = {{pub_key}};
   const frontendApi = '[your-domain].clerk.accounts.dev';
   const version = '@latest'; // Set to appropriate version
 
   // Creates asynchronous script
   const script = document.createElement('script');
   script.setAttribute('data-clerk-frontend-api', frontendApi);
-  script.setAttribute('data-clerk-publishable-key', clerkFrontendApi);
+  script.setAttribute('data-clerk-publishable-key', clerkPublishableKey);
   script.async = true;
   script.src = `https://${frontendApi}/npm/@clerk/clerk-js${version}/dist/clerk.browser.js`;
 

--- a/docs/references/javascript/types/oauth-strategy.mdx
+++ b/docs/references/javascript/types/oauth-strategy.mdx
@@ -35,7 +35,7 @@ type OAuthStrategy = |
 | `oauth_discord` | `string` | Specify Discord as the verification OAuth provider. |
 | `oauth_twitter` | `string` | Specify Twitter as the verification OAuth provider. |
 | `oauth_twitch` | `string` | Specify Twitch as the verification OAuth provider. |
-| `oauth_linkedin` | `string` | This strategy is now deprecated in favor of `oauth_linkedin_oidc`. |
+| `oauth_linkedin` (deprecated) | `string` | This strategy is now deprecated in favor of `oauth_linkedin_oidc`. |
 | `oauth_linkedin_oidc` | `string` | Specify LinkedIn as the verification OAuth provider. |
 | `oauth_dropbox` | `string` | Specify Dropbox as the verification OAuth provider. |
 | `oauth_bitbucket` | `string` | Specify Bitbucket as the verification OAuth provider. |

--- a/docs/references/javascript/user/user.mdx
+++ b/docs/references/javascript/user/user.mdx
@@ -24,7 +24,7 @@ The ClerkJS SDK provides some helper [methods](#methods) on the `User` object to
 | `username` | `string \| null` | The user's username. |
 | `imageUrl` | `string` | Holds the users profile image or avatar. |
 | `hasImage` | `boolean` | A getter boolean to check if the user has uploaded an image or one was copied from OAuth. Returns `false` if Clerk is displaying an avatar for the user. |
-| `profileImageUrl` (deprecated) | `string \| null` | The URL for the user's profile image.<br />This property is deprecated in favor of `image_url`. |
+| `profileImageUrl` (deprecated) | `string \| null` | Deprecated in favor of `image_url`. |
 | `primaryEmailAddress` | [`EmailAddress`][email-ref] \| `null` | Information about the user's primary email address. |
 | `primaryEmailAddressId` | `string \| null` | The unique identifier for the `EmailAddress` that the user has set as primary. |
 | `emailAddresses` | [`EmailAddress[]`][email-ref] | An array of all the `EmailAddress` objects associated with the user. Includes the primary. |

--- a/docs/references/javascript/user/user.mdx
+++ b/docs/references/javascript/user/user.mdx
@@ -71,7 +71,7 @@ All props below are optional.
 | Name | Type | Description |
 | --- | --- | --- |
 | `username` | `string` | The user's username. |
-| `password` (deprecated) | `string` | The user's password.<br />This property is deprecated. This will be removed in the next major version. Please use [`updatePassword(params)`](/docs/references/javascript/user/password-management#update-password) instead. |
+| `password` (deprecated) | `string` | The user's password.<br />This property is deprecated. This will be removed in the next major version (V5). Please use [`updatePassword(params)`](/docs/references/javascript/user/password-management#update-password) instead. |
 | `firstName` | `string` | The user's first name. |
 | `lastName` | `string` | The user's last name. |
 | `primaryEmailAddressId` | `string` | The unique identifier for the [`EmailAddress`][email-ref] that the user has set as primary. |

--- a/docs/references/javascript/user/user.mdx
+++ b/docs/references/javascript/user/user.mdx
@@ -24,7 +24,7 @@ The ClerkJS SDK provides some helper [methods](#methods) on the `User` object to
 | `username` | `string \| null` | The user's username. |
 | `imageUrl` | `string` | Holds the users profile image or avatar. |
 | `hasImage` | `boolean` | A getter boolean to check if the user has uploaded an image or one was copied from OAuth. Returns `false` if Clerk is displaying an avatar for the user. |
-| `profileImageUrl` | `string \| null` | The URL for the user's profile image.<br />**This property is deprecated** in favor of `image_url` |
+| `profileImageUrl` (deprecated) | `string \| null` | The URL for the user's profile image.<br />This property is deprecated in favor of `image_url`. |
 | `primaryEmailAddress` | [`EmailAddress`][email-ref] \| `null` | Information about the user's primary email address. |
 | `primaryEmailAddressId` | `string \| null` | The unique identifier for the `EmailAddress` that the user has set as primary. |
 | `emailAddresses` | [`EmailAddress[]`][email-ref] | An array of all the `EmailAddress` objects associated with the user. Includes the primary. |
@@ -71,7 +71,7 @@ All props below are optional.
 | Name | Type | Description |
 | --- | --- | --- |
 | `username` | `string` | The user's username. |
-| `password` | `string` | The user's password.<br />**This property is deprecated.** This will be removed in the next major version. Please use [`updatePassword(params)`](/docs/references/javascript/user/password-management#updatepassword) instead. |
+| `password` (deprecated) | `string` | The user's password.<br />This property is deprecated. This will be removed in the next major version. Please use [`updatePassword(params)`](/docs/references/javascript/user/password-management#update-password) instead. |
 | `firstName` | `string` | The user's first name. |
 | `lastName` | `string` | The user's last name. |
 | `primaryEmailAddressId` | `string` | The unique identifier for the [`EmailAddress`][email-ref] that the user has set as primary. |

--- a/docs/references/nextjs/with-clerk-middleware.mdx
+++ b/docs/references/nextjs/with-clerk-middleware.mdx
@@ -5,7 +5,7 @@ description: The withClerkMiddleware wrapper allows Clerk to access session data
 
 # `withClerkMiddleware()`
 
-<Callout type="warning">
+<Callout type="danger">
   `withClerkMiddleware()` is Clerk's previous middleware API and will soon be deprecated. Please use [`authMiddleware()`](/docs/references/nextjs/auth-middleware) going forward.
 </Callout>
 

--- a/docs/references/nextjs/with-clerk-middleware.mdx
+++ b/docs/references/nextjs/with-clerk-middleware.mdx
@@ -6,7 +6,7 @@ description: The withClerkMiddleware wrapper allows Clerk to access session data
 # `withClerkMiddleware()`
 
 <Callout type="danger">
-  `withClerkMiddleware()` is Clerk's previous middleware API and will soon be deprecated. Please use [`authMiddleware()`](/docs/references/nextjs/auth-middleware) going forward.
+  `withClerkMiddleware()` was deprecated and will be removed in the next major version (V5). Please use [`authMiddleware()`](/docs/references/nextjs/auth-middleware) going forward.
 </Callout>
 
 The `withClerkMiddleware` wrapper allows Clerk to access session data on the server side allowing you to use any of our server side helpers without any additonal network calls.

--- a/docs/references/nodejs/overview.mdx
+++ b/docs/references/nodejs/overview.mdx
@@ -127,7 +127,7 @@ If you have a `clerkClient` handle:
 - `clerkClient.secretKey = value;`
 - `clerkClient.serverApiUrl = value;`
 - `clerkClient.apiVersion = value;`
-- `clerkClient.httpOptions = value;`
+- <Badge label='Deprecated'>`clerkClient.httpOptions = value;`</Badge>
 
 If are using a sub-api handle and wish to change options on the (implicit) singleton `clerkClient` instance:
 

--- a/docs/references/nodejs/overview.mdx
+++ b/docs/references/nodejs/overview.mdx
@@ -127,7 +127,7 @@ If you have a `clerkClient` handle:
 - `clerkClient.secretKey = value;`
 - `clerkClient.serverApiUrl = value;`
 - `clerkClient.apiVersion = value;`
-- <Badge label='Deprecated'>`clerkClient.httpOptions = value;`</Badge>
+- `clerkClient.httpOptions = value;` (deprecated)
 
 If are using a sub-api handle and wish to change options on the (implicit) singleton `clerkClient` instance:
 

--- a/docs/references/nodejs/token-verification.mdx
+++ b/docs/references/nodejs/token-verification.mdx
@@ -12,7 +12,7 @@ To learn more about Clerk's token verification, you can find more information on
 The value of the JWT verification key can also be added on the instance level or on any single middleware call e.g. for Next.js.
 
 ```js
-import { withAuth } from '@clerk/nextjs/api';
+import { withAuth } from '@clerk/nextjs';
 
 const handler = (req, res) => {
   // ...
@@ -43,7 +43,7 @@ app.use(ClerkExpressRequireAuth({ authorizedParties }));
 ```
 
 ```js
-import { requireAuth } from '@clerk/nextjs/api';
+import { requireAuth } from '@clerk/nextjs';
 
 const authorizedParties = ['http://localhost:3000', 'https://example.com']
 

--- a/docs/references/ruby/overview.mdx
+++ b/docs/references/ruby/overview.mdx
@@ -116,7 +116,7 @@ Here's a list of all environment variables the SDK uses:
 | Variable name | Usage |
 | --- | --- |
 | `CLERK_API_BASE` | Overrides the default API base URL: `https://api.clerk.com/v1/` |
-| `CLERK_API_KEY` | The Secret key of your instance (required) |
+| `CLERK_SECRET_KEY` | The Secret key of your instance (required) |
 | `CLERK_SIGN_IN_URL` | Rails view helper: `clerk_sign_in_url` |
 | `CLERK_SIGN_IN_UP` | Rails view helper: `clerk_sign_up_url` |
 | `CLERK_USER_PROFILE_URL` | Rails view helper: `clerk_user_profile_url` |

--- a/docs/testing/cypress.mdx
+++ b/docs/testing/cypress.mdx
@@ -137,7 +137,7 @@ You need to make some slight modifications to test in an SSR context. Because Cl
 Here's a simple SSR page, where the auth check is done on the server side, and returned to the frontend.
 
 ```jsx
-import { withServerSideAuth } from "@clerk/nextjs/ssr";
+import { withServerSideAuth } from "@clerk/nextjs";
 
 export const getServerSideProps = withServerSideAuth(async ({ req }) => {
   const { sessionId, getToken } = req.auth;


### PR DESCRIPTION
This PR adds `<Callout />` components with `type="danger"` (instead of `type="info"`) to better highlight that something is deprecated. This PR also adds "(deprecated)" copy where necessary (in places that deprecated items were mentioned).

This PR also updates practices in reflection of [these major updates](https://github.com/clerk/javascript/blob/main/packages/nextjs/CHANGELOG.md#500-alpha-v50):
- use NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY instead of NEXT_PUBLIC_CLERK_FRONTEND_API env variable
- use NEXT_PUBLIC_CLERK_JS_VERSION instead of CLERK_JS_VERSION
- use CLERK_SECRET_KEY instead of CLERK_API_KEY
- use publishableKey instead of frontendApi
- use @clerk/nextjs instead of @clerk/nextjs/ssr
- use @clerk/nextjs instead of @clerk/nextjs/api
- use middleware with authMiddleware instead of withClerkMiddleware

Fixes DOCS-499