### PR TITLE
DOCS-525 add explanations for audiences and clock skew

### DIFF
--- a/docs/references/nextjs/auth-middleware.mdx
+++ b/docs/references/nextjs/auth-middleware.mdx
@@ -121,7 +121,8 @@ The `authMiddleware()` method accepts an optional object. The following options 
 | `audience?` | `string \| string[]` | A string or list of [audiences](https://datatracker.ietf.org/doc/html/rfc7519#section-4.1.3). If passed, it is checked against the `aud` claim in the token. |
 | `authorizedParties?` | `string[]` | An allowlist of origins to verify against, to protect your application from the subdomain cookie leaking attack.<br/>For example:<br/>`['http://localhost:3000', 'https://example.com']`<br/>For more information, refer to the [reference guide](/docs/references/nodejs/token-verification#validate-the-authorized-party-of-a-session-token). |
 | `beforeAuth?` | `function` | A function called before the authentication middleware is executed. If a redirect response is returned, the middleware will respect it and redirect the user. If `false` is returned, the auth middleware will not execute and the request will be handled as if the auth middleware was not present. |
-| `clockSkewInSeconds?` | `number` | Overrides the default allowed clock skew. Clock skew specifies the allowed time difference (in seconds) between the server and client clocks when validating a token. |
+| `clockSkewInSeconds? (deprecated)` | `number` | Deprecated in favor of `clockSkewInMs`. |
+| `clockSkewInMs?` | `number` | Specifies the allowed time difference (in milliseconds) between the Clerk server (which generates the token) and the clock of the user's application server when validating a token. Defaults to 5000 ms (5 seconds). |
 | `debug?` | `boolean` | Enables debugging mode in the Clerk middleware handler. Logs out additional debugging information. |
 | `domain?` | `string` | The domain used for satellites to inform Clerk where this application is deployed. |
 | `isSatellite?` | `boolean` | When using Clerk's satellite feature, this should be enabled for secondary domains. |

--- a/docs/references/nextjs/auth-middleware.mdx
+++ b/docs/references/nextjs/auth-middleware.mdx
@@ -118,10 +118,10 @@ The `authMiddleware()` method accepts an optional object. The following options 
 | --- | --- | --- |
 | `afterAuth?` | `function` | Called after the authentication middleware is executed. This function has access to the [`Authentication`](/docs/references/nextjs/authentication-object) object and can be used to execute logic based on the auth state. |
 | `apiRoutes?` | `string[]` | A list of routes that should return 401. You can use glob patterns to match multiple routes or a function to match against the request object. For example: `['/foo', '/bar(.*)']` or [/^\/foo\/.*$/] |
-| `audience?` | `string \| string[]` | A string or list of audiences. |
+| `audience?` | `string \| string[]` | A string or list of [audiences](https://datatracker.ietf.org/doc/html/rfc7519#section-4.1.3). If passed, it is checked against the `aud` claim in the token. |
 | `authorizedParties?` | `string[]` | An allowlist of origins to verify against, to protect your application from the subdomain cookie leaking attack.<br/>For example:<br/>`['http://localhost:3000', 'https://example.com']`<br/>For more information, refer to the [reference guide](/docs/references/nodejs/token-verification#validate-the-authorized-party-of-a-session-token). |
 | `beforeAuth?` | `function` | A function called before the authentication middleware is executed. If a redirect response is returned, the middleware will respect it and redirect the user. If `false` is returned, the auth middleware will not execute and the request will be handled as if the auth middleware was not present. |
-| `clockSkewInSeconds?` | `number` | Overrides the default allowed clock skew. |
+| `clockSkewInSeconds?` | `number` | Overrides the default allowed clock skew. Clock skew specifies the allowed time difference (in seconds) between the server and client clocks when validating a token. |
 | `debug?` | `boolean` | Enables debugging mode in the Clerk middleware handler. Logs out additional debugging information. |
 | `domain?` | `string` | The domain used for satellites to inform Clerk where this application is deployed. |
 | `isSatellite?` | `boolean` | When using Clerk's satellite feature, this should be enabled for secondary domains. |


### PR DESCRIPTION
[DOCS-525](https://linear.app/clerk/issue/DOCS-525/expand-on-authmiddleware-property-descriptions) states "User testing participants wondered about what audiences and clock skews are. This is an opportunity to expand on these topics or link to appropriate pages for all obscure properties."

🔎 [Old page](https://clerk.com/docs/references/nextjs/auth-middleware#options)
🔎 [New page](baking)