### PR TITLE
Fix indentation in `react.mdx`

### DIFF
--- a/docs/quickstarts/react.mdx
+++ b/docs/quickstarts/react.mdx
@@ -184,9 +184,9 @@ function ClerkProviderWithRoutes() {
             <SignedIn>
               <ProtectedPage />
             </SignedIn>
-             <SignedOut>
+            <SignedOut>
               <RedirectToSignIn />
-           </SignedOut>
+            </SignedOut>
           </>
           }
         />


### PR DESCRIPTION
Quick fix for indentation in the React quickstart.