### PR TITLE
DOCS-511 add information on how many orgs a user can belong to vs. create

### DIFF
--- a/docs/organizations/overview.mdx
+++ b/docs/organizations/overview.mdx
@@ -9,6 +9,8 @@ Organizations are shared accounts, useful for project and team leaders. Organiza
 
 All organization members have access to *most* of the organization resources, but depending on their [role](#roles), some members can take advantage of administrative features.
 
+There is no limit to the number of organizations a user can be a member of. However, a user can only create up to 100 organizations in a given application instance.
+
 Clerk provides [prebuilt components](/docs/components/overview), [React hooks](/docs/references/react/use-organization), and [APIs](/docs/references/javascript/organization/organization) to help you integrate organizations into your application.
 
 <Callout type="info">


### PR DESCRIPTION
[Feedback from a user](https://linear.app/clerk/issue/DOCS-511/feedback-for-organizationsoverview) about the [Organizations overview](https://clerk.com/docs/organizations/overview) states "This page doesn't indicate if there's a limit regarding how many organizations a person can belong to."

This PR adds the necessary information - gathered from [this Slack discussion](https://clerkinc.slack.com/archives/C05BEL0P7M4/p1698941780015749).