### PR TITLE
feat: Add note about MDP for LinkedIn OAuth provider

### DIFF
--- a/docs/authentication/social-connections/linkedin-oidc.mdx
+++ b/docs/authentication/social-connections/linkedin-oidc.mdx
@@ -69,7 +69,7 @@ Navigate back to your LinkedIn app and go to the **Auth** tab.
 
 Paste the **Redirect URL** value you copied from the Clerk Dashboard into the **Authorized redirect URLs for your app** input in the **OAuth 2.0 settings** section.
 
-Above that section, copy the **Client ID** and **Client Secret** from the **Application credentials** section. Go back to the Clerk Dashboard, where the modal should still be open, and paste these values into the respective fields. 
+Above that section, copy the **Client ID** and **Client Secret** from the **Application credentials** section. Go back to the Clerk Dashboard, where the modal should still be open, and paste these values into the respective fields.
 
 <Callout type="info">
   If the modal or page is not still open, go to the Clerk Dashboard and navigate to **User & Authentication > [Social Connections](https://dashboard.clerk.com/last-active?path=user-authentication/social-connections)**. Click on the settings cog icon next to the LinkedIn option. You can now paste the **Client ID** and **Client Secret** into their respective fields.
@@ -85,6 +85,10 @@ Above that section, copy the **Client ID** and **Client Secret** from the **Appl
 ### Enable OpenID Connect
 
 In the LinkedIn Developer portal for your application, go to the **Products** tab. Enable the **Sign In with LinkedIn using OpenID Connect** product for your OAuth application.
+
+<Callout type="info">
+  If you need to ensure the longevity of the user's access token without the need for re-authentication, make sure to obtain approval as a [Marketing Developer Platform (MDP) partner](https://learn.microsoft.com/en-us/linkedin/marketing/quick-start?view=li-lms-2023-10#step-1-apply-for-api-access). This is not required if you don't directly interact with the LinkedIn API using the access token.
+</Callout>
 
 <Images
   width={1096}

--- a/docs/authentication/social-connections/linkedin.mdx
+++ b/docs/authentication/social-connections/linkedin.mdx
@@ -40,6 +40,10 @@ The last thing you have to do is to enable the *Sign in with LinkedIn* product f
 
 ![Enable Sign In with LinkedIn product](/docs/images/authentication-providers/linkedin/9b2aae3fa3612dd7ae3b982b2c5a7e1d41409d49-1064x765.png)
 
+<Callout type="info">
+  If you need to ensure the longevity of the user's access token without the need for re-authentication, make sure to obtain approval as a [Marketing Developer Platform (MDP) partner](https://learn.microsoft.com/en-us/linkedin/marketing/quick-start?view=li-lms-2023-10#step-1-apply-for-api-access). This is not required if you don't directly interact with the LinkedIn API using the access token.
+</Callout>
+
 Copy the **Application ID** and **Secret** from the previous screen. Go back to the Clerk Dashboard and paste them into the respective fields.
 
 Don't forget to click **Apply** in the Clerk dashboard. Congratulations! Social connection with LinkedIn is now configured for your instance.


### PR DESCRIPTION
LinkedIn doesn't issue refresh tokens by default, only if you're approved as a Marketing Developer Platform (MDP) partner. I've added a note to clarify this on both the new and deprecated provider pages, for those who need this information.

Previews:
* https://docs-preview-489.clerkpreview.com/docs/authentication/social-connections/linkedin-oidc#enable-open-id-connect
* https://docs-preview-489.clerkpreview.com/docs/authentication/social-connections/linkedin#configuring-linked-in-social-connection