### PR TITLE
DOCS-422 clarify how/where to import themes; add examples on how to use `appearance` and `variables` props

### DIFF
--- a/docs/components/authentication/sign-in.mdx
+++ b/docs/components/authentication/sign-in.mdx
@@ -23,7 +23,7 @@ Below is basic implementation of the `<SignIn />` component. You can use this as
     You can embed the `<SignIn />` component using the [Next.js optional catch-all route](https://nextjs.org/docs/pages/building-your-application/routing/dynamic-routes#optional-catch-all-routes). This allows you to redirect the user inside your application. The `<SignIn />` component should be mounted on a public page.
 
     <CodeBlockTabs options={["App Router", "Pages Router"]}>
-      ```jsx filename="/app/sign-in/[[...sign-in]]/page.[jsx/tsx]"
+      ```jsx filename="/app/sign-in/[[...sign-in]]/page.tsx"
       import { SignIn } from "@clerk/nextjs";
 
       export default function Page() {
@@ -37,18 +37,20 @@ Below is basic implementation of the `<SignIn />` component. You can use this as
       const SignInPage = () => (
         <SignIn path="/sign-in" routing="path" signUpUrl="/sign-up" />
       );
+      
       export default SignInPage;
       ```
     </CodeBlockTabs>
   </Tab>
 
   <Tab>
-    ```jsx filename="/pages/sign-in/[[...index]].[jsx/tsx]"
-    import { SignIn } from "@clerk/react";
+    ```jsx filename="/src/sign-in/[[...index]].tsx"
+    import { SignIn } from "@clerk/clerk-react";
 
     const SignInPage = () => (
       <SignIn path="/sign-in" routing="path" signUpUrl="/sign-up" />
     );
+
     export default SignInPage;
     ```
   </Tab>

--- a/docs/components/customization/localization.mdx
+++ b/docs/components/customization/localization.mdx
@@ -38,7 +38,7 @@ The `@clerk/localizations` package contains predefined localizations for the Cle
 
 ### Usage
 
-To get started, you need to install the `@clerk/localizations` package.
+To get started, install the `@clerk/localizations` package.
 
 <CodeBlockTabs options={["npm", "yarn", "pnpm"]}>
   ```bash filename="terminal"

--- a/docs/components/customization/overview.mdx
+++ b/docs/components/customization/overview.mdx
@@ -27,106 +27,614 @@ Clerk offers [a set of themes that can be used with the `appearance` prop](/docs
   ```
 </CodeBlockTabs>
 
-#### Usage
+### Usage
 
-<CodeBlockTabs options={['Next.js', 'React', 'Remix']}>
-  ```tsx filename="app.tsx"
-  import { dark } from '@clerk/themes';
-  import { ClerkProvider, SignIn } from '@clerk/nextjs';
-  import type { AppProps } from "next/app";
+To use a theme, import it from `@clerk/themes` and pass it to the `appearance` prop of a Clerk component. You can pass it to the [`<ClerkProvider />`](/docs/components/clerk-provider) component to apply it to all Clerk components in your app or you can pass it to a single Clerk component.
 
-  function MyApp({ Component, pageProps }: AppProps) {
-    return (
-      <ClerkProvider
+> [Visit the Themes docs to see a list of the themes that Clerk offers.](/docs/components/customization/themes)
+
+#### Pass a theme to `<ClerkProvider />`
+
+To apply a theme to all Clerk components, pass the `appearance` prop to the `<ClerkProvider />` component. The `appearance` prop accepts the property `baseTheme`, which can be set to a theme.
+
+In the example below, the `dark` theme is applied to all Clerk components.
+
+<CodeBlockTabs options={['Next.js App Router', 'Next.js Pages Router', 'React', 'Remix']}>
+```tsx filename="/src/app/layout.tsx" {2,11-13}
+import { ClerkProvider } from '@clerk/nextjs';
+import { dark } from '@clerk/themes';
+
+export default function RootLayout({
+  children,
+}: {
+  children: React.ReactNode
+}) {
+  return (
+    <ClerkProvider
+      appearance={{
+        baseTheme: dark
+      }}
+    >
+      <html lang="en">
+        <body>{children}</body>
+      </html>
+    </ClerkProvider>
+  )
+}
+```
+
+```tsx filename="_app.tsx" {2,8,9,10}
+import { ClerkProvider } from '@clerk/nextjs';
+import { dark } from '@clerk/themes';
+import type { AppProps } from "next/app";
+
+function MyApp({ Component, pageProps }: AppProps) {
+  return (
+    <ClerkProvider
+      appearance={{
+        baseTheme: dark
+      }}
+    >
+      <Component {...pageProps}/>
+    </ClerkProvider>
+  )
+}
+
+export default MyApp;
+```
+
+```tsx filename="app.tsx" {3,14-16}
+import React from "react";
+import "./App.css";
+import { dark } from '@clerk/themes';
+import { ClerkProvider } from "@clerk/clerk-react";
+
+if (!process.env.REACT_APP_CLERK_PUBLISHABLE_KEY) {
+  throw new Error("Missing Publishable Key")
+}
+const clerkPubKey = process.env.REACT_APP_CLERK_PUBLISHABLE_KEY;
+
+function App() {
+  return (
+    <ClerkProvider 
+      appearance={{
+        baseTheme: dark
+      }} 
+      publishableKey={clerkPubKey}
+    >
+      <div>Hello from clerk</div>
+    </ClerkProvider>
+  );
+}
+
+export default App;
+```
+
+```tsx filename="app/root.tsx" {3,43-45}
+// Import ClerkApp
+import { ClerkApp } from "@clerk/remix";
+import { dark } from '@clerk/themes';
+import type { MetaFunction,LoaderFunction } from "@remix-run/node";
+
+import {
+  Links,
+  LiveReload,
+  Meta,
+  Outlet,
+  Scripts,
+  ScrollRestoration,
+} from "@remix-run/react";
+
+import { rootAuthLoader } from "@clerk/remix/ssr.server";
+
+export const meta: MetaFunction = () => ({
+  charset: "utf-8",
+  title: "New Remix App",
+  viewport: "width=device-width,initial-scale=1",
+});
+
+export const loader: LoaderFunction = (args) => rootAuthLoader(args);
+
+function App() {
+  return (
+    <html lang="en">
+      <head>
+        <Meta />
+        <Links />
+      </head>
+      <body>
+        <Outlet />
+        <ScrollRestoration />
+        <Scripts />
+        <LiveReload />
+      </body>
+    </html>
+  );
+}
+
+export default ClerkApp(App, {
+  appearance: {
+    baseTheme: dark,
+  },
+});
+```
+</CodeBlockTabs>
+
+You can also stack themes by passing an array of themes to the `baseTheme` property of the `appearance` prop. The themes will be applied in the order they are listed. If styles overlap, the last defined theme will take precedence.
+
+In the example below, the `dark` theme is applied first, then the `neobrutalism` theme is applied on top of it.
+
+<CodeBlockTabs options={['Next.js App Router', 'Next.js Pages Router', 'React', 'Remix']}>
+```tsx filename="/src/app/layout.tsx" {2,11-13}
+import { ClerkProvider } from '@clerk/nextjs';
+import { dark, neobrutalism } from '@clerk/themes';
+
+export default function RootLayout({
+  children,
+}: {
+  children: React.ReactNode
+}) {
+  return (
+    <ClerkProvider
+      appearance={{
+        baseTheme: [dark, neobrutalism]
+      }}
+    >
+      <html lang="en">
+        <body>{children}</body>
+      </html>
+    </ClerkProvider>
+  )
+}
+```
+
+```tsx filename="_app.tsx" {2,8-10}
+import { ClerkProvider, SignIn } from '@clerk/nextjs';
+import { dark, neobrutalism } from '@clerk/themes';
+import type { AppProps } from "next/app";
+
+function MyApp({ Component, pageProps }: AppProps) {
+  return (
+    <ClerkProvider
+      appearance={{
+        baseTheme: [dark, neobrutalism]
+      }}
+    >
+      <Component {...pageProps}/>
+    </ClerkProvider>
+  )
+}
+
+export default MyApp;
+```
+
+```tsx filename="app.tsx" {3,14-16}
+import React from "react";
+import "./App.css";
+import { dark, neobrutalism } from '@clerk/themes';
+import { ClerkProvider } from "@clerk/clerk-react";
+
+if (!process.env.REACT_APP_CLERK_PUBLISHABLE_KEY) {
+  throw new Error("Missing Publishable Key")
+}
+const clerkPubKey = process.env.REACT_APP_CLERK_PUBLISHABLE_KEY;
+
+function App() {
+  return (
+    <ClerkProvider 
+      appearance={{
+        baseTheme: [dark, neobrutalism]
+      }} 
+      publishableKey={clerkPubKey}
+    >
+      <div>Hello from clerk</div>
+    </ClerkProvider>
+  );
+}
+
+export default App;
+```
+
+```tsx filename="app/root.tsx" {3,43-45}
+// Import ClerkApp
+import { ClerkApp } from "@clerk/remix";
+import { dark, neobrutalism } from '@clerk/themes';
+import type { MetaFunction,LoaderFunction } from "@remix-run/node";
+
+import {
+  Links,
+  LiveReload,
+  Meta,
+  Outlet,
+  Scripts,
+  ScrollRestoration,
+} from "@remix-run/react";
+
+import { rootAuthLoader } from "@clerk/remix/ssr.server";
+
+export const meta: MetaFunction = () => ({
+  charset: "utf-8",
+  title: "New Remix App",
+  viewport: "width=device-width,initial-scale=1",
+});
+
+export const loader: LoaderFunction = (args) => rootAuthLoader(args);
+
+function App() {
+  return (
+    <html lang="en">
+      <head>
+        <Meta />
+        <Links />
+      </head>
+      <body>
+        <Outlet />
+        <ScrollRestoration />
+        <Scripts />
+        <LiveReload />
+      </body>
+    </html>
+  );
+}
+
+export default ClerkApp(App, {
+  appearance: {
+    baseTheme: [dark, neobrutalism]
+  },
+});
+```
+</CodeBlockTabs>
+
+You can apply a theme to all instances of a Clerk component by passing the component to the `appearance` prop of the `<ClerkProvider />`. The `appearance` prop accepts the name of the Clerk component you want to style as a key.
+
+In the example below, the `neobrutalism` theme is applied to all instances of the [`<SignIn />`](/docs/components/authentication/sign-in) component.
+
+<CodeBlockTabs options={['Next.js App Router', 'Next.js Pages Router', 'React', 'Remix']}>
+```tsx filename="/src/app/layout.tsx" {2,11-14}
+import { ClerkProvider } from '@clerk/nextjs';
+import { dark, neobrutalism } from '@clerk/themes';
+
+export default function RootLayout({
+  children,
+}: {
+  children: React.ReactNode
+}) {
+  return (
+    <ClerkProvider
+      appearance={{
+        baseTheme: dark,
+        signIn: { baseTheme: neobrutalism },
+      }}
+    >
+      <html lang="en">
+        <body>{children}</body>
+      </html>
+    </ClerkProvider>
+  )
+}
+```
+
+```tsx filename="_app.tsx" {2,8-11}
+import { ClerkProvider, SignIn } from '@clerk/nextjs';
+import { dark } from '@clerk/themes';
+import type { AppProps } from "next/app";
+
+function MyApp({ Component, pageProps }: AppProps) {
+  return (
+    <ClerkProvider
+      appearance={{
+        baseTheme: dark,
+        signIn: { baseTheme: neobrutalism },
+      }}
+    >
+      <Component {...pageProps}/>
+    </ClerkProvider>
+  )
+}
+
+export default MyApp;
+```
+
+```tsx filename="app.tsx" {3,14-17}
+import React from "react";
+import "./App.css";
+import { dark } from '@clerk/themes';
+import { ClerkProvider } from "@clerk/clerk-react";
+
+if (!process.env.REACT_APP_CLERK_PUBLISHABLE_KEY) {
+  throw new Error("Missing Publishable Key")
+}
+const clerkPubKey = process.env.REACT_APP_CLERK_PUBLISHABLE_KEY;
+
+function App() {
+  return (
+    <ClerkProvider 
+      appearance={{
+        baseTheme: dark,
+        signIn: { baseTheme: neobrutalism },
+      }} 
+      publishableKey={clerkPubKey}
+    >
+      <div>Hello from clerk</div>
+    </ClerkProvider>
+  );
+}
+
+export default App;
+```
+
+```tsx filename="app/root.tsx" {3,43-46}
+// Import ClerkApp
+import { ClerkApp } from "@clerk/remix";
+import { dark } from '@clerk/themes';
+import type { MetaFunction,LoaderFunction } from "@remix-run/node";
+
+import {
+  Links,
+  LiveReload,
+  Meta,
+  Outlet,
+  Scripts,
+  ScrollRestoration,
+} from "@remix-run/react";
+
+import { rootAuthLoader } from "@clerk/remix/ssr.server";
+
+export const meta: MetaFunction = () => ({
+  charset: "utf-8",
+  title: "New Remix App",
+  viewport: "width=device-width,initial-scale=1",
+});
+
+export const loader: LoaderFunction = (args) => rootAuthLoader(args);
+
+function App() {
+  return (
+    <html lang="en">
+      <head>
+        <Meta />
+        <Links />
+      </head>
+      <body>
+        <Outlet />
+        <ScrollRestoration />
+        <Scripts />
+        <LiveReload />
+      </body>
+    </html>
+  );
+}
+
+export default ClerkApp(App, {
+  appearance: {
+    baseTheme: dark,
+    signIn: { baseTheme: neobrutalism },
+  },
+});
+```
+</CodeBlockTabs>
+
+#### Pass a theme to a single Clerk component
+
+To apply a theme to a single Clerk component, pass the `appearance` prop to the component. The `appearance` prop accepts the property `baseTheme`, which can be set to a theme.
+
+<CodeBlockTabs options={['Next.js App Router', 'Next.js Pages Router', 'React', 'Remix']}>
+```tsx filename="/app/sign-in/[[...sign-in]]/page.tsx" {2,6-8}
+import { SignIn } from "@clerk/nextjs";
+import { dark } from "@clerk/themes";
+
+export default function Page() {
+  return <SignIn 
+    appearance={{
+      baseTheme: dark
+    }}
+  />;
+}
+```
+
+```tsx filename="/pages/sign-in/[[...index]].tsx" {2,6-8}
+import { SignIn } from "@clerk/nextjs";
+import { dark } from "@clerk/themes";
+ 
+const SignInPage = () => (
+  <SignIn 
+    appearance={{
+      baseTheme: dark
+    }}
+  />
+);
+
+export default SignInPage;
+```
+
+```tsx filename="/src/sign-in/[[...index]].tsx" {2,6-8}
+import { SignIn } from "@clerk/clerk-react";
+import { dark } from "@clerk/themes";
+
+const SignInPage = () => (
+  <SignIn 
+    appearance={{
+      baseTheme: dark
+    }}
+  />
+);
+
+export default SignInPage;
+```
+
+```tsx filename="app/routes/sign-in/$.tsx" {2,9-11}
+import { SignIn } from "@clerk/remix";
+import { dark } from "@clerk/themes";
+ 
+export default function SignInPage() {
+  return (
+    <div style={{ border: "2px solid blue", padding: "2rem" }}>
+      <h1>Sign In route</h1>
+      <SignIn 
         appearance={{
           baseTheme: dark
         }}
-      >
-        <Component {...pageProps}/>
-      </ClerkProvider>
-    )
-  }
-
-  export default MyApp;
-  ```
-
-  ```tsx filename="app.tsx"
-  import React from "react";
-  import "./App.css";
-  import { dark } from '@clerk/themes';
-  import { ClerkProvider } from "@clerk/clerk-react";
-
-  if (!process.env.REACT_APP_CLERK_PUBLISHABLE_KEY) {
-    throw new Error("Missing Publishable Key")
-  }
-  const clerkPubKey = process.env.REACT_APP_CLERK_PUBLISHABLE_KEY;
-
-  function App() {
-    return (
-      <ClerkProvider appearance={{
-        baseTheme: dark
-        }} publishableKey={clerkPubKey}>
-        <div>Hello from clerk</div>
-      </ClerkProvider>
-    );
-  }
-
-  export default App;
-  ```
-
-  ```tsx filename="app/root.tsx"
-  // Import ClerkApp
-  import { ClerkApp } from "@clerk/remix";
-  import { dark } from '@clerk/themes';
-  import type { MetaFunction,LoaderFunction } from "@remix-run/node";
-
-  import {
-    Links,
-    LiveReload,
-    Meta,
-    Outlet,
-    Scripts,
-    ScrollRestoration,
-  } from "@remix-run/react";
-
-  import { rootAuthLoader } from "@clerk/remix/ssr.server";
-
-  export const meta: MetaFunction = () => ({
-    charset: "utf-8",
-    title: "New Remix App",
-    viewport: "width=device-width,initial-scale=1",
-  });
-
-  export const loader: LoaderFunction = (args) => rootAuthLoader(args);
-
-  function App() {
-    return (
-      <html lang="en">
-        <head>
-          <Meta />
-          <Links />
-        </head>
-        <body>
-          <Outlet />
-          <ScrollRestoration />
-          <Scripts />
-          <LiveReload />
-        </body>
-      </html>
-    );
-  }
-
-  export default ClerkApp(App, {
-    appearance: {
-      baseTheme: dark,
-    },
-  });
-  ```
+        routing={"path"} 
+        path={"/sign-in"} 
+      />
+    </div>
+  );
+}
+```
 </CodeBlockTabs>
 
-> [You can see a list of the themes Clerk offers in our reference docs.](/docs/components/customization/themes)
+## Customize a theme using variables
 
-## Making a custom theme
+You can customize a theme by passing an object of variables to the `variables` property of the `appearance` prop. The `variables` property is used to adjust the general styles of the component's base theme, like colors, backgrounds, typography. 
+
+In the example below, all Clerk components will have the `dark` theme with the `neobrutalism` theme applied on top of it, and the primary color will be set to red. All `<SignIn />` components will have the `shadesOfPurple` theme applied on top of the `dark` and `neobrutalism` themes, and the primary color will be set to blue.
+
+<Callout type="info">
+  For a list of all of the variables you can customize, and for more examples on how to use the `variables` property, see the [Variables](/docs/components/customization/variables) docs.
+</Callout>
+
+<CodeBlockTabs options={['Next.js App Router', 'Next.js Pages Router', 'React', 'Remix']}>
+```tsx filename="/src/app/layout.tsx" {2,11-18}
+import { ClerkProvider } from '@clerk/nextjs';
+import { dark, neobrutalism, shadesOfPurple } from '@clerk/themes';
+
+export default function RootLayout({
+  children,
+}: {
+  children: React.ReactNode
+}) {
+  return (
+    <ClerkProvider
+      appearance={{
+        baseTheme: [dark, neobrutalism],
+        variables: { colorPrimary: 'red' },
+        signIn: { 
+          baseTheme: [shadesOfPurple], 
+          variables: { colorPrimary: 'blue' }
+        }
+      }}
+    >
+      <html lang="en">
+        <body>{children}</body>
+      </html>
+    </ClerkProvider>
+  )
+}
+```
+
+```tsx filename="_app.tsx" {2,8-15}
+import { ClerkProvider } from '@clerk/nextjs';
+import { dark, neobrutalism, shadesOfPurple } from '@clerk/themes';
+import type { AppProps } from "next/app";
+
+function MyApp({ Component, pageProps }: AppProps) {
+  return (
+    <ClerkProvider
+      appearance={{
+        baseTheme: [dark, neobrutalism],
+        variables: { colorPrimary: 'red' },
+        signIn: { 
+          baseTheme: [shadesOfPurple], 
+          variables: { colorPrimary: 'blue' }
+        }
+      }}
+    >
+      <Component {...pageProps}/>
+    </ClerkProvider>
+  )
+}
+
+export default MyApp;
+```
+
+```tsx filename="app.tsx" {3,14-21}
+import React from "react";
+import "./App.css";
+import { dark, neobrutalism, shadesOfPurple } from '@clerk/themes';
+import { ClerkProvider } from "@clerk/clerk-react";
+
+if (!process.env.REACT_APP_CLERK_PUBLISHABLE_KEY) {
+  throw new Error("Missing Publishable Key")
+}
+const clerkPubKey = process.env.REACT_APP_CLERK_PUBLISHABLE_KEY;
+
+function App() {
+  return (
+    <ClerkProvider 
+      appearance={{
+        baseTheme: [dark, neobrutalism],
+        variables: { colorPrimary: 'red' },
+        signIn: { 
+          baseTheme: [shadesOfPurple], 
+          variables: { colorPrimary: 'blue' }
+        }
+      }}
+      publishableKey={clerkPubKey}
+    >
+      <div>Hello from clerk</div>
+    </ClerkProvider>
+  );
+}
+
+export default App;
+```
+
+```tsx filename="app/root.tsx" {3,43-50}
+// Import ClerkApp
+import { ClerkApp } from "@clerk/remix";
+import { dark, neobrutalism, shadesOfPurple } from '@clerk/themes';
+import type { MetaFunction,LoaderFunction } from "@remix-run/node";
+
+import {
+  Links,
+  LiveReload,
+  Meta,
+  Outlet,
+  Scripts,
+  ScrollRestoration,
+} from "@remix-run/react";
+
+import { rootAuthLoader } from "@clerk/remix/ssr.server";
+
+export const meta: MetaFunction = () => ({
+  charset: "utf-8",
+  title: "New Remix App",
+  viewport: "width=device-width,initial-scale=1",
+});
+
+export const loader: LoaderFunction = (args) => rootAuthLoader(args);
+
+function App() {
+  return (
+    <html lang="en">
+      <head>
+        <Meta />
+        <Links />
+      </head>
+      <body>
+        <Outlet />
+        <ScrollRestoration />
+        <Scripts />
+        <LiveReload />
+      </body>
+    </html>
+  );
+}
+
+export default ClerkApp(App, {
+  appearance={{
+    baseTheme: [dark, neobrutalism],
+    variables: { colorPrimary: 'red' },
+    signIn: { 
+      baseTheme: [shadesOfPurple], 
+      variables: { colorPrimary: 'blue' }
+    }
+  }}
+});
+```
+</CodeBlockTabs>
+
+## Create a custom theme
 
 You can make a custom theme for your app's Clerk component by customizing the styles that are applied to each element.
 
@@ -140,7 +648,7 @@ This can be done with one of three different methods of styling:
 
 No matter which method you choose, you'll need to know how to identify the element you want to style.
 
-### Identifying the underlying element
+### Identify the underlying element
 
 You can identify the underlying element by inspecting the HTML of the Clerk component. You can do this by right-clicking on the component in your browser and selecting "Inspect Element" or "Inspect":
 
@@ -156,7 +664,7 @@ Any of the classes listed before the lock icon (🔒️) are safe to rely on, su
 
 > Anything after the lock icon (🔒️) are internal classes used for Clerk's internal styling and should not be modified.
 
-### Global CSS
+### Use global CSS to style Clerk components
 
 Using this knowledge about the publicly available classes, you can target the elements with global CSS.
 
@@ -178,7 +686,7 @@ Here's an example of how you can target the primary button in a Clerk component:
 
 ![The previously blue "Continue" button is now purple](/docs/images/customization/purple_button.png)
 
-### Using custom CSS classes
+### Use custom CSS classes to style Clerk components
 
 You're able to pass additional classes to Clerk component elements by using the `elements` property on `appearance` in your `ClerkProvider`.
 
@@ -211,7 +719,7 @@ function MyApp({ pageProps }: AppProps) {
 export default MyApp;
 ```
 
-#### Using Tailwind
+#### Use Tailwind classes to style Clerk components
 
 By using the method outlined above, you can use Tailwind classes to style Clerk components.
 
@@ -276,7 +784,7 @@ function MyApp({ pageProps }: AppProps) {
 export default MyApp;
 ```
 
-### Inline CSS objects
+### Use inline CSS objects to style Clerk components
 
 Using the same method for identifying elements as mentioned previously, you can pass an object of CSS properties to the `elements` property on `appearance` in your `ClerkProvider`.
 

--- a/docs/components/customization/themes.mdx
+++ b/docs/components/customization/themes.mdx
@@ -12,52 +12,64 @@ Clerk currently offers four pre-built themes that can be exported from `@clerk/t
 - [The "Shades of Purple" Theme](#shades-of-purple-theme)
 - [The "Neobrutalism" Theme](#neobrutalism-theme)
 
-## Default theme
+## Usage
+
+To use a theme, import it from `@clerk/themes` and pass it to the `appearance` prop of a Clerk component. You can pass it to the `<ClerkProvider />` component to apply it to all Clerk components in your app. To learn more about how to use themes, see the [Appearance prop](/docs/components/customization/overview#using-a-pre-built-theme) documentiation.
+
+### Default theme
 
 > Applied by default when no other theme is provided.
 
-<div style={{padding: "1rem 0", filter: "drop-shadow(rgba(0, 0, 0, 0.16) 0px 12px 24px)"}}><Images
-  width={496}
-  height={564}
-  src="/docs/images/themes/default.svg"
-  alt="A sign-in form with a light theme"
-/></div>
+<div style={{padding: "1rem 0", filter: "drop-shadow(rgba(0, 0, 0, 0.16) 0px 12px 24px)"}}>
+  <Images
+    width={496}
+    height={564}
+    src="/docs/images/themes/default.svg"
+    alt="A sign-in form with a light theme"
+  />
+</div>
 
-## Dark theme
+### Dark theme
 
 ```typescript
 import {dark} from "@clerk/themes";
 ```
 
-<div style={{padding: "1rem 0", filter: "drop-shadow(rgba(0, 0, 0, 0.16) 0px 12px 24px)"}}><Images
-  width={496}
-  height={564}
-  src="/docs/images/themes/dark.svg"
-  alt="A sign-in form with a dark theme"
-/></div>
+<div style={{padding: "1rem 0", filter: "drop-shadow(rgba(0, 0, 0, 0.16) 0px 12px 24px)"}}>
+  <Images
+    width={496}
+    height={564}
+    src="/docs/images/themes/dark.svg"
+    alt="A sign-in form with a dark theme"
+  />
+</div>
 
-## Shades of purple theme
+### Shades of purple theme
 
 ```typescript
 import {shadesOfPurple} from "@clerk/themes";
 ```
 
-<div style={{padding: "1rem 0", filter: "drop-shadow(rgba(0, 0, 0, 0.16) 0px 12px 24px)"}}><Images
-  width={496}
-  height={564}
-  src="/docs/images/themes/shades_of_purple.svg"
-  alt="A sign-in form with a purple and yellow theme"
-/></div>
+<div style={{padding: "1rem 0", filter: "drop-shadow(rgba(0, 0, 0, 0.16) 0px 12px 24px)"}}>
+  <Images
+    width={496}
+    height={564}
+    src="/docs/images/themes/shades_of_purple.svg"
+    alt="A sign-in form with a purple and yellow theme"
+  />
+</div>
 
-## Neobrutalism theme
+### Neobrutalism theme
 
 ```typescript
 import {neobrutalism} from "@clerk/themes";
 ```
 
-<div style={{padding: "1rem 0", filter: "drop-shadow(rgba(0, 0, 0, 0.16) 0px 12px 24px)"}}><Images
-  width={496}
-  height={564}
-  src="/docs/images/themes/neobrutalism.svg"
-  alt="A sign-in form with a neobrutalist red theme"
-/></div>
+<div style={{padding: "1rem 0", filter: "drop-shadow(rgba(0, 0, 0, 0.16) 0px 12px 24px)"}}>
+  <Images
+    width={496}
+    height={564}
+    src="/docs/images/themes/neobrutalism.svg"
+    alt="A sign-in form with a neobrutalist red theme"
+  />
+</div>

--- a/docs/components/customization/themes.mdx
+++ b/docs/components/customization/themes.mdx
@@ -14,7 +14,23 @@ Clerk currently offers four pre-built themes that can be exported from `@clerk/t
 
 ## Usage
 
-To use a theme, import it from `@clerk/themes` and pass it to the `appearance` prop of a Clerk component. You can pass it to the `<ClerkProvider />` component to apply it to all Clerk components in your app. To learn more about how to use themes, see the [Appearance prop](/docs/components/customization/overview#using-a-pre-built-theme) documentiation.
+To get started, install the `@clerk/themes` package.
+
+<CodeBlockTabs options={["npm", "yarn", "pnpm"]}>
+  ```bash filename="terminal"
+  npm install @clerk/themes
+  ```
+
+  ```bash filename="terminal"
+  yarn add @clerk/themes
+  ```
+
+  ```bash filename="terminal"
+  pnpm add @clerk/themes
+  ```
+</CodeBlockTabs>
+
+To use a theme, import it from `@clerk/themes` and pass it to the `appearance` prop of a Clerk component. You can pass it to the [`<ClerkProvider />`](/docs/components/clerk-provider) component to apply it to all Clerk components in your app or you can pass it to a single Clerk component. For guided examples and to learn further about how to use themes, see the [Appearance prop](/docs/components/customization/overview#using-a-pre-built-theme) documentiation.
 
 ### Default theme
 

--- a/docs/components/customization/variables.mdx
+++ b/docs/components/customization/variables.mdx
@@ -5,22 +5,365 @@ description: Utilize Clerk's variables property in order to adjust the general s
 
 # Variables
 
-The variables property is used to adjust the general styles of the component's base theme, like colors, backgrounds, typography.
+The `variables` property is used to adjust the general styles of the component's base theme, like colors, backgrounds, typography.
 
 ## Usage
 
-```tsx filename="app.tsx"
+You can customize Clerk components by passing an object of variables to the `variables` property of the [`appearance`](/docs/components/customization/overview) prop. You can pass it to the [`<ClerkProvider />`](/docs/components/clerk-provider) component to apply it to all Clerk components in your app or you can pass it to a single Clerk component.
+
+### Pass `variables` to `<ClerkProvider />`
+
+To customize all Clerk components, pass the `variables` property to the `appearance` prop to the `<ClerkProvider />` component.
+
+In the example below, the primary color is set to red and the text color is set to white. Because these styles are applied to the `<ClerkProvider />`, which wraps the entire application, these styles will be applied to all Clerk components that use the primary color and text color.
+
+<CodeBlockTabs options={["Next.js App Router", "Next.js Pages Router", "React", "Remix"]}>
+```tsx filename="/src/app/layout.tsx" {10-15}
 import { ClerkProvider } from '@clerk/nextjs';
 
-<ClerkProvider appearance={{
+export default function RootLayout({
+  children,
+}: {
+  children: React.ReactNode
+}) {
+  return (
+    <ClerkProvider
+      appearance={{
+        variables: {
+          colorPrimary: "red",
+          colorText: "white"
+        }
+      }}
+    >
+      <html lang="en">
+        <body>{children}</body>
+      </html>
+    </ClerkProvider>
+  )
+}
+```
+
+```tsx filename="_app.tsx" {7-12}
+import { ClerkProvider } from '@clerk/nextjs';
+import type { AppProps } from "next/app";
+
+function MyApp({ Component, pageProps }: AppProps) {
+  return (
+    <ClerkProvider
+      appearance={{
+        variables: {
+          colorPrimary: "red",
+          colorText: "white"
+        }
+      }}
+    >
+      <Component {...pageProps}/>
+    </ClerkProvider>
+  )
+}
+
+export default MyApp;
+```
+
+```tsx filename="app.tsx" {13-18}
+import React from "react";
+import "./App.css";
+import { ClerkProvider } from "@clerk/clerk-react";
+
+if (!process.env.REACT_APP_CLERK_PUBLISHABLE_KEY) {
+  throw new Error("Missing Publishable Key")
+}
+const clerkPubKey = process.env.REACT_APP_CLERK_PUBLISHABLE_KEY;
+
+function App() {
+  return (
+    <ClerkProvider 
+      appearance={{
+        variables: {
+          colorPrimary: "red",
+          colorText: "white"
+        }
+      }} 
+      publishableKey={clerkPubKey}
+    >
+      <div>Hello from clerk</div>
+    </ClerkProvider>
+  );
+}
+
+export default App;
+```
+
+```tsx filename="app/root.tsx" {42-47}
+// Import ClerkApp
+import { ClerkApp } from "@clerk/remix";
+import type { MetaFunction,LoaderFunction } from "@remix-run/node";
+
+import {
+  Links,
+  LiveReload,
+  Meta,
+  Outlet,
+  Scripts,
+  ScrollRestoration,
+} from "@remix-run/react";
+
+import { rootAuthLoader } from "@clerk/remix/ssr.server";
+
+export const meta: MetaFunction = () => ({
+  charset: "utf-8",
+  title: "New Remix App",
+  viewport: "width=device-width,initial-scale=1",
+});
+
+export const loader: LoaderFunction = (args) => rootAuthLoader(args);
+
+function App() {
+  return (
+    <html lang="en">
+      <head>
+        <Meta />
+        <Links />
+      </head>
+      <body>
+        <Outlet />
+        <ScrollRestoration />
+        <Scripts />
+        <LiveReload />
+      </body>
+    </html>
+  );
+}
+
+export default ClerkApp(App, {
+  appearance: {
     variables: {
+      colorPrimary: "red",
+      colorText: "white"
+    }
+  },
+});
+```
+</CodeBlockTabs>
+
+You can customize all instances of a Clerk component by passing the component to the `appearance` prop of the `<ClerkProvider />`. The `appearance` prop accepts the name of the Clerk component you want to style as a key. 
+
+In the example below, the primary color is set to red and the text color is set to white for all instances of the [`<SignIn />`](/docs/components/authentication/sign-in) component. 
+
+<CodeBlockTabs options={['Next.js App Router', 'Next.js Pages Router', 'React', 'Remix']}>
+```tsx filename="/src/app/layout.tsx" {10-17}
+import { ClerkProvider } from '@clerk/nextjs';
+
+export default function RootLayout({
+  children,
+}: {
+  children: React.ReactNode
+}) {
+  return (
+    <ClerkProvider
+      appearance={{
+        signIn: { 
+          variables: {
+            colorPrimary: "red",
+            colorText: "white"
+          } 
+        },
+      }}
+    >
+      <html lang="en">
+        <body>{children}</body>
+      </html>
+    </ClerkProvider>
+  )
+}
+```
+
+```tsx filename="_app.tsx" {7-14}
+import { ClerkProvider } from "@clerk/nextjs";
+import type { AppProps } from "next/app";
+
+function MyApp({ Component, pageProps }: AppProps) {
+  return (
+    <ClerkProvider
+      appearance={{
+        signIn: { 
+          variables: {
+            colorPrimary: "red",
+            colorText: "white"
+          } 
+        },
+      }}
+    >
+      <Component {...pageProps} />
+    </ClerkProvider>
+  );
+}
+
+export default MyApp;
+
+```
+
+```tsx filename="app.tsx" {13-20}
+import React from "react";
+import "./App.css";
+import { ClerkProvider } from "@clerk/clerk-react";
+
+if (!process.env.REACT_APP_CLERK_PUBLISHABLE_KEY) {
+  throw new Error("Missing Publishable Key")
+}
+const clerkPubKey = process.env.REACT_APP_CLERK_PUBLISHABLE_KEY;
+
+function App() {
+  return (
+    <ClerkProvider 
+      appearance={{
+        signIn: { 
+          variables: {
+            colorPrimary: "red",
+            colorText: "white"
+          } 
+        },
+      }}
+      publishableKey={clerkPubKey}
+    >
+      <div>Hello from clerk</div>
+    </ClerkProvider>
+  );
+}
+
+export default App;
+```
+
+```tsx filename="app/root.tsx" {42-49}
+// Import ClerkApp
+import { ClerkApp } from "@clerk/remix";
+import type { MetaFunction,LoaderFunction } from "@remix-run/node";
+
+import {
+  Links,
+  LiveReload,
+  Meta,
+  Outlet,
+  Scripts,
+  ScrollRestoration,
+} from "@remix-run/react";
+
+import { rootAuthLoader } from "@clerk/remix/ssr.server";
+
+export const meta: MetaFunction = () => ({
+  charset: "utf-8",
+  title: "New Remix App",
+  viewport: "width=device-width,initial-scale=1",
+});
+
+export const loader: LoaderFunction = (args) => rootAuthLoader(args);
+
+function App() {
+  return (
+    <html lang="en">
+      <head>
+        <Meta />
+        <Links />
+      </head>
+      <body>
+        <Outlet />
+        <ScrollRestoration />
+        <Scripts />
+        <LiveReload />
+      </body>
+    </html>
+  );
+}
+
+export default ClerkApp(App, {
+  appearance: {
+    signIn: { 
+      variables: {
         colorPrimary: "red",
         colorText: "white"
-    }
-}}>
-  {/* ... */}
-</ClerkProvider>
+      } 
+    },
+  },
+});
 ```
+</CodeBlockTabs>
+
+### Pass `variables` to a single component
+
+To customize a single Clerk component, pass the `variables` property to the `appearance` prop to the Clerk component.
+
+<CodeBlockTabs options={['Next.js App Router', 'Next.js Pages Router', 'React', 'Remix']}>
+```tsx filename="/app/sign-in/[[...sign-in]]/page.tsx" {5-10}
+import { SignIn } from "@clerk/nextjs";
+
+export default function Page() {
+  return <SignIn 
+    appearance={{
+      variables: {
+        colorPrimary: "red",
+        colorText: "white"
+      }
+    }}
+  />;
+}
+```
+
+```tsx filename="/pages/sign-in/[[...index]].tsx" {5-10}
+import { SignIn } from "@clerk/nextjs";
+ 
+const SignInPage = () => (
+  <SignIn 
+    appearance={{
+      variables: {
+        colorPrimary: "red",
+        colorText: "white"
+      }
+    }}
+  />
+);
+
+export default SignInPage;
+```
+
+```tsx filename="/src/sign-in/[[...index]].tsx" {5-10}
+import { SignIn } from "@clerk/clerk-react";
+
+const SignInPage = () => (
+  <SignIn 
+    appearance={{
+      variables: {
+        colorPrimary: "red",
+        colorText: "white"
+      }
+    }}
+  />
+);
+
+export default SignInPage;
+```
+
+```tsx filename="app/routes/sign-in/$.tsx" {8-13}
+import { SignIn } from "@clerk/remix";
+ 
+export default function SignInPage() {
+  return (
+    <div style={{ border: "2px solid blue", padding: "2rem" }}>
+      <h1>Sign In route</h1>
+      <SignIn 
+        appearance={{
+          variables: {
+            colorPrimary: "red",
+            colorText: "white"
+          }
+        }}
+        routing={"path"} 
+        path={"/sign-in"} 
+      />
+    </div>
+  );
+}
+```
+</CodeBlockTabs>
 
 ## Properties
 


### PR DESCRIPTION
Currently, the [Themes](https://clerk.com/docs/components/customization/themes) page shows code examples of how to import themes, but not where to import, nor how to use them.

This PR adds a section titled "Usage" and links users to the [Appearance](https://clerk.com/docs/components/customization/overview#using-a-pre-built-theme) prop page where it's explained how the appearance prop is used to change the theme of a component/all components.

Also, per [this Slack discussion](https://clerkinc.slack.com/archives/C05BEL0P7M4/p1698964339477739), more examples were added to cover different use cases for the `appearance` and `variables` props.
This PR adds examples for
- Passing a theme to `<ClerkProvider />` (*all* Clerk components)
  - passing a single theme to *all* components
  - passing an array of themes to *all* components
  - passing a theme to *all instances of a **single*** Clerk component
- Passing a theme to a *single* Clerk component
- Customizing a theme using variables
  - Stacking multiple themes for *all* Clerk components while also customizing the `variables` prop for *all* Clerk components while also setting a theme and customizing the `variables` prop for *all instances of a single Clerk component*
- Passing `variables` to `<ClerkProvider />` (*all* Clerk components)
  - to *all* components
  - to *all instances of a **single*** Clerk component
- Passing `variables` to a *single* Clerk component

Fixes DOCS-422
Fixes DOCS-380