### PR TITLE
Update organization-switcher.mdx

### DIFF
--- a/docs/components/organization/organization-switcher.mdx
+++ b/docs/components/organization/organization-switcher.mdx
@@ -89,7 +89,7 @@ All props below are optional.
 | `organizationProfileMode` | `'modal' \| 'navigation'` | Controls whether clicking the "Manage organization" button will cause the [`<OrganizationProfile />`][orgprofile-ref] component to open as a modal, or if the browser will navigate to the `organizationProfileUrl` where [`<OrganizationProfile />`][orgprofile-ref] is mounted as a page.<br />Defaults to: `'modal'`. |
 | `afterLeaveOrganizationUrl` | `string` | Full URL or path to navigate to after the user leaves the currently active organization. |
 | `afterSwitchOrganizationUrl` | `string` | Full URL or path to navigate after a successful organization switch. |
-| `hidePersonal` | `boolean` | By default, users can switch between organization and their personal account. This option controls whether [`<OrganizationSwitcher />`][orgswitcher-ref] will include the user's personal account in the organization list. Setting this to `false` will hide the personal account entry, and users will only be able to switch between organizations.<br />Defaults to: `true`. |
+| `hidePersonal` | `boolean` | By default, users can only switch between organizations. This option controls whether [`<OrganizationSwitcher />`][orgswitcher-ref] will include the user's personal workspace in the organization list. Setting this to `false` will show the personal workspace entry, and allow users to switch between organizations or their personal workspace.<br />Defaults to: `true`. |
 | `defaultOpen` | `boolean` | Controls the default state of the [`<OrganizationSwitcher />`][orgswitcher-ref] component. |
 | `organizationProfileProps` | `object` | Specify options for the underlying [`<OrganizationProfile />`][orgprofile-ref] component.<br />e.g. `{appearance: {...}}` |
 

--- a/docs/components/organization/organization-switcher.mdx
+++ b/docs/components/organization/organization-switcher.mdx
@@ -89,7 +89,7 @@ All props below are optional.
 | `organizationProfileMode` | `'modal' \| 'navigation'` | Controls whether clicking the "Manage organization" button will cause the [`<OrganizationProfile />`][orgprofile-ref] component to open as a modal, or if the browser will navigate to the `organizationProfileUrl` where [`<OrganizationProfile />`][orgprofile-ref] is mounted as a page.<br />Defaults to: `'modal'`. |
 | `afterLeaveOrganizationUrl` | `string` | Full URL or path to navigate to after the user leaves the currently active organization. |
 | `afterSwitchOrganizationUrl` | `string` | Full URL or path to navigate after a successful organization switch. |
-| `hidePersonal` | `boolean` | By default, users can only switch between organizations. This option controls whether [`<OrganizationSwitcher />`][orgswitcher-ref] will include the user's personal workspace in the organization list. Setting this to `false` will show the personal workspace entry, and allow users to switch between organizations or their personal workspace.<br />Defaults to: `true`. |
+| `hidePersonal` | `boolean` | By default, users can switch between organizations and their personal workspace. This option controls whether [`<OrganizationSwitcher />`][orgswitcher-ref] will include the user's personal workspace in the organization list. Setting this to `true` will hide the personal workspace entry, and allow users to switch only between organizations.<br />Defaults to: `false`. |
 | `defaultOpen` | `boolean` | Controls the default state of the [`<OrganizationSwitcher />`][orgswitcher-ref] component. |
 | `organizationProfileProps` | `object` | Specify options for the underlying [`<OrganizationProfile />`][orgprofile-ref] component.<br />e.g. `{appearance: {...}}` |
 


### PR DESCRIPTION
Currently, the `hidePersonal` property for the `<OrganizationSwitcher />` indicates that setting this property to `false` will **HIDE** the personal workspace entry (rather than **SHOW** this entry). Changed the wording here to accurately show that setting the prop to `false` will show the personal workspace instead of hiding it.