### PR TITLE
Add Hono to Community SDKs

### DIFF
--- a/docs/manifest.json
+++ b/docs/manifest.json
@@ -124,7 +124,7 @@
       "root": "backend-requests"
     },
     [
-      ["Overview", "/backend-requests/overview"],      
+      ["Overview", "/backend-requests/overview"],
       "# Making requests",
       ["Same-Origin Requests", "/backend-requests/making/same-origin"],
       ["Cross-Origin Requests", "/backend-requests/making/cross-origin"],
@@ -654,7 +654,7 @@
       "icon": "svelte",
       "root": "references/svelte",
       "tag": "Community"
-    },    
+    },
     [
       ["Svelte", "https://github.com/markjaquith/clerk-sveltekit"]
     ]
@@ -665,7 +665,7 @@
       "icon": "vue",
       "root": "references/vue",
       "tag": "Community"
-    },    
+    },
     [
       ["Vue", "https://vue-clerk.vercel.app/"]
     ]
@@ -676,7 +676,7 @@
       "icon": "elysia",
       "root": "references/elysia",
       "tag": "Community"
-    },    
+    },
     [
       ["Elysia", "https://github.com/wobsoriano/elysia-clerk"]
     ]
@@ -687,9 +687,20 @@
       "icon": "rust",
       "root": "references/rust",
       "tag": "Community"
-    },    
+    },
     [
       ["Rust", "https://github.com/cincinnati-ventures/clerk-rs"]
+    ]
+  ],
+  [
+    {
+      "title": "Hono",
+      "icon": "hono",
+      "root": "references/hono",
+      "tag": "Community"
+    },
+    [
+      ["Hono", "https://github.com/honojs/middleware/tree/main/packages/clerk-auth"]
     ]
   ],
   "# API References",


### PR DESCRIPTION
This PR adds [Hono](https://github.com/honojs/middleware/tree/main/packages/clerk-auth) to the list of the community SDKs.