### PR TITLE
DOCS-478 add callout about expo SDK only supporting mobile output

### DIFF
--- a/docs/quickstarts/expo.mdx
+++ b/docs/quickstarts/expo.mdx
@@ -3,21 +3,19 @@ title: Use Clerk with Expo
 description: Learn how to use Clerk to quickly and easily add secure authentication and user management to your Expo application.
 ---
 
-import { Callout } from "nextra-theme-docs";
-import {Steps} from "nextra-theme-docs";
-import { YouTube } from "@/components/Youtube";
-import { Images } from "@/components/Images";
-import {Cards} from "@/components/Cards";
-import { CodeBlockTabs } from "@/components/CodeBlockTabs";
-
 # Use Clerk with Expo
 
 Learn how to use Clerk to quickly and easily add secure authentication and user management to your Expo application.
 
+<Callout type="warning">
+  Currently the `@clerk/expo` SDK only supports mobile app output. You can upvote the addition of Clerk supporting web output [here](https://feedback.clerk.com/roadmap/fb56a8db-763a-4e0d-a4b2-f8a453be195c).
+</Callout>
+
 <Steps>
+
 ### Install `@clerk/clerk-expo`
 
-Once you have a Expo application ready, you need to install Clerk's Expo SDK.
+Once you have an Expo application ready, you need to install Clerk's Expo SDK.
 
 <CodeBlockTabs options={["npm", "yarn", "pnpm"]}>
   ```bash filename="terminal"
@@ -37,7 +35,7 @@ Once you have a Expo application ready, you need to install Clerk's Expo SDK.
 
 Below is an example of an `app.config.js` file. To get your keys, go to the API Keys page on the [Clerk dashboard](https://dashboard.clerk.com).
 
-```sh filename="app.config.js"
+```js filename="app.config.js"
 module.exports = {
   name: 'MyApp',
   version: '1.0.0',


### PR DESCRIPTION
"At the moment only expo android/iOS outputs will work with clerk. We should make sure there's a prominent note in the quickstart about this. We should also make sure we add a link to productlane where people can upvote the feature to this callout 😁 https://feedback.clerk.com/roadmap/fb56a8db-763a-4e0d-a4b2-f8a453be195c"

This PR adds a `<Callout />` component to let users know that Clerk currently only supports Expo for mobile outputs, and that users can upvote the addition of web support at the link provided.

🔎 [Current Expo page](https://clerk.com/docs/quickstarts/expo#use-clerk-with-expo)
🔎 [This PR's Expo page](https://docs-preview-461.clerkpreview.com/docs/quickstarts/expo)