### PR TITLE
Fix typo in Vulnerability Disclosure Policy

### DIFF
--- a/docs/security/vulnerability-disclosure-policy.mdx
+++ b/docs/security/vulnerability-disclosure-policy.mdx
@@ -10,9 +10,8 @@ description: Clerk's vulnerability disclosure policy.
 #### We require that all researchers:
 
 1. Make every effort to avoid privacy violations, degradation of user experience, disruption to production systems, and destruction of data during security testing.
-
 2. Perform research only within the scope set out below.
-3. Use the identified communication channels to report vulnerability information to us; an
+3. Use the identified communication channels to report vulnerability information to us.
 4. Keep information about any vulnerabilities you’ve discovered confidential between yourself and Clerk, Inc. until we’ve had 90 days to resolve the issue.
 
 If you follow these guidelines when reporting an issue to us, we commit to:


### PR DESCRIPTION
- Remove extra whitespace
- Add consistent punctuation
- s/an/and/