### PR TITLE
docs-541 add code examples on how to sign out of a session in a multisession app

### DIFF
--- a/docs/components/unstyled/sign-out-button.mdx
+++ b/docs/components/unstyled/sign-out-button.mdx
@@ -9,7 +9,9 @@ The `<SignOutButton />` component is a button that signs a user out. By default,
 
 ## Usage
 
-#### Basic Usage
+### Basic usage
+
+The example below shows how to use the `<SignOutButton />` component. 
 
 <Tabs items={['Next.js', 'React', 'Remix', 'Gatsby']}>
   <Tab>
@@ -88,7 +90,7 @@ The `<SignOutButton />` component is a button that signs a user out. By default,
   </Tab>
 </Tabs>
 
-#### Custom Usage
+### Custom usage
 
 You can create a custom button by wrapping your own button, or button text, in the `<SignOutButton />` component.
 
@@ -172,6 +174,101 @@ You can create a custom button by wrapping your own button, or button text, in t
           <SignOutButton>
             <button>Sign in with Clerk</button>
           </SignOutButton>
+        </div>
+      );
+    }
+    ```
+  </Tab>
+</Tabs>
+
+### Multi-session usage
+
+You can sign out of a specific session by passing in a `sessionId` to the `signOutOptions` prop. This is useful for multi-session applications.
+
+In the example below, the `sessionId` is retrieved from the [`useAuth()`](/docs/references/react/use-auth) hook.
+
+<Tabs items={['Next.js', 'React', 'Remix', 'Gatsby']}>
+  <Tab>
+    <CodeBlockTabs options={["App Router", "Pages Router"]}>
+      ```tsx filename="app/page.tsx"
+      "use client"
+      
+      import { SignInButton, SignOutButton, useAuth } from "@clerk/nextjs";
+
+      export default function Home() {
+        const { sessionId } = useAuth();
+
+        return (
+          <div>
+            <h1> Sign out </h1>
+            <SignOutButton signOutOptions={{ sessionId }} />
+          </div>
+        );
+      }
+      ```
+
+      ```tsx filename="pages/index.tsx"
+      import { SignInButton, SignOutButton, useAuth } from "@clerk/nextjs";
+
+      export default function Home() {
+        const { sessionId } = useAuth();
+
+        return (
+          <div>
+            <h1> Sign out </h1>
+            <SignOutButton signOutOptions={{ sessionId }} />
+          </div>
+        );
+      }
+      ```
+    </CodeBlockTabs>
+  </Tab>
+
+  <Tab>
+    ```jsx filename="example.js"
+    import { SignInButton, SignOutButton, useAuth } from "@clerk/clerk-react";
+
+    export default function Home() {
+      const { sessionId } = useAuth();
+
+      return (
+        <div>
+          <h1> Sign out </h1>
+          <SignOutButton signOutOptions={{ sessionId }} />
+        </div>
+      );
+    }
+    ```
+  </Tab>
+
+  <Tab>
+    ```jsx filename="pages/index.js"
+    import { SignInButton, SignOutButton, useAuth } from "@clerk/remix";
+
+    export default function Home() {
+      const { sessionId } = useAuth();
+
+      return (
+        <div>
+          <h1> Sign out </h1>
+          <SignOutButton signOutOptions={{ sessionId }} />
+        </div>
+      );
+    }
+    ```
+  </Tab>
+
+  <Tab>
+    ```jsx filename="pages/index.js"
+    import { SignInButton, SignOutButton, useAuth } from "gatsby-plugin-clerk";
+
+    export default function Home() {
+      const { sessionId } = useAuth();
+
+      return (
+        <div>
+          <h1> Sign out </h1>
+          <SignOutButton signOutOptions={{ sessionId }} />
         </div>
       );
     }

--- a/docs/components/unstyled/sign-out-button.mdx
+++ b/docs/components/unstyled/sign-out-button.mdx
@@ -183,7 +183,9 @@ You can create a custom button by wrapping your own button, or button text, in t
 
 ### Multi-session usage
 
-You can sign out of a specific session by passing in a `sessionId` to the `signOutOptions` prop. This is useful for multi-session applications.
+#### Sign out of a specific session
+
+You can sign out of a specific session by passing in a `sessionId` to the `signOutOptions` prop. This is useful for signing a single account out of a multi-session (multiple account) application.
 
 In the example below, the `sessionId` is retrieved from the [`useAuth()`](/docs/references/react/use-auth) hook.
 
@@ -197,6 +199,15 @@ In the example below, the `sessionId` is retrieved from the [`useAuth()`](/docs/
 
       export default function Home() {
         const { sessionId } = useAuth();
+
+        if (!sessionId) {
+          return (
+            <div>
+              <h1> Sign in </h1>
+              <SignInButton />
+            </div>
+          );
+        }
 
         return (
           <div>
@@ -212,6 +223,15 @@ In the example below, the `sessionId` is retrieved from the [`useAuth()`](/docs/
 
       export default function Home() {
         const { sessionId } = useAuth();
+
+        if (!sessionId) {
+          return (
+            <div>
+              <h1> Sign in </h1>
+              <SignInButton />
+            </div>
+          );
+        }
 
         return (
           <div>
@@ -230,6 +250,15 @@ In the example below, the `sessionId` is retrieved from the [`useAuth()`](/docs/
 
     export default function Home() {
       const { sessionId } = useAuth();
+     
+      if (!sessionId) {
+        return (
+          <div>
+            <h1> Sign in </h1>
+            <SignInButton />
+          </div>
+        );
+      }
 
       return (
         <div>
@@ -248,6 +277,15 @@ In the example below, the `sessionId` is retrieved from the [`useAuth()`](/docs/
     export default function Home() {
       const { sessionId } = useAuth();
 
+      if (!sessionId) {
+        return (
+          <div>
+            <h1> Sign in </h1>
+            <SignInButton />
+          </div>
+        );
+      }
+
       return (
         <div>
           <h1> Sign out </h1>
@@ -265,10 +303,114 @@ In the example below, the `sessionId` is retrieved from the [`useAuth()`](/docs/
     export default function Home() {
       const { sessionId } = useAuth();
 
+      if (!sessionId) {
+        return (
+          <div>
+            <h1> Sign in </h1>
+            <SignInButton />
+          </div>
+        );
+      }
+
       return (
         <div>
           <h1> Sign out </h1>
           <SignOutButton signOutOptions={{ sessionId }} />
+        </div>
+      );
+    }
+    ```
+  </Tab>
+</Tabs>
+
+#### Sign out of all sessions
+
+You can sign out of all currently active sessions by passing a callback that returns the `signOut()` method to the `signOutCallback` prop. This is useful for signing out all currently active accounts from a multi-session (multiple account) application.
+
+In the example below, the `signOut()` method is retrieved from the [`useAuth()`](/docs/references/react/use-auth) hook.
+
+<Tabs items={['Next.js', 'React', 'Remix', 'Gatsby']}>
+  <Tab>
+    <CodeBlockTabs options={["App Router", "Pages Router"]}>
+      ```tsx filename="app/page.tsx"
+      "use client";
+
+      import { SignOutButton, useClerk } from "@clerk/nextjs";
+
+      export default function Home() {
+        const { signOut } = useClerk();
+
+        return (
+          <div>
+            <h1> Sign out </h1>
+            <SignOutButton signOutCallback={() => signOut()} />
+          </div>
+        );
+      }
+      ```
+
+      ```tsx filename="pages/index.tsx"
+      import { SignOutButton, useClerk } from "@clerk/nextjs";
+
+      export default function Home() {
+        const { signOut } = useClerk();
+
+        return (
+          <div>
+            <h1> Sign out </h1>
+            <SignOutButton signOutCallback={() => signOut()} />
+          </div>
+        );
+      }
+      ```
+    </CodeBlockTabs>
+  </Tab>
+
+  <Tab>
+    ```jsx filename="example.js"
+    import { SignOutButton, useClerk } from "@clerk/clerk-react";
+
+    export default function Home() {
+      const { signOut } = useClerk();
+
+      return (
+        <div>
+          <h1> Sign out </h1>
+          <SignOutButton signOutCallback={() => signOut()} />
+        </div>
+      );
+    }
+    ```
+  </Tab>
+
+  <Tab>
+    ```jsx filename="pages/index.js"
+    import { SignOutButton, useClerk } from "@clerk/remix";
+
+    export default function Home() {
+      const { signOut } = useClerk();
+
+      return (
+        <div>
+          <h1> Sign out </h1>
+          <SignOutButton signOutCallback={() => signOut()} />
+        </div>
+      );
+    }
+    ```
+  </Tab>
+
+  <Tab>
+    ```jsx filename="pages/index.js"
+    import { SignOutButton, useClerk } from "gatsby-plugin-clerk";
+
+    export default function Home() {
+      const { signOut } = useClerk();
+
+      return (
+        <div>
+          <h1> Sign out </h1>
+          <SignOutButton signOutCallback={() => signOut()} />
         </div>
       );
     }


### PR DESCRIPTION
A [user feedback ticket](https://linear.app/clerk/issue/DOCS-541/%F0%9F%98%A2-feedback-for-componentsunstyledsign-out-button) expressed that our docs "need examples how to logout from all sessions".

This PR
- fixes headings (broke a11y as they were in the wrong order)
- adds a section on "multi-session usage" with 
   - code examples on how to utilize the `signOutOptions` property for signing out of a specific session in a multi-session application. (🔎 [see the updated section here](https://docs-preview-472.clerkpreview.com/docs/components/unstyled/sign-out-button#sign-out-of-a-specific-session))
   - code examples on how to utilize the `signOutCallback` property for signing out of all sessions in a multi-session application. (🔎 [see the updated section here](https://docs-preview-472.clerkpreview.com/docs/components/unstyled/sign-out-button#sign-out-of-all-sessions))

🔎 [Old page](https://clerk.com/docs/components/unstyled/sign-out-button#sign-out-button)
🔎 [New page](https://docs-preview-472.clerkpreview.com/docs/components/unstyled/sign-out-button)