### PR TITLE
Fix copy-paste error in Session options docs

### DIFF
--- a/docs/authentication/configuration/session-options.mdx
+++ b/docs/authentication/configuration/session-options.mdx
@@ -21,7 +21,7 @@ Fortunately, with Clerk you have to ability to fully control the lifetime of you
 
 ### Inactivity timeout
 
-Denotes the duration after which a session will expire and the user will have to sign in again, if they haven't been active on your site. By default, this setting is disabled for all newly created instances. You can enable it and set your desired value from the You can enable it and set your desired value from the [Sessions](https://dashboard.clerk.com/last-active?path=sessions) settings in the Clerk Dashboard.
+Denotes the duration after which a session will expire and the user will have to sign in again, if they haven't been active on your site. By default, this setting is disabled for all newly created instances. You can enable it and set your desired value from the [Sessions](https://dashboard.clerk.com/last-active?path=sessions) settings in the Clerk Dashboard.
 
 <Images 
 width={3024}


### PR DESCRIPTION
Deleted some extra text that didn't need to be there