### PR TITLE
Fix typo in useOrganizationList

### DIFF
--- a/docs/references/react/use-organization-list.mdx
+++ b/docs/references/react/use-organization-list.mdx
@@ -264,6 +264,6 @@ The `userMemberships`, `userInvitations`, and `userSuggestions` are returned as 
 | `pageCount` | A number that indicates the total amount of pages. It is calculated based on `count` , `initialPage` , and `pageSize` |
 | `fetchPage` | A function that triggers a specific page to be loaded. |
 | `fetchPrevious` | A helper function that triggers the previous page to be loaded. This is the same as `fetchPage(page=> Math.max(0, page - 1))` |
-| `fetchNext` | A helper function that triggers the previous page to be loaded. This is the same as `fetchPage(page=> Math.max(0, page + 1))` |
+| `fetchNext` | A helper function that triggers the next page to be loaded. This is the same as `fetchPage(page=> Math.max(0, page + 1))` |
 | `hasNextPage` | A boolean that indicates if there are available pages to be fetched. |
 | `hasPreviousPage` | A boolean that indicates if there are available pages to be fetched. |


### PR DESCRIPTION
Fixes error in the description of the `fetchNext` variable in the `PaginatedResources` section.