### PR TITLE
DOCS-542 add examples of how to use different params for backend sdk methods

### DIFF
--- a/docs/references/backend/organization/get-organization-list.mdx
+++ b/docs/references/backend/organization/get-organization-list.mdx
@@ -18,17 +18,36 @@ getOrganizationList();
 | --- | --- | --- |
 | `limit?` | `number` | The number of results to return. |
 | `offset?` | `number` | The number of results to skip. |
-| `query?` | `string` | The query to search for. |
+| `query?` | `string` | A search query to filter organizations by. |
 
 ## Example 
 
 ### `getOrganizationList({ limit })`
 
-Retrieves organization list that is filtered by the number of results:
+Retrieves organization list that is filtered by the number of results.
 
 ```tsx
 const sessions = await clerkClient.organizations.getOrganizationList({
   // returns the first 10 results
   limit: 10,
 });
+```
+
+### `getOrganizationList({ offset })`
+
+Retrieves organization list that is filtered by the number of results to skip.
+
+```tsx
+const sessions = await clerkClient.organizations.getOrganizationList({
+  // skips the first 10 results
+  offset: 10,
+});
+```
+
+### `getOrganizationList({ query })`
+
+Retrieves list of organizations that match the query.
+
+```tsx
+const organizationsMatchingTest = await clerkClient.organizations.getOrganizationList({ query: 'test' })
 ```

--- a/docs/references/backend/organization/get-organization-membership-list.mdx
+++ b/docs/references/backend/organization/get-organization-membership-list.mdx
@@ -25,7 +25,7 @@ const memberships = await clerkClient.organizations.getOrganizationMembershipLis
 
 ### `getOrganizationMembershipList({ limit })`
 
-Retrieves orgnanization membership list that is filtered by the number of results:
+Retrieves orgnanization membership list that is filtered by the number of results.
 
 ```tsx
 const organizationId = 'my-organization-id';
@@ -34,5 +34,19 @@ const memberships = await clerkClient.organizations.getOrganizationMembershipLis
   organizationId,
   // returns the first 10 memberships
   limit: 10,
+});
+```
+
+### `getOrganizationMembershipList({ offset })`
+
+Retrieves orgnanization membership list that is filtered by the number of results to skip.
+
+```tsx
+const organizationId = 'my-organization-id';
+
+const memberships = await clerkClient.organizations.getOrganizationMembershipList({
+  organizationId,
+  // skips the first 10 memberships
+  offset: 10,
 });
 ```

--- a/docs/references/backend/organization/get-pending-organization-invitation-list.mdx
+++ b/docs/references/backend/organization/get-pending-organization-invitation-list.mdx
@@ -25,7 +25,7 @@ const invitations = await clerkClient.organizations.getPendingOrganizationInvita
 
 ### `getPendingOrganizationInvitationList({ limit })`
 
-Retrieves orgnanization invitation list that is filtered by the number of results:
+Retrieves orgnanization invitation list that is filtered by the number of results.
 
 ```tsx
 const organizationId = 'my-organization-id';
@@ -34,5 +34,19 @@ const invitations = await clerkClient.organizations.getPendingOrganizationInvita
   organizationId,
   // returns the first 10 results
   limit: 10,
+});
+```
+
+### `getPendingOrganizationInvitationList({ offset })`
+
+Retrieves orgnanization invitation list that is filtered by the number of results to skip.
+
+```tsx
+const organizationId = 'my-organization-id';
+
+const invitations = await clerkClient.organizations.getPendingOrganizationInvitationList({
+  organizationId,
+  // skips the first 10 results
+  offset: 10,
 });
 ```

--- a/docs/references/backend/user/get-count.mdx
+++ b/docs/references/backend/user/get-count.mdx
@@ -29,7 +29,9 @@ This can also be flitered down by adding parameters of the type `UserCountParams
 
 ### `getCount({ query })`
 
-Retrieves the total number of users matching the query.
+To do a broader match through a list of fields, you can use the query parameter which partially matches the fields: `userId`, `emailAddress`, `phoneNumber`, `username`, `web3Wallet`, and `externalId`.
+
+This example retrieves the total number of users matching the query `test`.
 
 ```tsx
 const totalUsersMatchingTest = await clerkClient.users.getCount({ query: 'test' })


### PR DESCRIPTION
[Feedback from a user](https://linear.app/clerk/issue/DOCS-542/feedback-for-referencesbackendorganizationget-organization-list) on our [`getOrganizationList`](https://clerk.com/docs/references/backend/organization/get-organization-list) page asks "Where can I find information on the query I think document is incomplete?" 

This PR adds examples on how to the `query` param, as well as other needed examples for backend SDK methods.