### PR TITLE
fix incorrect hook reference

### DIFF
--- a/docs/components/unstyled/sign-out-button.mdx
+++ b/docs/components/unstyled/sign-out-button.mdx
@@ -325,9 +325,9 @@ In the example below, the `sessionId` is retrieved from the [`useAuth()`](/docs/
 
 #### Sign out of all sessions
 
-You can sign out of all currently active sessions by passing a callback that returns the `signOut()` method to the `signOutCallback` prop. This is useful for signing out all currently active accounts from a multi-session (multiple account) application.
+You can sign out of all currently active sessions by passing a callback that returns the [`signOut()`](/docs/custom-flows/multi-session-applications#sign-out-all-sessions) method to the `signOutCallback` prop. This is useful for signing out all currently active accounts from a multi-session (multiple account) application.
 
-In the example below, the `signOut()` method is retrieved from the [`useAuth()`](/docs/references/react/use-auth) hook.
+In the example below, the `signOut()` method is retrieved from the [`useClerk()`](/docs/references/react/use-clerk) hook.
 
 <Tabs items={['Next.js', 'React', 'Remix', 'Gatsby']}>
   <Tab>


### PR DESCRIPTION
The code examples use the `signOut()` method from the `useClerk()` hook, not the `useAuth()` hook. 
Because our documentation on [multi-session applications](https://clerk.com/docs/custom-flows/multi-session-applications#sign-out-all-sessions) uses `useClerk()` in the code examples, we will also pull `signOut()` from `useClerk()` on this page, in the name of consistency.