### PR TITLE
Use <TutorialHero /> component in NextJS quickstart header

### DIFF
--- a/docs/quickstarts/nextjs.mdx
+++ b/docs/quickstarts/nextjs.mdx
@@ -4,6 +4,25 @@ description: Learn how to use Clerk to quickly and easily add secure authenticat
 ---
 
 <TutorialHero 
+  quickstart="remix"
+  beforeYouStart={[
+    {
+      title: "Set up a Clerk application",
+      link: "https://clerk.com/docs/quickstarts/setup-clerk"
+    },
+    {
+      title: "Create a Next.js application",
+      link: "https://nextjs.org/docs/getting-started/installation"
+    }
+  ]}
+>
+- Install `@clerk/nextjs`
+- Set up your environment keys
+- Wrap your Next.js app in `<ClerkProvider/>`  
+- Limit access to authenticated users
+- Embed the `<UserButton/>`
+</TutorialHero>
+{/* <TutorialHero 
   quickstart="nextjs"
   beforeYouStart={[
     {
@@ -15,16 +34,6 @@ description: Learn how to use Clerk to quickly and easily add secure authenticat
       link: "https://nextjs.org/docs/getting-started/installation"
     }
   ]}
-  exampleRepo={[
-    {
-      title: "App Router",
-      link: "https://github.com/clerkinc/clerk-nextjs-app-quickstart"
-    },
-    {
-      title: "Pages Router",
-      link: "https://github.com/clerkinc/clerk-nextjs-pages-quickstart"
-    }
-  ]}
 >
 - Install `@clerk/nextjs`
 - Set up your environment keys
@@ -32,6 +41,7 @@ description: Learn how to use Clerk to quickly and easily add secure authenticat
 - Limit access to authenticated users
 - Embed the `<UserButton/>`
 </TutorialHero>
+<NextjsExampleRepos /> */}
 
 <Steps>
 

--- a/docs/quickstarts/nextjs.mdx
+++ b/docs/quickstarts/nextjs.mdx
@@ -4,25 +4,6 @@ description: Learn how to use Clerk to quickly and easily add secure authenticat
 ---
 
 <TutorialHero 
-  quickstart="remix"
-  beforeYouStart={[
-    {
-      title: "Set up a Clerk application",
-      link: "https://clerk.com/docs/quickstarts/setup-clerk"
-    },
-    {
-      title: "Create a Next.js application",
-      link: "https://nextjs.org/docs/getting-started/installation"
-    }
-  ]}
->
-- Install `@clerk/nextjs`
-- Set up your environment keys
-- Wrap your Next.js app in `<ClerkProvider/>`  
-- Limit access to authenticated users
-- Embed the `<UserButton/>`
-</TutorialHero>
-{/* <TutorialHero 
   quickstart="nextjs"
   beforeYouStart={[
     {
@@ -41,7 +22,6 @@ description: Learn how to use Clerk to quickly and easily add secure authenticat
 - Limit access to authenticated users
 - Embed the `<UserButton/>`
 </TutorialHero>
-<NextjsExampleRepos /> */}
 
 <Steps>
 

--- a/docs/quickstarts/nextjs.mdx
+++ b/docs/quickstarts/nextjs.mdx
@@ -3,9 +3,35 @@ title: Add authentication and user management to your Next.js app with Clerk in 
 description: Learn how to use Clerk to quickly and easily add secure authentication and user management to your Next.js application. Clerk works seamlessly on both client side and server side components.
 ---
 
-<NextjsQuickstartHero />
-
-## Quickstart 
+<TutorialHero 
+  quickstart="nextjs"
+  beforeYouStart={[
+    {
+      title: "Set up a Clerk application",
+      link: "https://clerk.com/docs/quickstarts/setup-clerk"
+    },
+    {
+      title: "Create a Next.js application",
+      link: "https://nextjs.org/docs/getting-started/installation"
+    }
+  ]}
+  exampleRepo={[
+    {
+      title: "App Router",
+      link: "https://github.com/clerkinc/clerk-nextjs-app-quickstart"
+    },
+    {
+      title: "Pages Router",
+      link: "https://github.com/clerkinc/clerk-nextjs-pages-quickstart"
+    }
+  ]}
+>
+- Install `@clerk/nextjs`
+- Set up your environment keys
+- Wrap your Next.js app in `<ClerkProvider/>`  
+- Limit access to authenticated users
+- Embed the `<UserButton/>`
+</TutorialHero>
 
 <Steps>
 
@@ -176,7 +202,7 @@ If you would like a repository that demonstrates many of the features Clerk has 
 - [Clerk + Next.js App Router Demo](https://github.com/clerk/clerk-nextjs-demo-app-router)
 - [Clerk + Next.js Pages Router Demo](https://github.com/clerk/clerk-nextjs-demo-pages-router)
 
-# Next steps
+## Next steps
 
 <div className="container mx-auto my-4">
   <div className="grid grid-cols-1 gap-6 md:grid-cols-2">


### PR DESCRIPTION
This PR updates the Nextjs Quickstart to replace the old `NextjsQuickstartHero` with the new reusable MDX component `<TutorialHero />` (created in [this PR](https://github.com/clerk/clerk-marketing/pull/819)).

> Note: builds for this may fail, as it is relying on the merge of the mentioned PR. To test, you must run the marketing repo with the branch aa/DOCS-527 with the docs repo opened on branch aa/DOCS-527 (and run using `yarn dev:docs`) But for convenience, I have provided screenshots below.

### Preview on desktop:
<img width="1512" alt="Screenshot 2023-11-08 at 16 47 41" src="https://github.com/clerk/clerk-docs/assets/98043211/bb2f99b0-9b7a-4222-b503-001d4981ee14">

### Preview on smallest mobile screen:
<img width="456" alt="Screenshot 2023-11-08 at 16 47 22" src="https://github.com/clerk/clerk-docs/assets/98043211/215b0d3c-22f7-40b7-a379-e904fbbc7bc2">

<img width="456" alt="Screenshot 2023-11-08 at 16 47 26" src="https://github.com/clerk/clerk-docs/assets/98043211/d021146e-4b5f-47dc-8ed6-d6911395c8ab">

<img width="456" alt="Screenshot 2023-11-08 at 16 47 30" src="https://github.com/clerk/clerk-docs/assets/98043211/fb771ad3-b626-40e1-82a5-21d5c23ae17d">
