### PR TITLE
DOCS-267 Use new `type` property to sync `<CodeBlockTabs/>` and `<Tabs/>` instances

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -178,21 +178,137 @@ pnpm add @clerk/nextjs
 </CodeBlockTabs>
 ```
 
-#### `<Tabs />`
+The component also accepts a `type` property, which is used to sync the active tab across multiple instances by passing each instance the same exact `string` to the `type` property. 
 
-If you need to structure content in a tabular format, use the `<Tabs />` component. The component accepts an `items` property, which is an array of strings. For each option provided, render a `<Tab />` component:
+For example, in the example below, if the user were to choose "yarn" as the tab they want to see, both `<CodeBlockTabs />` components would change their active tab to "yarn" because both components were passed `"installer"` as their `type`.
 
 ```mdx
-<Tabs items={["React", "JavaScript"]}>
+Install the Clerk Next.js package by running the following command in your terminal: 
+
+<CodeBlockTabs type="installer" options={["npm", "yarn", "pnpm"]}>
+
+​```
+npm i @clerk/nextjs
+​```
+
+​```
+yarn add @clerk/nextjs
+​```
+
+​```
+pnpm add @clerk/nextjs
+​```
+
+</CodeBlockTabs>
+
+You can also install the install the Clerk React package by running the following command in your terminal: 
+
+<CodeBlockTabs type="installer" options={["npm", "yarn", "pnpm"]}>
+
+​```
+npm i @clerk/clerk-react
+​```
+
+​```
+yarn add @clerk/clerk-react
+​```
+
+​```
+pnpm add @clerk/clerk-react
+​```
+
+</CodeBlockTabs>
+```
+
+#### `<Tabs />`
+
+If you need to structure content in a tabular format, use the `<Tabs />` component. 
+
+The component accepts an `items` property, which is an array of strings. For each option provided, render a `<Tab />` component as shown in the example below.
+
+```mdx
+<Tabs type="framework" items={["React", "JavaScript"]}>
 <Tab>
 # React
 
+Here is some example text about React.
 </Tab>
 <Tab>
 # JavaScript
 
+Here is some example text about JavaScript.
 </Tab>
 </Tabs>
+```
+
+The component also accepts a `type` property, which is used to sync the active tab across multiple instances by passing each instance the same exact `string` to the `type` property. 
+
+For example, in the example below, if the user were to choose "JavaScript" as the tab they want to see, both `<Tabs />` components would change their active tab to "JavaScript" because both components were passed `"framework"` as their `type`.
+
+```mdx
+<Tabs type="framework" items={["React", "JavaScript"]}>
+<Tab>
+# React
+
+Here is some example text about React.
+</Tab>
+<Tab>
+# JavaScript
+
+Here is some example text about JavaScript.
+</Tab>
+</Tabs>
+
+<Tabs type="framework" items={["React", "JavaScript"]}>
+<Tab>
+# React
+
+Here is another example about React.
+</Tab>
+<Tab>
+# JavaScript
+
+Here is another example about JavaScript.
+</Tab>
+</Tabs>
+```
+
+#### Sync `<CodeBlockTabs />` and `<Tabs />`
+
+The `type` property can be used on both `<CodeBlockTabs />` and `<Tabs />` to sync instances of these components together.
+
+For example, in the example below, if the user were working with Next.js Pages Router and chose the "Pages Router" as the tab they want to see, both the `<Tabs />` and the `<CodeBlockTabs />` components would change their active tab to "Pages Router" because both components were passed `"router"` as their `type`.
+
+```mdx
+<Tabs type="router" items={["App Router", "Pages Router"]}>
+<Tab>
+The App Router information is here.
+</Tab>
+
+<Tab>
+The Pages Router information is here.
+</Tab>
+</Tabs>
+
+<CodeBlockTabs type="router" options={["App Router", "Pages Router"]}>
+```tsx filename="/app/sign-in/[[...sign-in]]/page.tsx"
+import { SignIn } from "@clerk/nextjs";
+ 
+export default function Page() {
+  return <SignIn />;
+}
+```
+
+```tsx filename="/pages/sign-in/[[...index]].tsx"
+import { SignIn } from "@clerk/nextjs";
+ 
+const SignInPage = () => (
+  <SignIn />
+);
+ 
+export default SignInPage;
+```
+</CodeBlockTabs>
 ```
 
 ### Tables

--- a/docs/account-portal/custom-redirects.mdx
+++ b/docs/account-portal/custom-redirects.mdx
@@ -11,7 +11,7 @@ After a user signs in or signs up, Clerk automatically redirects users back to y
 
 You can define the paths you want the users to be redirected to via environment variables. In this example, we redirect users to `/dashboard` after signing in, and to `/onboarding` after signing up.
 
-<CodeBlockTabs options={['Next.js', 'Remix']}>
+<CodeBlockTabs type="framework" options={["Next.js", "Remix"]}>
 ```sh filename=".env"
 NEXT_PUBLIC_CLERK_AFTER_SIGN_IN_URL=/dashboard
 NEXT_PUBLIC_CLERK_AFTER_SIGN_UP_URL=/onboarding
@@ -105,7 +105,7 @@ function App() {
 
 In the case that you are using a [`<SignInButton />`](/docs/components/unstyled/sign-in-button) or [`<SignUpButton />`](/docs/components/unstyled/sign-up-button), you can also pass the properties into those components. We recommend defining both `afterSignInUrl` and `afterSignUpUrl` redirects in each button as some users may choose to sign up instead after attempting to sign in.
 
-<CodeBlockTabs options={['Next.js', 'React', 'Remix', 'Gatsby']}>
+<CodeBlockTabs type="framework" options={["Next.js", "React", "Remix", "Gatsby"]}>
   ```jsx filename="pages/index.js"
   import { SignInButton, SignUpButton } from "@clerk/nextjs";
 

--- a/docs/advanced-usage/satellite-domains.mdx
+++ b/docs/advanced-usage/satellite-domains.mdx
@@ -49,7 +49,7 @@ alt="The 'Satellite' tab on the Domains page in the Clerk Dashboard."
 
 You need to configure your satellite application as a satellite application. You can do so with the environment variables below or via properties (see the next step).
 
-<CodeBlockTabs options={["Next.js", "Remix"]}>
+<CodeBlockTabs type="framework" options={["Next.js", "Remix"]}>
 ```env filename=".env.local"
 NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY={{pub_key}}
 CLERK_SECRET_KEY={{secret}}
@@ -82,7 +82,7 @@ The properties related to the multi domain setup are as follows:
 
 The `URL` mentioned above is the request url for server side usage or the current location for client usage.
 
-<Tabs items={['Next.js', 'Remix']}>
+<Tabs type="framework" items={["Next.js", "Remix"]}>
   <Tab>
     You can embed the [`<SignIn />`][signin] component using the [Next.js optional catch-all route](https://nextjs.org/docs/pages/building-your-application/routing/dynamic-routes#optional-catch-all-routes). This allows you to redirect the user inside your application. The [`<SignIn />`][signin] component should be mounted on a public page.
 

--- a/docs/advanced-usage/using-proxies.mdx
+++ b/docs/advanced-usage/using-proxies.mdx
@@ -40,7 +40,7 @@ Requests to `https://app.dev/__clerk/*` must be forwarded to `https://frontend-a
 
 #### Example Configuration
 
-<Tabs items={['Nginx', 'Cloudflare Workers']}>
+<Tabs items={["Nginx", "Cloudflare Workers"]}>
   <Tab>
     ```conf filename="nginx.conf"
     http {
@@ -118,7 +118,7 @@ In order to enable proxying, you need to set a proxy URL for your Clerk instance
   Make sure your proxy forwards requests to the Clerk Frontend API correctly and includes the required headers.
 </Callout>
 
-<Tabs items={['Dashboard', 'Backend API']}>
+<Tabs items={["Dashboard", "Backend API"]}>
   <Tab>
     1. In the Clerk Dashboard, go to the **[Domains](https://dashboard.clerk.com/last-active?path=domains)** page.
     2. Navigate to the **Frontend API** section.
@@ -142,10 +142,10 @@ In order to enable proxying, you need to set a proxy URL for your Clerk instance
 
 You can configure your proxy setup via environment variables or via properties.
 
-<Tabs items={['Environment Variables', 'Properties']}>
+<Tabs items={["Environment Variables", "Properties"]}>
   <Tab>
     <InjectKeys>
-      <CodeBlockTabs options={["Next.js", "Remix", 'Gatsby']}>
+      <CodeBlockTabs type="framework" options={["Next.js", "Remix", 'Gatsby']}>
         ```env filename=".env.local"
         NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY={{pub_key}}
         CLERK_SECRET_KEY={{secret}}
@@ -173,7 +173,7 @@ You can configure your proxy setup via environment variables or via properties.
 
     This is an alternative configuration to the environment variable based setup that we described in the previous step.
 
-    <CodeBlockTabs options={['Next.js', 'Remix', 'JavaScript']}>
+    <CodeBlockTabs type="framework" options={["Next.js", "Remix", "JavaScript"]}>
       ```tsx filename="_app.tsx"
         import { ClerkProvider } from "@clerk/nextjs";
         import Head from "next/head";

--- a/docs/backend-requests/handling/nodejs.mdx
+++ b/docs/backend-requests/handling/nodejs.mdx
@@ -15,7 +15,7 @@ The Clerk Node SDK offers two authentication middlewares specifically for [Expre
 
 `ClerkExpressWithAuth` is a lax middleware that returns an empty auth object when an unauthenticated request is made.
 
-<CodeBlockTabs options={['JavaScript', 'TypeScript']}>
+<CodeBlockTabs type="js-ts" options={["JavaScript", "TypeScript"]}>
   ```js
   import "dotenv/config"; // To read CLERK_API_KEY
   import { ClerkExpressWithAuth } from "@clerk/clerk-sdk-node";
@@ -85,7 +85,7 @@ app.listen(port, () => {
 
 `ClerkExpressRequireAuth` is a strict middleware that raises an error when an unauthenticated request is made.
 
-<CodeBlockTabs options={['JavaScript', 'TypeScript']}>
+<CodeBlockTabs type="js-ts" options={["JavaScript", "TypeScript"]}>
   ```js
   import "dotenv/config"; // To read CLERK_API_KEY
   import { ClerkExpressRequireAuth } from '@clerk/clerk-sdk-node';

--- a/docs/backend-requests/making/custom-session-token.mdx
+++ b/docs/backend-requests/making/custom-session-token.mdx
@@ -56,7 +56,7 @@ Now that you have added the custom claims to your session token, you can use the
 
 #### Using `getAuth` in your Next.js application
 
-<CodeBlockTabs options={["App Router", "Pages Router"]}>
+<CodeBlockTabs type="router" options={["App Router", "Pages Router"]}>
 ```tsx filename="app/page.[jsx/tsx]"
 import { auth } from '@clerk/nextjs';
 import { NextResponse } from 'next/server';

--- a/docs/backend-requests/making/same-origin.mdx
+++ b/docs/backend-requests/making/same-origin.mdx
@@ -19,7 +19,7 @@ fetch('/api/foo').then(res => res.json());
 
 If you are using React or Next.js and would like to use the [useSWR](https://swr.vercel.app/) hook, it’s as simple as supplying the API route with whichever fetcher function you are using. Because of the [automatic revalidation feature](https://swr.vercel.app/docs/revalidation) of SWR, you need to retrieve and set the session token in the Authorization header. Call the asynchronous `getToken` method from the [`useAuth()`](/docs/references/react/use-auth) hook and add it as a Bearer token.
 
-<CodeBlockTabs options={["index.jsx", "index.tsx"]}>
+<CodeBlockTabs type="js-ts" options={["JavaScript", "TypeScript"]}>
 ```jsx
 import useSWR from 'swr';
 import { useAuth } from '@clerk/nextjs';

--- a/docs/components/authentication/sign-in.mdx
+++ b/docs/components/authentication/sign-in.mdx
@@ -18,11 +18,11 @@ The `<SignIn />` component renders a UI for signing in users. The functionality 
 
 Below is basic implementation of the `<SignIn />` component. You can use this as a starting point for your own implementation.
 
-<Tabs items={['Next.js', 'React', 'Remix', 'Gatsby', 'JavaScript']}>
+<Tabs type="framework" items={["Next.js", "React", "Remix", "Gatsby", "JavaScript"]}>
   <Tab>
     You can embed the `<SignIn />` component using the [Next.js optional catch-all route](https://nextjs.org/docs/pages/building-your-application/routing/dynamic-routes#optional-catch-all-routes). This allows you to redirect the user inside your application. The `<SignIn />` component should be mounted on a public page.
 
-    <CodeBlockTabs options={["App Router", "Pages Router"]}>
+    <CodeBlockTabs type="router" options={["App Router", "Pages Router"]}>
       ```jsx filename="/app/sign-in/[[...sign-in]]/page.tsx"
       import { SignIn } from "@clerk/nextjs";
 

--- a/docs/components/authentication/sign-up.mdx
+++ b/docs/components/authentication/sign-up.mdx
@@ -18,13 +18,13 @@ The `<SignUp />` component renders a UI for signing up users. The functionality 
 
 Below is basic implementation of the `<SignUp />` component. You can use this as a starting point for your own implementation
 
-<Tabs items={['Next.js', 'React', 'Remix', 'Gatsby', 'JavaScript']}>
+<Tabs type="framework" items={["Next.js", "React", "Remix", "Gatsby", "JavaScript"]}>
   <Tab>
     You can embed the `<SignUp />` component using the [Next.js optional catch-all route](https://nextjs.org/docs/pages/building-your-application/routing/dynamic-routes#optional-catch-all-routes). This allows you to redirect the user inside your application. The `<SignUp />` component should be mounted on a public page.
 
     <Callout>The example below shows the Sign In page mounted on the url /sign-in. For more information on how to implement this, check out the [`<SignIn />` UI page](/docs/components/authentication/sign-in).</Callout>
 
-    <CodeBlockTabs options={["App Router", "Pages Router"]}>
+    <CodeBlockTabs type="router" options={["App Router", "Pages Router"]}>
       ```jsx filename="/app/sign-up/[[...sign-up]]/page.[jsx/tsx]"
       import { SignUp } from "@clerk/nextjs";
 

--- a/docs/components/clerk-provider.mdx
+++ b/docs/components/clerk-provider.mdx
@@ -11,79 +11,79 @@ The `<ClerkProvider />` component wraps your React application to provide active
 
 The `<ClerkProvider />` component must be added to your React entrypoint.
 
-<Tabs items={['Next.js', 'React']}>
-<Tab>
+<Tabs type="framework" items={["Next.js", "React"]}>
+  <Tab>
+  The `<ClerkProvider />` component needs to access headers to authenticate correctly. This means anything wrapped by the provider will be opted into dynamic rendering at request time. If you have static-optimized or ISR pages that you would prefer not to be opted into dynamic rendering, make sure they are not wrapped by `<ClerkProvider />`.
 
-The `<ClerkProvider />` component needs to access headers to authenticate correctly. This means anything wrapped by the provider will be opted into dynamic rendering at request time. If you have static-optimized or ISR pages that you would prefer not to be opted into dynamic rendering, make sure they are not wrapped by `<ClerkProvider />`.
+  This is easiest to accomplish by ensuring that `<ClerkProvider />` is added further down the tree to wrap route groups that explicitly need authentication instead of having the provider wrap your application root as recommended above. For example, if your project includes a set of landing/marketing pages as well as a dashboard that requires login, you would create separate (marketing) and (dashboard) route groups. Adding `<ClerkProvider />` to the (dashboard)/layout.jsx layout file will ensure that only those routes are opted into dynamic rendering, allowing the marketing routes to be statically optimized.
 
-This is easiest to accomplish by ensuring that `<ClerkProvider />` is added further down the tree to wrap route groups that explicitly need authentication instead of having the provider wrap your application root as recommended above. For example, if your project includes a set of landing/marketing pages as well as a dashboard that requires login, you would create separate (marketing) and (dashboard) route groups. Adding `<ClerkProvider />` to the (dashboard)/layout.jsx layout file will ensure that only those routes are opted into dynamic rendering, allowing the marketing routes to be statically optimized.
+  <Callout type="info">
+    The root layout is a server component. If you plan to use the `<ClerkProvider />` outside the root layout, it will need to be a server component as well.
+  </Callout>
 
-<Callout type="info">
-  The root layout is a server component. If you plan to use the `<ClerkProvider />` outside the root layout, it will need to be a server component as well.
-</Callout>
+    <CodeBlockTabs type="router" options={["App Router", "Pages Router"]}>
 
-<CodeBlockTabs options={["App Router", "Pages Router"]}>
+    ```tsx filename="app/layout.tsx"
+    import React from "react";
+    import { ClerkProvider } from "@clerk/nextjs";
 
-```tsx filename="app/layout.tsx"
-import React from "react";
-import { ClerkProvider } from "@clerk/nextjs";
+    export default function RootLayout({
+      children,
+    }: {
+      children: React.ReactNode;
+    }) {
+      return (
+        <html lang="en">
+          <head>
+            <title>Next.js 13 with Clerk</title>
+          </head>
+          <ClerkProvider>
+            <body>{children}</body>
+          </ClerkProvider>
+        </html>
+      );
+    }
+    ```
 
-export default function RootLayout({
-  children,
-}: {
-  children: React.ReactNode;
-}) {
-  return (
-    <html lang="en">
-      <head>
-        <title>Next.js 13 with Clerk</title>
-      </head>
-      <ClerkProvider>
-        <body>{children}</body>
+    ```tsx filename="_app.tsx"
+    import { ClerkProvider } from "@clerk/nextjs";
+    import type { AppProps } from "next/app";
+
+    function MyApp({ Component, pageProps }: AppProps) {
+      return (
+        <ClerkProvider {...pageProps}>
+        <Component {...pageProps} />
+        </ClerkProvider>
+      );
+    }
+
+    export default MyApp;
+    ```
+
+    </CodeBlockTabs>
+  </Tab>
+
+  <Tab>
+
+  ```tsx filename="index.tsx"
+  import React from "react";
+  import ReactDOM from "react-dom";
+  import { ClerkProvider } from "@clerk/clerk-react";
+  import App from "./App";
+
+  const publishableKey = process.env.REACT_APP_CLERK_PUBLISHABLE_KEY;
+
+  ReactDOM.render(
+    <React.StrictMode>
+      <ClerkProvider publishableKey={publishableKey}>
+        <App/>
       </ClerkProvider>
-    </html>
+    </React.StrictMode>,
+    document.getElementById("root")
   );
-}
-```
+  ```
 
-```tsx filename="_app.tsx"
-import { ClerkProvider } from "@clerk/nextjs";
-import type { AppProps } from "next/app";
-
-function MyApp({ Component, pageProps }: AppProps) {
-  return (
-    <ClerkProvider {...pageProps}>
-     <Component {...pageProps} />
-    </ClerkProvider>
-  );
-}
-
-export default MyApp;
-```
-
-</CodeBlockTabs>
-</Tab>
-<Tab>
-
-```tsx filename="index.tsx"
-import React from "react";
-import ReactDOM from "react-dom";
-import { ClerkProvider } from "@clerk/clerk-react";
-import App from "./App";
-
-const publishableKey = process.env.REACT_APP_CLERK_PUBLISHABLE_KEY;
-
-ReactDOM.render(
-  <React.StrictMode>
-    <ClerkProvider publishableKey={publishableKey}>
-      <App/>
-    </ClerkProvider>
-  </React.StrictMode>,
-  document.getElementById("root")
-);
-```
-
-</Tab>
+  </Tab>
 </Tabs>
 
 {/* TODO: Make dedicated docs pages for these meta-frameworks */}

--- a/docs/components/control/authenticate-with-callback.mdx
+++ b/docs/components/control/authenticate-with-callback.mdx
@@ -9,130 +9,128 @@ The `<AuthenticateWithRedirectCallback />` is used to complete a custom OAuth fl
 
 ## Usage
 
-<Tabs items={['Next.js', 'React']}>
+<Tabs type="framework" items={["Next.js", "React"]}>
+  <Tab>
+  This example below uses built in Next.js pages, but you could use any routing library you want.
 
-<Tab>
-This example below uses built in Next.js pages, but you could use any routing library you want.
+  ```tsx filename="app.tsx"
+  import '@/styles/globals.css';
+  import { ClerkProvider, SignedIn, SignedOut, useSignIn } from '@clerk/nextjs';
+  import { AppProps } from 'next/app';
+  import { useRouter } from 'next/router';
 
-```tsx filename="app.tsx"
-import '@/styles/globals.css';
-import { ClerkProvider, SignedIn, SignedOut, useSignIn } from '@clerk/nextjs';
-import { AppProps } from 'next/app';
-import { useRouter } from 'next/router';
+  const publicPages: Array<string> = [];
 
-const publicPages: Array<string> = [];
+  const SignInOAuthButtons = () => {
+    const { signIn, isLoaded } = useSignIn();
+    if (!isLoaded) {
+      return null;
+    }
+    const signInWithGoogle = () =>
+      signIn.authenticateWithRedirect({
+        strategy: 'oauth_google',
+        redirectUrl: '/sso-callback',
+        redirectUrlComplete: '/'
+      });
+    return <button onClick={signInWithGoogle}>Sign in with Google</button>;
+  };
+  function MyApp({ Component, pageProps }: AppProps) {
+    const { pathname } = useRouter();
+    const isPublicPage = publicPages.includes(pathname);
 
-const SignInOAuthButtons = () => {
-  const { signIn, isLoaded } = useSignIn();
-  if (!isLoaded) {
-    return null;
+    return (
+      <ClerkProvider {...pageProps}>
+        {isPublicPage ? (
+          <Component {...pageProps} />
+        ) : (
+          <>
+            <SignedIn>
+              <Component {...pageProps} />
+            </SignedIn>
+            <SignedOut>
+              <SignInOAuthButtons />
+            </SignedOut>
+          </>
+        )}
+      </ClerkProvider>
+    );
   }
-  const signInWithGoogle = () =>
-    signIn.authenticateWithRedirect({
-      strategy: 'oauth_google',
-      redirectUrl: '/sso-callback',
-      redirectUrlComplete: '/'
-    });
-  return <button onClick={signInWithGoogle}>Sign in with Google</button>;
-};
-function MyApp({ Component, pageProps }: AppProps) {
-  const { pathname } = useRouter();
-  const isPublicPage = publicPages.includes(pathname);
 
-  return (
-    <ClerkProvider {...pageProps}>
-      {isPublicPage ? (
-        <Component {...pageProps} />
-      ) : (
-        <>
-          <SignedIn>
-            <Component {...pageProps} />
-          </SignedIn>
-          <SignedOut>
-            <SignInOAuthButtons />
-          </SignedOut>
-        </>
-      )}
-    </ClerkProvider>
-  );
-}
+  export default MyApp;
+  ```
 
-export default MyApp;
-```
+  Once you have implemented your sign in flow, you can implement the callback page.
 
-Once you have implemented your sign in flow, you can implement the callback page.
+  ```tsx filename="/pages/sso-callback.tsx"
+  import { AuthenticateWithRedirectCallback } from '@clerk/nextjs';
 
-```tsx filename="/pages/sso-callback.tsx"
-import { AuthenticateWithRedirectCallback } from '@clerk/nextjs';
-
-export default function SSOCallBack() {
-  return <AuthenticateWithRedirectCallback />;
-}
-```
-
-</Tab>
-<Tab>
-
-This example below is using the `react-router-dom` library. You can use any routing library you want.
-
-```tsx filename="app.tsx"
-import {
-  ClerkProvider,
-  AuthenticateWithRedirectCallback,
-  SignedOut,
-  useSignIn,
-  SignedIn
-} from '@clerk/clerk-react';
-
-import { Route, Routes } from 'react-router-dom';
-
-function App() {
-  return (
-    <ClerkProvider publishableKey="pk_test_••••••••••••••••••••••••••••••••••">
-      {/* Define a / route that displays the OAuth button */}
-      <Routes>
-        <Route path="/" element={<HomePages />} />
-
-        <Route
-          path="/sso-callback"
-          element={<AuthenticateWithRedirectCallback />}
-        />
-      </Routes>
-    </ClerkProvider>
-  );
-}
-
-function HomePages() {
-  return (
-    <>
-      <SignedOut>
-        <SignInOAuthButtons />
-      </SignedOut>
-      <SignedIn>
-        <div>Hello! You are Signed In!</div>
-      </SignedIn>
-    </>
-  );
-}
-
-function SignInOAuthButtons() {
-  const { signIn, isLoaded } = useSignIn();
-  if (!isLoaded) {
-    return null;
+  export default function SSOCallBack() {
+    return <AuthenticateWithRedirectCallback />;
   }
-  const signInWithGoogle = () =>
-    signIn.authenticateWithRedirect({
-      strategy: 'oauth_google',
-      redirectUrl: '/sso-callback',
-      redirectUrlComplete: '/'
-    });
-  return <button onClick={signInWithGoogle}>Sign in with Google</button>;
-}
+  ```
+  </Tab>
 
-export default App;
-```
+  <Tab>
+  This example below is using the `react-router-dom` library. You can use any routing library you want.
 
-</Tab>
+  ```tsx filename="app.tsx"
+  import {
+    ClerkProvider,
+    AuthenticateWithRedirectCallback,
+    SignedOut,
+    useSignIn,
+    SignedIn
+  } from '@clerk/clerk-react';
+
+  import { Route, Routes } from 'react-router-dom';
+
+  function App() {
+    return (
+      <ClerkProvider publishableKey="pk_test_••••••••••••••••••••••••••••••••••">
+        {/* Define a / route that displays the OAuth button */}
+        <Routes>
+          <Route path="/" element={<HomePages />} />
+
+          <Route
+            path="/sso-callback"
+            element={<AuthenticateWithRedirectCallback />}
+          />
+        </Routes>
+      </ClerkProvider>
+    );
+  }
+
+  function HomePages() {
+    return (
+      <>
+        <SignedOut>
+          <SignInOAuthButtons />
+        </SignedOut>
+        <SignedIn>
+          <div>Hello! You are Signed In!</div>
+        </SignedIn>
+      </>
+    );
+  }
+
+  function SignInOAuthButtons() {
+    const { signIn, isLoaded } = useSignIn();
+    if (!isLoaded) {
+      return null;
+    }
+    const signInWithGoogle = () =>
+      signIn.authenticateWithRedirect({
+        strategy: 'oauth_google',
+        redirectUrl: '/sso-callback',
+        redirectUrlComplete: '/'
+      });
+    return <button onClick={signInWithGoogle}>Sign in with Google</button>;
+  }
+
+  export default App;
+  ```
+
+  </Tab>
 </Tabs>
 
 ## Properties

--- a/docs/components/control/clerk-loaded.mdx
+++ b/docs/components/control/clerk-loaded.mdx
@@ -9,92 +9,93 @@ The `<ClerkLoaded />` component guarantees that the Clerk object has loaded and 
 
 ## Usage
 
-<Tabs items={['Next.js', 'React', 'Remix']}>
-<Tab>
-```tsx filename="pages/_app.tsx"
-import "@/styles/globals.css";
-import { ClerkLoaded, ClerkProvider } from "@clerk/nextjs";
-import { AppProps } from "next/app";
+<Tabs type="framework" items={["Next.js", "React", "Remix"]}>
+  <Tab>
+  ```tsx filename="pages/_app.tsx"
+  import "@/styles/globals.css";
+  import { ClerkLoaded, ClerkProvider } from "@clerk/nextjs";
+  import { AppProps } from "next/app";
 
-function MyApp({ Component, pageProps }: AppProps) {
-  return (
+  function MyApp({ Component, pageProps }: AppProps) {
+    return (
 
-  <ClerkProvider {...pageProps}>
-    <ClerkLoaded>
-      <Component {...pageProps} />
-    </ClerkLoaded>
-  </ClerkProvider>
-  ); 
-}
-
-export default MyApp;
-```
-
-Once you have wrapped your app with `<ClerkLoaded />`, you can access the `Clerk` object without the need to check if it exists.
-
-```tsx filename="pages/index.tsx"
-declare global {
-  interface Window {
-    Clerk: any;
-  }
-}
-
-export default function Home() {
-  return <div>This page uses Clerk {window.Clerk.version}; </div>;
-}
-```
-
-</Tab>
-<Tab>
-```tsx filename="app.tsx"
-import { useEffect } from "react";
-import { ClerkLoaded, ClerkProvider } from "@clerk/clerk-react";
-
-declare global {
-  interface Window {
-    Clerk: any;
-  }
-}
-
-function App() {
-  return (
-    <ClerkProvider publishableKey="pk_test_••••••••••••••••••••••••••••••••••">
+    <ClerkProvider {...pageProps}>
       <ClerkLoaded>
-        <Page />
+        <Component {...pageProps} />
       </ClerkLoaded>
     </ClerkProvider>
-  ); 
-}
+    ); 
+  }
 
-function Page() {
-  useEffect(() => {
-    // no need to check if window.Clerk exists
-    document.title = "This page uses Clerk " +
-    window.Clerk.version;
-  }, []);
+  export default MyApp;
+  ```
 
-  return (
-    <div>The content </div>
-  ); 
-}
+  Once you have wrapped your app with `<ClerkLoaded />`, you can access the `Clerk` object without the need to check if it exists.
 
-export default App;
-```
-</Tab>
-<Tab>
-```tsx filename="routes/index.tsx"
-import { ClerkLoaded } from "@clerk/remix";
+  ```tsx filename="pages/index.tsx"
+  declare global {
+    interface Window {
+      Clerk: any;
+    }
+  }
 
-export default function Index() {
-  return (
-    <div>
-      <ClerkLoaded>
-        <div>Clerk is loaded</div>
-        <p>window.Clerk.version</p>
-      </ClerkLoaded>
-    </div>
-  );
-}
-```
-</Tab>
+  export default function Home() {
+    return <div>This page uses Clerk {window.Clerk.version}; </div>;
+  }
+  ```
+  </Tab>
+
+  <Tab>
+  ```tsx filename="app.tsx"
+  import { useEffect } from "react";
+  import { ClerkLoaded, ClerkProvider } from "@clerk/clerk-react";
+
+  declare global {
+    interface Window {
+      Clerk: any;
+    }
+  }
+
+  function App() {
+    return (
+      <ClerkProvider publishableKey="pk_test_••••••••••••••••••••••••••••••••••">
+        <ClerkLoaded>
+          <Page />
+        </ClerkLoaded>
+      </ClerkProvider>
+    ); 
+  }
+
+  function Page() {
+    useEffect(() => {
+      // no need to check if window.Clerk exists
+      document.title = "This page uses Clerk " +
+      window.Clerk.version;
+    }, []);
+
+    return (
+      <div>The content </div>
+    ); 
+  }
+
+  export default App;
+  ```
+  </Tab>
+
+  <Tab>
+  ```tsx filename="routes/index.tsx"
+  import { ClerkLoaded } from "@clerk/remix";
+
+  export default function Index() {
+    return (
+      <div>
+        <ClerkLoaded>
+          <div>Clerk is loaded</div>
+          <p>window.Clerk.version</p>
+        </ClerkLoaded>
+      </div>
+    );
+  }
+  ```
+  </Tab>
 </Tabs>

--- a/docs/components/control/clerk-loading.mdx
+++ b/docs/components/control/clerk-loading.mdx
@@ -9,70 +9,71 @@ The `<ClerkLoading />` renders its children while Clerk is loading, and is helpf
 
 ## Usage
 
-<Tabs items={['Next.js', 'React', 'Remix']}>
-<Tab>
-```tsx filename="pages/_app.tsx"
-import "@/styles/globals.css";
-import { ClerkLoaded, ClerkLoading, ClerkProvider } from "@clerk/nextjs";
-import { AppProps } from "next/app";
+<Tabs type="framework" items={["Next.js", "React", "Remix"]}>
+  <Tab>
+  ```tsx filename="pages/_app.tsx"
+  import "@/styles/globals.css";
+  import { ClerkLoaded, ClerkLoading, ClerkProvider } from "@clerk/nextjs";
+  import { AppProps } from "next/app";
 
-function MyApp({ Component, pageProps }: AppProps) {
-  return (
+  function MyApp({ Component, pageProps }: AppProps) {
+    return (
 
-  <ClerkProvider {...pageProps}>
-    <ClerkLoading>
-      <div>Clerk is loading</div>
-    </ClerkLoading>
-    <ClerkLoaded>
-      <Component {...pageProps} />
-    </ClerkLoaded>
-  </ClerkProvider>
-  ); 
-}
-
-export default MyApp;
-```
-</Tab>
-<Tab>
-
-```tsx filename="app.tsx"
-import { ClerkLoaded, ClerkLoading, ClerkProvider } from '@clerk/clerk-react';
-
-function App() {
-  return (
-    <ClerkProvider publishableKey="pk_test_.........................">
+    <ClerkProvider {...pageProps}>
       <ClerkLoading>
         <div>Clerk is loading</div>
       </ClerkLoading>
       <ClerkLoaded>
-        <Page />
+        <Component {...pageProps} />
       </ClerkLoaded>
-      <div>This div is always visible</div>
     </ClerkProvider>
-  );
-}
+    ); 
+  }
 
-function Page() {
-  return <div>The content</div>;
-}
+  export default MyApp;
+  ```
+  </Tab>
 
-export default App;
-```
+  <Tab>
+  ```tsx filename="app.tsx"
+  import { ClerkLoaded, ClerkLoading, ClerkProvider } from '@clerk/clerk-react';
 
-</Tab>
-<Tab>
-```tsx filename="routes/index.tsx"
-import { ClerkLoading } from "@clerk/remix";
+  function App() {
+    return (
+      <ClerkProvider publishableKey="pk_test_.........................">
+        <ClerkLoading>
+          <div>Clerk is loading</div>
+        </ClerkLoading>
+        <ClerkLoaded>
+          <Page />
+        </ClerkLoaded>
+        <div>This div is always visible</div>
+      </ClerkProvider>
+    );
+  }
 
-export default function Index() {
-  return (
-    <div>
-      <ClerkLoading>
-        <div>Clerk is loading</div>
-      </ClerkLoading>
-    </div>
-  );
-}
-```
-</Tab>
+  function Page() {
+    return <div>The content</div>;
+  }
+
+  export default App;
+  ```
+
+  </Tab>
+
+  <Tab>
+  ```tsx filename="routes/index.tsx"
+  import { ClerkLoading } from "@clerk/remix";
+
+  export default function Index() {
+    return (
+      <div>
+        <ClerkLoading>
+          <div>Clerk is loading</div>
+        </ClerkLoading>
+      </div>
+    );
+  }
+  ```
+  </Tab>
 </Tabs>

--- a/docs/components/control/multi-session.mdx
+++ b/docs/components/control/multi-session.mdx
@@ -9,47 +9,47 @@ The `<MultisessionAppSupport />` provides a wrapper for your React application t
 
 ## Usage
 
-<Tabs items={['Next.js', 'React']}>
-<Tab>
-```tsx filename="pages/_app.tsx"
-import "@/styles/globals.css";
-import { MultisessionAppSupport,ClerkProvider } from "@clerk/nextjs";
-import { AppProps } from "next/app";
+<Tabs type="framework" items={["Next.js", "React"]}>
+  <Tab>
+  ```tsx filename="pages/_app.tsx"
+  import "@/styles/globals.css";
+  import { MultisessionAppSupport,ClerkProvider } from "@clerk/nextjs";
+  import { AppProps } from "next/app";
 
-function MyApp({ Component, pageProps }: AppProps) {
-  return (
-    <ClerkProvider {...pageProps}>
-      <MultisessionAppSupport>
-        <Component {...pageProps} />
-      </MultisessionAppSupport>
-    </ClerkProvider>
-  );
-}
+  function MyApp({ Component, pageProps }: AppProps) {
+    return (
+      <ClerkProvider {...pageProps}>
+        <MultisessionAppSupport>
+          <Component {...pageProps} />
+        </MultisessionAppSupport>
+      </ClerkProvider>
+    );
+  }
 
-export default MyApp;
-```
-</Tab>
+  export default MyApp;
+  ```
+  </Tab>
 
-<Tab>
-```tsx filename="app.tsx"
-import { ClerkProvider, MultisessionAppSupport } from "@clerk/clerk-react";
+  <Tab>
+  ```tsx filename="app.tsx"
+  import { ClerkProvider, MultisessionAppSupport } from "@clerk/clerk-react";
 
-function App() {
-  return (
-    <ClerkProvider publishableKey="pk_test_••••••••••••••••••••••••••••••••••">
-      <MultisessionAppSupport>
-        <Page />
-      </MultisessionAppSupport>
-    </ClerkProvider>
-  );
-}
+  function App() {
+    return (
+      <ClerkProvider publishableKey="pk_test_••••••••••••••••••••••••••••••••••">
+        <MultisessionAppSupport>
+          <Page />
+        </MultisessionAppSupport>
+      </ClerkProvider>
+    );
+  }
 
-function Page() {
-  return (
-    <div>The content</div>
-  );
-}
+  function Page() {
+    return (
+      <div>The content</div>
+    );
+  }
 
-```
-</Tab>
+  ```
+  </Tab>
 </Tabs>

--- a/docs/components/control/redirect-to-createorganization.mdx
+++ b/docs/components/control/redirect-to-createorganization.mdx
@@ -9,79 +9,79 @@ The `<RedirectToCreateOrganization />` component will navigate to the create org
 
 ## Usage
 
-<Tabs items={['Next.js', 'React', 'Remix']}>
-<Tab>
-```tsx filename="pages/_app.tsx"
-import {
-  ClerkProvider,
-  SignedIn,
-  SignedOut,
-  RedirectToCreateOrganization,
-} from "@clerk/nextjs";
-import { AppProps } from "next/app";
+<Tabs type="framework" items={["Next.js", "React", "Remix"]}>
+  <Tab>
+  ```tsx filename="pages/_app.tsx"
+  import {
+    ClerkProvider,
+    SignedIn,
+    SignedOut,
+    RedirectToCreateOrganization,
+  } from "@clerk/nextjs";
+  import { AppProps } from "next/app";
 
 
-function MyApp({ Component, pageProps } : AppProps) {
-  return (
-    <ClerkProvider {...pageProps}>
-      <SignedIn>
-        <RedirectToCreateOrganization/>
-      </SignedIn>
-      <SignedOut>
-        Please Sign In
-      </SignedOut>
-    </ClerkProvider>
-  );
-}
+  function MyApp({ Component, pageProps } : AppProps) {
+    return (
+      <ClerkProvider {...pageProps}>
+        <SignedIn>
+          <RedirectToCreateOrganization/>
+        </SignedIn>
+        <SignedOut>
+          Please Sign In
+        </SignedOut>
+      </ClerkProvider>
+    );
+  }
 
-export default MyApp;
-```
-</Tab>
+  export default MyApp;
+  ```
+  </Tab>
 
-<Tab>
-```tsx filename="pages/privatepage.tsx"
-import {
-  ClerkProvider,
-  SignedIn,
-  SignedOut,
-  RedirectToCreateOrganization
-} from "@clerk/clerk-react";
+  <Tab>
+  ```tsx filename="pages/privatepage.tsx"
+  import {
+    ClerkProvider,
+    SignedIn,
+    SignedOut,
+    RedirectToCreateOrganization
+  } from "@clerk/clerk-react";
 
-function PrivatePage() {
-  return (
-    <ClerkProvider publishableKey="pk_test_••••••••••••••••••••••••••••••••••">
-      <SignedIn>
-        <RedirectToCreateOrganization/>
-      </SignedIn>
-      <SignedOut>
-        Please Sign In
-      </SignedOut>
-    </div>
-  );
-}
-```
-</Tab>
+  function PrivatePage() {
+    return (
+      <ClerkProvider publishableKey="pk_test_••••••••••••••••••••••••••••••••••">
+        <SignedIn>
+          <RedirectToCreateOrganization/>
+        </SignedIn>
+        <SignedOut>
+          Please Sign In
+        </SignedOut>
+      </div>
+    );
+  }
+  ```
+  </Tab>
 
-<Tab>
-```tsx filename="routes/index.tsx"
-import {
-  SignedIn,
-  SignedOut,
-  RedirectToCreateOrganization
-} from "@clerk/remix";
+  <Tab>
+  ```tsx filename="routes/index.tsx"
+  import {
+    SignedIn,
+    SignedOut,
+    RedirectToCreateOrganization
+  } from "@clerk/remix";
 
-export default function Index() {
-  return (
-    <div>
-      <SignedIn>
-        <RedirectToCreateOrganization/>
-      </SignedIn>
-      <SignedOut>
-        <p>Please sign in </p>
-      </SignedOut>
-    </div>
-  );
-}
-```
-</Tab>
+  export default function Index() {
+    return (
+      <div>
+        <SignedIn>
+          <RedirectToCreateOrganization/>
+        </SignedIn>
+        <SignedOut>
+          <p>Please sign in </p>
+        </SignedOut>
+      </div>
+    );
+  }
+  ```
+  </Tab>
 </Tabs>

--- a/docs/components/control/redirect-to-organizationprofile.mdx
+++ b/docs/components/control/redirect-to-organizationprofile.mdx
@@ -9,79 +9,79 @@ The `<RedirectToOrganizationProfile />` component will navigate to the organizat
 
 ## Usage
 
-<Tabs items={['Next.js', 'React', 'Remix']}>
-<Tab>
-```tsx filename="pages/_app.tsx"
-import {
-  ClerkProvider,
-  SignedIn,
-  SignedOut,
-  RedirectToOrganizationProfile,
-} from "@clerk/nextjs";
-import { AppProps } from "next/app";
+<Tabs type="framework" items={["Next.js", "React", "Remix"]}>
+  <Tab>
+  ```tsx filename="pages/_app.tsx"
+  import {
+    ClerkProvider,
+    SignedIn,
+    SignedOut,
+    RedirectToOrganizationProfile,
+  } from "@clerk/nextjs";
+  import { AppProps } from "next/app";
 
 
-function MyApp({ Component, pageProps } : AppProps) {
-  return (
-    <ClerkProvider {...pageProps}>
-      <SignedIn>
-        <RedirectToOrganizationProfile/>
-      </SignedIn>
-      <SignedOut>
-        Please Sign In
-      </SignedOut>
-    </ClerkProvider>
-  );
-}
+  function MyApp({ Component, pageProps } : AppProps) {
+    return (
+      <ClerkProvider {...pageProps}>
+        <SignedIn>
+          <RedirectToOrganizationProfile/>
+        </SignedIn>
+        <SignedOut>
+          Please Sign In
+        </SignedOut>
+      </ClerkProvider>
+    );
+  }
 
-export default MyApp;
-```
-</Tab>
+  export default MyApp;
+  ```
+  </Tab>
 
-<Tab>
-```tsx filename="pages/privatepage.tsx"
-import {
-  ClerkProvider,
-  SignedIn,
-  SignedOut,
-  RedirectToOrganizationProfile
-} from "@clerk/clerk-react";
+  <Tab>
+  ```tsx filename="pages/privatepage.tsx"
+  import {
+    ClerkProvider,
+    SignedIn,
+    SignedOut,
+    RedirectToOrganizationProfile
+  } from "@clerk/clerk-react";
 
-function PrivatePage() {
-  return (
-    <ClerkProvider publishableKey="pk_test_••••••••••••••••••••••••••••••••••">
-      <SignedIn>
-        <RedirectToOrganizationProfile/>
-      </SignedIn>
-      <SignedOut>
-        Please Sign In
-      </SignedOut>
-    </div>
-  );
-}
-```
-</Tab>
+  function PrivatePage() {
+    return (
+      <ClerkProvider publishableKey="pk_test_••••••••••••••••••••••••••••••••••">
+        <SignedIn>
+          <RedirectToOrganizationProfile/>
+        </SignedIn>
+        <SignedOut>
+          Please Sign In
+        </SignedOut>
+      </div>
+    );
+  }
+  ```
+  </Tab>
 
-<Tab>
-```tsx filename="routes/index.tsx"
-import {
-  SignedIn,
-  SignedOut,
-  RedirectToOrganizationProfile
-} from "@clerk/remix";
+  <Tab>
+  ```tsx filename="routes/index.tsx"
+  import {
+    SignedIn,
+    SignedOut,
+    RedirectToOrganizationProfile
+  } from "@clerk/remix";
 
-export default function Index() {
-  return (
-    <div>
-      <SignedIn>
-        <RedirectToOrganizationProfile/>
-      </SignedIn>
-      <SignedOut>
-        <p>Please sign in </p>
-      </SignedOut>
-    </div>
-  );
-}
-```
-</Tab>
+  export default function Index() {
+    return (
+      <div>
+        <SignedIn>
+          <RedirectToOrganizationProfile/>
+        </SignedIn>
+        <SignedOut>
+          <p>Please sign in </p>
+        </SignedOut>
+      </div>
+    );
+  }
+  ```
+  </Tab>
 </Tabs>

--- a/docs/components/control/redirect-to-signin.mdx
+++ b/docs/components/control/redirect-to-signin.mdx
@@ -9,83 +9,85 @@ The `<RedirectToSignIn />` component will navigate to the sign in URL which has 
 
 ## Usage
 
-<Tabs items={['Next.js', 'React', 'Remix']}>
-<Tab>
-```tsx filename="pages/_app.tsx"
-import {
-  ClerkProvider,
-  SignedIn,
-  SignedOut,
-  RedirectToSignIn,
-} from "@clerk/nextjs";
-import { AppProps } from "next/app";
+<Tabs type="framework" items={["Next.js", "React", "Remix"]}>
+  <Tab>
+  ```tsx filename="pages/_app.tsx"
+  import {
+    ClerkProvider,
+    SignedIn,
+    SignedOut,
+    RedirectToSignIn,
+  } from "@clerk/nextjs";
+  import { AppProps } from "next/app";
 
-function MyApp({ Component, pageProps } : AppProps) {
-  return (
-    <ClerkProvider {...pageProps}>
-      <SignedIn>
-        <Component {...pageProps} />
-      </SignedIn>
-      <SignedOut>
-        <RedirectToSignIn />
-      </SignedOut>
-    </ClerkProvider>
-  );
-}
+  function MyApp({ Component, pageProps } : AppProps) {
+    return (
+      <ClerkProvider {...pageProps}>
+        <SignedIn>
+          <Component {...pageProps} />
+        </SignedIn>
+        <SignedOut>
+          <RedirectToSignIn />
+        </SignedOut>
+      </ClerkProvider>
+    );
+  }
 
-export default MyApp;
-```
-</Tab>
-<Tab>
-```tsx filename="pages/privatepage.tsx"
-import {
-  ClerkProvider,
-  SignedIn,
-  SignedOut,
-  RedirectToSignIn
-} from "@clerk/clerk-react";
+  export default MyApp;
+  ```
+  </Tab>
+  
+  <Tab>
+  ```tsx filename="pages/privatepage.tsx"
+  import {
+    ClerkProvider,
+    SignedIn,
+    SignedOut,
+    RedirectToSignIn
+  } from "@clerk/clerk-react";
 
-function PrivatePage() {
-  return (
-    <ClerkProvider publishableKey="pk_test_••••••••••••••••••••••••••••••••••">
-      <SignedIn>
-        Content that is displayed to signed in
-        users.
-      </SignedIn>
-      <SignedOut>
-        <RedirectToSignIn />
-      </SignedOut>
-    </div>
-  );
-}
+  function PrivatePage() {
+    return (
+      <ClerkProvider publishableKey="pk_test_••••••••••••••••••••••••••••••••••">
+        <SignedIn>
+          Content that is displayed to signed in
+          users.
+        </SignedIn>
+        <SignedOut>
+          <RedirectToSignIn />
+        </SignedOut>
+      </div>
+    );
+  }
 
-```
-</Tab>
-<Tab>
-```tsx filename="routes/index.tsx"
-import {
-  SignedIn,
-  SignedOut,
-  RedirectToSignIn,
-  UserButton,
-} from "@clerk/remix";
+  ```
+  </Tab>
 
-export default function Index() {
-  return (
-    <div>
-      <SignedIn>
-        <h1>Index route</h1>
-        <p>You are signed in!</p>
-        <UserButton />
-      </SignedIn>
-      <SignedOut>
-        <RedirectToSignIn />
-      </SignedOut>
-    </div>
-  );
-}
-```
-</Tab>
+  <Tab>
+  ```tsx filename="routes/index.tsx"
+  import {
+    SignedIn,
+    SignedOut,
+    RedirectToSignIn,
+    UserButton,
+  } from "@clerk/remix";
+
+  export default function Index() {
+    return (
+      <div>
+        <SignedIn>
+          <h1>Index route</h1>
+          <p>You are signed in!</p>
+          <UserButton />
+        </SignedIn>
+        <SignedOut>
+          <RedirectToSignIn />
+        </SignedOut>
+      </div>
+    );
+  }
+  ```
+  </Tab>
 </Tabs>
 
 ## Properties

--- a/docs/components/control/redirect-to-signup.mdx
+++ b/docs/components/control/redirect-to-signup.mdx
@@ -9,84 +9,84 @@ The `<RedirectToSignUp />` component will navigate to the sign up URL which has 
 
 ## Usage
 
-<Tabs items={['Next.js', 'React', 'Remix']}>
-<Tab>
-```tsx filename="pages/_app.tsx"
-import {
-  ClerkProvider,
-  SignedIn,
-  SignedOut,
-  RedirectToSignUp,
-} from "@clerk/nextjs";
-import { AppProps } from "next/app";
+<Tabs type="framework" items={["Next.js", "React", "Remix"]}>
+  <Tab>
+  ```tsx filename="pages/_app.tsx"
+  import {
+    ClerkProvider,
+    SignedIn,
+    SignedOut,
+    RedirectToSignUp,
+  } from "@clerk/nextjs";
+  import { AppProps } from "next/app";
 
-function MyApp({ Component, pageProps } : AppProps) {
-  return (
-    <ClerkProvider {...pageProps}>
-      <SignedIn>
-        <Component {...pageProps} />
-      </SignedIn>
-      <SignedOut>
-        <RedirectToSignUp />
-      </SignedOut>
-    </ClerkProvider>
-  );
-}
+  function MyApp({ Component, pageProps } : AppProps) {
+    return (
+      <ClerkProvider {...pageProps}>
+        <SignedIn>
+          <Component {...pageProps} />
+        </SignedIn>
+        <SignedOut>
+          <RedirectToSignUp />
+        </SignedOut>
+      </ClerkProvider>
+    );
+  }
 
-export default MyApp;
-```
-</Tab>
+  export default MyApp;
+  ```
+  </Tab>
 
-<Tab>
-```tsx filename="pages/privatepage.tsx"
-import {
-  ClerkProvider,
-  SignedIn,
-  SignedOut,
-  RedirectToSignUp
-} from "@clerk/clerk-react";
+  <Tab>
+  ```tsx filename="pages/privatepage.tsx"
+  import {
+    ClerkProvider,
+    SignedIn,
+    SignedOut,
+    RedirectToSignUp
+  } from "@clerk/clerk-react";
 
-function PrivatePage() {
-  return (
-    <ClerkProvider publishableKey="pk_test_••••••••••••••••••••••••••••••••••">
-      <SignedIn>
-        Content that is displayed to signed in
-        users.
-      </SignedIn>
-      <SignedOut>
-        <RedirectToSignUp />
-      </SignedOut>
-    </div>
-  );
-}
-```
-</Tab>
+  function PrivatePage() {
+    return (
+      <ClerkProvider publishableKey="pk_test_••••••••••••••••••••••••••••••••••">
+        <SignedIn>
+          Content that is displayed to signed in
+          users.
+        </SignedIn>
+        <SignedOut>
+          <RedirectToSignUp />
+        </SignedOut>
+      </div>
+    );
+  }
+  ```
+  </Tab>
 
-<Tab>
-```tsx filename="routes/index.tsx"
-import {
-  SignedIn,
-  SignedOut,
-  RedirectToSignUp,
-  UserButton,
-} from "@clerk/remix";
+  <Tab>
+  ```tsx filename="routes/index.tsx"
+  import {
+    SignedIn,
+    SignedOut,
+    RedirectToSignUp,
+    UserButton,
+  } from "@clerk/remix";
 
-export default function Index() {
-  return (
-    <div>
-      <SignedIn>
-        <h1>Index route</h1>
-        <p>You are signed in!</p>
-        <UserButton />
-      </SignedIn>
-      <SignedOut>
-        <RedirectToSignUp />
-      </SignedOut>
-    </div>
-  );
-}
-```
-</Tab>
+  export default function Index() {
+    return (
+      <div>
+        <SignedIn>
+          <h1>Index route</h1>
+          <p>You are signed in!</p>
+          <UserButton />
+        </SignedIn>
+        <SignedOut>
+          <RedirectToSignUp />
+        </SignedOut>
+      </div>
+    );
+  }
+  ```
+  </Tab>
 </Tabs>
 
 ## Properties

--- a/docs/components/control/redirect-to-userprofile.mdx
+++ b/docs/components/control/redirect-to-userprofile.mdx
@@ -9,79 +9,79 @@ The `<RedirectToUserProfile />` component will navigate to the user profile URL 
 
 ## Usage
 
-<Tabs items={['Next.js', 'React', 'Remix']}>
-<Tab>
-```tsx filename="pages/_app.tsx"
-import {
-  ClerkProvider,
-  SignedIn,
-  SignedOut,
-  RedirectToUserProfile,
-} from "@clerk/nextjs";
-import { AppProps } from "next/app";
+<Tabs type="framework" items={["Next.js", "React", "Remix"]}>
+  <Tab>
+  ```tsx filename="pages/_app.tsx"
+  import {
+    ClerkProvider,
+    SignedIn,
+    SignedOut,
+    RedirectToUserProfile,
+  } from "@clerk/nextjs";
+  import { AppProps } from "next/app";
 
 
-function MyApp({ Component, pageProps } : AppProps) {
-  return (
-    <ClerkProvider {...pageProps}>
-      <SignedIn>
-        <RedirectToUserProfile/>
-      </SignedIn>
-      <SignedOut>
-        Please Sign In
-      </SignedOut>
-    </ClerkProvider>
-  );
-}
+  function MyApp({ Component, pageProps } : AppProps) {
+    return (
+      <ClerkProvider {...pageProps}>
+        <SignedIn>
+          <RedirectToUserProfile/>
+        </SignedIn>
+        <SignedOut>
+          Please Sign In
+        </SignedOut>
+      </ClerkProvider>
+    );
+  }
 
-export default MyApp;
-```
-</Tab>
+  export default MyApp;
+  ```
+  </Tab>
 
-<Tab>
-```tsx filename="pages/privatepage.tsx"
-import {
-  ClerkProvider,
-  SignedIn,
-  SignedOut,
-  RedirectToUserProfile
-} from "@clerk/clerk-react";
+  <Tab>
+  ```tsx filename="pages/privatepage.tsx"
+  import {
+    ClerkProvider,
+    SignedIn,
+    SignedOut,
+    RedirectToUserProfile
+  } from "@clerk/clerk-react";
 
-function PrivatePage() {
-  return (
-    <ClerkProvider publishableKey="pk_test_••••••••••••••••••••••••••••••••••">
-      <SignedIn>
-        <RedirectToUserProfile/>
-      </SignedIn>
-      <SignedOut>
-        Please Sign In
-      </SignedOut>
-    </div>
-  );
-}
-```
-</Tab>
+  function PrivatePage() {
+    return (
+      <ClerkProvider publishableKey="pk_test_••••••••••••••••••••••••••••••••••">
+        <SignedIn>
+          <RedirectToUserProfile/>
+        </SignedIn>
+        <SignedOut>
+          Please Sign In
+        </SignedOut>
+      </div>
+    );
+  }
+  ```
+  </Tab>
 
-<Tab>
-```tsx filename="routes/index.tsx"
-import {
-  SignedIn,
-  SignedOut,
-  RedirectToUserProfile
-} from "@clerk/remix";
+  <Tab>
+  ```tsx filename="routes/index.tsx"
+  import {
+    SignedIn,
+    SignedOut,
+    RedirectToUserProfile
+  } from "@clerk/remix";
 
-export default function Index() {
-  return (
-    <div>
-      <SignedIn>
-        <RedirectToUserProfile/>
-      </SignedIn>
-      <SignedOut>
-        <p>Please sign in </p>
-      </SignedOut>
-    </div>
-  );
-}
-```
-</Tab>
+  export default function Index() {
+    return (
+      <div>
+        <SignedIn>
+          <RedirectToUserProfile/>
+        </SignedIn>
+        <SignedOut>
+          <p>Please sign in </p>
+        </SignedOut>
+      </div>
+    );
+  }
+  ```
+  </Tab>
 </Tabs>

--- a/docs/components/control/signed-in.mdx
+++ b/docs/components/control/signed-in.mdx
@@ -9,75 +9,77 @@ description: Conditionally render content only when a user is signed in.
 The `<SignedIn />` component offers authentication checks as a cross-cutting concern. Any children components wrapped by a `<SignedIn />` component will be rendered only if there's a User with an active Session signed in your application.
 
 ## Usage
-<Tabs items={['Next.js', 'React', 'Remix']}>
-<Tab>
-```tsx filename="app.tsx"
-import "@/styles/globals.css";
-import {
-  ClerkProvider,
-  RedirectToSignIn,
-  SignedIn,
-} from "@clerk/nextjs";
-import { AppProps } from "next/app";
+<Tabs type="framework" items={["Next.js", "React", "Remix"]}>
+  <Tab>
+  ```tsx filename="app.tsx"
+  import "@/styles/globals.css";
+  import {
+    ClerkProvider,
+    RedirectToSignIn,
+    SignedIn,
+  } from "@clerk/nextjs";
+  import { AppProps } from "next/app";
 
-function MyApp({ Component, pageProps }: AppProps) {
-  return (
-    <ClerkProvider {...pageProps}>
-      <SignedIn>
-        <div>You are signed in</div>
-      </SignedIn>
-      <div>Always visible</div>
-    </ClerkProvider>
-  );
-}
-
-export default MyApp;
-
-```
-</Tab>
-<Tab>
-```tsx filename="app.tsx"
-import { SignedIn, ClerkProvider } from "@clerk/clerk-react";
-
-function Page() {
-  return (
-    <ClerkProvider publishableKey="pk_test_••••••••••••••••••••••••••••••••••">
-      <section>
-        <div>
-          This content is always visible.
-        </div>
+  function MyApp({ Component, pageProps }: AppProps) {
+    return (
+      <ClerkProvider {...pageProps}>
         <SignedIn>
-          <div>
-            This content is visible only to
-            signed in users.
-          </div>
+          <div>You are signed in</div>
         </SignedIn>
-      </section>
-    </ClerkProvider>
-  );
-}
-```
-</Tab>
-<Tab>
-```tsx filename="routes/index.tsx"
-import {
-  SignedIn,
-  UserButton,
-} from "@clerk/remix";
+        <div>Always visible</div>
+      </ClerkProvider>
+    );
+  }
 
-export default function Index() {
-  return (
-    <div>
-      <SignedIn>
-        <h1>Index route</h1>
-        <p>You are signed in!</p>
-        <UserButton />
-      </SignedIn>
-    </div>
-  );
-}
-```
-</Tab>
+  export default MyApp;
+
+  ```
+  </Tab>
+
+  <Tab>
+  ```tsx filename="app.tsx"
+  import { SignedIn, ClerkProvider } from "@clerk/clerk-react";
+
+  function Page() {
+    return (
+      <ClerkProvider publishableKey="pk_test_••••••••••••••••••••••••••••••••••">
+        <section>
+          <div>
+            This content is always visible.
+          </div>
+          <SignedIn>
+            <div>
+              This content is visible only to
+              signed in users.
+            </div>
+          </SignedIn>
+        </section>
+      </ClerkProvider>
+    );
+  }
+  ```
+  </Tab>
+
+  <Tab>
+  ```tsx filename="routes/index.tsx"
+  import {
+    SignedIn,
+    UserButton,
+  } from "@clerk/remix";
+
+  export default function Index() {
+    return (
+      <div>
+        <SignedIn>
+          <h1>Index route</h1>
+          <p>You are signed in!</p>
+          <UserButton />
+        </SignedIn>
+      </div>
+    );
+  }
+  ```
+  </Tab>
 </Tabs>
 
 ### Usage with React Router

--- a/docs/components/control/signed-out.mdx
+++ b/docs/components/control/signed-out.mdx
@@ -8,109 +8,111 @@ description: Conditionally render content only when a user is signed out.
 The `<SignedOut />` component offers authentication checks as a cross-cutting concern. Any child nodes wrapped by a `<SignedOut />` component will be rendered only if there's no User signed in to your application.
 
 ## Usage
-<Tabs items={['Next.js', 'React', 'Remix']}>
-<Tab>
-```tsx filename="app.tsx"
-import "@/styles/globals.css";
-import {
-  ClerkProvider,
-  RedirectToSignIn,
-  SignedOut,
-} from "@clerk/nextjs";
-import { AppProps } from "next/app";
+<Tabs type="framework" items={["Next.js", "React", "Remix"]}>
+  <Tab>
+  ```tsx filename="app.tsx"
+  import "@/styles/globals.css";
+  import {
+    ClerkProvider,
+    RedirectToSignIn,
+    SignedOut,
+  } from "@clerk/nextjs";
+  import { AppProps } from "next/app";
 
-function MyApp({ Component, pageProps }: AppProps) {
-  return (
-    <ClerkProvider {...pageProps}>
-      <SignedOut>
-        <div>You are signed Out</div>
-      </SignedOut>
-      <div>Always visible</div>
-    </ClerkProvider>
-  );
-}
-
-export default MyApp;
-```
-</Tab>
-<Tab>
-```tsx filename="app.tsx"
-import { SignedOut, ClerkProvider } from "@clerk/clerk-react";
-
-function Page() {
-  return (
-    <ClerkProvider publishableKey="pk_test_••••••••••••••••••••••••••••••••••">
-      <section>
-        <div>
-          This content is always visible.
-        </div>
+  function MyApp({ Component, pageProps }: AppProps) {
+    return (
+      <ClerkProvider {...pageProps}>
         <SignedOut>
-          <div>
-            This content is visible only to signed out users.
-          </div>
+          <div>You are signed Out</div>
         </SignedOut>
-      </section>
-    </ClerkProvider>
-  );
-}
-```
+        <div>Always visible</div>
+      </ClerkProvider>
+    );
+  }
 
-### Usage with React Router
+  export default MyApp;
+  ```
+  </Tab>
+  
+  <Tab>
+  ```tsx filename="app.tsx"
+  import { SignedOut, ClerkProvider } from "@clerk/clerk-react";
 
-Below is an example of how to use `<SignedOut />` with React Router. The `<SignedOut />` component can be used as a child of a `<Route />` component to render content only to signed in users.
-
-```tsx filename="app.tsx"
-import { Routes, Route } from 'react-router-dom';
-import {
-  ClerkProvider,
-  SignedOut,
-  RedirectToSignIn
-} from "@clerk/clerk-react";
-
-function App() {
-  return (
-    <ClerkProvider publishableKey="pk_test_••••••••••••••••••••••••••••••••••">
-      <Routes>
-      <Route
-        path="/"
-        element={<div>This page is publicly accessible.</div>}
-      />
-      <Route
-        path="/public"
-        element={
+  function Page() {
+    return (
+      <ClerkProvider publishableKey="pk_test_••••••••••••••••••••••••••••••••••">
+        <section>
+          <div>
+            This content is always visible.
+          </div>
           <SignedOut>
-            <div>This content is accessible only to users that are signed out.</div>
+            <div>
+              This content is visible only to signed out users.
+            </div>
           </SignedOut>
-        }
-      />
-    </Routes>
-    </ClerkProvider>
-  );
-}
-```
-</Tab>
-<Tab>
-```tsx filename="routes/index.tsx"
-import {
-  SignedIn,
-  SignedOut,
-  UserButton,
-} from "@clerk/remix";
+        </section>
+      </ClerkProvider>
+    );
+  }
+  ```
 
-export default function Index() {
-  return (
-    <div>
-      <SignedIn>
-        <h1>Index route</h1>
-        <p>You are signed in!</p>
-        <UserButton />
-      </SignedIn>
-      <SignedOut>
-      <p> You are signed out </p>
-      </SignedOut>
-    </div>
-  );
-}
-```
-</Tab>
+  ### Usage with React Router
+
+  Below is an example of how to use `<SignedOut />` with React Router. The `<SignedOut />` component can be used as a child of a `<Route />` component to render content only to signed in users.
+
+  ```tsx filename="app.tsx"
+  import { Routes, Route } from 'react-router-dom';
+  import {
+    ClerkProvider,
+    SignedOut,
+    RedirectToSignIn
+  } from "@clerk/clerk-react";
+
+  function App() {
+    return (
+      <ClerkProvider publishableKey="pk_test_••••••••••••••••••••••••••••••••••">
+        <Routes>
+        <Route
+          path="/"
+          element={<div>This page is publicly accessible.</div>}
+        />
+        <Route
+          path="/public"
+          element={
+            <SignedOut>
+              <div>This content is accessible only to users that are signed out.</div>
+            </SignedOut>
+          }
+        />
+      </Routes>
+      </ClerkProvider>
+    );
+  }
+  ```
+  </Tab>
+
+  <Tab>
+  ```tsx filename="routes/index.tsx"
+  import {
+    SignedIn,
+    SignedOut,
+    UserButton,
+  } from "@clerk/remix";
+
+  export default function Index() {
+    return (
+      <div>
+        <SignedIn>
+          <h1>Index route</h1>
+          <p>You are signed in!</p>
+          <UserButton />
+        </SignedIn>
+        <SignedOut>
+        <p> You are signed out </p>
+        </SignedOut>
+      </div>
+    );
+  }
+  ```
+  </Tab>
 </Tabs>

--- a/docs/components/customization/localization.mdx
+++ b/docs/components/customization/localization.mdx
@@ -44,7 +44,7 @@ The `@clerk/localizations` package contains predefined localizations for the Cle
 
 To get started, install the `@clerk/localizations` package.
 
-<CodeBlockTabs options={["npm", "yarn", "pnpm"]}>
+<CodeBlockTabs type="installer" options={["npm", "yarn", "pnpm"]}>
   ```bash filename="terminal"
   npm install @clerk/localizations
   ```
@@ -120,7 +120,7 @@ To find the key for your translation (like the `socialButtonsBlockButton` from t
 
 For example, if you want to change the 'to continue to' string from the `<SignIn />` and `<SignUp />` components, you would search for 'to continue to'. You will find several instances of this. Some of those are in the the following `signUp` object:
 
-```json
+```js
 signUp: {
     start: {
       title: 'Create your account',

--- a/docs/components/customization/organization-profile.mdx
+++ b/docs/components/customization/organization-profile.mdx
@@ -15,11 +15,11 @@ To add a custom page to the [`<OrganizationProfile />`][orgprofile-ref] componen
 
 ### Usage
 
-<Tabs items={['Next.js', 'React', 'Remix']}>
+<Tabs type="framework" items={["Next.js", "React", "Remix"]}>
   <Tab>
     `<OrganizationProfile.Page />` can be rendered **only on the client**. For Next.js applications using App Router, the `"use client";` directive must be added.
 
-    <CodeBlockTabs options={["App Router", "Pages Router"]}>
+    <CodeBlockTabs type="router" options={["App Router", "Pages Router"]}>
       ```jsx filename="/app/organization-profile/[[...organization-profile]]/page.tsx"
       "use client";
 
@@ -122,11 +122,11 @@ You can add external links to the [`<OrganizationProfile />`][orgprofile-ref] na
 
 ### Usage
 
-<Tabs items={['Next.js', 'React', 'Remix']}>
+<Tabs type="framework" items={["Next.js", "React", "Remix"]}>
   <Tab>
     `<OrganizationProfile.Link />` can be rendered **only on the client**. For Next.js applications using App Router, the `"use client";` directive must be added.
 
-    <CodeBlockTabs options={["App Router", "Pages Router"]}>
+    <CodeBlockTabs type="router" options={["App Router", "Pages Router"]}>
       ```jsx filename="/app/organization-profile/[[...organization-profile]]/page.tsx"
       "use client";
 
@@ -208,11 +208,11 @@ If you want to reorder the default routes (`Members` and `Settings`) in the `Org
 
 ### Usage
 
-<Tabs items={['Next.js', 'React', 'Remix']}>
+<Tabs type="framework" items={["Next.js", "React", "Remix"]}>
   <Tab>
     `<OrganizationProfile.Page />` and `<OrganizationProfile.Link />` can be rendered **only on the client**.  For Next.js applications that use App Router, the `"use client";` directive needs to be used.
 
-    <CodeBlockTabs options={["App Router", "Pages Router"]}>
+    <CodeBlockTabs type="router" options={["App Router", "Pages Router"]}>
       ```jsx filename="/app/organization-profile/[[...organization-profile]]/page.tsx"
       "use client";
 
@@ -313,11 +313,11 @@ If you are using the `<OrganizationSwitcher />` component with the default props
 
 ### Usage
 
-<Tabs items={['Next.js', 'React', 'Remix']}>
+<Tabs type="framework" items={["Next.js", "React", "Remix"]}>
   <Tab>
     `<OrganizationSwitcher.OrganizationProfilePage />` and `<OrganizationSwitcher.OrganizationProfileLink />` can be rendered **only on the client**.  For Next.js applications using App Router, the `"use client";` directive must be added.
 
-    <CodeBlockTabs options={["App Router", "Pages Router"]}>
+    <CodeBlockTabs type="router" options={["App Router", "Pages Router"]}>
       ```jsx filename="/app/components/Header.tsx"
       "use client";
 

--- a/docs/components/customization/overview.mdx
+++ b/docs/components/customization/overview.mdx
@@ -13,7 +13,7 @@ This applies to all of the React-based packages, like [Next.js](/docs/quickstart
 
 Clerk offers [a set of themes that can be used with the `appearance` prop](/docs/components/customization/themes). The themes are available as a package called `@clerk/themes`.
 
-<CodeBlockTabs options={["npm", "yarn", "pnpm"]}>
+<CodeBlockTabs type="installer" options={["npm", "yarn", "pnpm"]}>
   ```bash filename="terminal"
   npm install @clerk/themes
   ```
@@ -39,449 +39,481 @@ To apply a theme to all Clerk components, pass the `appearance` prop to the `<Cl
 
 In the example below, the `dark` theme is applied to all Clerk components.
 
-<CodeBlockTabs options={['Next.js App Router', 'Next.js Pages Router', 'React', 'Remix']}>
-```tsx filename="/src/app/layout.tsx" {2,11-13}
-import { ClerkProvider } from '@clerk/nextjs';
-import { dark } from '@clerk/themes';
+<Tabs type="framework" items={["Next.js", "React", "Remix"]}>
+  <Tab>
+    <CodeBlockTabs type="router" options={["App Router", "Pages Router"]}>
+    ```tsx filename="/src/app/layout.tsx" {2,11-13}
+    import { ClerkProvider } from '@clerk/nextjs';
+    import { dark } from '@clerk/themes';
 
-export default function RootLayout({
-  children,
-}: {
-  children: React.ReactNode
-}) {
-  return (
-    <ClerkProvider
-      appearance={{
-        baseTheme: dark
-      }}
-    >
+    export default function RootLayout({
+      children,
+    }: {
+      children: React.ReactNode
+    }) {
+      return (
+        <ClerkProvider
+          appearance={{
+            baseTheme: dark
+          }}
+        >
+          <html lang="en">
+            <body>{children}</body>
+          </html>
+        </ClerkProvider>
+      )
+    }
+    ```
+
+    ```tsx filename="_app.tsx" {2,8,9,10}
+    import { ClerkProvider } from '@clerk/nextjs';
+    import { dark } from '@clerk/themes';
+    import type { AppProps } from "next/app";
+
+    function MyApp({ Component, pageProps }: AppProps) {
+      return (
+        <ClerkProvider
+          appearance={{
+            baseTheme: dark
+          }}
+        >
+          <Component {...pageProps}/>
+        </ClerkProvider>
+      )
+    }
+
+    export default MyApp;
+    ```
+    </CodeBlockTabs>
+  </Tab>
+
+  <Tab>
+  ```tsx filename="app.tsx" {3,14-16}
+  import React from "react";
+  import "./App.css";
+  import { dark } from '@clerk/themes';
+  import { ClerkProvider } from "@clerk/clerk-react";
+
+  if (!process.env.REACT_APP_CLERK_PUBLISHABLE_KEY) {
+    throw new Error("Missing Publishable Key")
+  }
+  const clerkPubKey = process.env.REACT_APP_CLERK_PUBLISHABLE_KEY;
+
+  function App() {
+    return (
+      <ClerkProvider 
+        appearance={{
+          baseTheme: dark
+        }} 
+        publishableKey={clerkPubKey}
+      >
+        <div>Hello from clerk</div>
+      </ClerkProvider>
+    );
+  }
+
+  export default App;
+  ```
+  </Tab>
+
+  <Tab>
+  ```tsx filename="app/root.tsx" {3,43-45}
+  // Import ClerkApp
+  import { ClerkApp } from "@clerk/remix";
+  import { dark } from '@clerk/themes';
+  import type { MetaFunction,LoaderFunction } from "@remix-run/node";
+
+  import {
+    Links,
+    LiveReload,
+    Meta,
+    Outlet,
+    Scripts,
+    ScrollRestoration,
+  } from "@remix-run/react";
+
+  import { rootAuthLoader } from "@clerk/remix/ssr.server";
+
+  export const meta: MetaFunction = () => ({
+    charset: "utf-8",
+    title: "New Remix App",
+    viewport: "width=device-width,initial-scale=1",
+  });
+
+  export const loader: LoaderFunction = (args) => rootAuthLoader(args);
+
+  function App() {
+    return (
       <html lang="en">
-        <body>{children}</body>
+        <head>
+          <Meta />
+          <Links />
+        </head>
+        <body>
+          <Outlet />
+          <ScrollRestoration />
+          <Scripts />
+          <LiveReload />
+        </body>
       </html>
-    </ClerkProvider>
-  )
-}
-```
+    );
+  }
 
-```tsx filename="_app.tsx" {2,8,9,10}
-import { ClerkProvider } from '@clerk/nextjs';
-import { dark } from '@clerk/themes';
-import type { AppProps } from "next/app";
-
-function MyApp({ Component, pageProps }: AppProps) {
-  return (
-    <ClerkProvider
-      appearance={{
-        baseTheme: dark
-      }}
-    >
-      <Component {...pageProps}/>
-    </ClerkProvider>
-  )
-}
-
-export default MyApp;
-```
-
-```tsx filename="app.tsx" {3,14-16}
-import React from "react";
-import "./App.css";
-import { dark } from '@clerk/themes';
-import { ClerkProvider } from "@clerk/clerk-react";
-
-if (!process.env.REACT_APP_CLERK_PUBLISHABLE_KEY) {
-  throw new Error("Missing Publishable Key")
-}
-const clerkPubKey = process.env.REACT_APP_CLERK_PUBLISHABLE_KEY;
-
-function App() {
-  return (
-    <ClerkProvider 
-      appearance={{
-        baseTheme: dark
-      }} 
-      publishableKey={clerkPubKey}
-    >
-      <div>Hello from clerk</div>
-    </ClerkProvider>
-  );
-}
-
-export default App;
-```
-
-```tsx filename="app/root.tsx" {3,43-45}
-// Import ClerkApp
-import { ClerkApp } from "@clerk/remix";
-import { dark } from '@clerk/themes';
-import type { MetaFunction,LoaderFunction } from "@remix-run/node";
-
-import {
-  Links,
-  LiveReload,
-  Meta,
-  Outlet,
-  Scripts,
-  ScrollRestoration,
-} from "@remix-run/react";
-
-import { rootAuthLoader } from "@clerk/remix/ssr.server";
-
-export const meta: MetaFunction = () => ({
-  charset: "utf-8",
-  title: "New Remix App",
-  viewport: "width=device-width,initial-scale=1",
-});
-
-export const loader: LoaderFunction = (args) => rootAuthLoader(args);
-
-function App() {
-  return (
-    <html lang="en">
-      <head>
-        <Meta />
-        <Links />
-      </head>
-      <body>
-        <Outlet />
-        <ScrollRestoration />
-        <Scripts />
-        <LiveReload />
-      </body>
-    </html>
-  );
-}
-
-export default ClerkApp(App, {
-  appearance: {
-    baseTheme: dark,
-  },
-});
-```
-</CodeBlockTabs>
+  export default ClerkApp(App, {
+    appearance: {
+      baseTheme: dark,
+    },
+  });
+  ```
+  </Tab>
+</Tabs>
 
 You can also stack themes by passing an array of themes to the `baseTheme` property of the `appearance` prop. The themes will be applied in the order they are listed. If styles overlap, the last defined theme will take precedence.
 
 In the example below, the `dark` theme is applied first, then the `neobrutalism` theme is applied on top of it.
 
-<CodeBlockTabs options={['Next.js App Router', 'Next.js Pages Router', 'React', 'Remix']}>
-```tsx filename="/src/app/layout.tsx" {2,11-13}
-import { ClerkProvider } from '@clerk/nextjs';
-import { dark, neobrutalism } from '@clerk/themes';
+<Tabs type="framework" items={["Next.js", "React", "Remix"]}>
+  <Tab>
+    <CodeBlockTabs type="router" options={["App Router", "Pages Router"]}>
+    ```tsx filename="/src/app/layout.tsx" {2,11-13}
+    import { ClerkProvider } from '@clerk/nextjs';
+    import { dark, neobrutalism } from '@clerk/themes';
 
-export default function RootLayout({
-  children,
-}: {
-  children: React.ReactNode
-}) {
-  return (
-    <ClerkProvider
-      appearance={{
-        baseTheme: [dark, neobrutalism]
-      }}
-    >
+    export default function RootLayout({
+      children,
+    }: {
+      children: React.ReactNode
+    }) {
+      return (
+        <ClerkProvider
+          appearance={{
+            baseTheme: [dark, neobrutalism]
+          }}
+        >
+          <html lang="en">
+            <body>{children}</body>
+          </html>
+        </ClerkProvider>
+      )
+    }
+    ```
+
+    ```tsx filename="_app.tsx" {2,8-10}
+    import { ClerkProvider, SignIn } from '@clerk/nextjs';
+    import { dark, neobrutalism } from '@clerk/themes';
+    import type { AppProps } from "next/app";
+
+    function MyApp({ Component, pageProps }: AppProps) {
+      return (
+        <ClerkProvider
+          appearance={{
+            baseTheme: [dark, neobrutalism]
+          }}
+        >
+          <Component {...pageProps}/>
+        </ClerkProvider>
+      )
+    }
+
+    export default MyApp;
+    ```
+    </CodeBlockTabs>
+  </Tab>
+
+  <Tab>
+  ```tsx filename="app.tsx" {3,14-16}
+  import React from "react";
+  import "./App.css";
+  import { dark, neobrutalism } from '@clerk/themes';
+  import { ClerkProvider } from "@clerk/clerk-react";
+
+  if (!process.env.REACT_APP_CLERK_PUBLISHABLE_KEY) {
+    throw new Error("Missing Publishable Key")
+  }
+  const clerkPubKey = process.env.REACT_APP_CLERK_PUBLISHABLE_KEY;
+
+  function App() {
+    return (
+      <ClerkProvider 
+        appearance={{
+          baseTheme: [dark, neobrutalism]
+        }} 
+        publishableKey={clerkPubKey}
+      >
+        <div>Hello from clerk</div>
+      </ClerkProvider>
+    );
+  }
+
+  export default App;
+  ```
+  </Tab>
+
+  <Tab>
+  ```tsx filename="app/root.tsx" {3,43-45}
+  // Import ClerkApp
+  import { ClerkApp } from "@clerk/remix";
+  import { dark, neobrutalism } from '@clerk/themes';
+  import type { MetaFunction,LoaderFunction } from "@remix-run/node";
+
+  import {
+    Links,
+    LiveReload,
+    Meta,
+    Outlet,
+    Scripts,
+    ScrollRestoration,
+  } from "@remix-run/react";
+
+  import { rootAuthLoader } from "@clerk/remix/ssr.server";
+
+  export const meta: MetaFunction = () => ({
+    charset: "utf-8",
+    title: "New Remix App",
+    viewport: "width=device-width,initial-scale=1",
+  });
+
+  export const loader: LoaderFunction = (args) => rootAuthLoader(args);
+
+  function App() {
+    return (
       <html lang="en">
-        <body>{children}</body>
+        <head>
+          <Meta />
+          <Links />
+        </head>
+        <body>
+          <Outlet />
+          <ScrollRestoration />
+          <Scripts />
+          <LiveReload />
+        </body>
       </html>
-    </ClerkProvider>
-  )
-}
-```
+    );
+  }
 
-```tsx filename="_app.tsx" {2,8-10}
-import { ClerkProvider, SignIn } from '@clerk/nextjs';
-import { dark, neobrutalism } from '@clerk/themes';
-import type { AppProps } from "next/app";
-
-function MyApp({ Component, pageProps }: AppProps) {
-  return (
-    <ClerkProvider
-      appearance={{
-        baseTheme: [dark, neobrutalism]
-      }}
-    >
-      <Component {...pageProps}/>
-    </ClerkProvider>
-  )
-}
-
-export default MyApp;
-```
-
-```tsx filename="app.tsx" {3,14-16}
-import React from "react";
-import "./App.css";
-import { dark, neobrutalism } from '@clerk/themes';
-import { ClerkProvider } from "@clerk/clerk-react";
-
-if (!process.env.REACT_APP_CLERK_PUBLISHABLE_KEY) {
-  throw new Error("Missing Publishable Key")
-}
-const clerkPubKey = process.env.REACT_APP_CLERK_PUBLISHABLE_KEY;
-
-function App() {
-  return (
-    <ClerkProvider 
-      appearance={{
-        baseTheme: [dark, neobrutalism]
-      }} 
-      publishableKey={clerkPubKey}
-    >
-      <div>Hello from clerk</div>
-    </ClerkProvider>
-  );
-}
-
-export default App;
-```
-
-```tsx filename="app/root.tsx" {3,43-45}
-// Import ClerkApp
-import { ClerkApp } from "@clerk/remix";
-import { dark, neobrutalism } from '@clerk/themes';
-import type { MetaFunction,LoaderFunction } from "@remix-run/node";
-
-import {
-  Links,
-  LiveReload,
-  Meta,
-  Outlet,
-  Scripts,
-  ScrollRestoration,
-} from "@remix-run/react";
-
-import { rootAuthLoader } from "@clerk/remix/ssr.server";
-
-export const meta: MetaFunction = () => ({
-  charset: "utf-8",
-  title: "New Remix App",
-  viewport: "width=device-width,initial-scale=1",
-});
-
-export const loader: LoaderFunction = (args) => rootAuthLoader(args);
-
-function App() {
-  return (
-    <html lang="en">
-      <head>
-        <Meta />
-        <Links />
-      </head>
-      <body>
-        <Outlet />
-        <ScrollRestoration />
-        <Scripts />
-        <LiveReload />
-      </body>
-    </html>
-  );
-}
-
-export default ClerkApp(App, {
-  appearance: {
-    baseTheme: [dark, neobrutalism]
-  },
-});
-```
-</CodeBlockTabs>
+  export default ClerkApp(App, {
+    appearance: {
+      baseTheme: [dark, neobrutalism]
+    },
+  });
+  ```
+  </Tab>
+</Tabs>
 
 You can apply a theme to all instances of a Clerk component by passing the component to the `appearance` prop of the `<ClerkProvider />`. The `appearance` prop accepts the name of the Clerk component you want to style as a key.
 
 In the example below, the `neobrutalism` theme is applied to all instances of the [`<SignIn />`](/docs/components/authentication/sign-in) component.
 
-<CodeBlockTabs options={['Next.js App Router', 'Next.js Pages Router', 'React', 'Remix']}>
-```tsx filename="/src/app/layout.tsx" {2,11-14}
-import { ClerkProvider } from '@clerk/nextjs';
-import { dark, neobrutalism } from '@clerk/themes';
+<Tabs type="framework" items={["Next.js", "React", "Remix"]}>
+  <Tab>
+    <CodeBlockTabs type="router" options={["App Router", "Pages Router"]}>
+    ```tsx filename="/src/app/layout.tsx" {2,11-14}
+    import { ClerkProvider } from '@clerk/nextjs';
+    import { dark, neobrutalism } from '@clerk/themes';
 
-export default function RootLayout({
-  children,
-}: {
-  children: React.ReactNode
-}) {
-  return (
-    <ClerkProvider
-      appearance={{
-        baseTheme: dark,
-        signIn: { baseTheme: neobrutalism },
-      }}
-    >
+    export default function RootLayout({
+      children,
+    }: {
+      children: React.ReactNode
+    }) {
+      return (
+        <ClerkProvider
+          appearance={{
+            baseTheme: dark,
+            signIn: { baseTheme: neobrutalism },
+          }}
+        >
+          <html lang="en">
+            <body>{children}</body>
+          </html>
+        </ClerkProvider>
+      )
+    }
+    ```
+
+    ```tsx filename="_app.tsx" {2,8-11}
+    import { ClerkProvider, SignIn } from '@clerk/nextjs';
+    import { dark } from '@clerk/themes';
+    import type { AppProps } from "next/app";
+
+    function MyApp({ Component, pageProps }: AppProps) {
+      return (
+        <ClerkProvider
+          appearance={{
+            baseTheme: dark,
+            signIn: { baseTheme: neobrutalism },
+          }}
+        >
+          <Component {...pageProps}/>
+        </ClerkProvider>
+      )
+    }
+
+    export default MyApp;
+    ```
+    </CodeBlockTabs>
+  </Tab>
+
+  <Tab>
+  ```tsx filename="app.tsx" {3,14-17}
+  import React from "react";
+  import "./App.css";
+  import { dark } from '@clerk/themes';
+  import { ClerkProvider } from "@clerk/clerk-react";
+
+  if (!process.env.REACT_APP_CLERK_PUBLISHABLE_KEY) {
+    throw new Error("Missing Publishable Key")
+  }
+  const clerkPubKey = process.env.REACT_APP_CLERK_PUBLISHABLE_KEY;
+
+  function App() {
+    return (
+      <ClerkProvider 
+        appearance={{
+          baseTheme: dark,
+          signIn: { baseTheme: neobrutalism },
+        }} 
+        publishableKey={clerkPubKey}
+      >
+        <div>Hello from clerk</div>
+      </ClerkProvider>
+    );
+  }
+
+  export default App;
+  ```
+  </Tab>
+
+  <Tab>
+  ```tsx filename="app/root.tsx" {3,43-46}
+  // Import ClerkApp
+  import { ClerkApp } from "@clerk/remix";
+  import { dark } from '@clerk/themes';
+  import type { MetaFunction,LoaderFunction } from "@remix-run/node";
+
+  import {
+    Links,
+    LiveReload,
+    Meta,
+    Outlet,
+    Scripts,
+    ScrollRestoration,
+  } from "@remix-run/react";
+
+  import { rootAuthLoader } from "@clerk/remix/ssr.server";
+
+  export const meta: MetaFunction = () => ({
+    charset: "utf-8",
+    title: "New Remix App",
+    viewport: "width=device-width,initial-scale=1",
+  });
+
+  export const loader: LoaderFunction = (args) => rootAuthLoader(args);
+
+  function App() {
+    return (
       <html lang="en">
-        <body>{children}</body>
+        <head>
+          <Meta />
+          <Links />
+        </head>
+        <body>
+          <Outlet />
+          <ScrollRestoration />
+          <Scripts />
+          <LiveReload />
+        </body>
       </html>
-    </ClerkProvider>
-  )
-}
-```
+    );
+  }
 
-```tsx filename="_app.tsx" {2,8-11}
-import { ClerkProvider, SignIn } from '@clerk/nextjs';
-import { dark } from '@clerk/themes';
-import type { AppProps } from "next/app";
-
-function MyApp({ Component, pageProps }: AppProps) {
-  return (
-    <ClerkProvider
-      appearance={{
-        baseTheme: dark,
-        signIn: { baseTheme: neobrutalism },
-      }}
-    >
-      <Component {...pageProps}/>
-    </ClerkProvider>
-  )
-}
-
-export default MyApp;
-```
-
-```tsx filename="app.tsx" {3,14-17}
-import React from "react";
-import "./App.css";
-import { dark } from '@clerk/themes';
-import { ClerkProvider } from "@clerk/clerk-react";
-
-if (!process.env.REACT_APP_CLERK_PUBLISHABLE_KEY) {
-  throw new Error("Missing Publishable Key")
-}
-const clerkPubKey = process.env.REACT_APP_CLERK_PUBLISHABLE_KEY;
-
-function App() {
-  return (
-    <ClerkProvider 
-      appearance={{
-        baseTheme: dark,
-        signIn: { baseTheme: neobrutalism },
-      }} 
-      publishableKey={clerkPubKey}
-    >
-      <div>Hello from clerk</div>
-    </ClerkProvider>
-  );
-}
-
-export default App;
-```
-
-```tsx filename="app/root.tsx" {3,43-46}
-// Import ClerkApp
-import { ClerkApp } from "@clerk/remix";
-import { dark } from '@clerk/themes';
-import type { MetaFunction,LoaderFunction } from "@remix-run/node";
-
-import {
-  Links,
-  LiveReload,
-  Meta,
-  Outlet,
-  Scripts,
-  ScrollRestoration,
-} from "@remix-run/react";
-
-import { rootAuthLoader } from "@clerk/remix/ssr.server";
-
-export const meta: MetaFunction = () => ({
-  charset: "utf-8",
-  title: "New Remix App",
-  viewport: "width=device-width,initial-scale=1",
-});
-
-export const loader: LoaderFunction = (args) => rootAuthLoader(args);
-
-function App() {
-  return (
-    <html lang="en">
-      <head>
-        <Meta />
-        <Links />
-      </head>
-      <body>
-        <Outlet />
-        <ScrollRestoration />
-        <Scripts />
-        <LiveReload />
-      </body>
-    </html>
-  );
-}
-
-export default ClerkApp(App, {
-  appearance: {
-    baseTheme: dark,
-    signIn: { baseTheme: neobrutalism },
-  },
-});
-```
-</CodeBlockTabs>
+  export default ClerkApp(App, {
+    appearance: {
+      baseTheme: dark,
+      signIn: { baseTheme: neobrutalism },
+    },
+  });
+  ```
+  </Tab>
+</Tabs>
 
 #### Pass a theme to a single Clerk component
 
 To apply a theme to a single Clerk component, pass the `appearance` prop to the component. The `appearance` prop accepts the property `baseTheme`, which can be set to a theme.
 
-<CodeBlockTabs options={['Next.js App Router', 'Next.js Pages Router', 'React', 'Remix']}>
-```tsx filename="/app/sign-in/[[...sign-in]]/page.tsx" {2,6-8}
-import { SignIn } from "@clerk/nextjs";
-import { dark } from "@clerk/themes";
+<Tabs type="framework" items={["Next.js", "React", "Remix"]}>
+  <Tab>
+    <CodeBlockTabs type="router" options={["App Router", "Pages Router"]}>
+    ```tsx filename="/app/sign-in/[[...sign-in]]/page.tsx" {2,6-8}
+    import { SignIn } from "@clerk/nextjs";
+    import { dark } from "@clerk/themes";
 
-export default function Page() {
-  return <SignIn 
-    appearance={{
-      baseTheme: dark
-    }}
-  />;
-}
-```
+    export default function Page() {
+      return <SignIn 
+        appearance={{
+          baseTheme: dark
+        }}
+      />;
+    }
+    ```
 
-```tsx filename="/pages/sign-in/[[...index]].tsx" {2,6-8}
-import { SignIn } from "@clerk/nextjs";
-import { dark } from "@clerk/themes";
- 
-const SignInPage = () => (
-  <SignIn 
-    appearance={{
-      baseTheme: dark
-    }}
-  />
-);
-
-export default SignInPage;
-```
-
-```tsx filename="/src/sign-in/[[...index]].tsx" {2,6-8}
-import { SignIn } from "@clerk/clerk-react";
-import { dark } from "@clerk/themes";
-
-const SignInPage = () => (
-  <SignIn 
-    appearance={{
-      baseTheme: dark
-    }}
-  />
-);
-
-export default SignInPage;
-```
-
-```tsx filename="app/routes/sign-in/$.tsx" {2,9-11}
-import { SignIn } from "@clerk/remix";
-import { dark } from "@clerk/themes";
- 
-export default function SignInPage() {
-  return (
-    <div style={{ border: "2px solid blue", padding: "2rem" }}>
-      <h1>Sign In route</h1>
+    ```tsx filename="/pages/sign-in/[[...index]].tsx" {2,6-8}
+    import { SignIn } from "@clerk/nextjs";
+    import { dark } from "@clerk/themes";
+    
+    const SignInPage = () => (
       <SignIn 
         appearance={{
           baseTheme: dark
         }}
-        routing={"path"} 
-        path={"/sign-in"} 
       />
-    </div>
+    );
+
+    export default SignInPage;
+    ```
+    </CodeBlockTabs>
+  </Tab>
+
+  <Tab>
+  ```tsx filename="/src/sign-in/[[...index]].tsx" {2,6-8}
+  import { SignIn } from "@clerk/clerk-react";
+  import { dark } from "@clerk/themes";
+
+  const SignInPage = () => (
+    <SignIn 
+      appearance={{
+        baseTheme: dark
+      }}
+    />
   );
-}
-```
-</CodeBlockTabs>
+
+  export default SignInPage;
+  ```
+  </Tab>
+
+  <Tab>
+  ```tsx filename="app/routes/sign-in/$.tsx" {2,9-11}
+  import { SignIn } from "@clerk/remix";
+  import { dark } from "@clerk/themes";
+  
+  export default function SignInPage() {
+    return (
+      <div style={{ border: "2px solid blue", padding: "2rem" }}>
+        <h1>Sign In route</h1>
+        <SignIn 
+          appearance={{
+            baseTheme: dark
+          }}
+          routing={"path"} 
+          path={"/sign-in"} 
+        />
+      </div>
+    );
+  }
+  ```
+  </Tab>
+</Tabs>
 
 ## Customize a theme using variables
 
@@ -493,146 +525,154 @@ In the example below, all Clerk components will have the `dark` theme with the `
   For a list of all of the variables you can customize, and for more examples on how to use the `variables` property, see the [Variables](/docs/components/customization/variables) docs.
 </Callout>
 
-<CodeBlockTabs options={['Next.js App Router', 'Next.js Pages Router', 'React', 'Remix']}>
-```tsx filename="/src/app/layout.tsx" {2,11-18}
-import { ClerkProvider } from '@clerk/nextjs';
-import { dark, neobrutalism, shadesOfPurple } from '@clerk/themes';
+<Tabs type="framework" items={["Next.js", "React", "Remix"]}>
+  <Tab>
+    <CodeBlockTabs type="router" options={["App Router", "Pages Router"]}>
+    ```tsx filename="/src/app/layout.tsx" {2,11-18}
+    import { ClerkProvider } from '@clerk/nextjs';
+    import { dark, neobrutalism, shadesOfPurple } from '@clerk/themes';
 
-export default function RootLayout({
-  children,
-}: {
-  children: React.ReactNode
-}) {
-  return (
-    <ClerkProvider
-      appearance={{
-        baseTheme: [dark, neobrutalism],
-        variables: { colorPrimary: 'red' },
-        signIn: { 
-          baseTheme: [shadesOfPurple], 
-          variables: { colorPrimary: 'blue' }
-        }
-      }}
-    >
-      <html lang="en">
-        <body>{children}</body>
-      </html>
-    </ClerkProvider>
-  )
-}
-```
-
-```tsx filename="_app.tsx" {2,8-15}
-import { ClerkProvider } from '@clerk/nextjs';
-import { dark, neobrutalism, shadesOfPurple } from '@clerk/themes';
-import type { AppProps } from "next/app";
-
-function MyApp({ Component, pageProps }: AppProps) {
-  return (
-    <ClerkProvider
-      appearance={{
-        baseTheme: [dark, neobrutalism],
-        variables: { colorPrimary: 'red' },
-        signIn: { 
-          baseTheme: [shadesOfPurple], 
-          variables: { colorPrimary: 'blue' }
-        }
-      }}
-    >
-      <Component {...pageProps}/>
-    </ClerkProvider>
-  )
-}
-
-export default MyApp;
-```
-
-```tsx filename="app.tsx" {3,14-21}
-import React from "react";
-import "./App.css";
-import { dark, neobrutalism, shadesOfPurple } from '@clerk/themes';
-import { ClerkProvider } from "@clerk/clerk-react";
-
-if (!process.env.REACT_APP_CLERK_PUBLISHABLE_KEY) {
-  throw new Error("Missing Publishable Key")
-}
-const clerkPubKey = process.env.REACT_APP_CLERK_PUBLISHABLE_KEY;
-
-function App() {
-  return (
-    <ClerkProvider 
-      appearance={{
-        baseTheme: [dark, neobrutalism],
-        variables: { colorPrimary: 'red' },
-        signIn: { 
-          baseTheme: [shadesOfPurple], 
-          variables: { colorPrimary: 'blue' }
-        }
-      }}
-      publishableKey={clerkPubKey}
-    >
-      <div>Hello from clerk</div>
-    </ClerkProvider>
-  );
-}
-
-export default App;
-```
-
-```tsx filename="app/root.tsx" {3,43-50}
-// Import ClerkApp
-import { ClerkApp } from "@clerk/remix";
-import { dark, neobrutalism, shadesOfPurple } from '@clerk/themes';
-import type { MetaFunction,LoaderFunction } from "@remix-run/node";
-
-import {
-  Links,
-  LiveReload,
-  Meta,
-  Outlet,
-  Scripts,
-  ScrollRestoration,
-} from "@remix-run/react";
-
-import { rootAuthLoader } from "@clerk/remix/ssr.server";
-
-export const meta: MetaFunction = () => ({
-  charset: "utf-8",
-  title: "New Remix App",
-  viewport: "width=device-width,initial-scale=1",
-});
-
-export const loader: LoaderFunction = (args) => rootAuthLoader(args);
-
-function App() {
-  return (
-    <html lang="en">
-      <head>
-        <Meta />
-        <Links />
-      </head>
-      <body>
-        <Outlet />
-        <ScrollRestoration />
-        <Scripts />
-        <LiveReload />
-      </body>
-    </html>
-  );
-}
-
-export default ClerkApp(App, {
-  appearance={{
-    baseTheme: [dark, neobrutalism],
-    variables: { colorPrimary: 'red' },
-    signIn: { 
-      baseTheme: [shadesOfPurple], 
-      variables: { colorPrimary: 'blue' }
+    export default function RootLayout({
+      children,
+    }: {
+      children: React.ReactNode
+    }) {
+      return (
+        <ClerkProvider
+          appearance={{
+            baseTheme: [dark, neobrutalism],
+            variables: { colorPrimary: 'red' },
+            signIn: { 
+              baseTheme: [shadesOfPurple], 
+              variables: { colorPrimary: 'blue' }
+            }
+          }}
+        >
+          <html lang="en">
+            <body>{children}</body>
+          </html>
+        </ClerkProvider>
+      )
     }
-  }}
-});
-```
-</CodeBlockTabs>
+    ```
+
+    ```tsx filename="_app.tsx" {2,8-15}
+    import { ClerkProvider } from '@clerk/nextjs';
+    import { dark, neobrutalism, shadesOfPurple } from '@clerk/themes';
+    import type { AppProps } from "next/app";
+
+    function MyApp({ Component, pageProps }: AppProps) {
+      return (
+        <ClerkProvider
+          appearance={{
+            baseTheme: [dark, neobrutalism],
+            variables: { colorPrimary: 'red' },
+            signIn: { 
+              baseTheme: [shadesOfPurple], 
+              variables: { colorPrimary: 'blue' }
+            }
+          }}
+        >
+          <Component {...pageProps}/>
+        </ClerkProvider>
+      )
+    }
+
+    export default MyApp;
+    ```
+    </CodeBlockTabs>
+  </Tab>
+
+  <Tab>
+  ```tsx filename="app.tsx" {3,14-21}
+  import React from "react";
+  import "./App.css";
+  import { dark, neobrutalism, shadesOfPurple } from '@clerk/themes';
+  import { ClerkProvider } from "@clerk/clerk-react";
+
+  if (!process.env.REACT_APP_CLERK_PUBLISHABLE_KEY) {
+    throw new Error("Missing Publishable Key")
+  }
+  const clerkPubKey = process.env.REACT_APP_CLERK_PUBLISHABLE_KEY;
+
+  function App() {
+    return (
+      <ClerkProvider 
+        appearance={{
+          baseTheme: [dark, neobrutalism],
+          variables: { colorPrimary: 'red' },
+          signIn: { 
+            baseTheme: [shadesOfPurple], 
+            variables: { colorPrimary: 'blue' }
+          }
+        }}
+        publishableKey={clerkPubKey}
+      >
+        <div>Hello from clerk</div>
+      </ClerkProvider>
+    );
+  }
+
+  export default App;
+  ```
+  </Tab>
+
+  <Tab>
+  ```tsx filename="app/root.tsx" {3,43-50}
+  // Import ClerkApp
+  import { ClerkApp } from "@clerk/remix";
+  import { dark, neobrutalism, shadesOfPurple } from '@clerk/themes';
+  import type { MetaFunction,LoaderFunction } from "@remix-run/node";
+
+  import {
+    Links,
+    LiveReload,
+    Meta,
+    Outlet,
+    Scripts,
+    ScrollRestoration,
+  } from "@remix-run/react";
+
+  import { rootAuthLoader } from "@clerk/remix/ssr.server";
+
+  export const meta: MetaFunction = () => ({
+    charset: "utf-8",
+    title: "New Remix App",
+    viewport: "width=device-width,initial-scale=1",
+  });
+
+  export const loader: LoaderFunction = (args) => rootAuthLoader(args);
+
+  function App() {
+    return (
+      <html lang="en">
+        <head>
+          <Meta />
+          <Links />
+        </head>
+        <body>
+          <Outlet />
+          <ScrollRestoration />
+          <Scripts />
+          <LiveReload />
+        </body>
+      </html>
+    );
+  }
+
+  export default ClerkApp(App, {
+    appearance={{
+      baseTheme: [dark, neobrutalism],
+      variables: { colorPrimary: 'red' },
+      signIn: { 
+        baseTheme: [shadesOfPurple], 
+        variables: { colorPrimary: 'blue' }
+      }
+    }}
+  });
+  ```
+  </Tab>
+</Tabs>
 
 ## Create a custom theme
 
@@ -640,11 +680,11 @@ You can make a custom theme for your app's Clerk component by customizing the st
 
 This can be done with one of three different methods of styling:
 
-1.  [Using global CSS styling](#global-css)
-2.  [Passing custom CSS classes](#using-custom-css-classes)
-    *   [Using Tailwind](#using-tailwind)
-    *   [Using CSS Modules](#using-css-modules)
-3.  [Passing inline CSS to your Clerk options](#inline-css-objects)
+1. [Using global CSS styling](#global-css)
+2. [Passing custom CSS classes](#using-custom-css-classes)
+  * [Using Tailwind](#using-tailwind)
+  * [Using CSS Modules](#using-css-modules)
+3. [Passing inline CSS to your Clerk options](#inline-css-objects)
 
 No matter which method you choose, you'll need to know how to identify the element you want to style.
 

--- a/docs/components/customization/themes.mdx
+++ b/docs/components/customization/themes.mdx
@@ -16,7 +16,7 @@ Clerk currently offers four pre-built themes that can be exported from `@clerk/t
 
 To get started, install the `@clerk/themes` package.
 
-<CodeBlockTabs options={["npm", "yarn", "pnpm"]}>
+<CodeBlockTabs type="installer" options={["npm", "yarn", "pnpm"]}>
   ```bash filename="terminal"
   npm install @clerk/themes
   ```

--- a/docs/components/customization/user-profile.mdx
+++ b/docs/components/customization/user-profile.mdx
@@ -15,11 +15,11 @@ To add a custom page to the [`<UserProfile />`][userprofile-ref] component, use 
 
 ### Usage
 
-<Tabs items={['Next.js', 'React', 'Remix']}>
+<Tabs type="framework" items={["Next.js", "React", "Remix"]}>
   <Tab>
     `<UserProfile.Page />` can be rendered **only on the client**. For Next.js applications using App Router, the `"use client";` directive must be added.
 
-    <CodeBlockTabs options={["App Router", "Pages Router"]}>
+    <CodeBlockTabs type="router" options={["App Router", "Pages Router"]}>
       ```jsx filename="/app/user-profile/[[...user-profile]]/page.tsx"
       "use client";
 
@@ -122,11 +122,11 @@ You can add external links to the [`<UserProfile />`][userprofile-ref] navigatio
 
 ### Usage
 
-<Tabs items={['Next.js', 'React', 'Remix']}>
+<Tabs type="framework" items={["Next.js", "React", "Remix"]}>
   <Tab>
     `<UserProfile.Link />` can be rendered **only on the client**. For Next.js applications using App Router, the `"use client";` directive must be added.
 
-    <CodeBlockTabs options={["App Router", "Pages Router"]}>
+    <CodeBlockTabs type="router" options={["App Router", "Pages Router"]}>
       ```jsx filename="/app/user-profile/[[...user-profile]]/page.tsx"
       "use client";
 
@@ -208,11 +208,11 @@ If you want to reorder the default routes (`Account` and `Security`) in the `Use
 
 ### Usage
 
-<Tabs items={['Next.js', 'React', 'Remix']}>
+<Tabs type="framework" items={["Next.js", "React", "Remix"]}>
   <Tab>
     `<UserProfile.Page />` and `<UserProfile.Link />` can be rendered **only on the client**. For Next.js applications using App Router, the `"use client";` directive must be added.
 
-    <CodeBlockTabs options={["App Router", "Pages Router"]}>
+    <CodeBlockTabs type="router" options={["App Router", "Pages Router"]}>
       ```jsx filename="/app/user-profile/[[...user-profile]]/page.tsx"
       "use client";
 
@@ -313,11 +313,11 @@ If you are using the `<UserButton />` component with the default props (where th
 
 ### Usage
 
-<Tabs items={['Next.js', 'React', 'Remix']}>
+<Tabs type="framework" items={["Next.js", "React", "Remix"]}>
   <Tab>
     `<UserButton.UserProfilePage />` and `<UserButton.UserProfileLink />` can be rendered **only on the client**. For Next.js applications using App Router, the `"use client";` directive must be added.
 
-    <CodeBlockTabs options={["App Router", "Pages Router"]}>
+    <CodeBlockTabs type="router" options={["App Router", "Pages Router"]}>
       ```jsx filename="/app/components/Header.tsx"
       "use client";
 

--- a/docs/components/customization/variables.mdx
+++ b/docs/components/customization/variables.mdx
@@ -17,338 +17,318 @@ To customize all Clerk components, pass the `variables` property to the `appeara
 
 In the example below, the primary color is set to red and the text color is set to white. Because these styles are applied to the `<ClerkProvider />`, which wraps the entire application, these styles will be applied to all Clerk components that use the primary color and text color.
 
-<CodeBlockTabs options={["Next.js App Router", "Next.js Pages Router", "React", "Remix"]}>
-```tsx filename="/src/app/layout.tsx" {10-15}
-import { ClerkProvider } from '@clerk/nextjs';
+<Tabs type="framework" items={["Next.js", "React", "Remix"]}>
+  <Tab>
+    <CodeBlockTabs type="router" options={["App Router", "Pages Router"]}>
+    ```tsx filename="/src/app/layout.tsx" {10-15}
+    import { ClerkProvider } from '@clerk/nextjs';
 
-export default function RootLayout({
-  children,
-}: {
-  children: React.ReactNode
-}) {
-  return (
-    <ClerkProvider
-      appearance={{
-        variables: {
-          colorPrimary: "red",
-          colorText: "white"
-        }
-      }}
-    >
-      <html lang="en">
-        <body>{children}</body>
-      </html>
-    </ClerkProvider>
-  )
-}
-```
-
-```tsx filename="_app.tsx" {7-12}
-import { ClerkProvider } from '@clerk/nextjs';
-import type { AppProps } from "next/app";
-
-function MyApp({ Component, pageProps }: AppProps) {
-  return (
-    <ClerkProvider
-      appearance={{
-        variables: {
-          colorPrimary: "red",
-          colorText: "white"
-        }
-      }}
-    >
-      <Component {...pageProps}/>
-    </ClerkProvider>
-  )
-}
-
-export default MyApp;
-```
-
-```tsx filename="app.tsx" {13-18}
-import React from "react";
-import "./App.css";
-import { ClerkProvider } from "@clerk/clerk-react";
-
-if (!process.env.REACT_APP_CLERK_PUBLISHABLE_KEY) {
-  throw new Error("Missing Publishable Key")
-}
-const clerkPubKey = process.env.REACT_APP_CLERK_PUBLISHABLE_KEY;
-
-function App() {
-  return (
-    <ClerkProvider 
-      appearance={{
-        variables: {
-          colorPrimary: "red",
-          colorText: "white"
-        }
-      }} 
-      publishableKey={clerkPubKey}
-    >
-      <div>Hello from clerk</div>
-    </ClerkProvider>
-  );
-}
-
-export default App;
-```
-
-```tsx filename="app/root.tsx" {42-47}
-// Import ClerkApp
-import { ClerkApp } from "@clerk/remix";
-import type { MetaFunction,LoaderFunction } from "@remix-run/node";
-
-import {
-  Links,
-  LiveReload,
-  Meta,
-  Outlet,
-  Scripts,
-  ScrollRestoration,
-} from "@remix-run/react";
-
-import { rootAuthLoader } from "@clerk/remix/ssr.server";
-
-export const meta: MetaFunction = () => ({
-  charset: "utf-8",
-  title: "New Remix App",
-  viewport: "width=device-width,initial-scale=1",
-});
-
-export const loader: LoaderFunction = (args) => rootAuthLoader(args);
-
-function App() {
-  return (
-    <html lang="en">
-      <head>
-        <Meta />
-        <Links />
-      </head>
-      <body>
-        <Outlet />
-        <ScrollRestoration />
-        <Scripts />
-        <LiveReload />
-      </body>
-    </html>
-  );
-}
-
-export default ClerkApp(App, {
-  appearance: {
-    variables: {
-      colorPrimary: "red",
-      colorText: "white"
+    export default function RootLayout({
+      children,
+    }: {
+      children: React.ReactNode
+    }) {
+      return (
+        <ClerkProvider
+          appearance={{
+            variables: {
+              colorPrimary: "red",
+              colorText: "white"
+            }
+          }}
+        >
+          <html lang="en">
+            <body>{children}</body>
+          </html>
+        </ClerkProvider>
+      )
     }
-  },
-});
-```
-</CodeBlockTabs>
+    ```
+
+    ```tsx filename="_app.tsx" {7-12}
+    import { ClerkProvider } from '@clerk/nextjs';
+    import type { AppProps } from "next/app";
+
+    function MyApp({ Component, pageProps }: AppProps) {
+      return (
+        <ClerkProvider
+          appearance={{
+            variables: {
+              colorPrimary: "red",
+              colorText: "white"
+            }
+          }}
+        >
+          <Component {...pageProps}/>
+        </ClerkProvider>
+      )
+    }
+
+    export default MyApp;
+    ```
+    </CodeBlockTabs>
+  </Tab>
+
+  <Tab>
+  ```tsx filename="app.tsx" {13-18}
+  import React from "react";
+  import "./App.css";
+  import { ClerkProvider } from "@clerk/clerk-react";
+
+  if (!process.env.REACT_APP_CLERK_PUBLISHABLE_KEY) {
+    throw new Error("Missing Publishable Key")
+  }
+  const clerkPubKey = process.env.REACT_APP_CLERK_PUBLISHABLE_KEY;
+
+  function App() {
+    return (
+      <ClerkProvider 
+        appearance={{
+          variables: {
+            colorPrimary: "red",
+            colorText: "white"
+          }
+        }} 
+        publishableKey={clerkPubKey}
+      >
+        <div>Hello from clerk</div>
+      </ClerkProvider>
+    );
+  }
+
+  export default App;
+  ```
+  </Tab>
+
+  <Tab>
+  ```tsx filename="app/root.tsx" {42-47}
+  // Import ClerkApp
+  import { ClerkApp } from "@clerk/remix";
+  import type { MetaFunction,LoaderFunction } from "@remix-run/node";
+
+  import {
+    Links,
+    LiveReload,
+    Meta,
+    Outlet,
+    Scripts,
+    ScrollRestoration,
+  } from "@remix-run/react";
+
+  import { rootAuthLoader } from "@clerk/remix/ssr.server";
+
+  export const meta: MetaFunction = () => ({
+    charset: "utf-8",
+    title: "New Remix App",
+    viewport: "width=device-width,initial-scale=1",
+  });
+
+  export const loader: LoaderFunction = (args) => rootAuthLoader(args);
+
+  function App() {
+    return (
+      <html lang="en">
+        <head>
+          <Meta />
+          <Links />
+        </head>
+        <body>
+          <Outlet />
+          <ScrollRestoration />
+          <Scripts />
+          <LiveReload />
+        </body>
+      </html>
+    );
+  }
+
+  export default ClerkApp(App, {
+    appearance: {
+      variables: {
+        colorPrimary: "red",
+        colorText: "white"
+      }
+    },
+  });
+  ```
+  </Tab>
+</Tabs>
 
 You can customize all instances of a Clerk component by passing the component to the `appearance` prop of the `<ClerkProvider />`. The `appearance` prop accepts the name of the Clerk component you want to style as a key. 
 
 In the example below, the primary color is set to red and the text color is set to white for all instances of the [`<SignIn />`](/docs/components/authentication/sign-in) component. 
 
-<CodeBlockTabs options={['Next.js App Router', 'Next.js Pages Router', 'React', 'Remix']}>
-```tsx filename="/src/app/layout.tsx" {10-17}
-import { ClerkProvider } from '@clerk/nextjs';
+<Tabs type="framework" items={["Next.js", "React", "Remix"]}>
+  <Tab>
+    <CodeBlockTabs type="router" options={["App Router", "Pages Router"]}>
+    ```tsx filename="/src/app/layout.tsx" {10-17}
+    import { ClerkProvider } from '@clerk/nextjs';
 
-export default function RootLayout({
-  children,
-}: {
-  children: React.ReactNode
-}) {
-  return (
-    <ClerkProvider
-      appearance={{
-        signIn: { 
-          variables: {
-            colorPrimary: "red",
-            colorText: "white"
-          } 
-        },
-      }}
-    >
+    export default function RootLayout({
+      children,
+    }: {
+      children: React.ReactNode
+    }) {
+      return (
+        <ClerkProvider
+          appearance={{
+            signIn: { 
+              variables: {
+                colorPrimary: "red",
+                colorText: "white"
+              } 
+            },
+          }}
+        >
+          <html lang="en">
+            <body>{children}</body>
+          </html>
+        </ClerkProvider>
+      )
+    }
+    ```
+
+    ```tsx filename="_app.tsx" {7-14}
+    import { ClerkProvider } from "@clerk/nextjs";
+    import type { AppProps } from "next/app";
+
+    function MyApp({ Component, pageProps }: AppProps) {
+      return (
+        <ClerkProvider
+          appearance={{
+            signIn: { 
+              variables: {
+                colorPrimary: "red",
+                colorText: "white"
+              } 
+            },
+          }}
+        >
+          <Component {...pageProps} />
+        </ClerkProvider>
+      );
+    }
+
+    export default MyApp;
+    ```
+    </CodeBlockTabs>
+  </Tab>
+
+  <Tab>
+  ```tsx filename="app.tsx" {13-20}
+  import React from "react";
+  import "./App.css";
+  import { ClerkProvider } from "@clerk/clerk-react";
+
+  if (!process.env.REACT_APP_CLERK_PUBLISHABLE_KEY) {
+    throw new Error("Missing Publishable Key")
+  }
+  const clerkPubKey = process.env.REACT_APP_CLERK_PUBLISHABLE_KEY;
+
+  function App() {
+    return (
+      <ClerkProvider 
+        appearance={{
+          signIn: { 
+            variables: {
+              colorPrimary: "red",
+              colorText: "white"
+            } 
+          },
+        }}
+        publishableKey={clerkPubKey}
+      >
+        <div>Hello from clerk</div>
+      </ClerkProvider>
+    );
+  }
+
+  export default App;
+  ```
+  </Tab>
+
+  <Tab>
+  ```tsx filename="app/root.tsx" {42-49}
+  // Import ClerkApp
+  import { ClerkApp } from "@clerk/remix";
+  import type { MetaFunction,LoaderFunction } from "@remix-run/node";
+
+  import {
+    Links,
+    LiveReload,
+    Meta,
+    Outlet,
+    Scripts,
+    ScrollRestoration,
+  } from "@remix-run/react";
+
+  import { rootAuthLoader } from "@clerk/remix/ssr.server";
+
+  export const meta: MetaFunction = () => ({
+    charset: "utf-8",
+    title: "New Remix App",
+    viewport: "width=device-width,initial-scale=1",
+  });
+
+  export const loader: LoaderFunction = (args) => rootAuthLoader(args);
+
+  function App() {
+    return (
       <html lang="en">
-        <body>{children}</body>
+        <head>
+          <Meta />
+          <Links />
+        </head>
+        <body>
+          <Outlet />
+          <ScrollRestoration />
+          <Scripts />
+          <LiveReload />
+        </body>
       </html>
-    </ClerkProvider>
-  )
-}
-```
+    );
+  }
 
-```tsx filename="_app.tsx" {7-14}
-import { ClerkProvider } from "@clerk/nextjs";
-import type { AppProps } from "next/app";
-
-function MyApp({ Component, pageProps }: AppProps) {
-  return (
-    <ClerkProvider
-      appearance={{
-        signIn: { 
-          variables: {
-            colorPrimary: "red",
-            colorText: "white"
-          } 
-        },
-      }}
-    >
-      <Component {...pageProps} />
-    </ClerkProvider>
-  );
-}
-
-export default MyApp;
-
-```
-
-```tsx filename="app.tsx" {13-20}
-import React from "react";
-import "./App.css";
-import { ClerkProvider } from "@clerk/clerk-react";
-
-if (!process.env.REACT_APP_CLERK_PUBLISHABLE_KEY) {
-  throw new Error("Missing Publishable Key")
-}
-const clerkPubKey = process.env.REACT_APP_CLERK_PUBLISHABLE_KEY;
-
-function App() {
-  return (
-    <ClerkProvider 
-      appearance={{
-        signIn: { 
-          variables: {
-            colorPrimary: "red",
-            colorText: "white"
-          } 
-        },
-      }}
-      publishableKey={clerkPubKey}
-    >
-      <div>Hello from clerk</div>
-    </ClerkProvider>
-  );
-}
-
-export default App;
-```
-
-```tsx filename="app/root.tsx" {42-49}
-// Import ClerkApp
-import { ClerkApp } from "@clerk/remix";
-import type { MetaFunction,LoaderFunction } from "@remix-run/node";
-
-import {
-  Links,
-  LiveReload,
-  Meta,
-  Outlet,
-  Scripts,
-  ScrollRestoration,
-} from "@remix-run/react";
-
-import { rootAuthLoader } from "@clerk/remix/ssr.server";
-
-export const meta: MetaFunction = () => ({
-  charset: "utf-8",
-  title: "New Remix App",
-  viewport: "width=device-width,initial-scale=1",
-});
-
-export const loader: LoaderFunction = (args) => rootAuthLoader(args);
-
-function App() {
-  return (
-    <html lang="en">
-      <head>
-        <Meta />
-        <Links />
-      </head>
-      <body>
-        <Outlet />
-        <ScrollRestoration />
-        <Scripts />
-        <LiveReload />
-      </body>
-    </html>
-  );
-}
-
-export default ClerkApp(App, {
-  appearance: {
-    signIn: { 
-      variables: {
-        colorPrimary: "red",
-        colorText: "white"
-      } 
+  export default ClerkApp(App, {
+    appearance: {
+      signIn: { 
+        variables: {
+          colorPrimary: "red",
+          colorText: "white"
+        } 
+      },
     },
-  },
-});
-```
-</CodeBlockTabs>
+  });
+  ```
+  </Tab>
+</Tabs>
 
 ### Pass `variables` to a single component
 
 To customize a single Clerk component, pass the `variables` property to the `appearance` prop to the Clerk component.
 
-<CodeBlockTabs options={['Next.js App Router', 'Next.js Pages Router', 'React', 'Remix']}>
-```tsx filename="/app/sign-in/[[...sign-in]]/page.tsx" {5-10}
-import { SignIn } from "@clerk/nextjs";
+<Tabs type="framework" items={["Next.js", "React", "Remix"]}>
+  <Tab>
+    <CodeBlockTabs type="router" options={["App Router", "Pages Router"]}>
+    ```tsx filename="/app/sign-in/[[...sign-in]]/page.tsx" {5-10}
+    import { SignIn } from "@clerk/nextjs";
 
-export default function Page() {
-  return <SignIn 
-    appearance={{
-      variables: {
-        colorPrimary: "red",
-        colorText: "white"
-      }
-    }}
-  />;
-}
-```
+    export default function Page() {
+      return <SignIn 
+        appearance={{
+          variables: {
+            colorPrimary: "red",
+            colorText: "white"
+          }
+        }}
+      />;
+    }
+    ```
 
-```tsx filename="/pages/sign-in/[[...index]].tsx" {5-10}
-import { SignIn } from "@clerk/nextjs";
- 
-const SignInPage = () => (
-  <SignIn 
-    appearance={{
-      variables: {
-        colorPrimary: "red",
-        colorText: "white"
-      }
-    }}
-  />
-);
-
-export default SignInPage;
-```
-
-```tsx filename="/src/sign-in/[[...index]].tsx" {5-10}
-import { SignIn } from "@clerk/clerk-react";
-
-const SignInPage = () => (
-  <SignIn 
-    appearance={{
-      variables: {
-        colorPrimary: "red",
-        colorText: "white"
-      }
-    }}
-  />
-);
-
-export default SignInPage;
-```
-
-```tsx filename="app/routes/sign-in/$.tsx" {8-13}
-import { SignIn } from "@clerk/remix";
- 
-export default function SignInPage() {
-  return (
-    <div style={{ border: "2px solid blue", padding: "2rem" }}>
-      <h1>Sign In route</h1>
+    ```tsx filename="/pages/sign-in/[[...index]].tsx" {5-10}
+    import { SignIn } from "@clerk/nextjs";
+    
+    const SignInPage = () => (
       <SignIn 
         appearance={{
           variables: {
@@ -356,14 +336,57 @@ export default function SignInPage() {
             colorText: "white"
           }
         }}
-        routing={"path"} 
-        path={"/sign-in"} 
       />
-    </div>
+    );
+
+    export default SignInPage;
+    ```
+    </CodeBlockTabs>
+  </Tab>
+
+  <Tab>
+  ```tsx filename="/src/sign-in/[[...index]].tsx" {5-10}
+  import { SignIn } from "@clerk/clerk-react";
+
+  const SignInPage = () => (
+    <SignIn 
+      appearance={{
+        variables: {
+          colorPrimary: "red",
+          colorText: "white"
+        }
+      }}
+    />
   );
-}
-```
-</CodeBlockTabs>
+
+  export default SignInPage;
+  ```
+  </Tab>
+
+  <Tab>
+  ```tsx filename="app/routes/sign-in/$.tsx" {8-13}
+  import { SignIn } from "@clerk/remix";
+  
+  export default function SignInPage() {
+    return (
+      <div style={{ border: "2px solid blue", padding: "2rem" }}>
+        <h1>Sign In route</h1>
+        <SignIn 
+          appearance={{
+            variables: {
+              colorPrimary: "red",
+              colorText: "white"
+            }
+          }}
+          routing={"path"} 
+          path={"/sign-in"} 
+        />
+      </div>
+    );
+  }
+  ```
+  </Tab>
+</Tabs>
 
 ## Properties
 

--- a/docs/components/organization/create-organization.mdx
+++ b/docs/components/organization/create-organization.mdx
@@ -16,9 +16,9 @@ The `<CreateOrganization />` component is used to render an organization creatio
 
 ## Usage
 
-<Tabs items={['Next.js', 'React', 'Remix']}>
+<Tabs type="framework" items={["Next.js", "React", "Remix"]}>
   <Tab>
-    <CodeBlockTabs options={["App Router", "Pages Router"]}>
+    <CodeBlockTabs type="router" options={["App Router", "Pages Router"]}>
       ```jsx filename="/app/create-organization/[[...create-organization]]/page.[jsx/tsx]"
       import { CreateOrganization } from "@clerk/nextjs";
 

--- a/docs/components/organization/organization-list.mdx
+++ b/docs/components/organization/organization-list.mdx
@@ -16,63 +16,71 @@ The `<OrganizationList />` component is used to display organization related mem
 
 ## Usage
 
-<CodeBlockTabs options={["Next.js App Router", "Next.js Pages Router", "React", "Remix"]}>
-```jsx copy filename="/app/discover/page.[jsx/tsx]"
-import { OrganizationList } from "@clerk/nextjs";
+<Tabs type="framework" items={["Next.js", "React", "Remix"]}>
+  <Tab>
+    <CodeBlockTabs type="router" options={["App Router", "Pages Router"]}>
+    ```jsx copy filename="/app/discover/page.[jsx/tsx]"
+    import { OrganizationList } from "@clerk/nextjs";
 
-export default function OrganizationListPage() {
-  return (
-      <OrganizationList
-          afterCreateOrganizationUrl='/organization/:slug'
-          afterSelectPersonalUrl='/user/:id'
-          afterSelectOrganizationUrl='/organization/:slug'
-      />
-  );
-}
-```
+    export default function OrganizationListPage() {
+      return (
+          <OrganizationList
+              afterCreateOrganizationUrl='/organization/:slug'
+              afterSelectPersonalUrl='/user/:id'
+              afterSelectOrganizationUrl='/organization/:slug'
+          />
+      );
+    }
+    ```
 
-```jsx copy filename="/pages/discover.[jsx/tsx]"
-import { OrganizationList } from "@clerk/nextjs";
+    ```jsx copy filename="/pages/discover.[jsx/tsx]"
+    import { OrganizationList } from "@clerk/nextjs";
 
-export default function OrganizationListPage() {
-  return (
-      <OrganizationList
-          afterCreateOrganizationUrl={org => `/organization/${org.slug}`}
-          afterSelectPersonalUrl={user => `/user/${user.id}`}
-          afterSelectOrganizationUrl={org => `/organization/${org.slug}`}
-      />
-  );
-}
-```
+    export default function OrganizationListPage() {
+      return (
+          <OrganizationList
+              afterCreateOrganizationUrl={org => `/organization/${org.slug}`}
+              afterSelectPersonalUrl={user => `/user/${user.id}`}
+              afterSelectOrganizationUrl={org => `/organization/${org.slug}`}
+          />
+      );
+    }
+    ```
+    </CodeBlockTabs>
+  </Tab>
 
-```jsx copy filename="discover.tsx"
-import { OrganizationList } from "@clerk/clerk-react";
+  <Tab>
+  ```jsx copy filename="discover.tsx"
+  import { OrganizationList } from "@clerk/clerk-react";
 
-export default function OrganizationListPage() {
-  return (
-      <OrganizationList
-          afterCreateOrganizationUrl={org => `/organization/${org.slug}`}
-          afterSelectPersonalUrl={user => `/user/${user.id}`}
-          afterSelectOrganizationUrl={org => `/organization/${org.slug}`}
-      />
-  );
-}
-```
+  export default function OrganizationListPage() {
+    return (
+        <OrganizationList
+            afterCreateOrganizationUrl={org => `/organization/${org.slug}`}
+            afterSelectPersonalUrl={user => `/user/${user.id}`}
+            afterSelectOrganizationUrl={org => `/organization/${org.slug}`}
+        />
+    );
+  }
+  ```
+  </Tab>
 
-```jsx copy filename="/route/discover.tsx"
-import { OrganizationList } from "@clerk/remix";
+  <Tab>
+  ```jsx copy filename="/route/discover.tsx"
+  import { OrganizationList } from "@clerk/remix";
 
-export default function OrganizationListPage() {
-  return (
-      <OrganizationList
-          afterCreateOrganizationUrl={org => `/organization/${org.slug}`}
-          afterSelectPersonalUrl={user => `/user/${user.id}`}
-          afterSelectOrganizationUrl={org => `/organization/${org.slug}`}
-      />
-  );
-}
-```
-</CodeBlockTabs>
+  export default function OrganizationListPage() {
+    return (
+        <OrganizationList
+            afterCreateOrganizationUrl={org => `/organization/${org.slug}`}
+            afterSelectPersonalUrl={user => `/user/${user.id}`}
+            afterSelectOrganizationUrl={org => `/organization/${org.slug}`}
+        />
+    );
+  }
+  ```
+  </Tab>
+</Tabs>
 
 ### Force Organizations
 

--- a/docs/components/organization/organization-profile.mdx
+++ b/docs/components/organization/organization-profile.mdx
@@ -16,11 +16,11 @@ The `<OrganizationProfile />` component is used to render a beautiful, full-feat
 
 ## Usage
 
-<Tabs items={['Next.js', 'React', 'Remix']}>
+<Tabs type="framework" items={["Next.js", "React", "Remix"]}>
   <Tab>
     You can embed the `<OrganizationProfile />` component using the [Next.js optional catch-all route](https://nextjs.org/docs/pages/building-your-application/routing/dynamic-routes#optional-catch-all-routes). This allows you to redirect the user inside your application.
   
-    <CodeBlockTabs options={["App Router", "Pages Router"]}>
+    <CodeBlockTabs type="router" options={["App Router", "Pages Router"]}>
       ```jsx filename="/app/organization-profile/[[...organization-profile]]/page.[jsx/tsx]"
       import { OrganizationProfile } from "@clerk/nextjs";
 

--- a/docs/components/organization/organization-switcher.mdx
+++ b/docs/components/organization/organization-switcher.mdx
@@ -16,9 +16,9 @@ The [`<OrganizationSwitcher />`][orgswitcher-ref] component is used to enable th
 
 ## Usage
 
-<Tabs items={['Next.js', 'React', 'Remix']}>
+<Tabs items={["Next.js", "React", "Remix"]}>
   <Tab>
-    <CodeBlockTabs options={["App Router", "Pages Router"]}>
+    <CodeBlockTabs type="router" options={["App Router", "Pages Router"]}>
       ```jsx filename="/app/organization-switcher/[[...organization-switcher]]/page.[jsx/tsx]"
       import { OrganizationSwitcher } from "@clerk/nextjs";
 

--- a/docs/components/unstyled/sign-in-button.mdx
+++ b/docs/components/unstyled/sign-in-button.mdx
@@ -11,7 +11,7 @@ The `<SignInButton />` component is a button that links to the sign-in page or d
 
 #### Basic usage
 
-<CodeBlockTabs options={['Next.js', 'React', 'Remix', 'Gatsby']}>
+<CodeBlockTabs type="framework" options={["Next.js", "React", "Remix", "Gatsby"]}>
   ```jsx filename="pages/index.js"
   import { SignInButton } from "@clerk/nextjs";
 
@@ -69,7 +69,7 @@ The `<SignInButton />` component is a button that links to the sign-in page or d
 
 In some cases you will want to use your own button, or button text. You can do that by wrapping your button up.
 
-<CodeBlockTabs options={['Next.js', 'React', 'Remix', 'Gatsby']}>
+<CodeBlockTabs type="framework" options={["Next.js", "React", "Remix", "Gatsby"]}>
   ```jsx filename="pages/index.js"
   import { SignInButton } from "@clerk/nextjs";
 

--- a/docs/components/unstyled/sign-in-with-metamask.mdx
+++ b/docs/components/unstyled/sign-in-with-metamask.mdx
@@ -11,7 +11,7 @@ The `<SignInWithMetamaskButton />` component is used to complete a one-click, cr
 
 #### Basic usage
 
-<CodeBlockTabs options={['Next.js', 'React', 'Remix', 'Gatsby']}>
+<CodeBlockTabs type="framework" options={["Next.js", "React", "Remix", "Gatsby"]}>
   ```jsx filename="pages/index.js"
   import { SignInWithMetamaskButton } from "@clerk/nextjs";
 
@@ -69,7 +69,7 @@ The `<SignInWithMetamaskButton />` component is used to complete a one-click, cr
 
 In some cases you will want to use your own button, or button text. You can do that by wrapping your button up.
 
-<CodeBlockTabs options={['Next.js', 'React', 'Remix', 'Gatsby']}>
+<CodeBlockTabs type="framework" options={["Next.js", "React", "Remix", "Gatsby"]}>
   ```jsx filename="pages/index.js"
   import { SignInWithMetamaskButton } from "@clerk/nextjs";
 

--- a/docs/components/unstyled/sign-out-button.mdx
+++ b/docs/components/unstyled/sign-out-button.mdx
@@ -13,9 +13,9 @@ The `<SignOutButton />` component is a button that signs a user out. By default,
 
 The example below shows how to use the `<SignOutButton />` component. 
 
-<Tabs items={['Next.js', 'React', 'Remix', 'Gatsby']}>
+<Tabs type="framework" items={["Next.js", "React", "Remix", "Gatsby"]}>
   <Tab>
-    <CodeBlockTabs options={["App Router", "Pages Router"]}>
+    <CodeBlockTabs type="router" options={["App Router", "Pages Router"]}>
       ```jsx filename="app/page.js"
       import { SignOutButton } from "@clerk/nextjs";
 
@@ -94,9 +94,9 @@ The example below shows how to use the `<SignOutButton />` component.
 
 You can create a custom button by wrapping your own button, or button text, in the `<SignOutButton />` component.
 
-<Tabs items={['Next.js', 'React', 'Remix', 'Gatsby']}>
+<Tabs type="framework" items={["Next.js", "React", "Remix", "Gatsby"]}>
   <Tab>
-    <CodeBlockTabs options={["App Router", "Pages Router"]}>
+    <CodeBlockTabs type="router" options={["App Router", "Pages Router"]}>
       ```jsx filename="app/page.js"
       import { SignOutButton } from "@clerk/nextjs";
 
@@ -189,9 +189,9 @@ You can sign out of a specific session by passing in a `sessionId` to the `signO
 
 In the example below, the `sessionId` is retrieved from the [`useAuth()`](/docs/references/react/use-auth) hook.
 
-<Tabs items={['Next.js', 'React', 'Remix', 'Gatsby']}>
+<Tabs type="framework" items={["Next.js", "React", "Remix", "Gatsby"]}>
   <Tab>
-    <CodeBlockTabs options={["App Router", "Pages Router"]}>
+    <CodeBlockTabs type="router" options={["App Router", "Pages Router"]}>
       ```tsx filename="app/page.tsx"
       "use client"
       
@@ -329,9 +329,9 @@ You can sign out of all currently active sessions by passing a callback that ret
 
 In the example below, the `signOut()` method is retrieved from the [`useClerk()`](/docs/references/react/use-clerk) hook.
 
-<Tabs items={['Next.js', 'React', 'Remix', 'Gatsby']}>
+<Tabs type="framework" items={["Next.js", "React", "Remix", "Gatsby"]}>
   <Tab>
-    <CodeBlockTabs options={["App Router", "Pages Router"]}>
+    <CodeBlockTabs type="router" options={["App Router", "Pages Router"]}>
       ```tsx filename="app/page.tsx"
       "use client";
 

--- a/docs/components/unstyled/sign-up-button.mdx
+++ b/docs/components/unstyled/sign-up-button.mdx
@@ -11,7 +11,7 @@ The `<SignUpButton />` component is a button that links to the sign-up page or d
 
 #### Basic usage
 
-<CodeBlockTabs options={['Next.js', 'React', 'Remix', 'Gatsby']}>
+<CodeBlockTabs type="framework" options={["Next.js", "React", "Remix", "Gatsby"]}>
   ```jsx filename="pages/index.js"
   import { SignUpButton } from "@clerk/nextjs";
 
@@ -69,7 +69,7 @@ The `<SignUpButton />` component is a button that links to the sign-up page or d
 
 In some cases you will want to use your own button, or button text. You can do that by wrapping your button up.
 
-<CodeBlockTabs options={['Next.js', 'React', 'Remix', 'Gatsby']}>
+<CodeBlockTabs type="framework" options={["Next.js", "React", "Remix", "Gatsby"]}>
   ```jsx filename="pages/index.js"
   import { SignUpButton } from "@clerk/nextjs";
 

--- a/docs/components/user/user-button.mdx
+++ b/docs/components/user/user-button.mdx
@@ -15,9 +15,9 @@ Clerk is the only provider with multi-session support, allowing users to sign in
 
 In this example, `<UserButton />` is mounted inside a header component, which is a common pattern on many websites and applications. When the user is signed in, they will see their avatar and be able to open the popup menu.
 
-<Tabs items={['Next.js', 'React', 'Remix']}>
+<Tabs type="framework" items={["Next.js", "React", "Remix"]}>
   <Tab>
-    <CodeBlockTabs options={["App Router", "Pages Router"]}>
+    <CodeBlockTabs type="router" options={["App Router", "Pages Router"]}>
       ```jsx filename="layout.[jsx/tsx]"
       import {
         ClerkProvider,

--- a/docs/components/user/user-profile.mdx
+++ b/docs/components/user/user-profile.mdx
@@ -17,7 +17,7 @@ The `<UserProfile />` component is used to render a beautiful, full-featured acc
 ## Usage
 
 
-<Tabs items={['Next.js', 'React', 'Remix']}>
+<Tabs type="framework" items={["Next.js", "React", "Remix"]}>
   <Tab>
     You can embed the `<UserProfile />` component using the [Next.js optional catch-all route](https://nextjs.org/docs/pages/building-your-application/routing/dynamic-routes#optional-catch-all-routes). This allows you to redirect the user inside your application.
 

--- a/docs/custom-flows/email-password.mdx
+++ b/docs/custom-flows/email-password.mdx
@@ -31,1182 +31,1180 @@ A successful sign-up consists of the following steps:
 3. Attempt to complete the email address verification by supplying the one-time code.
 4. If the email address verification is successful, complete the sign-up process by creating the user account and setting their session as active.
 
-<Tabs items={["Next.js","React","Remix", "Gatsby", "Expo", "JavaScript"]}>
-
-<Tab>
-<CodeBlockTabs options={['App Router', 'Pages Router']}>
-```tsx filename="app/sign-up/[[...sign-up]]/page.tsx
-'use client'
-
-import * as React from 'react';
-import { useSignUp } from '@clerk/nextjs';
-import { useRouter } from 'next/navigation';
-import { ClerkAPIErrorJSON } from '@clerk/types';
-
-export default function Page() {
-  const { isLoaded, signUp, setActive } = useSignUp();
-  const [emailAddress, setEmailAddress] = React.useState("");
-  const [password, setPassword] = React.useState("");
-  const [verifying, setVerifying] = React.useState(false);
-  const [code, setCode] = React.useState("");
-  const router = useRouter();
-
-  // This function will handle the user submitting their email and password
-  const handleSubmit = async (e: React.FormEvent) => {
-    e.preventDefault();
-    if (!isLoaded) return;
-    
-    // Start the sign-up process using the email and password provided
-    try {
-      await signUp.create({
-        emailAddress, password
-      });
-
-      // Send the user an email with the verification code
-      await signUp.prepareEmailAddressVerification({
-        strategy: 'email_code'
-      });
-
-      // Set 'verifying' true to display second form and capture the OTP code
-      setVerifying(true);
-    }
-    catch (err: any) {
-      // This can return an array of errors.
-      // See https://clerk.com/docs/custom-flows/error-handling to learn about error handling
-      console.error('Error:', JSON.stringify(err, null, 2));
-    }
-  }
-
-  // This function will handle the user submitting a code for verification
-  const handleVerify = async (e: React.FormEvent) => {
-    e.preventDefault();
-    if (!isLoaded) return;
-
-    try {
-      // Submit the code that the user provides to attempt verification
-      const completeSignUp = await signUp.attemptEmailAddressVerification({
-        code
-      });
-
-      if (completeSignUp.status !== "complete") {
-        // The status can also be `abandoned` or `missing_requirements`
-        // Please see https://clerk.com/docs/references/react/use-sign-up#result-status for  more information
-        console.log(JSON.stringify(completeSignUp, null, 2));
-      }
-
-      // Check the status to see if it is complete
-      // If complete, the user has been created -- set the session active
-      if (completeSignUp.status === "complete") {
-        await setActive({ session: completeSignUp.createdSessionId });
-        // Redirect the user to a post sign-up route
-        router.push("/");
-      }
-    }
-    catch (err: any) {
-      // This can return an array of errors.
-      // See https://clerk.com/docs/custom-flows/error-handling to learn about error handling
-      console.error('Error:', JSON.stringify(err, null, 2));
-    }
-  }
-
-  // Once the sign-up form was submitted, verifying was set to true and as a result, this verification form is presented to the user to input their verification code.
-  if (verifying) {
-    return (
-      <form onSubmit={handleVerify}>
-        <label id="code">Code</label>
-        <input value={code} id="code" name="code" onChange={(e) => setCode(e.target.value)} />
-        <button type="submit">Complete Sign Up</button>
-      </form>
-    )
-  }
-  
-  // Display the initial sign-up form to capture the email and password
-  return (
-    <form onSubmit={handleSubmit}>
-      <div>
-        <label htmlFor="email">Email address</label>
-        <input id="email" type='email' name="email" value={emailAddress} onChange={(e) => setEmailAddress(e.target.value)} />
-      </div>
-      <div>
-        <label className="block text-sm mt-8" htmlFor="password">Password</label>
-        <input id="password" type='password' name="password" value={password} onChange={(e) => setPassword(e.target.value)} />
-      </div>
-      <div>
-        <button type="submit">Verify Email</button>
-      </div>
-    </form>
-  );
-}
-```
-```tsx filename="pages/sign-up/[[...index]].tsx"
-
-import { useState } from "react";
-import { useSignUp } from "@clerk/nextjs";
-import { useRouter } from "next/router";
-
-export default function SignUpForm() {
-  const { isLoaded, signUp, setActive } = useSignUp();
-  const [emailAddress, setEmailAddress] = useState("");
-  const [password, setPassword] = useState("");
-  const [pendingVerification, setPendingVerification] = useState(false);
-  const [code, setCode] = useState("");
-  const router = useRouter();
-
-  // This function will handle the user submitting their email and password
-  const handleSubmit = async (e) => {
-    e.preventDefault();
-    if (!isLoaded) {
-      return;
-    }
-
-    // Start the sign-up process using the email and password provided
-    try {
-      await signUp.create({
-        emailAddress,
-        password,
-      });
-
-      // Send the user an email with the verification code
-      await signUp.prepareEmailAddressVerification({ strategy: "email_code" });
-
-      // Set 'verifying' true to display second form and capture the OTP code
-      setPendingVerification(true);
-    } catch (err: any) {      
-      // This can return an array of errors.
-      // See https://clerk.com/docs/custom-flows/error-handling to learn about error handling
-      console.error(JSON.stringify(err, null, 2));
-    }
-  };
-
-  // This function will handle the user submitting a code for verification
-  const onPressVerify = async (e) => {
-    e.preventDefault();
-    if (!isLoaded) {
-      return;
-    }
-
-    try {
-      // Submit the code that the user provides to attempt verification
-      const completeSignUp = await signUp.attemptEmailAddressVerification({
-        code,
-      });
-
-      if (completeSignUp.status !== "complete") {
-        // The status can also be `abandoned` or `missing_requirements`
-        // Please see https://clerk.com/docs/references/react/use-sign-up#result-status for  more information
-        console.log(JSON.stringify(completeSignUp, null, 2));
-      }
-
-      // Check the status to see if it is complete
-      // If complete, the user has been created -- set the session active
-      if (completeSignUp.status === "complete") {
-        await setActive({ session: completeSignUp.createdSessionId })
-        // Redirect the user to a post sign-up route
-        router.push("/");
-      }
-    } catch (err: any) {      
-      // This can return an array of errors.
-      // See https://clerk.com/docs/custom-flows/error-handling to learn about error handling
-      console.error(JSON.stringify(err, null, 2));
-    }
-  };
-
-  return (
-    <div>
-      {!pendingVerification && (
-        <form>
-          <div>
-            <label htmlFor="email">Email</label>
-            <input onChange={(e) => setEmailAddress(e.target.value)} id="email" name="email" type="email" />
-          </div>
-          <div>
-            <label htmlFor="password">Password</label>
-            <input onChange={(e) => setPassword(e.target.value)} id="password" name="password" type="password" />
-          </div>
-          <button onClick={handleSubmit}>Sign up</button>
-        </form>
-      )}
-      {pendingVerification && (
-        <div>
-          <form>
-            <input
-              value={code}
-              placeholder="Code..."
-              onChange={(e) => setCode(e.target.value)}
-            />
-            <button onClick={onPressVerify}>
-              Verify Email
-            </button>
-          </form>
-        </div>
-      )}
-    </div>
-  );
-}
-```
-</CodeBlockTabs>
-</Tab>
-
-<Tab>
-```tsx filename="signup.tsx"
-import { useState } from "react";
-import { useSignUp } from "@clerk/clerk-react";
-
-export default function SignUpForm() {
-  const { isLoaded, signUp, setActive } = useSignUp();
-  const [emailAddress, setEmailAddress] = useState("");
-  const [password, setPassword] = useState("");
-  const [verifying, setVerifying] = React.useState(false);
-  const [code, setCode] = useState("");
-
-  // This function will handle the user submitting their email and password
-  const handleSubmit = async (e) => {
-    e.preventDefault();
-    if (!isLoaded) {
-      return;
-    }
-
-    // Start the sign-up process using the email and password provided
-    try {
-      await signUp.create({
-        emailAddress,
-        password,
-      });
-
-      // Send the user an email with the verification code
-      await signUp.prepareEmailAddressVerification({ strategy: "email_code" });
-
-      // Set 'verifying' true to display second form and capture the OTP code
-      setVerifying(true);
-    } catch (err: any) {
-      // This can return an array of errors.
-      // See https://clerk.com/docs/custom-flows/error-handling to learn about error handling
-      console.error(JSON.stringify(err, null, 2));
-    }
-  };
-
-  // This function will handle the user submitting a code for verification
-  const handleVerify = async (e) => {
-    e.preventDefault();
-    if (!isLoaded) {
-      return;
-    }
-
-    try {
-      // Submit the code that the user provides to attempt verification
-      const completeSignUp = await signUp.attemptEmailAddressVerification({
-        code,
-      });
-
-      if (completeSignUp.status !== "complete") {
-        // The status can also be `abandoned` or `missing_requirements`
-        // Please see https://clerk.com/docs/references/react/use-sign-up#result-status for  more information
-        console.log(JSON.stringify(completeSignUp, null, 2));
-      }
-
-      // Check the status to see if it is complete
-      // If complete, the user has been created -- set the session active
-      if (completeSignUp.status === "complete") {
-        await setActive({ session: completeSignUp.createdSessionId })
-        // Handle your own logic here, like redirecting to a new page if needed.
-      }
-    } catch (err: any) {
-      // This can return an array of errors.
-      // See https://clerk.com/docs/custom-flows/error-handling to learn about error handling
-      console.error(JSON.stringify(err, null, 2));
-    }
-  };
-
-  return (
-    <div>
-      {!verifying && (
-        <form>
-          <div>
-            <label htmlFor="email">Email</label>
-            <input onChange={(e) => setEmailAddress(e.target.value)} id="email" name="email" type="email" />
-          </div>
-          <div>
-            <label htmlFor="password">Password</label>
-            <input onChange={(e) => setPassword(e.target.value)} id="password" name="password" type="password" />
-          </div>
-          <button onClick={handleSubmit}>Sign up</button>
-        </form>
-      )}
-      {verifying && (
-        <div>
-          <form>
-            <input
-              value={code}
-              placeholder="Code..."
-              onChange={(e) => setCode(e.target.value)}
-            />
-            <button onClick={handleVerify}>
-              Verify Email
-            </button>
-          </form>
-        </div>
-      )}
-    </div>
-  );
-}
-```
-</Tab>
-
-<Tab>
-```tsx filename="app/routes/sign-up/$.tsx"
-import { useState } from "react";
-import { useSignUp } from "@clerk/remix";
-
-export default function SignUpForm() {
-  const { isLoaded, signUp, setActive } = useSignUp();
-  const [emailAddress, setEmailAddress] = useState("");
-  const [password, setPassword] = useState("");
-  const [verifying, setVerifying] = React.useState(false);
-  const [code, setCode] = useState("");
- 
-  // This function will handle the user submitting their email and password
-  const handleSubmit = async (e) => {
-    e.preventDefault();
-    if (!isLoaded) {
-      return;
-    }
-
-    // Start the sign-up process using the email and password provided
-    try {
-      await signUp.create({
-        emailAddress,
-        password,
-      });
-
-      // Send the user an email with the verification code
-      await signUp.prepareEmailAddressVerification({ strategy: "email_code" });
-
-      // Set 'verifying' true to display second form and capture the OTP code
-      setVerifying(true);
-    } catch (err: any) {
-      // This can return an array of errors.
-      // See https://clerk.com/docs/custom-flows/error-handling to learn about error handling
-      console.error(JSON.stringify(err, null, 2));
-    }
-  };
-
-  // This function will handle the user submitting a code for verification
-  const handleVerify = async (e) => {
-    e.preventDefault();
-    if (!isLoaded) {
-      return;
-    }
-
-    try {
-      // Submit the code that the user provides to attempt verification
-      const completeSignUp = await signUp.attemptEmailAddressVerification({
-        code,
-      });
-
-      if (completeSignUp.status !== "complete") {
-        // The status can also be `abandoned` or `missing_requirements`
-        // Please see https://clerk.com/docs/references/react/use-sign-up#result-status for  more information
-         or if the user needs to complete more steps.*/
-        console.log(JSON.stringify(completeSignUp, null, 2));
-      }
-
-      // Check the status to see if it is complete
-      // If complete, the user has been created -- set the session active
-      if (completeSignUp.status === "complete") {
-        await setActive({ session: completeSignUp.createdSessionId })
-        // Handle your own logic here, like redirecting to a new page if needed.
-      }
-    } catch (err: any) {
-      // This can return an array of errors.
-      // See https://clerk.com/docs/custom-flows/error-handling to learn about error handling
-      console.error(JSON.stringify(err, null, 2));
-    }
-  };
-
-  return (
-    <div>
-      {!verifying && (
-        <form>
-          <div>
-            <label htmlFor="email">Email</label>
-            <input onChange={(e) => setEmailAddress(e.target.value)} id="email" name="email" type="email" />
-          </div>
-          <div>
-            <label htmlFor="password">Password</label>
-            <input onChange={(e) => setPassword(e.target.value)} id="password" name="password" type="password" />
-          </div>
-          <button onClick={handleSubmit}>Sign up</button>
-        </form>
-      )}
-      {verifying && (
-        <div>
-          <form>
-            <input
-              value={code}
-              placeholder="Code..."
-              onChange={(e) => setCode(e.target.value)}
-            />
-            <button onClick={handleVerify}>
-              Verify Email
-            </button>
-          </form>
-        </div>
-      )}
-    </div>
-  );
-}
-```
-</Tab>
-
-<Tab>
-```tsx filename="sign-up.tsx"
-import { useState } from "react";
-// Use the react package when using Gatsby
-import { useSignUp } from "@clerk/react";
-import { useRouter } from "next/router";
-
-export default function SignUpForm() {
-  const { isLoaded, signUp, setActive } = useSignUp();
-  const [emailAddress, setEmailAddress] = useState("");
-  const [password, setPassword] = useState("");
-  const [verifying, setVerifying] = React.useState(false);
-  const [code, setCode] = useState("");
-  const router = useRouter();
-  
-  // This function will handle the user submitting their email and password
-  const handleSubmit = async (e) => {
-    e.preventDefault();
-    if (!isLoaded) {
-      return;
-    }
-
-    // Start the sign-up process using the email and password provided
-    try {
-      await signUp.create({
-        emailAddress,
-        password,
-      });
-
-      // Send the user an email with the verification code
-      await signUp.prepareEmailAddressVerification({ strategy: "email_code" });
-
-      // Set 'verifying' true to display second form and capture the OTP code
-      setVerifying(true);
-    } catch (err: any) {
-      // This can return an array of errors.
-      // See https://clerk.com/docs/custom-flows/error-handling to learn about error handling
-      console.error(JSON.stringify(err, null, 2));
-    }
-  };
-
-  // This function will handle the user submitting a code for verification
-  const handleVerify = async (e) => {
-    e.preventDefault();
-    if (!isLoaded) {
-      return;
-    }
-
-    try {
-      // Submit the code that the user provides to attempt verification
-      const completeSignUp = await signUp.attemptEmailAddressVerification({
-        code,
-      });
-
-      if (completeSignUp.status !== "complete") {
-        // The status can also be `abandoned` or `missing_requirements`
-        // Please see https://clerk.com/docs/references/react/use-sign-up#result-status for  more information
-        console.log(JSON.stringify(completeSignUp, null, 2));
-      }
-
-      // Check the status to see if it is complete
-      // If complete, the user has been created -- set the session active
-      if (completeSignUp.status === "complete") {
-        await setActive({ session: completeSignUp.createdSessionId })
-        // Redirect the user to a post sign-up route
-        router.push("/");
-      }
-    } catch (err: any) {
-      // This can return an array of errors.
-      // See https://clerk.com/docs/custom-flows/error-handling to learn about error handling
-      console.error(JSON.stringify(err, null, 2));
-    }
-  };
-
-  return (
-    <div>
-      {!verifying && (
-        <form>
-          <div>
-            <label htmlFor="email">Email</label>
-            <input onChange={(e) => setEmailAddress(e.target.value)} id="email" name="email" type="email" />
-          </div>
-          <div>
-            <label htmlFor="password">Password</label>
-            <input onChange={(e) => setPassword(e.target.value)} id="password" name="password" type="password" />
-          </div>
-          <button onClick={handleSubmit}>Sign up</button>
-        </form>
-      )}
-      {verifying && (
-        <div>
-          <form>
-            <input
-              value={code}
-              placeholder="Code..."
-              onChange={(e) => setCode(e.target.value)}
-            />
-            <button onClick={handleVerify}>
-              Verify Email
-            </button>
-          </form>
-        </div>
-      )}
-    </div>
-  );
-}
-```
-</Tab>
-
-<Tab>
-```tsx filename="SignUpScreen.tsx"
-import * as React from "react";
-import { Text, TextInput, TouchableOpacity, View } from "react-native";
-import { useSignUp } from "@clerk/clerk-expo";
-
-export default function SignUpScreen() {
-  const { isLoaded, signUp, setActive } = useSignUp();
-
-  const [emailAddress, setEmailAddress] = React.useState("");
-  const [password, setPassword] = React.useState("");
-  const [verifying, setVerifying] = React.useState(false);
-  const [code, setCode] = React.useState("");
-
-  // This function will handle the user submitting their email and password
-  const onSignUpPress = async () => {
-    if (!isLoaded) {
-      return;
-    }
-
-    // Start the sign-up process using the email and password provided
-    try {
-      await signUp.create({
-        emailAddress,
-        password,
-      });
-
-      // Send the user an email with the verification code
-      await signUp.prepareEmailAddressVerification({ strategy: "email_code" });
-
-      // Set 'verifying' true to display second form and capture the OTP code
-      setVerifying(true);
-    } catch (err: any) {
-      // This can return an array of errors.
-      // See https://clerk.com/docs/custom-flows/error-handling to learn about error handling
-      console.error(JSON.stringify(err, null, 2));
-    }
-  };
-
-  // This function will handle the user submitting a code for verification
-  const handleVerify = async () => {
-    if (!isLoaded) {
-      return;
-    }
-
-    try {
-      // Submit the code that the user provides to attempt verification
-      const completeSignUp = await signUp.attemptEmailAddressVerification({
-        code,
-      });
-
-     if (completeSignUp.status !== "complete") {
-        // The status can also be `abandoned` or `missing_requirements`
-        // Please see https://clerk.com/docs/references/react/use-sign-up#result-status for  more information
-        console.log(JSON.stringify(completeSignUp, null, 2));
-      }
-
-      // Check the status to see if it is complete
-      // If complete, the user has been created -- set the session active
-      if (completeSignUp.status === "complete") {
-        await setActive({ session: completeSignUp.createdSessionId });
-        // Handle your own logic here, like redirecting to a new page if needed.
-      }
-    } catch (err: any) {
-      // This can return an array of errors.
-      // See https://clerk.com/docs/custom-flows/error-handling to learn about error handling
-      console.error(JSON.stringify(err, null, 2));
-    }
-  };
-
-  return (
-    <View>
-      {!verifying && (
-        <View>
-          <View>
-            <TextInput
-              autoCapitalize="none"
-              value={emailAddress}
-              placeholder="Email..."
-              onChangeText={(email) => setEmailAddress(email)}
-            />
-          </View>
-
-          <View>
-            <TextInput
-              value={password}
-              placeholder="Password..."
-              placeholderTextColor="#000"
-              secureTextEntry={true}
-              onChangeText={(password) => setPassword(password)}
-            />
-          </View>
-
-          <TouchableOpacity onPress={onSignUpPress}>
-            <Text>Sign up</Text>
-          </TouchableOpacity>
-        </View>
-      )}
-      {verifying && (
-        <View>
-          <View>
-            <TextInput
-              value={code}
-              placeholder="Code..."
-              onChangeText={(code) => setCode(code)}
-            />
-          </View>
-          <TouchableOpacity onPress={handleVerify}>
-            <Text>Verify Email</Text>
-          </TouchableOpacity>
-        </View>
-      )}
-    </View>
-  );
-}
-```
-</Tab>
-
-<Tab>
-```html filename="your-app.html"
-<!DOCTYPE html>
-<html lang="en">
-
-<head>
-    <meta charset="UTF-8" />
-    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Clerk JavaScript Email + Password</title>
-</head>
-
-<body>
-    <h1>Clerk JavaScript Email + Password</h1>
-
-    <div id="auth-signup">
-        <input placeholder="email" id="email" type="email"></input>
-        <input placeholder="password" id="password" type="password"></input>
-        <button onclick="SignUp()">SignUp</button>
-
-    </div>
-    <div id="auth-verification" hidden="true">
-        <input placeholder="code" id="code" type="text"></input>
-        <button onclick="VerifyEmailAddress()">Verify</button>
-    </div>
-
-    <div id="user-button" />
-    <script>
-        const SignUp = async () => {
-            const emailAddress = document.getElementById('email').value;
-            const password = document.getElementById('password').value;
-            const {client} = window.Clerk;
-            try {
-                await client.signUp.create({
-                    emailAddress,
-                    password
-                });
-                await client.signUp.prepareEmailAddressVerification();
-                //hide signup form
-                document.getElementById('auth-signup').hidden = true;
-                //show verification form
-                document.getElementById('auth-verification').hidden = false;
-            }
-            catch (err) {
-                console.log(err)
-            }
-        };
-        const VerifyEmailAddress = async () => {
-            const code = document.getElementById('code').value;
-            const {client, setActive} = window.Clerk;
-            try {
-                // Verify the email address.
-                const verify = await client.signUp.attemptEmailAddressVerification({
-                    code
-                });
-                // User is created. Now, set the session to active. session is never null.
-                await setActive({session: verify.createdSessionId})
-            }
-
-            catch (err) {
-                console.log(err)
-            }
+<Tabs type="framework" items={["Next.js","React","Remix", "Gatsby", "Expo", "JavaScript"]}>
+  <Tab>
+    <CodeBlockTabs type="router" options={["App Router", "Pages Router"]}>
+    ```tsx filename="app/sign-up/[[...sign-up]]/page.tsx
+    'use client'
+
+    import * as React from 'react';
+    import { useSignUp } from '@clerk/nextjs';
+    import { useRouter } from 'next/navigation';
+    import { ClerkAPIErrorJSON } from '@clerk/types';
+
+    export default function Page() {
+      const { isLoaded, signUp, setActive } = useSignUp();
+      const [emailAddress, setEmailAddress] = React.useState("");
+      const [password, setPassword] = React.useState("");
+      const [verifying, setVerifying] = React.useState(false);
+      const [code, setCode] = React.useState("");
+      const router = useRouter();
+
+      // This function will handle the user submitting their email and password
+      const handleSubmit = async (e: React.FormEvent) => {
+        e.preventDefault();
+        if (!isLoaded) return;
+        
+        // Start the sign-up process using the email and password provided
+        try {
+          await signUp.create({
+            emailAddress, password
+          });
+
+          // Send the user an email with the verification code
+          await signUp.prepareEmailAddressVerification({
+            strategy: 'email_code'
+          });
+
+          // Set 'verifying' true to display second form and capture the OTP code
+          setVerifying(true);
         }
-    </script>
-    // Script to load Clerk up
-    <script src="src/script.js" async crossorigin="anonymous"></script>
-</body>
+        catch (err: any) {
+          // This can return an array of errors.
+          // See https://clerk.com/docs/custom-flows/error-handling to learn about error handling
+          console.error('Error:', JSON.stringify(err, null, 2));
+        }
+      }
 
-</html>
-```
-</Tab>
+      // This function will handle the user submitting a code for verification
+      const handleVerify = async (e: React.FormEvent) => {
+        e.preventDefault();
+        if (!isLoaded) return;
+
+        try {
+          // Submit the code that the user provides to attempt verification
+          const completeSignUp = await signUp.attemptEmailAddressVerification({
+            code
+          });
+
+          if (completeSignUp.status !== "complete") {
+            // The status can also be `abandoned` or `missing_requirements`
+            // Please see https://clerk.com/docs/references/react/use-sign-up#result-status for  more information
+            console.log(JSON.stringify(completeSignUp, null, 2));
+          }
+
+          // Check the status to see if it is complete
+          // If complete, the user has been created -- set the session active
+          if (completeSignUp.status === "complete") {
+            await setActive({ session: completeSignUp.createdSessionId });
+            // Redirect the user to a post sign-up route
+            router.push("/");
+          }
+        }
+        catch (err: any) {
+          // This can return an array of errors.
+          // See https://clerk.com/docs/custom-flows/error-handling to learn about error handling
+          console.error('Error:', JSON.stringify(err, null, 2));
+        }
+      }
+
+      // Once the sign-up form was submitted, verifying was set to true and as a result, this verification form is presented to the user to input their verification code.
+      if (verifying) {
+        return (
+          <form onSubmit={handleVerify}>
+            <label id="code">Code</label>
+            <input value={code} id="code" name="code" onChange={(e) => setCode(e.target.value)} />
+            <button type="submit">Complete Sign Up</button>
+          </form>
+        )
+      }
+      
+      // Display the initial sign-up form to capture the email and password
+      return (
+        <form onSubmit={handleSubmit}>
+          <div>
+            <label htmlFor="email">Email address</label>
+            <input id="email" type='email' name="email" value={emailAddress} onChange={(e) => setEmailAddress(e.target.value)} />
+          </div>
+          <div>
+            <label className="block text-sm mt-8" htmlFor="password">Password</label>
+            <input id="password" type='password' name="password" value={password} onChange={(e) => setPassword(e.target.value)} />
+          </div>
+          <div>
+            <button type="submit">Verify Email</button>
+          </div>
+        </form>
+      );
+    }
+    ```
+    ```tsx filename="pages/sign-up/[[...index]].tsx"
+
+    import { useState } from "react";
+    import { useSignUp } from "@clerk/nextjs";
+    import { useRouter } from "next/router";
+
+    export default function SignUpForm() {
+      const { isLoaded, signUp, setActive } = useSignUp();
+      const [emailAddress, setEmailAddress] = useState("");
+      const [password, setPassword] = useState("");
+      const [pendingVerification, setPendingVerification] = useState(false);
+      const [code, setCode] = useState("");
+      const router = useRouter();
+
+      // This function will handle the user submitting their email and password
+      const handleSubmit = async (e) => {
+        e.preventDefault();
+        if (!isLoaded) {
+          return;
+        }
+
+        // Start the sign-up process using the email and password provided
+        try {
+          await signUp.create({
+            emailAddress,
+            password,
+          });
+
+          // Send the user an email with the verification code
+          await signUp.prepareEmailAddressVerification({ strategy: "email_code" });
+
+          // Set 'verifying' true to display second form and capture the OTP code
+          setPendingVerification(true);
+        } catch (err: any) {      
+          // This can return an array of errors.
+          // See https://clerk.com/docs/custom-flows/error-handling to learn about error handling
+          console.error(JSON.stringify(err, null, 2));
+        }
+      };
+
+      // This function will handle the user submitting a code for verification
+      const onPressVerify = async (e) => {
+        e.preventDefault();
+        if (!isLoaded) {
+          return;
+        }
+
+        try {
+          // Submit the code that the user provides to attempt verification
+          const completeSignUp = await signUp.attemptEmailAddressVerification({
+            code,
+          });
+
+          if (completeSignUp.status !== "complete") {
+            // The status can also be `abandoned` or `missing_requirements`
+            // Please see https://clerk.com/docs/references/react/use-sign-up#result-status for  more information
+            console.log(JSON.stringify(completeSignUp, null, 2));
+          }
+
+          // Check the status to see if it is complete
+          // If complete, the user has been created -- set the session active
+          if (completeSignUp.status === "complete") {
+            await setActive({ session: completeSignUp.createdSessionId })
+            // Redirect the user to a post sign-up route
+            router.push("/");
+          }
+        } catch (err: any) {      
+          // This can return an array of errors.
+          // See https://clerk.com/docs/custom-flows/error-handling to learn about error handling
+          console.error(JSON.stringify(err, null, 2));
+        }
+      };
+
+      return (
+        <div>
+          {!pendingVerification && (
+            <form>
+              <div>
+                <label htmlFor="email">Email</label>
+                <input onChange={(e) => setEmailAddress(e.target.value)} id="email" name="email" type="email" />
+              </div>
+              <div>
+                <label htmlFor="password">Password</label>
+                <input onChange={(e) => setPassword(e.target.value)} id="password" name="password" type="password" />
+              </div>
+              <button onClick={handleSubmit}>Sign up</button>
+            </form>
+          )}
+          {pendingVerification && (
+            <div>
+              <form>
+                <input
+                  value={code}
+                  placeholder="Code..."
+                  onChange={(e) => setCode(e.target.value)}
+                />
+                <button onClick={onPressVerify}>
+                  Verify Email
+                </button>
+              </form>
+            </div>
+          )}
+        </div>
+      );
+    }
+    ```
+    </CodeBlockTabs>
+  </Tab>
+
+  <Tab>
+  ```tsx filename="signup.tsx"
+  import { useState } from "react";
+  import { useSignUp } from "@clerk/clerk-react";
+
+  export default function SignUpForm() {
+    const { isLoaded, signUp, setActive } = useSignUp();
+    const [emailAddress, setEmailAddress] = useState("");
+    const [password, setPassword] = useState("");
+    const [verifying, setVerifying] = React.useState(false);
+    const [code, setCode] = useState("");
+
+    // This function will handle the user submitting their email and password
+    const handleSubmit = async (e) => {
+      e.preventDefault();
+      if (!isLoaded) {
+        return;
+      }
+
+      // Start the sign-up process using the email and password provided
+      try {
+        await signUp.create({
+          emailAddress,
+          password,
+        });
+
+        // Send the user an email with the verification code
+        await signUp.prepareEmailAddressVerification({ strategy: "email_code" });
+
+        // Set 'verifying' true to display second form and capture the OTP code
+        setVerifying(true);
+      } catch (err: any) {
+        // This can return an array of errors.
+        // See https://clerk.com/docs/custom-flows/error-handling to learn about error handling
+        console.error(JSON.stringify(err, null, 2));
+      }
+    };
+
+    // This function will handle the user submitting a code for verification
+    const handleVerify = async (e) => {
+      e.preventDefault();
+      if (!isLoaded) {
+        return;
+      }
+
+      try {
+        // Submit the code that the user provides to attempt verification
+        const completeSignUp = await signUp.attemptEmailAddressVerification({
+          code,
+        });
+
+        if (completeSignUp.status !== "complete") {
+          // The status can also be `abandoned` or `missing_requirements`
+          // Please see https://clerk.com/docs/references/react/use-sign-up#result-status for  more information
+          console.log(JSON.stringify(completeSignUp, null, 2));
+        }
+
+        // Check the status to see if it is complete
+        // If complete, the user has been created -- set the session active
+        if (completeSignUp.status === "complete") {
+          await setActive({ session: completeSignUp.createdSessionId })
+          // Handle your own logic here, like redirecting to a new page if needed.
+        }
+      } catch (err: any) {
+        // This can return an array of errors.
+        // See https://clerk.com/docs/custom-flows/error-handling to learn about error handling
+        console.error(JSON.stringify(err, null, 2));
+      }
+    };
+
+    return (
+      <div>
+        {!verifying && (
+          <form>
+            <div>
+              <label htmlFor="email">Email</label>
+              <input onChange={(e) => setEmailAddress(e.target.value)} id="email" name="email" type="email" />
+            </div>
+            <div>
+              <label htmlFor="password">Password</label>
+              <input onChange={(e) => setPassword(e.target.value)} id="password" name="password" type="password" />
+            </div>
+            <button onClick={handleSubmit}>Sign up</button>
+          </form>
+        )}
+        {verifying && (
+          <div>
+            <form>
+              <input
+                value={code}
+                placeholder="Code..."
+                onChange={(e) => setCode(e.target.value)}
+              />
+              <button onClick={handleVerify}>
+                Verify Email
+              </button>
+            </form>
+          </div>
+        )}
+      </div>
+    );
+  }
+  ```
+  </Tab>
+
+  <Tab>
+  ```tsx filename="app/routes/sign-up/$.tsx"
+  import { useState } from "react";
+  import { useSignUp } from "@clerk/remix";
+
+  export default function SignUpForm() {
+    const { isLoaded, signUp, setActive } = useSignUp();
+    const [emailAddress, setEmailAddress] = useState("");
+    const [password, setPassword] = useState("");
+    const [verifying, setVerifying] = React.useState(false);
+    const [code, setCode] = useState("");
+  
+    // This function will handle the user submitting their email and password
+    const handleSubmit = async (e) => {
+      e.preventDefault();
+      if (!isLoaded) {
+        return;
+      }
+
+      // Start the sign-up process using the email and password provided
+      try {
+        await signUp.create({
+          emailAddress,
+          password,
+        });
+
+        // Send the user an email with the verification code
+        await signUp.prepareEmailAddressVerification({ strategy: "email_code" });
+
+        // Set 'verifying' true to display second form and capture the OTP code
+        setVerifying(true);
+      } catch (err: any) {
+        // This can return an array of errors.
+        // See https://clerk.com/docs/custom-flows/error-handling to learn about error handling
+        console.error(JSON.stringify(err, null, 2));
+      }
+    };
+
+    // This function will handle the user submitting a code for verification
+    const handleVerify = async (e) => {
+      e.preventDefault();
+      if (!isLoaded) {
+        return;
+      }
+
+      try {
+        // Submit the code that the user provides to attempt verification
+        const completeSignUp = await signUp.attemptEmailAddressVerification({
+          code,
+        });
+
+        if (completeSignUp.status !== "complete") {
+          // The status can also be `abandoned` or `missing_requirements`
+          // Please see https://clerk.com/docs/references/react/use-sign-up#result-status for  more information
+          or if the user needs to complete more steps.*/
+          console.log(JSON.stringify(completeSignUp, null, 2));
+        }
+
+        // Check the status to see if it is complete
+        // If complete, the user has been created -- set the session active
+        if (completeSignUp.status === "complete") {
+          await setActive({ session: completeSignUp.createdSessionId })
+          // Handle your own logic here, like redirecting to a new page if needed.
+        }
+      } catch (err: any) {
+        // This can return an array of errors.
+        // See https://clerk.com/docs/custom-flows/error-handling to learn about error handling
+        console.error(JSON.stringify(err, null, 2));
+      }
+    };
+
+    return (
+      <div>
+        {!verifying && (
+          <form>
+            <div>
+              <label htmlFor="email">Email</label>
+              <input onChange={(e) => setEmailAddress(e.target.value)} id="email" name="email" type="email" />
+            </div>
+            <div>
+              <label htmlFor="password">Password</label>
+              <input onChange={(e) => setPassword(e.target.value)} id="password" name="password" type="password" />
+            </div>
+            <button onClick={handleSubmit}>Sign up</button>
+          </form>
+        )}
+        {verifying && (
+          <div>
+            <form>
+              <input
+                value={code}
+                placeholder="Code..."
+                onChange={(e) => setCode(e.target.value)}
+              />
+              <button onClick={handleVerify}>
+                Verify Email
+              </button>
+            </form>
+          </div>
+        )}
+      </div>
+    );
+  }
+  ```
+  </Tab>
+
+  <Tab>
+  ```tsx filename="sign-up.tsx"
+  import { useState } from "react";
+  // Use the react package when using Gatsby
+  import { useSignUp } from "@clerk/react";
+  import { useRouter } from "next/router";
+
+  export default function SignUpForm() {
+    const { isLoaded, signUp, setActive } = useSignUp();
+    const [emailAddress, setEmailAddress] = useState("");
+    const [password, setPassword] = useState("");
+    const [verifying, setVerifying] = React.useState(false);
+    const [code, setCode] = useState("");
+    const router = useRouter();
+    
+    // This function will handle the user submitting their email and password
+    const handleSubmit = async (e) => {
+      e.preventDefault();
+      if (!isLoaded) {
+        return;
+      }
+
+      // Start the sign-up process using the email and password provided
+      try {
+        await signUp.create({
+          emailAddress,
+          password,
+        });
+
+        // Send the user an email with the verification code
+        await signUp.prepareEmailAddressVerification({ strategy: "email_code" });
+
+        // Set 'verifying' true to display second form and capture the OTP code
+        setVerifying(true);
+      } catch (err: any) {
+        // This can return an array of errors.
+        // See https://clerk.com/docs/custom-flows/error-handling to learn about error handling
+        console.error(JSON.stringify(err, null, 2));
+      }
+    };
+
+    // This function will handle the user submitting a code for verification
+    const handleVerify = async (e) => {
+      e.preventDefault();
+      if (!isLoaded) {
+        return;
+      }
+
+      try {
+        // Submit the code that the user provides to attempt verification
+        const completeSignUp = await signUp.attemptEmailAddressVerification({
+          code,
+        });
+
+        if (completeSignUp.status !== "complete") {
+          // The status can also be `abandoned` or `missing_requirements`
+          // Please see https://clerk.com/docs/references/react/use-sign-up#result-status for  more information
+          console.log(JSON.stringify(completeSignUp, null, 2));
+        }
+
+        // Check the status to see if it is complete
+        // If complete, the user has been created -- set the session active
+        if (completeSignUp.status === "complete") {
+          await setActive({ session: completeSignUp.createdSessionId })
+          // Redirect the user to a post sign-up route
+          router.push("/");
+        }
+      } catch (err: any) {
+        // This can return an array of errors.
+        // See https://clerk.com/docs/custom-flows/error-handling to learn about error handling
+        console.error(JSON.stringify(err, null, 2));
+      }
+    };
+
+    return (
+      <div>
+        {!verifying && (
+          <form>
+            <div>
+              <label htmlFor="email">Email</label>
+              <input onChange={(e) => setEmailAddress(e.target.value)} id="email" name="email" type="email" />
+            </div>
+            <div>
+              <label htmlFor="password">Password</label>
+              <input onChange={(e) => setPassword(e.target.value)} id="password" name="password" type="password" />
+            </div>
+            <button onClick={handleSubmit}>Sign up</button>
+          </form>
+        )}
+        {verifying && (
+          <div>
+            <form>
+              <input
+                value={code}
+                placeholder="Code..."
+                onChange={(e) => setCode(e.target.value)}
+              />
+              <button onClick={handleVerify}>
+                Verify Email
+              </button>
+            </form>
+          </div>
+        )}
+      </div>
+    );
+  }
+  ```
+  </Tab>
+
+  <Tab>
+  ```tsx filename="SignUpScreen.tsx"
+  import * as React from "react";
+  import { Text, TextInput, TouchableOpacity, View } from "react-native";
+  import { useSignUp } from "@clerk/clerk-expo";
+
+  export default function SignUpScreen() {
+    const { isLoaded, signUp, setActive } = useSignUp();
+
+    const [emailAddress, setEmailAddress] = React.useState("");
+    const [password, setPassword] = React.useState("");
+    const [verifying, setVerifying] = React.useState(false);
+    const [code, setCode] = React.useState("");
+
+    // This function will handle the user submitting their email and password
+    const onSignUpPress = async () => {
+      if (!isLoaded) {
+        return;
+      }
+
+      // Start the sign-up process using the email and password provided
+      try {
+        await signUp.create({
+          emailAddress,
+          password,
+        });
+
+        // Send the user an email with the verification code
+        await signUp.prepareEmailAddressVerification({ strategy: "email_code" });
+
+        // Set 'verifying' true to display second form and capture the OTP code
+        setVerifying(true);
+      } catch (err: any) {
+        // This can return an array of errors.
+        // See https://clerk.com/docs/custom-flows/error-handling to learn about error handling
+        console.error(JSON.stringify(err, null, 2));
+      }
+    };
+
+    // This function will handle the user submitting a code for verification
+    const handleVerify = async () => {
+      if (!isLoaded) {
+        return;
+      }
+
+      try {
+        // Submit the code that the user provides to attempt verification
+        const completeSignUp = await signUp.attemptEmailAddressVerification({
+          code,
+        });
+
+      if (completeSignUp.status !== "complete") {
+          // The status can also be `abandoned` or `missing_requirements`
+          // Please see https://clerk.com/docs/references/react/use-sign-up#result-status for  more information
+          console.log(JSON.stringify(completeSignUp, null, 2));
+        }
+
+        // Check the status to see if it is complete
+        // If complete, the user has been created -- set the session active
+        if (completeSignUp.status === "complete") {
+          await setActive({ session: completeSignUp.createdSessionId });
+          // Handle your own logic here, like redirecting to a new page if needed.
+        }
+      } catch (err: any) {
+        // This can return an array of errors.
+        // See https://clerk.com/docs/custom-flows/error-handling to learn about error handling
+        console.error(JSON.stringify(err, null, 2));
+      }
+    };
+
+    return (
+      <View>
+        {!verifying && (
+          <View>
+            <View>
+              <TextInput
+                autoCapitalize="none"
+                value={emailAddress}
+                placeholder="Email..."
+                onChangeText={(email) => setEmailAddress(email)}
+              />
+            </View>
+
+            <View>
+              <TextInput
+                value={password}
+                placeholder="Password..."
+                placeholderTextColor="#000"
+                secureTextEntry={true}
+                onChangeText={(password) => setPassword(password)}
+              />
+            </View>
+
+            <TouchableOpacity onPress={onSignUpPress}>
+              <Text>Sign up</Text>
+            </TouchableOpacity>
+          </View>
+        )}
+        {verifying && (
+          <View>
+            <View>
+              <TextInput
+                value={code}
+                placeholder="Code..."
+                onChangeText={(code) => setCode(code)}
+              />
+            </View>
+            <TouchableOpacity onPress={handleVerify}>
+              <Text>Verify Email</Text>
+            </TouchableOpacity>
+          </View>
+        )}
+      </View>
+    );
+  }
+  ```
+  </Tab>
+
+  <Tab>
+  ```html filename="your-app.html"
+  <!DOCTYPE html>
+  <html lang="en">
+
+  <head>
+      <meta charset="UTF-8" />
+      <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+      <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+      <title>Clerk JavaScript Email + Password</title>
+  </head>
+
+  <body>
+      <h1>Clerk JavaScript Email + Password</h1>
+
+      <div id="auth-signup">
+          <input placeholder="email" id="email" type="email"></input>
+          <input placeholder="password" id="password" type="password"></input>
+          <button onclick="SignUp()">SignUp</button>
+
+      </div>
+      <div id="auth-verification" hidden="true">
+          <input placeholder="code" id="code" type="text"></input>
+          <button onclick="VerifyEmailAddress()">Verify</button>
+      </div>
+
+      <div id="user-button" />
+      <script>
+          const SignUp = async () => {
+              const emailAddress = document.getElementById('email').value;
+              const password = document.getElementById('password').value;
+              const {client} = window.Clerk;
+              try {
+                  await client.signUp.create({
+                      emailAddress,
+                      password
+                  });
+                  await client.signUp.prepareEmailAddressVerification();
+                  //hide signup form
+                  document.getElementById('auth-signup').hidden = true;
+                  //show verification form
+                  document.getElementById('auth-verification').hidden = false;
+              }
+              catch (err) {
+                  console.log(err)
+              }
+          };
+          const VerifyEmailAddress = async () => {
+              const code = document.getElementById('code').value;
+              const {client, setActive} = window.Clerk;
+              try {
+                  // Verify the email address.
+                  const verify = await client.signUp.attemptEmailAddressVerification({
+                      code
+                  });
+                  // User is created. Now, set the session to active. session is never null.
+                  await setActive({session: verify.createdSessionId})
+              }
+
+              catch (err) {
+                  console.log(err)
+              }
+          }
+      </script>
+      // Script to load Clerk up
+      <script src="src/script.js" async crossorigin="anonymous"></script>
+  </body>
+
+  </html>
+  ```
+  </Tab>
 </Tabs>
 
 ### Create sign in flow
 
 In email/password authentication, the sign-in is a process that requires users to provide their email address and their password and authenticates them by creating a new session for the user.
 
-<Tabs items={["Next.js","React","Remix", "Gatsby", "Expo", "JavaScript"]}>
+<Tabs type="framework" items={["Next.js", "React", "Remix", "Gatsby", "Expo", "JavaScript"]}>
+  <Tab>
+    <CodeBlockTabs type="router" options={["App Router", "Pages Router"]}>
+    ```tsx  filename="app/sign-in/[[...sign-in]].page.tsx"
+    'use client'
 
-<Tab>
-<CodeBlockTabs options={['App Router', 'Pages Router']}>
-```tsx  filename="app/sign-in/[[...sign-in]].page.tsx"
-'use client'
+    import * as React from "react";
+    import { useSignIn } from "@clerk/nextjs";
+    import { useRouter } from "next/navigation";
 
-import * as React from "react";
-import { useSignIn } from "@clerk/nextjs";
-import { useRouter } from "next/navigation";
+    export default function SignInForm() {
+      const { isLoaded, signIn, setActive } = useSignIn();
+      const [email, setEmail] = React.useState("");
+      const [password, setPassword] = React.useState("");
+      const router = useRouter();
 
-export default function SignInForm() {
-  const { isLoaded, signIn, setActive } = useSignIn();
-  const [email, setEmail] = React.useState("");
-  const [password, setPassword] = React.useState("");
-  const router = useRouter();
+      // Handle the submission of the sign-in form
+      const handleSubmit = async (e: React.FormEvent) => {
+        e.preventDefault();
+        if (!isLoaded) {
+          return;
+        }
 
-  // Handle the submission of the sign-in form
-  const handleSubmit = async (e: React.FormEvent) => {
-    e.preventDefault();
-    if (!isLoaded) {
-      return;
+        // Start the sign-in process using the email and password provided
+        try {
+          const completeSignIn = await signIn.create({
+            identifier: email,
+            password,
+          });
+
+          if (completeSignIn.status !== 'complete') {
+            // The status can also be `needs_factor_on', 'needs_factor_two', or 'needs_identifier'
+            // Please see https://clerk.com/docs/references/react/use-sign-in#result-status for  more information
+            console.log(JSON.stringify(completeSignIn, null, 2));
+          }
+
+          if (completeSignIn.status === 'complete') {
+            // If complete, user exists and provided password match -- set session active
+            await setActive({ session: completeSignIn.createdSessionId });
+            // Redirect the user to a post sign-in route
+            router.push('/');
+          }
+        } catch (err: any) {
+          // This can return an array of errors.
+          // See https://clerk.com/docs/custom-flows/error-handling to learn about error handling
+          console.error(JSON.stringify(err, null, 2));
+        }
+      };
+
+      // Display a form to capture the user's email and password
+      return (
+        <div>
+          <form onSubmit={(e) => handleSubmit(e)}>
+            <div>
+              <label htmlFor="email">Email</label>
+              <input onChange={(e) => setEmail(e.target.value)} id="email" name="email" type="email" value={email} />
+            </div>
+            <div>
+              <label htmlFor="password">Password</label>
+              <input onChange={(e) => setPassword(e.target.value)} id="password" name="password" type="password" value={password} />
+            </div>
+            <button type="submit">Sign In</button>
+          </form>
+        </div>
+      );
     }
+    ```
 
+
+    ```tsx filename="pages/sign-in/[[...index]].tsx"
+    import { useState } from "react";
+    import { useSignIn } from "@clerk/nextjs";
+    import { useRouter } from "next/router";
+
+    export default function SignInForm() {
+      const { isLoaded, signIn, setActive } = useSignIn();
+      const [emailAddress, setEmailAddress] = useState("");
+      const [password, setPassword] = useState("");
+      const router = useRouter();
+
+      // Handle the submission of the sign-in form
+      const handleSubmit = async (e) => {
+        e.preventDefault();
+        if (!isLoaded) {
+          return;
+        }
+
+        // Start the sign-in process using the email and password provided
+        try {
+          const result = await signIn.create({
+            identifier: emailAddress,
+            password,
+          });
+
+          if (result.status === "complete") {
+            // If complete, user exists and provided password match -- set session active
+            await setActive({ session: result.createdSessionId });
+            // Redirect the user to a post sign-in route
+            router.push("/")
+          }
+          else {
+            // The status can also be `needs_factor_on', 'needs_factor_two', or 'needs_identifier'
+            // Please see https://clerk.com/docs/references/react/use-sign-in#result-status for  more information
+            console.error(JSON.stringify(results, null, 2));
+          }
+        } catch (err: any) {
+          // This can return an array of errors.
+          // See https://clerk.com/docs/custom-flows/error-handling to learn about error handling
+          console.error(JSON.stringify(err, null, 2));
+        }
+      };
+
+      // Display a form to capture the user's email and password
+      return (
+        <div>
+          <form>
+            <div>
+              <label htmlFor="email">Email</label>
+              <input onChange={(e) => setEmailAddress(e.target.value)} id="email" name="email" type="email" />
+            </div>
+            <div>
+              <label htmlFor="password">Password</label>
+              <input onChange={(e) => setPassword(e.target.value)} id="password" name="password" type="password" />
+            </div>
+            <button onClick={handleSubmit}>Sign In</button>
+          </form>
+        </div>
+      );
+    }
+    ```
+    </CodeBlockTabs>
+  </Tab>
+
+  <Tab>
+  ```tsx filename="signin.tsx"
+  import { useState } from "react";
+  import { useSignIn } from "@clerk/clerk-react";
+
+  export default function SignInForm() {
+    const { isLoaded, signIn, setActive } = useSignIn();
+    const [emailAddress, setEmailAddress] = useState("");
+    const [password, setPassword] = useState("");
+    
+    // Handle the submission of the sign-in form
+    const handleSubmit = async (e) => {
+      e.preventDefault();
+      if (!isLoaded) {
+        return;
+      }
+
+      // Start the sign-in process using the email and password provided
+      try {
+        const completeSignIn = await signIn.create({
+          identifier: emailAddress,
+          password,
+        });
+
+        if (completeSignIn.status !== 'complete') {
+          // The status can also be `needs_factor_on', 'needs_factor_two', or 'needs_identifier'
+          // Please see https://clerk.com/docs/references/react/use-sign-in#result-status for  more information
+          console.log(JSON.stringify(completeSignIn, null, 2));
+        }
+
+        if (completeSignIn.status === "complete") {
+          // If complete, user exists and provided password match -- set session active
+          await setActive({ session: completeSignIn.createdSessionId });
+          // redirect the user how you see fit.
+        }
+      } catch (err: any) { 
+        // This can return an array of errors.
+        // See https://clerk.com/docs/custom-flows/error-handling to learn about error handling
+        console.error(JSON.stringify(err, null, 2));
+      }
+    };
+
+    return (
+      <div>
+        <form>
+          <div>
+            <label htmlFor="email">Email</label>
+            <input onChange={(e) => setEmailAddress(e.target.value)} id="email" name="email" type="email" />
+          </div>
+          <div>
+            <label htmlFor="password">Password</label>
+            <input onChange={(e) => setPassword(e.target.value)} id="password" name="password" type="password" />
+          </div>
+          <button onClick={handleSubmit}>Sign In</button>
+        </form>
+      </div>
+    );
+  }
+  ```
+  </Tab>
+
+  <Tab>
+  ```tsx filename="app/routes/sign-in/$.tsx"
+  import { useState } from "react";
+  import { useSignIn } from "@clerk/remix";
+
+  export default function SignInForm() {
+    const { isLoaded, signIn, setActive } = useSignIn();
+    const [emailAddress, setEmailAddress] = useState("");
+    const [password, setPassword] = useState("");
+    
     // Start the sign-in process using the email and password provided
-    try {
-      const completeSignIn = await signIn.create({
-        identifier: email,
-        password,
-      });
-
-      if (completeSignIn.status !== 'complete') {
-        // The status can also be `needs_factor_on', 'needs_factor_two', or 'needs_identifier'
-        // Please see https://clerk.com/docs/references/react/use-sign-in#result-status for  more information
-        console.log(JSON.stringify(completeSignIn, null, 2));
+    const handleSubmit = async (e) => {
+      e.preventDefault();
+      if (!isLoaded) {
+        return;
       }
 
-      if (completeSignIn.status === 'complete') {
-        // If complete, user exists and provided password match -- set session active
-        await setActive({ session: completeSignIn.createdSessionId });
-        // Redirect the user to a post sign-in route
-        router.push('/');
+      // Start the sign-in process using the email and password provided
+      try {
+        const completeSignIn = await signIn.create({
+          identifier: emailAddress,
+          password,
+        });
+
+        if (completeSignIn.status !== 'complete') {
+          // The status can also be `needs_factor_on', 'needs_factor_two', or 'needs_identifier'
+          // Please see https://clerk.com/docs/references/react/use-sign-in#result-status for  more information
+          console.log(JSON.stringify(completeSignIn, null, 2));
+        }
+
+        if (completeSignIn.status === 'complete') {
+          // If complete, user exists and provided password match -- set session active
+          await setActive({ session: completeSignIn.createdSessionId });
+        }
+      } catch (err: any) {
+        // This can return an array of errors.
+        // See https://clerk.com/docs/custom-flows/error-handling to learn about error handling
+        console.error(JSON.stringify(err, null, 2));
       }
-    } catch (err: any) {
-      // This can return an array of errors.
-      // See https://clerk.com/docs/custom-flows/error-handling to learn about error handling
-      console.error(JSON.stringify(err, null, 2));
-    }
-  };
+    };
 
-  // Display a form to capture the user's email and password
-  return (
-    <div>
-      <form onSubmit={(e) => handleSubmit(e)}>
-        <div>
-          <label htmlFor="email">Email</label>
-          <input onChange={(e) => setEmail(e.target.value)} id="email" name="email" type="email" value={email} />
-        </div>
-        <div>
-          <label htmlFor="password">Password</label>
-          <input onChange={(e) => setPassword(e.target.value)} id="password" name="password" type="password" value={password} />
-        </div>
-        <button type="submit">Sign In</button>
-      </form>
-    </div>
-  );
-}
-```
+    // Display a form to capture the user's email and password
+    return (
+      <div>
+        <form>
+          <div>
+            <label htmlFor="email">Email</label>
+            <input onChange={(e) => setEmailAddress(e.target.value)} id="email" name="email" type="email" />
+          </div>
+          <div>
+            <label htmlFor="password">Password</label>
+            <input onChange={(e) => setPassword(e.target.value)} id="password" name="password" type="password" />
+          </div>
+          <button onClick={handleSubmit}>Sign In</button>
+        </form>
+      </div>
+    );
+  }
+  ```
+  </Tab>
 
+  <Tab>
+  ```tsx filename="sign-in.tsx"
+  import { useState } from "react";
+  // Use React for Gatsby
+  import { useSignIn } from "@clerk/clerk-react";
 
-```tsx filename="pages/sign-in/[[...index]].tsx"
-import { useState } from "react";
-import { useSignIn } from "@clerk/nextjs";
-import { useRouter } from "next/router";
-
-export default function SignInForm() {
-  const { isLoaded, signIn, setActive } = useSignIn();
-  const [emailAddress, setEmailAddress] = useState("");
-  const [password, setPassword] = useState("");
-  const router = useRouter();
-
-  // Handle the submission of the sign-in form
-  const handleSubmit = async (e) => {
-    e.preventDefault();
-    if (!isLoaded) {
-      return;
-    }
-
-    // Start the sign-in process using the email and password provided
-    try {
-      const result = await signIn.create({
-        identifier: emailAddress,
-        password,
-      });
-
-      if (result.status === "complete") {
-        // If complete, user exists and provided password match -- set session active
-        await setActive({ session: result.createdSessionId });
-        // Redirect the user to a post sign-in route
-        router.push("/")
-      }
-      else {
-        // The status can also be `needs_factor_on', 'needs_factor_two', or 'needs_identifier'
-        // Please see https://clerk.com/docs/references/react/use-sign-in#result-status for  more information
-        console.error(JSON.stringify(results, null, 2));
-      }
-    } catch (err: any) {
-      // This can return an array of errors.
-      // See https://clerk.com/docs/custom-flows/error-handling to learn about error handling
-      console.error(JSON.stringify(err, null, 2));
-    }
-  };
-
-  // Display a form to capture the user's email and password
-  return (
-    <div>
-      <form>
-        <div>
-          <label htmlFor="email">Email</label>
-          <input onChange={(e) => setEmailAddress(e.target.value)} id="email" name="email" type="email" />
-        </div>
-        <div>
-          <label htmlFor="password">Password</label>
-          <input onChange={(e) => setPassword(e.target.value)} id="password" name="password" type="password" />
-        </div>
-        <button onClick={handleSubmit}>Sign In</button>
-      </form>
-    </div>
-  );
-}
-```
-</CodeBlockTabs>
-</Tab>
-
-<Tab>
-```tsx filename="signin.tsx"
-import { useState } from "react";
-import { useSignIn } from "@clerk/clerk-react";
-
-export default function SignInForm() {
-  const { isLoaded, signIn, setActive } = useSignIn();
-  const [emailAddress, setEmailAddress] = useState("");
-  const [password, setPassword] = useState("");
-  
-  // Handle the submission of the sign-in form
-  const handleSubmit = async (e) => {
-    e.preventDefault();
-    if (!isLoaded) {
-      return;
-    }
-
-    // Start the sign-in process using the email and password provided
-    try {
-      const completeSignIn = await signIn.create({
-        identifier: emailAddress,
-        password,
-      });
-
-      if (completeSignIn.status !== 'complete') {
-        // The status can also be `needs_factor_on', 'needs_factor_two', or 'needs_identifier'
-        // Please see https://clerk.com/docs/references/react/use-sign-in#result-status for  more information
-        console.log(JSON.stringify(completeSignIn, null, 2));
+  export default function SignInForm() {
+    const { isLoaded, signIn, setActive } = useSignIn();
+    const [emailAddress, setEmailAddress] = useState("");
+    const [password, setPassword] = useState("");
+    
+    // Handle the submission of the sign-in form
+    const handleSubmit = async (e) => {
+      e.preventDefault();
+      if (!isLoaded) {
+        return;
       }
 
-      if (completeSignIn.status === "complete") {
-        // If complete, user exists and provided password match -- set session active
-        await setActive({ session: completeSignIn.createdSessionId });
-        // redirect the user how you see fit.
+      // Start the sign-in process using the email and password provided
+      try {
+        const completeSignIn = await signIn.create({
+          identifier: emailAddress,
+          password,
+        });
+
+        if (completeSignIn.status !== 'complete') {
+          // The status can also be `needs_factor_on', 'needs_factor_two', or 'needs_identifier'
+          // Please see https://clerk.com/docs/references/react/use-sign-in#result-status for  more information
+          console.log(JSON.stringify(completeSignIn, null, 2));
+        }
+
+        if (completeSignIn.status === 'complete') {
+          // If complete, user exists and provided password match -- set session active
+          await setActive({ session: completeSignIn.createdSessionId });
+          // Redirect the user to a post sign-in route
+          router.push('/');
+        }
+      } catch (err: any) {
+        // This can return an array of errors.
+        // See https://clerk.com/docs/custom-flows/error-handling to learn about error handling
+        console.error(JSON.stringify(err, null, 2));
       }
-    } catch (err: any) { 
-      // This can return an array of errors.
-      // See https://clerk.com/docs/custom-flows/error-handling to learn about error handling
-      console.error(JSON.stringify(err, null, 2));
-    }
-  };
+    };
 
-  return (
-    <div>
-      <form>
-        <div>
-          <label htmlFor="email">Email</label>
-          <input onChange={(e) => setEmailAddress(e.target.value)} id="email" name="email" type="email" />
-        </div>
-        <div>
-          <label htmlFor="password">Password</label>
-          <input onChange={(e) => setPassword(e.target.value)} id="password" name="password" type="password" />
-        </div>
-        <button onClick={handleSubmit}>Sign In</button>
-      </form>
-    </div>
-  );
-}
-```
-</Tab>
+    // Display a form to capture the user's email and password
+    return (
+      <div>
+        <form>
+          <div>
+            <label htmlFor="email">Email</label>
+            <input onChange={(e) => setEmailAddress(e.target.value)} id="email" name="email" type="email" />
+          </div>
+          <div>
+            <label htmlFor="password">Password</label>
+            <input onChange={(e) => setPassword(e.target.value)} id="password" name="password" type="password" />
+          </div>
+          <button onClick={handleSubmit}>Sign In</button>
+        </form>
+      </div>
+    );
+  }
+  ```
+  </Tab>
 
-<Tab>
-```tsx filename="app/routes/sign-in/$.tsx"
-import { useState } from "react";
-import { useSignIn } from "@clerk/remix";
+  <Tab>
+  ```tsx filename="SignUpScreen.tsx"
+  import React from "react";
+  import { Text, TextInput, TouchableOpacity, View } from "react-native";
+  import { useSignIn } from "@clerk/clerk-expo";
 
-export default function SignInForm() {
-  const { isLoaded, signIn, setActive } = useSignIn();
-  const [emailAddress, setEmailAddress] = useState("");
-  const [password, setPassword] = useState("");
-  
-  // Start the sign-in process using the email and password provided
-  const handleSubmit = async (e) => {
-    e.preventDefault();
-    if (!isLoaded) {
-      return;
-    }
+  export default function SignInScreen() {
+    const { signIn, setActive, isLoaded } = useSignIn();
 
-    // Start the sign-in process using the email and password provided
-    try {
-      const completeSignIn = await signIn.create({
-        identifier: emailAddress,
-        password,
-      });
+    const [emailAddress, setEmailAddress] = React.useState("");
+    const [password, setPassword] = React.useState("");
 
-      if (completeSignIn.status !== 'complete') {
-        // The status can also be `needs_factor_on', 'needs_factor_two', or 'needs_identifier'
-        // Please see https://clerk.com/docs/references/react/use-sign-in#result-status for  more information
-        console.log(JSON.stringify(completeSignIn, null, 2));
-      }
-
-      if (completeSignIn.status === 'complete') {
-        // If complete, user exists and provided password match -- set session active
-        await setActive({ session: completeSignIn.createdSessionId });
-      }
-    } catch (err: any) {
-      // This can return an array of errors.
-      // See https://clerk.com/docs/custom-flows/error-handling to learn about error handling
-      console.error(JSON.stringify(err, null, 2));
-    }
-  };
-
-  // Display a form to capture the user's email and password
-  return (
-    <div>
-      <form>
-        <div>
-          <label htmlFor="email">Email</label>
-          <input onChange={(e) => setEmailAddress(e.target.value)} id="email" name="email" type="email" />
-        </div>
-        <div>
-          <label htmlFor="password">Password</label>
-          <input onChange={(e) => setPassword(e.target.value)} id="password" name="password" type="password" />
-        </div>
-        <button onClick={handleSubmit}>Sign In</button>
-      </form>
-    </div>
-  );
-}
-```
-</Tab>
-
-<Tab>
-```tsx filename="sign-in.tsx"
-import { useState } from "react";
-// Use React for Gatsby
-import { useSignIn } from "@clerk/clerk-react";
-
-export default function SignInForm() {
-  const { isLoaded, signIn, setActive } = useSignIn();
-  const [emailAddress, setEmailAddress] = useState("");
-  const [password, setPassword] = useState("");
-  
-  // Handle the submission of the sign-in form
-  const handleSubmit = async (e) => {
-    e.preventDefault();
-    if (!isLoaded) {
-      return;
-    }
-
-    // Start the sign-in process using the email and password provided
-    try {
-      const completeSignIn = await signIn.create({
-        identifier: emailAddress,
-        password,
-      });
-
-      if (completeSignIn.status !== 'complete') {
-        // The status can also be `needs_factor_on', 'needs_factor_two', or 'needs_identifier'
-        // Please see https://clerk.com/docs/references/react/use-sign-in#result-status for  more information
-        console.log(JSON.stringify(completeSignIn, null, 2));
+    // Handle the submission of the sign-in form
+    const onSignInPress = async () => {
+      if (!isLoaded) {
+        return;
       }
 
-      if (completeSignIn.status === 'complete') {
-        // If complete, user exists and provided password match -- set session active
-        await setActive({ session: completeSignIn.createdSessionId });
-        // Redirect the user to a post sign-in route
-        router.push('/');
+      // Start the sign-in process using the email and password provided
+      try {
+        const completeSignIn = await signIn.create({
+          identifier: emailAddress,
+          password,
+        });
+        
+        if (completeSignIn.status !== 'complete') {
+          // The status can also be `needs_factor_on', 'needs_factor_two', or 'needs_identifier'
+          // Please see https://clerk.com/docs/references/react/use-sign-in#result-status for  more information
+          console.log(JSON.stringify(completeSignIn, null, 2));
+        }
+
+        if (completeSignIn.status === 'complete') {
+          // If complete, user exists and provided password match -- set session active
+          await setActive({ session: completeSignIn.createdSessionId });
+          // Redirect the user to a post sign-in route
+          router.push('/');
+        }
+      } catch (err: any) {
+        // This can return an array of errors.
+        // See https://clerk.com/docs/custom-flows/error-handling to learn about error handling
+        console.error(JSON.stringify(err, null, 2));
       }
-    } catch (err: any) {
-      // This can return an array of errors.
-      // See https://clerk.com/docs/custom-flows/error-handling to learn about error handling
-      console.error(JSON.stringify(err, null, 2));
-    }
-  };
+    };
 
-  // Display a form to capture the user's email and password
-  return (
-    <div>
-      <form>
-        <div>
-          <label htmlFor="email">Email</label>
-          <input onChange={(e) => setEmailAddress(e.target.value)} id="email" name="email" type="email" />
-        </div>
-        <div>
-          <label htmlFor="password">Password</label>
-          <input onChange={(e) => setPassword(e.target.value)} id="password" name="password" type="password" />
-        </div>
-        <button onClick={handleSubmit}>Sign In</button>
-      </form>
-    </div>
-  );
-}
-```
-</Tab>
-
-<Tab>
-```tsx filename="SignUpScreen.tsx"
-import React from "react";
-import { Text, TextInput, TouchableOpacity, View } from "react-native";
-import { useSignIn } from "@clerk/clerk-expo";
-
-export default function SignInScreen() {
-  const { signIn, setActive, isLoaded } = useSignIn();
-
-  const [emailAddress, setEmailAddress] = React.useState("");
-  const [password, setPassword] = React.useState("");
-
-  // Handle the submission of the sign-in form
-  const onSignInPress = async () => {
-    if (!isLoaded) {
-      return;
-    }
-
-    // Start the sign-in process using the email and password provided
-    try {
-      const completeSignIn = await signIn.create({
-        identifier: emailAddress,
-        password,
-      });
-      
-      if (completeSignIn.status !== 'complete') {
-        // The status can also be `needs_factor_on', 'needs_factor_two', or 'needs_identifier'
-        // Please see https://clerk.com/docs/references/react/use-sign-in#result-status for  more information
-        console.log(JSON.stringify(completeSignIn, null, 2));
-      }
-
-      if (completeSignIn.status === 'complete') {
-        // If complete, user exists and provided password match -- set session active
-        await setActive({ session: completeSignIn.createdSessionId });
-        // Redirect the user to a post sign-in route
-        router.push('/');
-      }
-    } catch (err: any) {
-      // This can return an array of errors.
-      // See https://clerk.com/docs/custom-flows/error-handling to learn about error handling
-      console.error(JSON.stringify(err, null, 2));
-    }
-  };
-
-  // Display a form to capture the user's email and password
-  return (
-    <View>
+    // Display a form to capture the user's email and password
+    return (
       <View>
-        <TextInput
-          autoCapitalize="none"
-          value={emailAddress}
-          placeholder="Email..."
-          onChangeText={(emailAddress) => setEmailAddress(emailAddress)}
-        />
+        <View>
+          <TextInput
+            autoCapitalize="none"
+            value={emailAddress}
+            placeholder="Email..."
+            onChangeText={(emailAddress) => setEmailAddress(emailAddress)}
+          />
+        </View>
+
+        <View>
+          <TextInput
+            value={password}
+            placeholder="Password..."
+            secureTextEntry={true}
+            onChangeText={(password) => setPassword(password)}
+          />
+        </View>
+
+        <TouchableOpacity onPress={onSignInPress}>
+          <Text>Sign in</Text>
+        </TouchableOpacity>
       </View>
+    );
+  }
+  ```
+  </Tab>
 
-      <View>
-        <TextInput
-          value={password}
-          placeholder="Password..."
-          secureTextEntry={true}
-          onChangeText={(password) => setPassword(password)}
-        />
-      </View>
+  <Tab>
+  ```html filename="your-app.html"
+  <!DOCTYPE html>
+  <html lang="en">
 
-      <TouchableOpacity onPress={onSignInPress}>
-        <Text>Sign in</Text>
-      </TouchableOpacity>
-    </View>
-  );
-}
-```
-</Tab>
+  <head>
+      <meta charset="UTF-8" />
+      <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+      <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+      <title>Clerk JavaScript Email + Password</title>
+  </head>
 
-<Tab>
-```html filename="your-app.html"
-<!DOCTYPE html>
-<html lang="en">
+  <body>
+      <h1>Clerk JavaScript Email + Password</h1>
 
-<head>
-    <meta charset="UTF-8" />
-    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Clerk JavaScript Email + Password</title>
-</head>
+      <div id="auth-signin">
+          <input placeholder="email" id="email" type="email"></input>
+          <input placeholder="password" id="password" type="password"></input>
+          <button onclick="SignIn()">SignIn</button>
 
-<body>
-    <h1>Clerk JavaScript Email + Password</h1>
+      </div>
+      <script>
+          const SignIn = async () => {
+              const emailAddress = document.getElementById('email').value;
+              const password = document.getElementById('password').value;
+              const {client} = window.Clerk;
+              try {
+                const signInAttempt = await client.signIn.create({
+                      emailAddress,
+                      password
+                  });
+                if (signInAttempt.status === "complete") {
+                  await setActive({ session: signInAttempt.createdSessionId });
+                  // redirect the user how you see fit.
+                }
+                else {
+                  /*Investigate why the login hasn't completed */
+                  console.log(signInAttempt);
+                }
+              }
+              catch (err) {
+                  console.log(err)
+              }
+          };
+      </script>
+      // Script to load Clerk up
+      <script src="src/script.js" async crossorigin="anonymous"></script>
+  </body>
 
-    <div id="auth-signin">
-        <input placeholder="email" id="email" type="email"></input>
-        <input placeholder="password" id="password" type="password"></input>
-        <button onclick="SignIn()">SignIn</button>
-
-    </div>
-    <script>
-        const SignIn = async () => {
-            const emailAddress = document.getElementById('email').value;
-            const password = document.getElementById('password').value;
-            const {client} = window.Clerk;
-            try {
-               const signInAttempt = await client.signIn.create({
-                    emailAddress,
-                    password
-                });
-               if (signInAttempt.status === "complete") {
-                 await setActive({ session: signInAttempt.createdSessionId });
-                 // redirect the user how you see fit.
-               }
-               else {
-                 /*Investigate why the login hasn't completed */
-                 console.log(signInAttempt);
-               }
-            }
-            catch (err) {
-                console.log(err)
-            }
-        };
-    </script>
-    // Script to load Clerk up
-    <script src="src/script.js" async crossorigin="anonymous"></script>
-</body>
-
-</html>
-```
-</Tab>
+  </html>
+  ```
+  </Tab>
 </Tabs>
 </Steps>

--- a/docs/custom-flows/email-sms-otp.mdx
+++ b/docs/custom-flows/email-sms-otp.mdx
@@ -59,153 +59,161 @@ A successful sign-up consists of the following steps:
 
 Let's see the above in action. If you want to learn more about sign-ups, check out our documentation on Clerk's [sign-up flow](/docs/custom-flows/overview#sign-up-flow).
 
-<CodeBlockTabs options={["Next App Router", "React", "JavaScript"]}>
-```ts filename="app/sign-up/page.tsx"
-'use client'
+<Tabs type="framework" items={["Next.js", "React", "JavaScript"]}>
+  <Tab>
+    <CodeBlockTabs type="router" options={["App Router"]}>
+    ```ts filename="app/sign-up/page.tsx"
+    'use client'
 
-import * as React from 'react'
-import { useSignUp } from "@clerk/nextjs";
-import { useRouter } from 'next/navigation';
+    import * as React from 'react'
+    import { useSignUp } from "@clerk/nextjs";
+    import { useRouter } from 'next/navigation';
 
-export default function Page() {
-  const { isLoaded, signUp, setActive } = useSignUp();
-  const [verifying, setVerifying] = React.useState(false)
-  const [phone, setPhone] = React.useState("")
-  const [code, setCode] = React.useState("")
-  const router = useRouter()
+    export default function Page() {
+      const { isLoaded, signUp, setActive } = useSignUp();
+      const [verifying, setVerifying] = React.useState(false)
+      const [phone, setPhone] = React.useState("")
+      const [code, setCode] = React.useState("")
+      const router = useRouter()
 
-  async function handleSubmit(e: React.FormEvent) {
-    e.preventDefault();
-
-    if (!isLoaded && !signUp) return null
-
-    try {
-      // Start the Sign Up process using the phone number method
-      await signUp.create({
-        phoneNumber: phone,
-      });
-
-      // Start the verification - a SMS message will be sent to the 
-      // number with a one-time code
-      await signUp.preparePhoneNumberVerification();
-
-      // Set 'verifying' true to display second form and capture the OTP code
-      setVerifying(true)
-    }
-    catch (err) {
-      // See https://clerk.com/docs/custom-flows/error-handling for more on error handling
-      console.error('Error:', JSON.stringify(err, null, 2))
-    }
-  }
-
-  async function handleVerification(e: React.FormEvent) {
-    e.preventDefault()
-
-    if (!isLoaded && !signUp) return null
-
-    try {
-      // Use the code provided by the user and attempt verification
-      const completeSignUp = await signUp.attemptPhoneNumberVerification({
-        code,
-      });
-
-      // This mainly for debuggin while developing.
-      // Once your Instance is setup this should not be required.
-      if (completeSignUp.status !== 'complete') {
-        console.error(JSON.stringify(completeSignUp, null, 2))
-      }
-
-      // If verification was completed, create a session for the user
-      if (completeSignUp.status === 'complete') {
-        await setActive({ session: completeSignUp.createdSessionId });
-
-        // redirect user 
-        router.push("/")
-      }
-    }
-    catch (err) {
-      // See https://clerk.com/docs/custom-flows/error-handling for more on error handling
-      console.error('Error:', JSON.stringify(err, null, 2))
-    }
-  }
-
-  if (verifying) {
-    return (
-      <form onSubmit={handleVerification}>
-        <label id="code">Code</label>
-        <input value={code} id="code" name="code" onChange={(e) => setCode(e.target.value)} />
-        <button type="submit">Verify</button>
-      </form>
-    )
-  }
-
-  return (
-    <form onSubmit={handleSubmit}>
-      <label id="phone">Phone</label>
-      <input value={phone} id="phone" name="phone" type="tel" onChange={(e) => setPhone(e.target.value)} />
-      <button type="submit">Send Code</button>
-    </form>
-  );
-}
-````
-
-```jsx filename="SignUpPage.jsx"
-import { useSignUp } from "@clerk/clerk-react";
-
-function SignUpPage() {
-    const { signUp,setActive } = useSignUp();
-    
-    async function onClick(e) {
+      async function handleSubmit(e: React.FormEvent) {
         e.preventDefault();
-        // Kick off the sign-up process, passing the user's
-        // phone number.
-        await signUp.create({
-            phoneNumber: "+11111111111",
-        });
-        
-        // Prepare phone number verification. An SMS message 
-        // will be sent to the user with a one-time 
-        // verification code.
-        await signUp.preparePhoneNumberVerification();
-        
-        // Attempt to verify the user's phone number by 
-        // providing the one-time code they received.
-        await signUp.attemptPhoneNumberVerification({
-            code: "123456",
-        }); 
-        
-        await setActive({sessionId: signUp.createdSessionId});
+
+        if (!isLoaded && !signUp) return null
+
+        try {
+          // Start the Sign Up process using the phone number method
+          await signUp.create({
+            phoneNumber: phone,
+          });
+
+          // Start the verification - a SMS message will be sent to the 
+          // number with a one-time code
+          await signUp.preparePhoneNumberVerification();
+
+          // Set 'verifying' true to display second form and capture the OTP code
+          setVerifying(true)
+        }
+        catch (err) {
+          // See https://clerk.com/docs/custom-flows/error-handling for more on error handling
+          console.error('Error:', JSON.stringify(err, null, 2))
+        }
+      }
+
+      async function handleVerification(e: React.FormEvent) {
+        e.preventDefault()
+
+        if (!isLoaded && !signUp) return null
+
+        try {
+          // Use the code provided by the user and attempt verification
+          const completeSignUp = await signUp.attemptPhoneNumberVerification({
+            code,
+          });
+
+          // This mainly for debuggin while developing.
+          // Once your Instance is setup this should not be required.
+          if (completeSignUp.status !== 'complete') {
+            console.error(JSON.stringify(completeSignUp, null, 2))
+          }
+
+          // If verification was completed, create a session for the user
+          if (completeSignUp.status === 'complete') {
+            await setActive({ session: completeSignUp.createdSessionId });
+
+            // redirect user 
+            router.push("/")
+          }
+        }
+        catch (err) {
+          // See https://clerk.com/docs/custom-flows/error-handling for more on error handling
+          console.error('Error:', JSON.stringify(err, null, 2))
+        }
+      }
+
+      if (verifying) {
+        return (
+          <form onSubmit={handleVerification}>
+            <label id="code">Code</label>
+            <input value={code} id="code" name="code" onChange={(e) => setCode(e.target.value)} />
+            <button type="submit">Verify</button>
+          </form>
+        )
+      }
+
+      return (
+        <form onSubmit={handleSubmit}>
+          <label id="phone">Phone</label>
+          <input value={phone} id="phone" name="phone" type="tel" onChange={(e) => setPhone(e.target.value)} />
+          <button type="submit">Send Code</button>
+        </form>
+      );
     }
-    
-    return (
-        <button onClick={onClick}>
-            Sign up without password
-        </button>
-    );
-}
-```
+    ```
+    </CodeBlockTabs>
+  </Tab>
 
-```js filename="SignUpPage.js"
-const { client } = window.Clerk;
+  <Tab>
+  ```jsx filename="SignUpPage.jsx"
+  import { useSignUp } from "@clerk/clerk-react";
 
-// Kick off the sign-up process, 
-// passing the user's phone number.
-const signUp = await client.signUp.create({
-    phoneNumber: "+11111111111",
-});
+  function SignUpPage() {
+      const { signUp,setActive } = useSignUp();
+      
+      async function onClick(e) {
+          e.preventDefault();
+          // Kick off the sign-up process, passing the user's
+          // phone number.
+          await signUp.create({
+              phoneNumber: "+11111111111",
+          });
+          
+          // Prepare phone number verification. An SMS message 
+          // will be sent to the user with a one-time 
+          // verification code.
+          await signUp.preparePhoneNumberVerification();
+          
+          // Attempt to verify the user's phone number by 
+          // providing the one-time code they received.
+          await signUp.attemptPhoneNumberVerification({
+              code: "123456",
+          }); 
+          
+          await setActive({sessionId: signUp.createdSessionId});
+      }
+      
+      return (
+          <button onClick={onClick}>
+              Sign up without password
+          </button>
+      );
+  }
+  ```
+  </Tab>
 
-// Prepare phone number verification. An SMS will 
-// be sent to the user with a one-time verification 
-// code.
-await signUp.preparePhoneNumberVerification();
+  <Tab>
+  ```js filename="SignUpPage.js"
+  const { client } = window.Clerk;
 
-// Attempt to verify the user's phone number by providing
-// the one-time code they received.
-await signUp.attemptPhoneNumberVerification({
-    code: "123456",
-});
-```
-</CodeBlockTabs>
+  // Kick off the sign-up process, 
+  // passing the user's phone number.
+  const signUp = await client.signUp.create({
+      phoneNumber: "+11111111111",
+  });
+
+  // Prepare phone number verification. An SMS will 
+  // be sent to the user with a one-time verification 
+  // code.
+  await signUp.preparePhoneNumberVerification();
+
+  // Attempt to verify the user's phone number by providing
+  // the one-time code they received.
+  await signUp.attemptPhoneNumberVerification({
+      code: "123456",
+  });
+  ```
+  </Tab>
+</Tabs>
 
 You can also verify your users via their email address. There's two additional helper methods: [`prepareEmailAddressVerification`](/docs/references/javascript/sign-up/email-verification#prepare-email-address-verification) and [`attemptEmailAddressVerification`](/docs/references/javascript/sign-up/email-verification#attempt-email-address-verification) that work the same way as their phone number counterparts do. You can find all available methods in the [`SignUp`](/docs/references/javascript/sign-in/sign-in) object documentation. 
 

--- a/docs/custom-flows/embedded-magic-links.mdx
+++ b/docs/custom-flows/embedded-magic-links.mdx
@@ -40,24 +40,7 @@ Now that you have a way to process a token, you'll need to setup a page on your 
 
 Signing a user in with a token is very similar to all of our other custom flows.
 
-<CodeBlockTabs options={["React", "Next.js"]}>
-```jsx filename="accept-token.js"
-// Grab the sign in token from the query string
-const queryParams = new URLSearchParams(window.location.search);
-const signInToken = queryParams.get('token');
-
-const { signIn, setSession } = useSignIn();
-
-// Create a sign in with the ticket strategy, and the sign-in-token
-const res = await signIn.create({
-  strategy: "ticket",
-  ticket: "signInToken",
-});
-
-// Set the session as active, and then do whatever you need to!
-setSession(res.createdSessionId, () => console.log("SignedIn!"));
-```
-
+<CodeBlockTabs type="framework" options={["Next.js", "React"]}>
 ```jsx filename="pages/accept-token.jsx"
 import { InferGetServerSidePropsType, GetServerSideProps } from "next";
 import { useUser, useSignIn } from "@clerk/nextjs";
@@ -117,5 +100,22 @@ const AcceptToken = ({
 };
 
 export default AcceptToken;
+```
+
+```jsx filename="accept-token.js"
+// Grab the sign in token from the query string
+const queryParams = new URLSearchParams(window.location.search);
+const signInToken = queryParams.get('token');
+
+const { signIn, setSession } = useSignIn();
+
+// Create a sign in with the ticket strategy, and the sign-in-token
+const res = await signIn.create({
+  strategy: "ticket",
+  ticket: "signInToken",
+});
+
+// Set the session as active, and then do whatever you need to!
+setSession(res.createdSessionId, () => console.log("SignedIn!"));
 ```
 </CodeBlockTabs>

--- a/docs/custom-flows/error-handling.mdx
+++ b/docs/custom-flows/error-handling.mdx
@@ -11,7 +11,7 @@ When using the [`signUp()`](/docs/references/react/use-sign-up) or [`signIn()`](
 
 A user is attempting to sign up with your application, but they are attempting to use a password that has been found in an online data breach. This will return a 422 error code with the message: "Password has been found in an online data breach. For account safety, please use a different password."
 
-<CodeBlockTabs options={["React", "JavaScript"]}>
+<CodeBlockTabs type="framework" options={["React", "JavaScript"]}>
 ```jsx
 import { useState } from "react";
 import { useSignUp } from "@clerk/clerk-react";
@@ -57,7 +57,7 @@ const signUp = await client.signUp.create({
 
 Errors returned from the [`signIn()`](/docs/references/react/use-sign-in) function are handled in a similar way:
 
-<CodeBlockTabs options={["React", "JavaScript"]}>
+<CodeBlockTabs type="framework" options={["React", "JavaScript"]}>
 ```jsx
 import { useState } from "react";
 import { useSignIn } from "@clerk/clerk-react";

--- a/docs/custom-flows/forgot-password.mdx
+++ b/docs/custom-flows/forgot-password.mdx
@@ -11,7 +11,7 @@ If these options will not work for you, or if you want more control of your user
 
 ## Example
 
-<CodeBlockTabs options={["React"]}>
+<CodeBlockTabs type="framework" options={["React"]}>
 ```jsx
 import React, { SyntheticEvent, useState } from 'react';
 import { useSignIn } from '@clerk/nextjs';

--- a/docs/custom-flows/magic-links.mdx
+++ b/docs/custom-flows/magic-links.mdx
@@ -104,7 +104,7 @@ Let's see all the steps involved in more detail.
 
 Clerk provides a highly flexible API that allows you to hook into any of the above steps while abstracting away all the complexities of a magic link-based sign-up flow.
 
-<CodeBlockTabs options={["Next.js", "React", "JavaScript"]}>
+<CodeBlockTabs type="framework" options={["Next.js", "React", "JavaScript"]}>
 ```jsx
 import React from "react";
 import { useRouter } from "next/router";
@@ -503,7 +503,7 @@ Let's see all the steps involved in more detail.
 
 Clerk provides a highly flexible API that allows you to hook into any of the above steps, while abstracting away all the complexities of a magic link based sign-in flow.
 
-<CodeBlockTabs options={["Next.js", "React", "JavaScript"]}>
+<CodeBlockTabs type="framework" options={["Next.js", "React", "JavaScript"]}>
 ```jsx
 import React from "react";
 import { useRouter } from "next/router";
@@ -897,7 +897,7 @@ Magic links can also provide a nice user experience for verifying email addresse
 
 Clerk provides a highly flexible API that allows you to hook into any of the above steps while abstracting away all the complexities of a magic link-based email address verification.
 
-<CodeBlockTabs options={["Next.js", "React", "JavaScript"]}>
+<CodeBlockTabs type="framework" options={["Next.js", "React", "JavaScript"]}>
 ```jsx
 import React from "react";
 import { useUser, useMagicLink } from "@clerk/nextjs";

--- a/docs/custom-flows/mfa.mdx
+++ b/docs/custom-flows/mfa.mdx
@@ -61,7 +61,7 @@ Signing in to an MFA-enabled account is identical to the regular sign-in process
 
 Let's see the above in action.
 
-<CodeBlockTabs options={["React", "JavaScript"]}>
+<CodeBlockTabs type="framework" options={["React", "JavaScript"]}>
 ```jsx
 import { useSignIn } from "@clerk/clerk-react";
 

--- a/docs/custom-flows/multi-session-applications.mdx
+++ b/docs/custom-flows/multi-session-applications.mdx
@@ -50,7 +50,7 @@ The easiest way to add multi-session features to your application is by using th
 
 This component has buttons add a new account, switch between accounts, and sign out from one or all accounts.
 
-<CodeBlockTabs options={["React", "JavaScript"]}>
+<CodeBlockTabs type="framework" options={["React", "JavaScript"]}>
 ```jsx
 import { UserButton } from "@clerk/clerk-react";
 
@@ -89,7 +89,7 @@ In case the pre-built user button doesn't cover your needs and you prefer a cust
 
 ### Active session/user
 
-<CodeBlockTabs options={["React", "JavaScript"]}>
+<CodeBlockTabs type="framework" options={["React", "JavaScript"]}>
 ```jsx
 import { useClerk } from "@clerk/clerk-react";
 
@@ -108,7 +108,7 @@ const activeUser = window.Clerk.user;
 
 ### Switching between sessions
 
-<CodeBlockTabs options={["React", "JavaScript"]}>
+<CodeBlockTabs type="framework" options={["React", "JavaScript"]}>
 ```jsx
 import { useClerk } from "@clerk/clerk-react";
 
@@ -144,7 +144,7 @@ For more information on how Clerk's sign-in flow works, check out the [detailed 
 
 This version of sign out will deactivate the active session. The rest of the available sessions will remain intact.
 
-<CodeBlockTabs options={["React", "JavaScript"]}>
+<CodeBlockTabs type="framework" options={["React", "JavaScript"]}>
 ```jsx
 import { useClerk } from "@clerk/clerk-react";
 
@@ -164,7 +164,7 @@ await window.Clerk.signOutOne();
 
 This request will deactivate all sessions on the current client.
 
-<CodeBlockTabs options={["React", "JavaScript"]}>
+<CodeBlockTabs type="framework" options={["React", "JavaScript"]}>
 ```jsx
 import { useClerk } from "@clerk/clerk-react";
 

--- a/docs/custom-flows/oauth-connections.mdx
+++ b/docs/custom-flows/oauth-connections.mdx
@@ -18,7 +18,7 @@ When using OAuth, the sign-in and sign-up are equivalent. A successful OAuth flo
 
 The React example below uses `react-router-dom` to define the required route. For NextJS apps, you only need to create a `pages/sso-callback` file.
 
-<CodeBlockTabs options={["React"]}>
+<CodeBlockTabs type="framework" options={["React"]}>
 ```jsx
 import React from "react";
 import {
@@ -133,7 +133,7 @@ When a user initiates an OAuth verification during sign-in or sign-up, it may so
 
 For example, if someone already has an account, and tries to go through the sign up flow with the same OAuth account, they can't perform a successful sign-up again. Or, if someone attempts to sign in with their OAuth credentials but does not yet have an account, they won't be signed in to the account. For these scenarios, Clerk provides "account transfers."
 
-<CodeBlockTabs options={["JavaScript"]}>
+<CodeBlockTabs type="framework" options={["JavaScript"]}>
 ```js
 // Get sign-in and sign-up objects in the OAuth callback page
 const { signIn, signUp } = window.Clerk.client;

--- a/docs/custom-flows/saml-connections.mdx
+++ b/docs/custom-flows/saml-connections.mdx
@@ -18,7 +18,7 @@ When using SAML, the sign-in and sign-up are equivalent. A successful SAML flow 
 
 The React example below uses `react-router-dom` to define the required route. For NextJS apps, you only need to create a `pages/sso-callback` file.
 
-<CodeBlockTabs options={["React"]}>
+<CodeBlockTabs type="framework" options={["React"]}>
 ```jsx
 import React from "react";
 import {
@@ -119,7 +119,7 @@ When a user initiates a SAML SSO verification during sign-in, or sign-up, it may
 
 For example, if someone already has an account, and tries to go through the sign up flow with the same SAML account, they can’t perform a successful sign up again. Or, if someone attempts to sign in with their SAML credentials but does not yet have an account, they won’t be signed in to the account. For these scenarios, we have “account transfers.”
 
-<CodeBlockTabs options={["JavaScript"]}>
+<CodeBlockTabs type="framework" options={["JavaScript"]}>
 ```js
 // Get sign-in and sign-up objects in the SAML callback page
 const { signIn, signUp } = window.Clerk.client;

--- a/docs/custom-flows/sign-out.mdx
+++ b/docs/custom-flows/sign-out.mdx
@@ -36,7 +36,7 @@ In an application with [multisession](/docs/custom-flows/multi-session-applicati
   alt="The User Button component with multiple accounts signed in."
 />
 
-<CodeBlockTabs options={["React", "JavaScript"]}>
+<CodeBlockTabs type="framework" options={["React", "JavaScript"]}>
 ```jsx
 import { UserButton } from "@clerk/clerk-react";
 
@@ -78,7 +78,7 @@ If the pre-built [`<UserButton />`][user-button] doesn't cover your needs, you c
 
 In this example, the [`useClerk()`](/docs/references/react/use-clerk) hook is used to access the [`signOut()`](https://clerk.com/docs/references/javascript/clerk/clerk#sign-out) function. We then use the [`useRouter()`](https://nextjs.org/docs/pages/api-reference/functions/use-router) hook from Next.js to redirect the user to the home page (`/`) after they sign out.
 
-<CodeBlockTabs options={["React", "JavaScript"]}>
+<CodeBlockTabs type="framework" options={["React", "JavaScript"]}>
 ```jsx
 import { useClerk } from "@clerk/clerk-react";
 import { useRouter } from 'next/navigation'

--- a/docs/custom-flows/user-impersonation.mdx
+++ b/docs/custom-flows/user-impersonation.mdx
@@ -102,7 +102,7 @@ The above JSON snippet shows what a Clerk session token looks like when a user i
 
 When working with frontend (client-side) code, you can easily detect impersonated sessions and gain access to the actor ID or other information from the `act` claim.
 
-<CodeBlockTabs options={["Next.js", "React", "JavaScript"]}>
+<CodeBlockTabs type="framework" options={["Next.js", "React", "JavaScript"]}>
 ```jsx
 import { useAuth } from "@clerk/nextjs";
 import { withServerSideAuth } from "@clerk/nextjs";
@@ -180,7 +180,7 @@ if (session.actor) {
 
 When working with backend code, Clerk provides middleware that can be used in Next.js API routes or directly in express-like Node.js applications. The middleware will provide information about impersonated sessions and the actor ID.
 
-<CodeBlockTabs options={["Next.js", "Node"]}>
+<CodeBlockTabs type="framework" options={["Next.js", "Node"]}>
 ```jsx
 // pages/api/some-handler.js
 import { withAuth } from "@clerk/nextjs";

--- a/docs/organizations/creating-organizations.mdx
+++ b/docs/organizations/creating-organizations.mdx
@@ -17,9 +17,9 @@ When creating an organization, you can specify an optional slug for the new orga
 
 ## Usage
 
-{/* TO-DO (DOCS-316): Update and validate these code examples. */}
+{/* TODO (DOCS-316): Update and validate these code examples. */}
 
-<CodeBlockTabs options={["Next.js", "React", "JavaScript"]}>
+<CodeBlockTabs type="framework" options={["Next.js", "React", "JavaScript"]}>
 ```jsx 
 // Form to create a new organization. The current user
 // will become the organization administrator.

--- a/docs/organizations/inviting-users.mdx
+++ b/docs/organizations/inviting-users.mdx
@@ -13,7 +13,7 @@ Administrators are also able to revoke organization invitations for users that h
 
 ## Usage
 
-{/* TO-DO (DOCS-316): Add examples for React and JavaScript. Update and validate these code examples. */}
+{/* TODO (DOCS-316): Add examples for React and JavaScript. Update and validate these code examples. */}
 
 An example implementation in Next.js for inviting users and revoking pending invitations:
 

--- a/docs/organizations/managing-roles.mdx
+++ b/docs/organizations/managing-roles.mdx
@@ -17,7 +17,7 @@ Methods for [changing a member's role](/docs/references/backend/organization/upd
 
 {/* TODO (DOCS-316): Update and validate these examples. */}
 
-<CodeBlockTabs options={["Next.js", "React", "JavaScript"]}>
+<CodeBlockTabs type="framework" options={["Next.js", "React", "JavaScript"]}>
 ```tsx filename="pages/organizations/[id].ts"
 import { useState, useEffect } from "react";
 import { useOrganization } from "@clerk/nextjs";
@@ -506,6 +506,6 @@ function InviteMember(){
 ```
 </CodeBlockTabs>
 
-{/* TO-DO: Should we mention the update method on the OrganizationMembership object? Or the updateMember method on the Organization object? Or the updateOrganizationMembership method from the Backend API? */}
+{/* TODO: Should we mention the update method on the OrganizationMembership object? Or the updateMember method on the Organization object? Or the updateOrganizationMembership method from the Backend API? */}
 
-{/* TO-DO: ## Remove members plus examples? */}
+{/* TODO: ## Remove members plus examples? */}

--- a/docs/organizations/updating-organizations.mdx
+++ b/docs/organizations/updating-organizations.mdx
@@ -15,9 +15,9 @@ You can also use the `updateOrganization` method, which can be accessed from the
 
 This example uses the [`useOrganization()`](/docs/references/react/use-organization) hook to update the organization name.
 
-{/* TO-DO (DOCS-316): Update and validate these code examples. */}
+{/* TODO (DOCS-316): Update and validate these code examples. */}
 
-<CodeBlockTabs options={["Next.js", "React", "JavaScript"]}>
+<CodeBlockTabs type="framework" options={["Next.js", "React", "JavaScript"]}>
 ```jsx
 import { useState, useEffect } from 'react';
 import { useRouter } from 'next/router';

--- a/docs/organizations/viewing-memberships.mdx
+++ b/docs/organizations/viewing-memberships.mdx
@@ -19,7 +19,7 @@ You can use the `getOrganizationMembershipList()` method to retrieve a list of m
 
 {/* TODO (DOCS-316): Update and validate these code examples. */}
 
-<CodeBlockTabs options={["Next.js", "React", "JavaScript"]}>
+<CodeBlockTabs type="framework" options={["Next.js", "React", "JavaScript"]}>
 ```tsx filename="pages/joined-organizations.tsx"
 import { useOrganizationList } from "@clerk/nextjs";
 import React from "react";

--- a/docs/quickstarts/expo.mdx
+++ b/docs/quickstarts/expo.mdx
@@ -17,7 +17,7 @@ Learn how to use Clerk to quickly and easily add secure authentication and user 
 
 Once you have an Expo application ready, you need to install Clerk's Expo SDK.
 
-<CodeBlockTabs options={["npm", "yarn", "pnpm"]}>
+<CodeBlockTabs type="installer" options={["npm", "yarn", "pnpm"]}>
   ```bash filename="terminal"
   npm install @clerk/clerk-expo
   ```
@@ -462,7 +462,7 @@ You can use it as your client JWT storage by setting the `tokenCache` prop in yo
 
 #### Install expo-secure-store
 
-<CodeBlockTabs options={["npm", "yarn", "pnpm"]}>
+<CodeBlockTabs type="installer" options={["npm", "yarn", "pnpm"]}>
   ```bash filename="terminal"
   npm install expo-secure-store
   ```

--- a/docs/quickstarts/fastify.mdx
+++ b/docs/quickstarts/fastify.mdx
@@ -24,7 +24,7 @@ If you're looking for a more complete example, check out our [Fastify example ap
 <Steps>
 ### Install `@clerk/fastify`
 
-<CodeBlockTabs options={['npm', 'yarn', 'pnpm']}>
+<CodeBlockTabs type="installer" options={["npm", "yarn", "pnpm"]}>
   ```bash filename="terminal"
   npm install @clerk/fastify
   ```
@@ -54,7 +54,7 @@ CLERK_SECRET_KEY={{secret}}
 
 This examples uses `dotenv` to load the environment variables. You can use any other library or method, if you so wish.
 
-<CodeBlockTabs options={['npm', 'yarn', 'pnpm']}>
+<CodeBlockTabs type="installer" options={["npm", "yarn", "pnpm"]}>
   ```bash filename="terminal"
   npm install dotenv
   npm install -D @types/dotenv

--- a/docs/quickstarts/gatsby.mdx
+++ b/docs/quickstarts/gatsby.mdx
@@ -17,7 +17,7 @@ Learn how to use Clerk to quickly and easily add secure authentication and user 
 
 Once you have a React application ready, you need to install Clerk's React SDK. This gives you access to our prebuilt components and hooks for React applications.
 
-<CodeBlockTabs options={['npm', 'yarn', 'pnpm']}>
+<CodeBlockTabs type="installer" options={["npm", "yarn", "pnpm"]}>
   ```bash filename="terminal"
   npm install gatsby-plugin-clerk
   ```

--- a/docs/quickstarts/javascript.mdx
+++ b/docs/quickstarts/javascript.mdx
@@ -20,7 +20,7 @@ To use the ClerkJS package, you have two options:
 
 At the root of your project, install the ClerkJS package using your package manager of choice:
 
-<CodeBlockTabs options={['npm', 'yarn', 'pnpm']}>
+<CodeBlockTabs type="installer" options={["npm", "yarn", "pnpm"]}>
   ```bash filename="terminal"
   npm install @clerk/clerk-js
   ```
@@ -125,7 +125,7 @@ This example uses [the `<UserButton />` component](/docs/references/javascript/c
 
 <InjectKeys>
 
-<CodeBlockTabs options={['NPM Module', 'window.Clerk']}>
+<CodeBlockTabs type="npm-script" options={['NPM Module', 'window.Clerk']}>
   ```typescript {14}
   import Clerk from '@clerk/clerk-js';
 

--- a/docs/quickstarts/nextjs.mdx
+++ b/docs/quickstarts/nextjs.mdx
@@ -83,7 +83,7 @@ This sets your public and secret keys.
 
 The [`<ClerkProvider />`](/docs/components/clerk-provider) component provides active session and user context to Clerk's hooks and other components. Import it into your app by adding `import { ClerkProvider } from '@clerk/nextjs'` at the top of your file. 
 
-<Tabs type="framework" items={["App Router", "Pages Router"]}>
+<Tabs type="router" items={["App Router", "Pages Router"]}>
   <Tab>
     
     <Callout>
@@ -164,7 +164,7 @@ Clerk offers a set of [prebuilt components](/docs/components/overview) to add fu
 
 Add it anywhere inside `<ClerkProvider />` in your app. First add `import { UserButton } from "@clerk/nextjs";` to the top of your file. Then add `<UserButton afterSignOutUrl="/"/>`. The `afterSignOutUrl` prop lets you customize what page the user will be redirected to after sign out.
 
-<CodeBlockTabs type="framework" options={["App Router", "Pages Router"]}>
+<CodeBlockTabs type="router" options={["App Router", "Pages Router"]}>
 ```tsx filename="app/page.tsx" {1,6}
 import { UserButton } from "@clerk/nextjs";
 
@@ -195,7 +195,7 @@ export default function Home() {
 
 ### TEST
 
-<CodeBlockTabs type="framework" options={["App Router", "Pages Router"]}>
+<CodeBlockTabs type="framework" options={["React", "Remix"]}>
 ```tsx filename="app/page.tsx" {1,6}
 import { UserButton } from "@clerk/nextjs";
 
@@ -205,6 +205,52 @@ export default function Home() {
       <UserButton afterSignOutUrl="/"/>
     </div>
   )
+}
+```
+
+```tsx filename="pages/index.tsx" {1,7}
+import { UserButton } from "@clerk/nextjs";
+
+export default function Home() {
+  return (
+    <>
+			<header>
+				<UserButton afterSignOutUrl="/"/>
+			</header>
+			<div>Your page's content can go here.</div>
+    </>
+  );
+}
+```
+</CodeBlockTabs>
+
+### TEST
+
+<CodeBlockTabs type="framework" options={["React", "Remix", "Gatsby"]}>
+```tsx filename="app/page.tsx" {1,6}
+import { UserButton } from "@clerk/nextjs";
+
+export default function Home() {
+  return (
+    <div>
+      <UserButton afterSignOutUrl="/"/>
+    </div>
+  )
+}
+```
+
+```tsx filename="pages/index.tsx" {1,7}
+import { UserButton } from "@clerk/nextjs";
+
+export default function Home() {
+  return (
+    <>
+			<header>
+				<UserButton afterSignOutUrl="/"/>
+			</header>
+			<div>Your page's content can go here.</div>
+    </>
+  );
 }
 ```
 

--- a/docs/quickstarts/nextjs.mdx
+++ b/docs/quickstarts/nextjs.mdx
@@ -44,6 +44,22 @@ Clerk's Next.js SDK gives you access to prebuilt [components](/docs/components/o
   ```
 </CodeBlockTabs>
 
+### TEST
+
+<CodeBlockTabs type="installer" options={['npm', 'yarn', 'pnpm']}>
+  ```bash filename="terminal"
+  npm install @clerk/nextjs
+  ```
+
+  ```bash filename="terminal"
+  yarn add @clerk/nextjs
+  ```
+
+  ```bash filename="terminal"
+  pnpm add @clerk/nextjs
+  ```
+</CodeBlockTabs>
+
 ### Set environment keys
 
 In your Next.js project's root folder, you may have an `.env.local` file alongside `package.json` and other configuration files. If you don't see it, create it.
@@ -67,7 +83,7 @@ This sets your public and secret keys.
 
 The [`<ClerkProvider />`](/docs/components/clerk-provider) component provides active session and user context to Clerk's hooks and other components. Import it into your app by adding `import { ClerkProvider } from '@clerk/nextjs'` at the top of your file. 
 
-<Tabs items={["App Router", "Pages Router"]}>
+<Tabs type="framework" items={["App Router", "Pages Router"]}>
   <Tab>
     
     <Callout>

--- a/docs/quickstarts/nextjs.mdx
+++ b/docs/quickstarts/nextjs.mdx
@@ -30,23 +30,7 @@ description: Learn how to use Clerk to quickly and easily add secure authenticat
 Clerk's Next.js SDK gives you access to prebuilt [components](/docs/components/overview), [hooks](/docs/references/nextjs/overview#client-side-helpers), and [helpers](/docs/references/nextjs/overview) for Next.js Server Components, Route Handlers and Middleware. Install it by running the following command in your terminal:
 
 
-<CodeBlockTabs type="installer" options={['npm', 'yarn', 'pnpm']}>
-  ```bash filename="terminal"
-  npm install @clerk/nextjs
-  ```
-
-  ```bash filename="terminal"
-  yarn add @clerk/nextjs
-  ```
-
-  ```bash filename="terminal"
-  pnpm add @clerk/nextjs
-  ```
-</CodeBlockTabs>
-
-### TEST
-
-<CodeBlockTabs type="installer" options={['npm', 'yarn', 'pnpm']}>
+<CodeBlockTabs type="installer" options={["npm", "yarn", "pnpm"]}>
   ```bash filename="terminal"
   npm install @clerk/nextjs
   ```
@@ -85,7 +69,6 @@ The [`<ClerkProvider />`](/docs/components/clerk-provider) component provides ac
 
 <Tabs type="router" items={["App Router", "Pages Router"]}>
   <Tab>
-    
     <Callout>
       The `app/layout.tsx` file might be in your `src` folder if it isn't in your root folder.
     </Callout>
@@ -174,83 +157,6 @@ export default function Home() {
       <UserButton afterSignOutUrl="/"/>
     </div>
   )
-}
-```
-
-```tsx filename="pages/index.tsx" {1,7}
-import { UserButton } from "@clerk/nextjs";
-
-export default function Home() {
-  return (
-    <>
-			<header>
-				<UserButton afterSignOutUrl="/"/>
-			</header>
-			<div>Your page's content can go here.</div>
-    </>
-  );
-}
-```
-</CodeBlockTabs>
-
-### TEST
-
-<CodeBlockTabs type="framework" options={["React", "Remix"]}>
-```tsx filename="app/page.tsx" {1,6}
-import { UserButton } from "@clerk/nextjs";
-
-export default function Home() {
-  return (
-    <div>
-      <UserButton afterSignOutUrl="/"/>
-    </div>
-  )
-}
-```
-
-```tsx filename="pages/index.tsx" {1,7}
-import { UserButton } from "@clerk/nextjs";
-
-export default function Home() {
-  return (
-    <>
-			<header>
-				<UserButton afterSignOutUrl="/"/>
-			</header>
-			<div>Your page's content can go here.</div>
-    </>
-  );
-}
-```
-</CodeBlockTabs>
-
-### TEST
-
-<CodeBlockTabs type="framework" options={["React", "Remix", "Gatsby"]}>
-```tsx filename="app/page.tsx" {1,6}
-import { UserButton } from "@clerk/nextjs";
-
-export default function Home() {
-  return (
-    <div>
-      <UserButton afterSignOutUrl="/"/>
-    </div>
-  )
-}
-```
-
-```tsx filename="pages/index.tsx" {1,7}
-import { UserButton } from "@clerk/nextjs";
-
-export default function Home() {
-  return (
-    <>
-			<header>
-				<UserButton afterSignOutUrl="/"/>
-			</header>
-			<div>Your page's content can go here.</div>
-    </>
-  );
 }
 ```
 

--- a/docs/quickstarts/nextjs.mdx
+++ b/docs/quickstarts/nextjs.mdx
@@ -30,7 +30,7 @@ description: Learn how to use Clerk to quickly and easily add secure authenticat
 Clerk's Next.js SDK gives you access to prebuilt [components](/docs/components/overview), [hooks](/docs/references/nextjs/overview#client-side-helpers), and [helpers](/docs/references/nextjs/overview) for Next.js Server Components, Route Handlers and Middleware. Install it by running the following command in your terminal:
 
 
-<CodeBlockTabs options={['npm', 'yarn', 'pnpm']}>
+<CodeBlockTabs type="installer" options={['npm', 'yarn', 'pnpm']}>
   ```bash filename="terminal"
   npm install @clerk/nextjs
   ```
@@ -148,7 +148,38 @@ Clerk offers a set of [prebuilt components](/docs/components/overview) to add fu
 
 Add it anywhere inside `<ClerkProvider />` in your app. First add `import { UserButton } from "@clerk/nextjs";` to the top of your file. Then add `<UserButton afterSignOutUrl="/"/>`. The `afterSignOutUrl` prop lets you customize what page the user will be redirected to after sign out.
 
-<CodeBlockTabs options={["App Router", "Pages Router"]}>
+<CodeBlockTabs type="framework" options={["App Router", "Pages Router"]}>
+```tsx filename="app/page.tsx" {1,6}
+import { UserButton } from "@clerk/nextjs";
+
+export default function Home() {
+  return (
+    <div>
+      <UserButton afterSignOutUrl="/"/>
+    </div>
+  )
+}
+```
+
+```tsx filename="pages/index.tsx" {1,7}
+import { UserButton } from "@clerk/nextjs";
+
+export default function Home() {
+  return (
+    <>
+			<header>
+				<UserButton afterSignOutUrl="/"/>
+			</header>
+			<div>Your page's content can go here.</div>
+    </>
+  );
+}
+```
+</CodeBlockTabs>
+
+### TEST
+
+<CodeBlockTabs type="framework" options={["App Router", "Pages Router"]}>
 ```tsx filename="app/page.tsx" {1,6}
 import { UserButton } from "@clerk/nextjs";
 

--- a/docs/quickstarts/react.mdx
+++ b/docs/quickstarts/react.mdx
@@ -20,7 +20,7 @@ Learn how to use Clerk to quickly and easily add secure authentication and user 
 
 Once you have a React application ready, you need to install Clerk's React SDK. This gives you access to our prebuilt components and hooks for React applications.
 
-<CodeBlockTabs options={['npm', 'yarn', 'pnpm']}>
+<CodeBlockTabs type="installer" options={["npm", "yarn", "pnpm"]}>
   ```bash filename="terminal"
   npm install @clerk/clerk-react
   ```

--- a/docs/quickstarts/remix.mdx
+++ b/docs/quickstarts/remix.mdx
@@ -8,11 +8,12 @@ description: Learn how to use Clerk to quickly and easily add secure authenticat
 Learn how to use Clerk to quickly and easily add secure authentication and user management to your Remix application. This guide assumes that you are using Remix v2 or later.
 
 <Steps>
+
 ### Install `@clerk/remix`
 
 Once you have a Remix application ready, you need to install Clerk's Remix SDK. This gives you access to our prebuilt components and hooks for Remix applications.
 
-<CodeBlockTabs options={['npm', 'yarn', 'pnpm']}>
+<CodeBlockTabs type="installer" options={["npm", "yarn", "pnpm"]}>
   ```bash filename="terminal"
   npm install @clerk/remix
   ```
@@ -372,98 +373,97 @@ export default function Example() {
 
 #### `getAuth()`
 
-<Tabs items={["Loader Function", "Action Function"]}>
+<Tabs type="function" items={["Loader Function", "Action Function"]}>
   <Tab>
+  The [`getAuth()`][get-auth] helper allows you to access the [Authentication Object][auth-obj], including the current `userId`. You can use this helper to protect your loader function or get data for the initial render of the route.
 
-The [`getAuth()`][get-auth] helper allows you to access the [Authentication Object][auth-obj], including the current `userId`. You can use this helper to protect your loader function or get data for the initial render of the route.
+  ```tsx filename="routes/example.tsx"
+  export const loader: LoaderFunction = async (args) => {
+    // Use getAuth to retrieve user data 
+    const { userId, sessionId, getToken } = await getAuth(args);
 
-```tsx filename="routes/example.tsx"
-export const loader: LoaderFunction = async (args) => {
-  // Use getAuth to retrieve user data 
-  const { userId, sessionId, getToken } = await getAuth(args);
+    // If there is no userId, then redirect to sign-in route
+    if (!userId) {
+      return redirect("/sign-in?redirect_url=" + args.request.url);
+    }
 
-  // If there is no userId, then redirect to sign-in route
-  if (!userId) {
-    return redirect("/sign-in?redirect_url=" + args.request.url);
+    // Use the userId to fetch data from your database
+    const posts = await mockGetPosts(userId);
+
+    return { posts };
+  };
+  ```
+  </Tab>
+
+  <Tab>
+  The [`getAuth()`][get-auth] helper allows you to access the [Authentication Object][auth-obj]. You can use the returns from `getAuth()` to protect the action function, update the user or perform mutations on data in your database.
+
+  ```tsx filename="routes/example.tsx"
+  export const action: ActionFunction = async (args) => {
+
+    // Use getAuth to retrieve user data 
+    const { userId, getToken } = await getAuth(args)
+
+    // Use the userId to perform a mutation on data in your database
+    const updatedPost = await mockUpdatePost(userId, postId, body)
+
+    return { updatedPost };
   }
-
-  // Use the userId to fetch data from your database
-  const posts = await mockGetPosts(userId);
-
-  return { posts };
-};
-```
-</Tab>
-<Tab>
-
-The [`getAuth()`][get-auth] helper allows you to access the [Authentication Object][auth-obj]. You can use the returns from `getAuth()` to protect the action function, update the user or perform mutations on data in your database.
-
-```tsx filename="routes/example.tsx"
-export const action: ActionFunction = async (args) => {
-
-  // Use getAuth to retrieve user data 
-  const { userId, getToken } = await getAuth(args)
-
-  // Use the userId to perform a mutation on data in your database
-  const updatedPost = await mockUpdatePost(userId, postId, body)
-
-  return { updatedPost };
-}
-```
-</Tab>
+  ```
+  </Tab>
 </Tabs>
 
 #### Examples of fetching and mutating user data
 
 
 
-<Tabs items={["Loader Function", "Action Function"]}>
+<Tabs type="function" items={["Loader Function", "Action Function"]}>
   <Tab>
+  ```tsx filename="routes/profile.tsx"
+  import { LoaderFunction, redirect } from "@remix-run/node";
+  import { getAuth } from "@clerk/remix/ssr.server";
+  import { createClerkClient } from '@clerk/remix/api.server';
 
+  export const loader: LoaderFunction = async (args) => {
+    const { userId } = await getAuth(args);
 
-```tsx filename="routes/profile.tsx"
-import { LoaderFunction, redirect } from "@remix-run/node";
-import { getAuth } from "@clerk/remix/ssr.server";
-import { createClerkClient } from '@clerk/remix/api.server';
+    if (!userId) {
+      return redirect("/sign-in?redirect_url=" + args.request.url);
+    }
 
-export const loader: LoaderFunction = async (args) => {
-  const { userId } = await getAuth(args);
+    const user = await createClerkClient({secretKey: process.env.CLERK_SECRET_KEY}).users.getUser(userId);
+    return { serialisedUser: JSON.stringify(user) };
+  };
+  ```
+  </Tab>
 
-  if (!userId) {
-    return redirect("/sign-in?redirect_url=" + args.request.url);
-  }
+  <Tab>
+  ```tsx filename="routes/profile.tsx"
+  import { ActionFunction, redirect } from "@remix-run/node";
+  import { getAuth } from "@clerk/remix/ssr.server";
+  import { createClerkClient } from '@clerk/remix/api.server';
 
-  const user = await createClerkClient({secretKey: process.env.CLERK_SECRET_KEY}).users.getUser(userId);
-  return { serialisedUser: JSON.stringify(user) };
-};
-```
-</Tab>
-<Tab>
-```tsx filename="routes/profile.tsx"
-import { ActionFunction, redirect } from "@remix-run/node";
-import { getAuth } from "@clerk/remix/ssr.server";
-import { createClerkClient } from '@clerk/remix/api.server';
+  export const action: ActionFunction = async (args) => {
+    // Use getAuth to retrieve user data
+    const { userId } = await getAuth(args)
 
-export const action: ActionFunction = async (args) => {
-  // Use getAuth to retrieve user data
-  const { userId } = await getAuth(args)
+    // If there is no userId, then redirect to sign-in route
+    if (!userId) {
+      return redirect("/sign-in?redirect_url=" + args.request.url);
+    }
+    // Prepare the data for the mutation
+    const params = { firstName: 'John', lastName: 'Wicker' };
 
-  // If there is no userId, then redirect to sign-in route
-  if (!userId) {
-    return redirect("/sign-in?redirect_url=" + args.request.url);
-  }
-  // Prepare the data for the mutation
-  const params = { firstName: 'John', lastName: 'Wicker' };
+    // Initialize clerkClient and perform the mutations
+    const updatedUser = await createClerkClient({ secretKey: process.env.CLERK_SECRET_KEY }).users.updateUser(userId, params);
 
-  // Initialize clerkClient and perform the mutations
-  const updatedUser = await createClerkClient({ secretKey: process.env.CLERK_SECRET_KEY }).users.updateUser(userId, params);
-
-  // Return the updated user
-  return { serialisedUser: JSON.stringify(updatedUser) };
-};
-```
-</Tab>
+    // Return the updated user
+    return { serialisedUser: JSON.stringify(updatedUser) };
+  };
+  ```
+  </Tab>
 </Tabs>
+
 </Steps>
 
 ### Next steps

--- a/docs/references/backend/overview.mdx
+++ b/docs/references/backend/overview.mdx
@@ -9,38 +9,38 @@ The [Clerk Backend SDK](https://github.com/clerk/javascript/tree/main/packages/b
 
 Clerk SDKs expose an instance of the Clerk Backend SDK for use in server environments.
 
-<Tabs items={["Next.js", "Remix", "Fastify", "Node"]}>
-<Tab>
-The Backend SDK is accessible via the `clerkClient` object if you are using Next.js.
+<Tabs type="framework" items={["Next.js", "Remix", "Fastify", "Node"]}>
+  <Tab>
+  The Backend SDK is accessible via the `clerkClient` object if you are using Next.js.
 
-```jsx
-import { clerkClient } from '@clerk/nextjs';
-```
-</Tab>
+  ```jsx
+  import { clerkClient } from '@clerk/nextjs';
+  ```
+  </Tab>
 
-<Tab>
-The Backend SDK is accessible via the `createClerkClient` function if you are using Remix. 
+  <Tab>
+  The Backend SDK is accessible via the `createClerkClient` function if you are using Remix. 
 
-```jsx
-import { createClerkClient } from '@clerk/remix/api.server';
-```
-</Tab>
+  ```jsx
+  import { createClerkClient } from '@clerk/remix/api.server';
+  ```
+  </Tab>
 
-<Tab>
-The Backend SDK is accessible via the `clerkClient` object if you are using Fastify.
+  <Tab>
+  The Backend SDK is accessible via the `clerkClient` object if you are using Fastify.
 
-```jsx
-import { clerkClient } from "@clerk/fastify";
-```
-</Tab>
+  ```jsx
+  import { clerkClient } from "@clerk/fastify";
+  ```
+  </Tab>
 
-<Tab>
-The Backend SDK is accessible via the `clerkClient` object if you are using Node.
+  <Tab>
+  The Backend SDK is accessible via the `clerkClient` object if you are using Node.
 
-```js
-import clerkClient from '@clerk/clerk-sdk-node';
-```
-</Tab>
+  ```js
+  import clerkClient from '@clerk/clerk-sdk-node';
+  ```
+  </Tab>
 </Tabs>
 
 ## User operations

--- a/docs/references/backend/user/update-user.mdx
+++ b/docs/references/backend/user/update-user.mdx
@@ -36,91 +36,96 @@ const user = await clerkClient.users.updateUser(userId, params);
 
 ## Examples
 
-<CodeBlockTabs options={["Next.js App Router", "Next.js Pages Router", "Node", "Remix"]}>
-```tsx filename="app/page.[jsx/tsx]"
-import { NextRequest, NextResponse } from 'next/server';
-import { getAuth, clerkClient } from '@clerk/nextjs/server';
+<Tabs type="framework" items={["Next.js", "Node", "Remix"]}>
+  <Tab>
+    <CodeBlockTabs type="router" options={["App Router", "Pages Router"]}>
+    ```tsx filename="app/page.[jsx/tsx]"
+    import { NextRequest, NextResponse } from 'next/server';
+    import { getAuth, clerkClient } from '@clerk/nextjs/server';
 
-// If you use `request` you don't need the type
-export async function POST(req: NextRequest) {
+    // If you use `request` you don't need the type
+    export async function POST(req: NextRequest) {
 
-	// Get the user ID from the session
-	const { userId } = getAuth(req);
+      // Get the user ID from the session
+      const { userId } = getAuth(req);
 
-	if (!userId) return NextResponse.redirect('/sign-in');
+      if (!userId) return NextResponse.redirect('/sign-in');
 
-	// The user attributes to update
-	const params = { firstName: 'John', lastName: 'Wick' };
+      // The user attributes to update
+      const params = { firstName: 'John', lastName: 'Wick' };
 
-	const updatedUser = await clerkClient.users.updateUser(userId, params);
+      const updatedUser = await clerkClient.users.updateUser(userId, params);
 
-	return NextResponse.json({ updatedUser });
-}
+      return NextResponse.json({ updatedUser });
+    }
+    ```
 
-```
+    ```tsx filename="pages/api/updateUser.[jsx/tsx]"
+    import { clerkClient, getAuth } from '@clerk/nextjs/server';
+    import type { NextApiRequest, NextApiResponse } from 'next';
 
-```tsx filename="pages/api/updateUser.[jsx/tsx]"
-import { clerkClient, getAuth } from '@clerk/nextjs/server';
-import type { NextApiRequest, NextApiResponse } from 'next';
+    export default async function handler(req: NextApiRequest, res: NextApiResponse) {
 
-export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+      // Get the user ID from the session
+      const { userId } = getAuth(req);
 
-  // Get the user ID from the session
-  const { userId } = getAuth(req);
+      if (!userId) {
+        return res.status(500).json({ error: "No valid user" })
+      }
 
-  if (!userId) {
-    return res.status(500).json({ error: "No valid user" })
-  }
+      // The user attributes to update
+      const params = { firstName: 'John', lastName: 'Wick' };
 
-  // The user attributes to update
-  const params = { firstName: 'John', lastName: 'Wick' };
+      const updatedUser = await clerkClient.users.updateUser(userId, params);
 
-  const updatedUser = await clerkClient.users.updateUser(userId, params);
+      return res.status(200).json({ updatedUser });
+    }
+    ```
+    </CodeBlockTabs>
+  </Tab>
 
-  return res.status(200).json({ updatedUser });
-}
-```
+  <Tab>
+  ```js filename="updateUser.js"
+  import clerkClient from '@clerk/clerk-sdk-node';
 
-```js filename="updateUser.js"
-import clerkClient from '@clerk/clerk-sdk-node';
+  app.post('/api/update-user',
+    // ClerkExpressRequireAuth returns an error for unauthorized requests
+    ClerkExpressRequireAuth(),
+    // Optionally ClerkExpressWithAuth returns an empty user with no error
+    // ClerkExpressWithAuth(),
+    async (req, res) => {
+    
+      // Get the user ID from req.auth
+      const userId = req.auth.userId
 
-app.post('/api/update-user',
-  // ClerkExpressRequireAuth returns an error for unauthorized requests
-  ClerkExpressRequireAuth(),
-  // Optionally ClerkExpressWithAuth returns an empty user with no error
-  // ClerkExpressWithAuth(),
-  async (req, res) => {
-  
-    // Get the user ID from req.auth
-    const userId = req.auth.userId
+      // The user attributes to update
+      const params = { firstName: "John", lastName: "Wick" }
+
+      const updatedUser = await clerkClient.users.updateUser(userId, params)
+
+      res.json({ updatedUser })
+    })
+  ```
+  </Tab>
+
+  <Tab>
+  ```js filename="app/routes/profile.[jsx/tsx]"
+  import { createClerkClient } from "@clerk/remix/api.server"
+  import { getAuth } from "@clerk/remix/ssr.server"
+  import { ActionFunction, json } from "@remix-run/node"
+
+  export const action: ActionFunction = async (req) => {
+    
+    // Get the user ID from the session
+    const { userId } = await getAuth(req)
 
     // The user attributes to update
-    const params = { firstName: "John", lastName: "Wick" }
+    const params = { firstName: 'John', lastName: 'Wick' };
 
-    const updatedUser = await clerkClient.users.updateUser(userId, params)
+    const updatedUser = await createClerkClient({ secretKey: process.env.CLERK_SECRET_KEY }).users.updateUser(userId, params)
 
-    res.json({ updatedUser })
-  })
-
-
-```
-
-```js filename="app/routes/profile.[jsx/tsx]"
-import { createClerkClient } from "@clerk/remix/api.server"
-import { getAuth } from "@clerk/remix/ssr.server"
-import { ActionFunction, json } from "@remix-run/node"
-
-export const action: ActionFunction = async (req) => {
-  
-  // Get the user ID from the session
-  const { userId } = await getAuth(req)
-
-  // The user attributes to update
-  const params = { firstName: 'John', lastName: 'Wick' };
-
-  const updatedUser = await createClerkClient({ secretKey: process.env.CLERK_SECRET_KEY }).users.updateUser(userId, params)
-
-  return json({ updatedUser })
-}
-```
-</CodeBlockTabs>
+    return json({ updatedUser })
+  }
+  ```
+  </Tab>
+</Tabs>

--- a/docs/references/javascript/clerk/create-organization.mdx
+++ b/docs/references/javascript/clerk/create-organization.mdx
@@ -15,7 +15,7 @@ Render the [`<CreateOrganization />`][createorg-ref] component to an HTML `<div>
 
 ### Usage
 
-<CodeBlockTabs options={['NPM Module', 'window.Clerk']}>
+<CodeBlockTabs type="npm-script" options={['NPM Module', 'window.Clerk']}>
   ```typescript {15-19}
   import Clerk from '@clerk/clerk-js';
   import { dark } from "@clerk/themes";
@@ -79,7 +79,7 @@ Unmount and run cleanup on an existing [`<CreateOrganization />`][createorg-ref]
 
 ### Usage
 
-<CodeBlockTabs options={['NPM Module', 'window.Clerk']}>
+<CodeBlockTabs type="npm-script" options={['NPM Module', 'window.Clerk']}>
   ```typescript {19}
   import Clerk from '@clerk/clerk-js';
 
@@ -142,7 +142,7 @@ Opens the [`<CreateOrganization />`][createorg-ref] component as an overlay at t
 
 ### Usage
 
-<CodeBlockTabs options={['NPM Module', 'window.Clerk']}>
+<CodeBlockTabs type="npm-script" options={['NPM Module', 'window.Clerk']}>
   ```typescript {7-11}
   import Clerk from '@clerk/clerk-js';
   import { dark } from "@clerk/themes";
@@ -194,7 +194,7 @@ Closes the organization profile overlay.
 
 ### Usage
 
-<CodeBlockTabs options={['NPM Module', 'window.Clerk']}>
+<CodeBlockTabs type="npm-script" options={['NPM Module', 'window.Clerk']}>
   ```typescript {11}
   import Clerk from '@clerk/clerk-js';
   import { dark } from "@clerk/themes";

--- a/docs/references/javascript/clerk/organization-profile.mdx
+++ b/docs/references/javascript/clerk/organization-profile.mdx
@@ -15,7 +15,7 @@ Render the [`<OrganizationProfile />`][orgprofile-ref] component to an HTML `<di
 
 ### Usage
 
-<CodeBlockTabs options={['NPM Module', 'window.Clerk']}>
+<CodeBlockTabs type="npm-script" options={['NPM Module', 'window.Clerk']}>
   ```typescript {15-19}
   import Clerk from '@clerk/clerk-js';
   import { dark } from "@clerk/themes";
@@ -79,7 +79,7 @@ Unmount and run cleanup on an existing [`<OrganizationProfile />`][orgprofile-re
 
 ### Usage
 
-<CodeBlockTabs options={['NPM Module', 'window.Clerk']}>
+<CodeBlockTabs type="npm-script" options={['NPM Module', 'window.Clerk']}>
   ```typescript {19}
   import Clerk from '@clerk/clerk-js';
 
@@ -142,7 +142,7 @@ Opens the [`<OrganizationProfile />`][orgprofile-ref] component as an overlay at
 
 ### Usage
 
-<CodeBlockTabs options={['NPM Module', 'window.Clerk']}>
+<CodeBlockTabs type="npm-script" options={['NPM Module', 'window.Clerk']}>
   ```typescript {7-11}
   import Clerk from '@clerk/clerk-js';
   import { dark } from "@clerk/themes";
@@ -194,7 +194,7 @@ Closes the organization profile overlay.
 
 ### Usage
 
-<CodeBlockTabs options={['NPM Module', 'window.Clerk']}>
+<CodeBlockTabs type="npm-script" options={['NPM Module', 'window.Clerk']}>
   ```typescript {11}
   import Clerk from '@clerk/clerk-js';
   import { dark } from "@clerk/themes";
@@ -241,7 +241,7 @@ function closeOrganizationProfile(): void;
 You can add customized pages for the [`<OrganizationProfile />`][orgprofile-ref] component by using the `customPages` prop.
 
 
-<CodeBlockTabs options={['NPM Module', 'window.Clerk']}>
+<CodeBlockTabs type="npm-script" options={['NPM Module', 'window.Clerk']}>
   ```typescript {11}
   import Clerk from '@clerk/clerk-js';
 

--- a/docs/references/javascript/clerk/organization-switcher.mdx
+++ b/docs/references/javascript/clerk/organization-switcher.mdx
@@ -15,7 +15,7 @@ Render the [`<OrganizationSwitcher />`][orgswitcher-ref] component to an HTML `<
 
 ### Usage
 
-<CodeBlockTabs options={['NPM Module', 'window.Clerk']}>
+<CodeBlockTabs type="npm-script" options={['NPM Module', 'window.Clerk']}>
   ```typescript {15-19}
   import Clerk from '@clerk/clerk-js';
   import { dark } from "@clerk/themes";
@@ -79,7 +79,7 @@ Unmount and run cleanup on an existing [`<OrganizationSwitcher />`][orgswitcher-
 
 ### Usage
 
-<CodeBlockTabs options={['NPM Module', 'window.Clerk']}>
+<CodeBlockTabs type="npm-script" options={['NPM Module', 'window.Clerk']}>
   ```typescript {19}
   import Clerk from '@clerk/clerk-js';
 

--- a/docs/references/javascript/clerk/sign-in.mdx
+++ b/docs/references/javascript/clerk/sign-in.mdx
@@ -17,7 +17,7 @@ Render the [`<SignIn />`][signin-ref] component to an HTML `<div>` element.
 
 ### Usage
 
-<CodeBlockTabs options={['NPM Module', 'window.Clerk']}>
+<CodeBlockTabs type="npm-script" options={['NPM Module', 'window.Clerk']}>
   ```typescript {15-19}
   import Clerk from '@clerk/clerk-js';
   import { dark } from "@clerk/themes";
@@ -81,7 +81,7 @@ Unmount and run cleanup on an existing [`<SignIn />`][signin-ref] component inst
 
 ### Usage
 
-<CodeBlockTabs options={['NPM Module', 'window.Clerk']}>
+<CodeBlockTabs type="npm-script" options={['NPM Module', 'window.Clerk']}>
   ```typescript {19}
   import Clerk from '@clerk/clerk-js';
 
@@ -144,7 +144,7 @@ Opens the `<SignIn />` component as an overlay at the root of your HTML `body` e
 
 ### Usage
 
-<CodeBlockTabs options={['NPM Module', 'window.Clerk']}>
+<CodeBlockTabs type="npm-script" options={['NPM Module', 'window.Clerk']}>
   ```typescript {7-11}
   import Clerk from '@clerk/clerk-js';
   import { dark } from "@clerk/themes";
@@ -196,7 +196,7 @@ Closes the sign in overlay.
 
 ### Usage
 
-<CodeBlockTabs options={['NPM Module', 'window.Clerk']}>
+<CodeBlockTabs type="npm-script" options={['NPM Module', 'window.Clerk']}>
   ```typescript {11}
   import Clerk from '@clerk/clerk-js';
   import { dark } from "@clerk/themes";

--- a/docs/references/javascript/clerk/sign-up.mdx
+++ b/docs/references/javascript/clerk/sign-up.mdx
@@ -17,7 +17,7 @@ Render the [`<SignUp />`][signup-ref] component to an HTML `<div>` element.
 
 ### Usage
 
-<CodeBlockTabs options={['NPM Module', 'window.Clerk']}>
+<CodeBlockTabs type="npm-script" options={['NPM Module', 'window.Clerk']}>
   ```typescript {15-19}
   import Clerk from '@clerk/clerk-js';
   import { dark } from "@clerk/themes";
@@ -81,7 +81,7 @@ Unmount and run cleanup on an existing [`<SignUp />`][signup-ref] component inst
 
 ### Usage
 
-<CodeBlockTabs options={['NPM Module', 'window.Clerk']}>
+<CodeBlockTabs type="npm-script" options={['NPM Module', 'window.Clerk']}>
   ```typescript {19}
   import Clerk from '@clerk/clerk-js';
 
@@ -144,7 +144,7 @@ Opens the [`<SignUp />`][signup-ref] component as an overlay at the root of your
 
 ### Usage
 
-<CodeBlockTabs options={['NPM Module', 'window.Clerk']}>
+<CodeBlockTabs type="npm-script" options={['NPM Module', 'window.Clerk']}>
   ```typescript {7-11}
   import Clerk from '@clerk/clerk-js';
   import { dark } from "@clerk/themes";
@@ -196,7 +196,7 @@ Closes the sign up overlay.
 
 ### Usage
 
-<CodeBlockTabs options={['NPM Module', 'window.Clerk']}>
+<CodeBlockTabs type="npm-script" options={['NPM Module', 'window.Clerk']}>
   ```typescript {11}
   import Clerk from '@clerk/clerk-js';
   import { dark } from "@clerk/themes";

--- a/docs/references/javascript/clerk/user-button.mdx
+++ b/docs/references/javascript/clerk/user-button.mdx
@@ -15,7 +15,7 @@ Render the [`<UserButton />`][userbutton-ref] component to an HTML `<div>` eleme
 
 ### Usage
 
-<CodeBlockTabs options={['NPM Module', 'window.Clerk']}>
+<CodeBlockTabs type="npm-script" options={['NPM Module', 'window.Clerk']}>
   ```typescript {15-19}
   import Clerk from '@clerk/clerk-js';
   import { dark } from "@clerk/themes";
@@ -79,7 +79,7 @@ Unmount and run cleanup on an existing [`<UserButton />`][userbutton-ref] compon
 
 ### Usage
 
-<CodeBlockTabs options={['NPM Module', 'window.Clerk']}>
+<CodeBlockTabs type="npm-script" options={['NPM Module', 'window.Clerk']}>
   ```typescript {19}
   import Clerk from '@clerk/clerk-js';
 

--- a/docs/references/javascript/clerk/user-profile.mdx
+++ b/docs/references/javascript/clerk/user-profile.mdx
@@ -15,7 +15,7 @@ Render the [`<UserProfile />`][userprofile-ref] component to an HTML `<div>` ele
 
 ### Usage
 
-<CodeBlockTabs options={['NPM Module', 'window.Clerk']}>
+<CodeBlockTabs type="npm-script" options={['NPM Module', 'window.Clerk']}>
   ```typescript {15-19}
   import Clerk from '@clerk/clerk-js';
   import { dark } from "@clerk/themes";
@@ -79,7 +79,7 @@ Unmount and run cleanup on an existing [`<UserProfile />`][userprofile-ref] comp
 
 ### Usage
 
-<CodeBlockTabs options={['NPM Module', 'window.Clerk']}>
+<CodeBlockTabs type="npm-script" options={['NPM Module', 'window.Clerk']}>
   ```typescript {19}
   import Clerk from '@clerk/clerk-js';
 
@@ -142,7 +142,7 @@ Opens the [`<UserProfile />`][userprofile-ref] component as an overlay at the ro
 
 ### Usage
 
-<CodeBlockTabs options={['NPM Module', 'window.Clerk']}>
+<CodeBlockTabs type="npm-script" options={['NPM Module', 'window.Clerk']}>
   ```typescript {7-11}
   import Clerk from '@clerk/clerk-js';
   import { dark } from "@clerk/themes";
@@ -194,7 +194,7 @@ Closes the user profile overlay.
 
 ### Usage
 
-<CodeBlockTabs options={['NPM Module', 'window.Clerk']}>
+<CodeBlockTabs type="npm-script" options={['NPM Module', 'window.Clerk']}>
   ```typescript {11}
   import Clerk from '@clerk/clerk-js';
   import { dark } from "@clerk/themes";
@@ -240,97 +240,97 @@ function closeUserProfile(): void;
 
 You can add customized pages for the [`<UserProfile />`][userprofile-ref] component by using the `customPages` prop.
 
-<CodeBlockTabs options={['NPM Module', 'window.Clerk']}>
-    ```typescript {11}
-    import Clerk from '@clerk/clerk-js';
+<CodeBlockTabs type="npm-script" options={['NPM Module', 'window.Clerk']}>
+```typescript {11}
+import Clerk from '@clerk/clerk-js';
 
-    const clerk = new Clerk('pk_[publishable_key]');
-    await clerk.load();
+const clerk = new Clerk('pk_[publishable_key]');
+await clerk.load();
 
-    clerk.openUserProfile({
-        customPages: [
-            {
-                url: "custom-page",
-                label: "Custom Page",
-                mountIcon: (el) => {
-                    el.innerHTML = "👋";
-                },
-                unmountIcon: (el) => {
-                    el.innerHTML = "";
-                },
-                mount: (el) => {
+clerk.openUserProfile({
+    customPages: [
+        {
+            url: "custom-page",
+            label: "Custom Page",
+            mountIcon: (el) => {
+                el.innerHTML = "👋";
+            },
+            unmountIcon: (el) => {
+                el.innerHTML = "";
+            },
+            mount: (el) => {
+                el.innerHTML = `
+                      <h1><b>Custom Page</b></h1>
+                      <p>This is the content of the custom page.</p>
+                      `;
+            },
+            unmount: (el) => {
+                el.innerHTML = "";
+            },
+        },
+        {
+            url: "/other-page",
+            label: "Other Page",
+            mountIcon: (el) => {
+                el.innerHTML = "🌐";
+            },
+            unmountIcon: (el) => {
+                el.innerHTML = "";
+            },
+        }
+    ]
+});
+
+```
+
+```html {14}
+<script>
+    const script = document.createElement('script');
+    script.setAttribute('data-clerk-publishable-key', 'pk_[publishable_key]');
+    script.async = true;
+    script.src = `https://[your-domain].clerk.accounts.dev/npm/@clerk/clerk-js@latest/dist/clerk.browser.js`;
+
+    script.addEventListener('load', async function () {
+        await window.Clerk.load();
+
+        window.Clerk.openUserProfile({
+            customPages: [
+                {
+                    url: "custom-page",
+                    label: "Custom Page",
+                    mountIcon: (el) => {
+                        el.innerHTML = "👋";
+                    },
+                    unmountIcon: (el) => {
+                        el.innerHTML = "";
+                    },
+                    mount: (el) => {
                     el.innerHTML = `
                           <h1><b>Custom Page</b></h1>
                           <p>This is the content of the custom page.</p>
                           `;
-                },
-                unmount: (el) => {
-                    el.innerHTML = "";
-                },
-            },
-            {
-                url: "/other-page",
-                label: "Other Page",
-                mountIcon: (el) => {
-                    el.innerHTML = "🌐";
-                },
-                unmountIcon: (el) => {
-                    el.innerHTML = "";
-                },
-            }
-        ]
-    });
-
-    ```
-
-    ```html {14}
-    <script>
-        const script = document.createElement('script');
-        script.setAttribute('data-clerk-publishable-key', 'pk_[publishable_key]');
-        script.async = true;
-        script.src = `https://[your-domain].clerk.accounts.dev/npm/@clerk/clerk-js@latest/dist/clerk.browser.js`;
-
-        script.addEventListener('load', async function () {
-            await window.Clerk.load();
-
-            window.Clerk.openUserProfile({
-                customPages: [
-                    {
-                        url: "custom-page",
-                        label: "Custom Page",
-                        mountIcon: (el) => {
-                            el.innerHTML = "👋";
-                        },
-                        unmountIcon: (el) => {
-                            el.innerHTML = "";
-                        },
-                        mount: (el) => {
-                        el.innerHTML = `
-                              <h1><b>Custom Page</b></h1>
-                              <p>This is the content of the custom page.</p>
-                              `;
-                        },
-                        unmount: (el) => {
-                            el.innerHTML = "";
-                        },
                     },
-                    {
-                        url: "/other-page",
-                        label: "Other Page",
-                        mountIcon: (el) => {
-                            el.innerHTML = "🌐";
-                        },
-                        unmountIcon: (el) => {
-                            el.innerHTML = "";
-                        },
-                    }
-                ]
-            });
-
+                    unmount: (el) => {
+                        el.innerHTML = "";
+                    },
+                },
+                {
+                    url: "/other-page",
+                    label: "Other Page",
+                    mountIcon: (el) => {
+                        el.innerHTML = "🌐";
+                    },
+                    unmountIcon: (el) => {
+                        el.innerHTML = "";
+                    },
+                }
+            ]
         });
-        document.body.appendChild(script);
-    </script>
-    ```
+
+    });
+    document.body.appendChild(script);
+</script>
+```
 </CodeBlockTabs>
 
 ## `UserProfileProps`

--- a/docs/references/javascript/overview.mdx
+++ b/docs/references/javascript/overview.mdx
@@ -17,7 +17,7 @@ There are two ways you can include ClerkJS in your project. You can either [impo
 
 ### Install ClerkJS as ES module
 
-<CodeBlockTabs options={['npm', 'yarn', 'pnpm']}>
+<CodeBlockTabs type="installer" options={["npm", "yarn", "pnpm"]}>
   ```bash filename="terminal"
   npm install @clerk/clerk-js
   ```

--- a/docs/references/nextjs/custom-signup-signin-pages.mdx
+++ b/docs/references/nextjs/custom-signup-signin-pages.mdx
@@ -17,44 +17,44 @@ Clerk offers a set of [prebuilt components](/docs/components/overview) and [cust
 
 Create a new file that will be used to render the sign-up page. In the file, import the [`<SignUp />`](/docs/components/authentication/sign-up) component from `@clerk/nextjs` and render it.
 
-<CodeBlockTabs options={["App Router", "Pages Router"]}>
-  ```tsx filename="app/sign-up/[[...sign-up]]/page.tsx"
-  import { SignUp } from "@clerk/nextjs";
+<CodeBlockTabs type="router" options={["App Router", "Pages Router"]}>
+```tsx filename="app/sign-up/[[...sign-up]]/page.tsx"
+import { SignUp } from "@clerk/nextjs";
 
-  export default function Page() {
-    return <SignUp />;
-  }
-  ```
+export default function Page() {
+  return <SignUp />;
+}
+```
 
-  ```tsx filename="/pages/sign-up/[[...index]].tsx"
-  import { SignUp } from "@clerk/nextjs";
+```tsx filename="/pages/sign-up/[[...index]].tsx"
+import { SignUp } from "@clerk/nextjs";
 
-  export default function Page() {
-    return <SignUp />;
-  }
-  ```
+export default function Page() {
+  return <SignUp />;
+}
+```
 </CodeBlockTabs>
 
 ### Build your sign-in page
 
 Create a new file that will be used to render the sign-up page. In the file, import the [`<SignIn />`](/docs/components/authentication/sign-in) component from `@clerk/nextjs` and render it.
 
-<CodeBlockTabs options={["App Router", "Pages Router"]}>
-  ```tsx filename="app/sign-in/[[...sign-in]]/page.tsx"
-  import { SignIn } from "@clerk/nextjs";
+<CodeBlockTabs type="router" options={["App Router", "Pages Router"]}>
+```tsx filename="app/sign-in/[[...sign-in]]/page.tsx"
+import { SignIn } from "@clerk/nextjs";
 
-  export default function Page() {
-    return <SignIn />;
-  }
-  ```
+export default function Page() {
+  return <SignIn />;
+}
+```
 
-  ```tsx filename="/pages/sign-in/[[...index]].tsx"
-  import { SignIn } from "@clerk/nextjs";
+```tsx filename="/pages/sign-in/[[...index]].tsx"
+import { SignIn } from "@clerk/nextjs";
 
-  export default function Page() {
-    return <SignIn />;
-  }
-  ```
+export default function Page() {
+  return <SignIn />;
+}
+```
 </CodeBlockTabs>
 
 ### Update your environment variables

--- a/docs/references/nextjs/trpc.mdx
+++ b/docs/references/nextjs/trpc.mdx
@@ -19,7 +19,7 @@ Learn how to integrate Clerk into your Next.js application using [tRPC](https://
 
 Clerk's Next.js SDK gives you access to prebuilt components and hooks, as well as our [helpers](/docs/references/nextjs/overview) for Next.js API routes, server-side rendering, and middleware.
 
-<CodeBlockTabs options={['npm', 'yarn', 'pnpm']}>
+<CodeBlockTabs type="installer" options={["npm", "yarn", "pnpm"]}>
   ```bash filename="terminal"
   npm install @clerk/nextjs
   ```

--- a/docs/references/nodejs/overview.mdx
+++ b/docs/references/nodejs/overview.mdx
@@ -17,7 +17,7 @@ You need to create a Clerk application in your Clerk Dashboard before you can se
 
 Once a Clerk application has been created, you can install and then start using Clerk Node.js in your application. An ES module for the Clerk Node SDK is available under the [`@clerk/clerk-sdk-node`](https://www.npmjs.com/package/@clerk/clerk-sdk-node) npm package.
 
-<CodeBlockTabs options={["npm", "yarn", "pnpm"]}>
+<CodeBlockTabs type="installer" options={["npm", "yarn", "pnpm"]}>
 ```sh filename="terminal"
 npm install @clerk/clerk-sdk-node
 ```
@@ -77,45 +77,45 @@ Another available environment variable is `CLERK_LOGGING`. You can set its value
 If you are comfortable with setting the `CLERK_SECRET_KEY` environment variable and being finished, the default instance created by the SDK will suffice for your needs.
 
 <Tabs items={["ESM", "CJS"]}>
-<Tab>
-```js
-import clerkClient from '@clerk/clerk-sdk-node';
+  <Tab>
+  ```js
+  import clerkClient from '@clerk/clerk-sdk-node';
 
-const userList = await clerkClient.users.getUserList();
-```
+  const userList = await clerkClient.users.getUserList();
+  ```
 
-Or if you are interested only in a certain resource:
+  Or if you are interested only in a certain resource:
 
-```js
-import { sessions } from '@clerk/clerk-sdk-node';
+  ```js
+  import { sessions } from '@clerk/clerk-sdk-node';
 
-const sessionList = await sessions.getSessionList();
-```
-</Tab>
+  const sessionList = await sessions.getSessionList();
+  ```
+  </Tab>
 
-<Tab>
-```js
-const pkg = require('@clerk/clerk-sdk-node');
-const clerkClient = pkg.default;
+  <Tab>
+  ```js
+  const pkg = require('@clerk/clerk-sdk-node');
+  const clerkClient = pkg.default;
 
-clerkClient.emails
-  .createEmail({ fromEmailName, subject, body, emailAddressId })
-  .then((email) => console.log(email))
-  .catch((error) => console.error(error));
-```
+  clerkClient.emails
+    .createEmail({ fromEmailName, subject, body, emailAddressId })
+    .then((email) => console.log(email))
+    .catch((error) => console.error(error));
+  ```
 
-Or if you prefer a resource sub-api directly:
+  Or if you prefer a resource sub-api directly:
 
-```js
-const pkg = require('@clerk/clerk-sdk-node');
-const { clients } = pkg;
+  ```js
+  const pkg = require('@clerk/clerk-sdk-node');
+  const { clients } = pkg;
 
-clients
-  .getClient(clientId)
-  .then((client) => console.log(client))
-  .catch((error) => console.error(error));
-```
-</Tab>
+  clients
+    .getClient(clientId)
+    .then((client) => console.log(client))
+    .catch((error) => console.error(error));
+  ```
+  </Tab>
 </Tabs>
 
 #### Setters

--- a/docs/references/nodejs/token-verification.mdx
+++ b/docs/references/nodejs/token-verification.mdx
@@ -33,15 +33,7 @@ const clerk = clerkClient({ jwtKey: 'my_clerk_public_key' });
 
 Clerk's JWT session token contains the `azp` claim, which equals the Origin of the request during token generation. You can provide the middlewares with a list of whitelisted origins to verify against, to protect your application of the subdomain cookie leaking attack. You can find an example below:
 
-<CodeBlockTabs options={["Express", "Next.js"]}>
-```js
-import { ClerkExpressRequireAuth } from '@clerk/clerk-sdk-node';
-
-const authorizedParties = ['http://localhost:3000', 'https://example.com'];
-
-app.use(ClerkExpressRequireAuth({ authorizedParties }));
-```
-
+<CodeBlockTabs type="framework" options={["Next.js", "Node"]}>
 ```js
 import { requireAuth } from '@clerk/nextjs';
 
@@ -52,5 +44,14 @@ function handler(req: RequireAuthProp<NextApiRequest>, res: NextApiResponse) {
 }
 
 export requireAuth(handler, { authorizedParties });
+```
+
+```js
+// Node + Express app
+import { ClerkExpressRequireAuth } from '@clerk/clerk-sdk-node';
+
+const authorizedParties = ['http://localhost:3000', 'https://example.com'];
+
+app.use(ClerkExpressRequireAuth({ authorizedParties }));
 ```
 </CodeBlockTabs>

--- a/docs/references/react/use-auth.mdx
+++ b/docs/references/react/use-auth.mdx
@@ -9,9 +9,9 @@ The `useAuth()` hook is a convenient way to access the current auth state. This 
 
 ## Usage
 
-<Tabs items={['Next.js', 'React']}>
+<Tabs type="framework" items={["Next.js", "React"]}>
   <Tab>
-    <CodeBlockTabs options={["App Router", "Pages Router"]}>
+    <CodeBlockTabs type="router" options={["App Router", "Pages Router"]}>
       ```tsx filename="/app/pageWithData/clientComponent.tsx"
       "use client";
 

--- a/docs/references/react/use-clerk.mdx
+++ b/docs/references/react/use-clerk.mdx
@@ -13,7 +13,7 @@ The `useClerk()` hook provides access to the the [`Clerk`](/docs/references/java
 
 ## Usage
 
-<CodeBlockTabs options={["Next.js", "React"]}>
+<CodeBlockTabs type="framework" options={["Next.js", "React"]}>
   ```tsx filename="pages/index.tsx"
   import { useClerk } from "@clerk/nextjs";
 

--- a/docs/references/react/use-organization-list.mdx
+++ b/docs/references/react/use-organization-list.mdx
@@ -16,7 +16,7 @@ The `useOrganizationList` hook requires developers to opt-in by specifying which
 </Callout>
 
 ### Infinite list of joined organizations
-<CodeBlockTabs options={['Next.js', 'React']}>
+<CodeBlockTabs type="framework" options={["Next.js", "React"]}>
 ```tsx filename="pages/joined-organizations.tsx"
 import { useOrganizationList } from "@clerk/nextjs";
 import React from "react";
@@ -105,7 +105,7 @@ export default JoinedOrganizationList;
 </CodeBlockTabs>
 
 ### Table of invitations
-<CodeBlockTabs options={['Next.js', 'React']}>
+<CodeBlockTabs type="framework" options={["Next.js", "React"]}>
 ```tsx filename="pages/joined-organizations.tsx"
 import { useOrganizationList } from "@clerk/nextjs";
 import React from "react";

--- a/docs/references/react/use-session-list.mdx
+++ b/docs/references/react/use-session-list.mdx
@@ -9,7 +9,7 @@ The `useSessionList()` hook returns an array of [`Session`](/docs/references/jav
 
 ## Usage
 
-<CodeBlockTabs options={['Next.js', 'React']}>
+<CodeBlockTabs type="framework" options={["Next.js", "React"]}>
 ```tsx filename="pages/index.tsx"
 import { useSessionList } from "@clerk/nextjs";
 

--- a/docs/references/react/use-session.mdx
+++ b/docs/references/react/use-session.mdx
@@ -9,7 +9,7 @@ The `useSession()` hook provides access to the current user's [`Session`](/docs/
 
 ## Usage
 
-<CodeBlockTabs options={['Next.js', 'React']}>
+<CodeBlockTabs type="framework" options={["Next.js", "React"]}>
 ```tsx filename="pages/index.tsx"
 import { useSession } from "@clerk/nextjs";
 

--- a/docs/references/react/use-sign-in.mdx
+++ b/docs/references/react/use-sign-in.mdx
@@ -9,7 +9,7 @@ The `useSignIn()` hook provides access to the [`SignIn`](/docs/references/javasc
 
 ## Usage
 
-<Tabs items={['Next.js', 'React']}>
+<Tabs type="framework" items={["Next.js", "React"]}>
   <Tab>
     #### Check the current sign-in status
 

--- a/docs/references/react/use-sign-up.mdx
+++ b/docs/references/react/use-sign-up.mdx
@@ -8,7 +8,7 @@ The `useSignUp()` hook gives you access to the [`SignUp`](/docs/references/javas
 
 ## Usage
 
-<Tabs items={['Next.js', 'React']}>
+<Tabs type="framework" items={["Next.js", "React"]}>
   <Tab>
     #### Check the current sign-up status
 

--- a/docs/references/react/use-user.mdx
+++ b/docs/references/react/use-user.mdx
@@ -15,7 +15,7 @@ The `useUser()` hook is a convenient way to access the current user data where y
 
 ### Retrieve the current user data
 
-<CodeBlockTabs options={['Next.js', 'React']}>
+<CodeBlockTabs type="framework" options={["Next.js", "React"]}>
 ```tsx filename="pages/index.tsx"
 import { useUser } from "@clerk/nextjs";
 
@@ -57,7 +57,7 @@ export default function Home() {
 
 ### Update the current user data
 
-<CodeBlockTabs options={['Next.js', 'React']}>
+<CodeBlockTabs type="framework" options={["Next.js", "React"]}>
 ```tsx filename="app/page.tsx"
 import { useUser } from "@clerk/nextjs";
 
@@ -107,7 +107,7 @@ export default function Home() {
 
 If you need to retrieve the latest user data after updating the user elsewhere, use the `user.reload()` method.
 
-<CodeBlockTabs options={['Next.js', 'React']}>
+<CodeBlockTabs type="framework" options={["Next.js", "React"]}>
 ```tsx filename="app/page.tsx"
 import { useUser } from "@clerk/nextjs";
 

--- a/docs/testing/postman-or-insomnia.mdx
+++ b/docs/testing/postman-or-insomnia.mdx
@@ -47,63 +47,63 @@ alt="The Dev Tools Console with the command 'await window.Clerk.session.getToken
 ## Using Postman or Insomnia
 
 <Tabs items={["Postman", "Insomnia"]}>
-<Tab>
-Open Postman and create a new request.
+  <Tab>
+  Open Postman and create a new request.
 
-<Images
-  src="/docs/images/testing/postman-new-request.webp"
-  width={2552}
-  height={1592}
-  alt="The Postman app with a red arrow pointing at the plus icon in the top left corner."
-/>
+  <Images
+    src="/docs/images/testing/postman-new-request.webp"
+    width={2552}
+    height={1592}
+    alt="The Postman app with a red arrow pointing at the plus icon in the top left corner."
+  />
 
-Configure Postman with the method and URL for the API Route you want to test. This example uses the `POST` method and the `/api/protected-route` route. 
+  Configure Postman with the method and URL for the API Route you want to test. This example uses the `POST` method and the `/api/protected-route` route. 
 
-<Images
-  src="/docs/images/testing/postman-configure-request.webp"
-  width={2552}
-  height={1592}
-  alt="The Postman app with a red box around the method and URL field."
-/>
+  <Images
+    src="/docs/images/testing/postman-configure-request.webp"
+    width={2552}
+    height={1592}
+    alt="The Postman app with a red box around the method and URL field."
+  />
 
-Navigate to the **Authorization** tab and for token type, select **Bearer Token**. Paste the token you copied from the console as the Bearer Token. Your request will now authenticate as the user you created the token with.
+  Navigate to the **Authorization** tab and for token type, select **Bearer Token**. Paste the token you copied from the console as the Bearer Token. Your request will now authenticate as the user you created the token with.
 
-<Images
-  src="/docs/images/testing/postman-bearer-token.webp"
-  width={2552}
-  height={1592}
-  alt="The Postman app with the first red arrow pointing at the Authorization tab, the second red arrow pointing at the token type with 'Bearer token' chosen, and a third red arrow pointing at the token field with the token pasted in."
-/>
-</Tab>
+  <Images
+    src="/docs/images/testing/postman-bearer-token.webp"
+    width={2552}
+    height={1592}
+    alt="The Postman app with the first red arrow pointing at the Authorization tab, the second red arrow pointing at the token type with 'Bearer token' chosen, and a third red arrow pointing at the token field with the token pasted in."
+  />
+  </Tab>
 
-<Tab>
-Open Insomnia and create a new request. 
+  <Tab>
+  Open Insomnia and create a new request. 
 
-<Images
-  src="/docs/images/testing/insomnia-new-request.webp"
-  width={2552}
-  height={1430}
-  alt="The Insomnia app with a red arrow pointing at the 'New HTTP Request' button."
-/>
+  <Images
+    src="/docs/images/testing/insomnia-new-request.webp"
+    width={2552}
+    height={1430}
+    alt="The Insomnia app with a red arrow pointing at the 'New HTTP Request' button."
+  />
 
-Configure Insomnia with the method and URL for the API Route you want to test. This example uses the `POST` method and the `/api/protected-route` route. 
+  Configure Insomnia with the method and URL for the API Route you want to test. This example uses the `POST` method and the `/api/protected-route` route. 
 
-<Images
-  src="/docs/images/testing/insomnia-configure-request.webp"
-  width={2552}
-  height={1430}
-  alt="The Insomnia app with a red box around the method and URL field."
-/>
+  <Images
+    src="/docs/images/testing/insomnia-configure-request.webp"
+    width={2552}
+    height={1430}
+    alt="The Insomnia app with a red box around the method and URL field."
+  />
 
-Navigate to the **Auth** tab and click on **Auth** again to show a menu of auth types. Choose the **Bearer token** option. Paste the token you copied from the console. Your request will now authenticate as the user you created the token with.
+  Navigate to the **Auth** tab and click on **Auth** again to show a menu of auth types. Choose the **Bearer token** option. Paste the token you copied from the console. Your request will now authenticate as the user you created the token with.
 
-<Images
-  src="/docs/images/testing/insomnia-bearer-token.webp"
-  width={2552}
-  height={1430}
-  alt="The Insomnia app with the first red arrow pointing at the Auth tab which has been switched to the 'Bearer token' option. The second red arrow points at the token field with the token pasted in."
-/>
-</Tab>
+  <Images
+    src="/docs/images/testing/insomnia-bearer-token.webp"
+    width={2552}
+    height={1430}
+    alt="The Insomnia app with the first red arrow pointing at the Auth tab which has been switched to the 'Bearer token' option. The second red arrow points at the token field with the token pasted in."
+  />
+  </Tab>
 </Tabs>
 
 ## Grouping requests

--- a/docs/users/deleting-users.mdx
+++ b/docs/users/deleting-users.mdx
@@ -9,61 +9,69 @@ Clerk currently supports deleting users through our [backend API](https://clerk.
 
 The [`deleteUser()`](/docs/references/backend/user/delete-user) method takes a single argument: the user ID of the user you want to delete. It can be accessed from the `users` sub-api of the `clerkClient` instance.
 
-<CodeBlockTabs options={["Curl", "Next.js App Router", "Next.js Pages Router", "Node"]}>
-```bash filename="curl.sh"
-curl -XDELETE -H 'Authorization: CLERK_SECRET_KEY' 'https://api.clerk.com/v1/users/{user_id}'
-```
+<Tabs type="framework" items={["Next.js", "Node", "cURL"]}>
+  <Tab>
+    <CodeBlockTabs type="router" options={["App Router", "Pages Router"]}>
+    ```ts filename="app/private/route.ts"
+    import { clerkClient } from "@clerk/nextjs";
+    import { NextResponse } from 'next/server';
 
-```ts filename="app/private/route.ts"
-import { clerkClient } from "@clerk/nextjs";
-import { NextResponse } from 'next/server';
+    export async function DELETE(request: Request) {
+      const { userId } = await request.body.json();
 
-export async function DELETE(request: Request) {
-  const { userId } = await request.body.json();
+      try {
+        await clerkClient.users.deleteUser(userId);
+        return NextResponse.json({ message: 'Success' });
+      }
+      catch (error) {
+        console.log(error);
+        return NextResponse.json({ error: 'Error deleting user' });
+      }
+    }
+    ```
 
-  try {
-    await clerkClient.users.deleteUser(userId);
-    return NextResponse.json({ message: 'Success' });
-  }
-  catch (error) {
-    console.log(error);
-    return NextResponse.json({ error: 'Error deleting user' });
-  }
-}
-```
+    ```ts filename="pages/api/private.ts"
+    import { clerkClient } from "@clerk/nextjs/server";
+    import { NextApiRequest, NextApiResponse } from "next";
 
-```ts filename="pages/api/private.ts"
-import { clerkClient } from "@clerk/nextjs/server";
-import { NextApiRequest, NextApiResponse } from "next";
+    export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+      const userId = req.body.userId;
 
-export default async function handler(req: NextApiRequest, res: NextApiResponse) {
-  const userId = req.body.userId;
+      try {
+        await clerkClient.users.deleteUser(userId);
+        return res.status(200).json({ message: 'Success' });
+      }
+      catch (error) {
+        console.log(error);
+        return res.status(500).json({ error: 'Error deleting user' });
+      }
+    }
+    ```
+    </CodeBlockTabs>
+  </Tab>
 
-  try {
-    await clerkClient.users.deleteUser(userId);
-    return res.status(200).json({ message: 'Success' });
-  }
-  catch (error) {
-    console.log(error);
-    return res.status(500).json({ error: 'Error deleting user' });
-  }
-}
-```
+  <Tab>
+  ```ts filename="private.ts"
+  import { clerkClient } from "@clerk/clerk-sdk-node";
 
-```ts filename="private.ts"
-import { clerkClient } from "@clerk/clerk-sdk-node";
+  app.post('/deleteUser', (req, res) => {
+    const userId = req.body.userId;
 
-app.post('/deleteUser', (req, res) => {
-  const userId = req.body.userId;
+    try {
+      await clerkClient.users.deleteUser(userId);
+      return res.status(200).json({ message: 'Success' });
+    }
+    catch (error) {
+      console.log(error);
+      return res.status(500).json({ error: 'Error deleting user' });
+    }
+  });
+  ```
+  </Tab>
 
-  try {
-    await clerkClient.users.deleteUser(userId);
-    return res.status(200).json({ message: 'Success' });
-  }
-  catch (error) {
-    console.log(error);
-    return res.status(500).json({ error: 'Error deleting user' });
-  }
-});
-```
-</CodeBlockTabs>
+  <Tab>
+  ```bash filename="curl.sh"
+  curl -XDELETE -H 'Authorization: CLERK_SECRET_KEY' 'https://api.clerk.com/v1/users/{user_id}'
+  ```
+  </Tab>
+</Tabs>

--- a/docs/users/metadata.mdx
+++ b/docs/users/metadata.mdx
@@ -19,14 +19,24 @@ Private metadata is only accessible by the backend, which makes this useful for 
 
 ### Setting private metadata
 
-<CodeBlockTabs options={['cURL', 'Pages Router', 'App Router', 'Node', 'Go','Ruby']}>
-```bash filename="curl.sh"
-curl -XPATCH -H 'Authorization: Bearer CLERK_SECRET_KEY' -H "Content-type: application/json" -d '{
-  "private_metadata": {
-    "stripeId": "12356"
-  }
-}' 'https://api.clerk.com/v1/users/{user_id}/metadata'
+<Tabs type="framework" items={["Next.js", "Node", "Go", "Ruby", "cURL"]}>
+<Tab>
+<CodeBlockTabs type="router" options={["App Router", "Pages Router"]}>
+```ts filename="app/route/private.ts"
+import { NextResponse } from 'next/server';
+import { clerkClient } from "@clerk/nextjs";
+
+export async function POST() {
+  const { stripeId, userId } = await body.json();
+  await clerkClient.users.updateUserMetadata(userId, {
+    privateMetadata: {
+      stripeId: stripeId
+    }
+  });
+  return NextResponse.json({ success: true });
+}
 ```
+
 ```ts filename="pages/api/private.ts"
 import { clerkClient } from "@clerk/nextjs";
 import { NextApiRequest, NextApiResponse } from "next";
@@ -44,20 +54,10 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
   res.status(200).json({ success: true });
 }
 ```
-```ts filename="app/route/private.ts"
-import { NextResponse } from 'next/server';
-import { clerkClient } from "@clerk/nextjs";
+</CodeBlockTabs>
+</Tab>
 
-export async function POST() {
-  const { stripeId, userId } = await body.json();
-  await clerkClient.users.updateUserMetadata(userId, {
-    privateMetadata: {
-      stripeId: stripeId
-    }
-  });
-  return NextResponse.json({ success: true });
-}
-```
+<Tab>
 ```ts filename="private.ts"
 import { clerkClient } from "@clerk/clerk-sdk-node";
 
@@ -73,6 +73,9 @@ app.post('/updateStripe', (req, res) => {
 });
 
 ```
+</Tab>
+
+<Tab>
 ```ts filename="private.go"
 var client clerk.Client
 
@@ -89,6 +92,9 @@ func addStripeCustomerID(user *clerk.User, stripeCustomerID string) error {
 	}
 }
 ```
+</Tab>
+
+<Tab>
 ```ts filename="private.rb"
 // ruby json example with a private metadata and stripe id
 require 'clerk'
@@ -102,83 +108,97 @@ privateMetadata = {
 clerk = Clerk::SDK.new(api_key: "your_clerk_secret_key")
 clerk.users.updateMetadata("user_xyz", private_metadata: privateMetadata)
 ```
-</CodeBlockTabs>
+</Tab>
+
+<Tab>
+```bash filename="curl.sh"
+curl -XPATCH -H 'Authorization: Bearer CLERK_SECRET_KEY' -H "Content-type: application/json" -d '{
+  "private_metadata": {
+    "stripeId": "12356"
+  }
+}' 'https://api.clerk.com/v1/users/{user_id}/metadata'
+```
+</Tab>
+</Tabs>
 
 ### Retrieving private metadata
 
 You can retrieve the private metadata for a user by using the [`getUser`](/docs/references/backend/user/get-user) method. This method will return the `User` object which contains the private metadata.
 
-<Tabs items={["Next.js", "Node", "cURL", "Go", "Ruby"]}>
+<Tabs type="framework" items={["Next.js", "Node", "cURL", "Go", "Ruby"]}>
   <Tab>
-<CodeBlockTabs options={['App Router', 'Pages Router']}>
+    <CodeBlockTabs type="router" options={["App Router", "Pages Router"]}>
 
-```ts filename="app/private/route.ts"
-import { NextResponse } from 'next/server';
-import { clerkClient } from "@clerk/nextjs";
+    ```ts filename="app/private/route.ts"
+    import { NextResponse } from 'next/server';
+    import { clerkClient } from "@clerk/nextjs";
 
-export async function GET(request: Request) {
-  const { stripeId, userId } = await request.body.json();
+    export async function GET(request: Request) {
+      const { stripeId, userId } = await request.body.json();
 
-  const user = await clerkClient.users.getUser(userId)
-  return NextResponse.json(user.privateMetadata);
-}
-```
+      const user = await clerkClient.users.getUser(userId)
+      return NextResponse.json(user.privateMetadata);
+    }
+    ```
 
-```ts filename="pages/api/private.ts"
-import { clerkClient } from "@clerk/nextjs";
-import { NextApiRequest, NextApiResponse } from "next";
+    ```ts filename="pages/api/private.ts"
+    import { clerkClient } from "@clerk/nextjs";
+    import { NextApiRequest, NextApiResponse } from "next";
 
-export default async function handler(req: NextApiRequest, res: NextApiResponse) {
-  const { userId } = await req.body.json();
+    export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+      const { userId } = await req.body.json();
 
-  const user = await clerkClient.users.getUser(userId)
+      const user = await clerkClient.users.getUser(userId)
 
-  res.status(200).json(user.privateMetadata);
-}
-```
-</CodeBlockTabs>
-  </Tab>
-  <Tab>
-```ts filename="private.ts"
-import { clerkClient } from "@clerk/clerk-sdk-node";
-
-app.post('/updateStripe', (req, res) => {
-  const { userId } = await req.body.json();
-
-  const user = await clerkClient.users.getUser(userId)
-
-  res.status(200).json(user.privateMetadata);
-});
-
-```
-  </Tab>
-  <Tab>
-```bash filename="curl.sh"
-curl -XGET -H 'Authorization: CLERK_SECRET_KEY' -H "Content-type: application/json" 'https://api.clerk.com/v1/users/{user_id}'
-```
-  </Tab>
-  <Tab>
-```ts filename="private.go"
-var client clerk.Client
-
-func GetUserMetadata(user *clerk.User, stripeCustomerID string) error {
-	user, err := s.clerkClient.Users().Read(sess.UserID)
-
-	if err != nil {
-		panic(err)
-	}
-}
-```
-  </Tab>
-  <Tab>
-```ts filename="private.rb"
-// ruby json example with a private metadata and stripe id
-require 'clerk'
-clerk = Clerk::SDK.new(api_key: "your_clerk_secret_key")
-clerk.users.getUser("user_xyz")
-```
+      res.status(200).json(user.privateMetadata);
+    }
+    ```
+    </CodeBlockTabs>
   </Tab>
 
+  <Tab>
+  ```ts filename="private.ts"
+  import { clerkClient } from "@clerk/clerk-sdk-node";
+
+  app.post('/updateStripe', (req, res) => {
+    const { userId } = await req.body.json();
+
+    const user = await clerkClient.users.getUser(userId)
+
+    res.status(200).json(user.privateMetadata);
+  });
+
+  ```
+  </Tab>
+
+  <Tab>
+  ```bash filename="curl.sh"
+  curl -XGET -H 'Authorization: CLERK_SECRET_KEY' -H "Content-type: application/json" 'https://api.clerk.com/v1/users/{user_id}'
+  ```
+  </Tab>
+    
+  <Tab>
+  ```ts filename="private.go"
+  var client clerk.Client
+
+  func GetUserMetadata(user *clerk.User, stripeCustomerID string) error {
+    user, err := s.clerkClient.Users().Read(sess.UserID)
+
+    if err != nil {
+      panic(err)
+    }
+  }
+  ```
+  </Tab>
+
+  <Tab>
+  ```ts filename="private.rb"
+  // ruby json example with a private metadata and stripe id
+  require 'clerk'
+  clerk = Clerk::SDK.new(api_key: "your_clerk_secret_key")
+  clerk.users.getUser("user_xyz")
+  ```
+  </Tab>
 </Tabs>
 
 ## Public metadata
@@ -187,92 +207,107 @@ Public metadata is accessible by both the frontend and the backend. This is usef
 
 ### Setting public metadata
 
-<CodeBlockTabs options={['cURL', 'Pages Router', 'App Router', 'Node', 'Go','Ruby']}>
-```bash filename="curl.sh"
-curl -XPATCH -H 'Authorization: Bearer CLERK_SECRET_KEY' -H "Content-type: application/json" -d '{
-  "public_metadata": {
-    "role": "shopper"
-  }
-}' 'https://api.clerk.com/v1/users/{user_id}/metadata'
-```
-```ts filename="pages/api/public.ts"
-import { clerkClient } from "@clerk/nextjs";
-import { NextApiRequest, NextApiResponse } from "next";
+<Tabs type="framework" items={["Next.js", "Node", "cURL", "Go", "Ruby"]}>
+  <Tab>
+    <CodeBlockTabs type="router" options={["App Router", "Pages Router"]}>
+    ```ts filename="app/route/public.ts"
+    import { NextResponse } from 'next/server';
+    import { clerkClient } from "@clerk/nextjs";
 
-export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+    export async function POST() {
+      const { role, userId } =  await body.json();
 
-  const { role, userId } = req.body;
-
-  await clerkClient.users.updateUserMetadata(userId, {
-    publicMetadata: {
-      role
+      await clerkClient.users.updateUserMetadata(userId, {
+        publicMetadata: {
+          role
+        }
+      })
+      return NextResponse.json({ success: true });
     }
-  })
+    ```
 
-  res.status(200).json({ success: true });
-}
-```
-```ts filename="app/route/public.ts"
-import { NextResponse } from 'next/server';
-import { clerkClient } from "@clerk/nextjs";
+    ```ts filename="pages/api/public.ts"
+    import { clerkClient } from "@clerk/nextjs";
+    import { NextApiRequest, NextApiResponse } from "next";
 
-export async function POST() {
-  const { role, userId } =  await body.json();
+    export default async function handler(req: NextApiRequest, res: NextApiResponse) {
 
-  await clerkClient.users.updateUserMetadata(userId, {
-    publicMetadata: {
-      role
+      const { role, userId } = req.body;
+
+      await clerkClient.users.updateUserMetadata(userId, {
+        publicMetadata: {
+          role
+        }
+      })
+
+      res.status(200).json({ success: true });
     }
-  })
-  return NextResponse.json({ success: true });
-}
-```
-```ts filename="public.ts"
-import { clerkClient } from "@clerk/clerk-sdk-node";
+    ```
+    </CodeBlockTabs>
+  </Tab>
 
-app.post('/updateRole', (req, res) => {
+  <Tab>
+  ```ts filename="public.ts"
+  import { clerkClient } from "@clerk/clerk-sdk-node";
 
-  const { role, userId } = req.body;
+  app.post('/updateRole', (req, res) => {
 
-  await clerkClient.users.updateUserMetadata(userId, {
-    publicMetadata: {
-      role
-    }
+    const { role, userId } = req.body;
+
+    await clerkClient.users.updateUserMetadata(userId, {
+      publicMetadata: {
+        role
+      }
+    });
+    res.status(200).json({ success: true });
   });
-  res.status(200).json({ success: true });
-});
+  ```
+  </Tab>
 
-```
-```ts filename="public.go"
-var client clerk.Client
+  <Tab>
+  ```ts filename="public.go"
+  var client clerk.Client
 
-func addStripeCustomerID(user *clerk.User, role string) error {
-    Role := map[string]interface{}{
-        "role": role,
+  func addStripeCustomerID(user *clerk.User, role string) error {
+      Role := map[string]interface{}{
+          "role": role,
+      }
+    user, err := s.clerkClient.Users().UpdateMetadata(sess.UserID, &clerk.updateMetadataRequest{
+      PublicMetadata: role,
+    })
+
+    if err != nil {
+      panic(err)
     }
-	user, err := s.clerkClient.Users().UpdateMetadata(sess.UserID, &clerk.updateMetadataRequest{
-		PublicMetadata: role,
-	})
+  }
+  ```
+  </Tab>
 
-	if err != nil {
-		panic(err)
-	}
-}
-```
-```ts filename="public.rb"
-// ruby json example with a private metadata and stripe id
-require 'clerk'
-require 'json'
+  <Tab>
+  ```ts filename="public.rb"
+  // ruby json example with a private metadata and stripe id
+  require 'clerk'
+  require 'json'
 
-publicMetadata = {
-  "role": "awesome-user",
-}
+  publicMetadata = {
+    "role": "awesome-user",
+  }
 
+  clerk = Clerk::SDK.new(api_key: "your_clerk_secret_key")
+  clerk.users.updateMetadata("user_xyz", public_metadata: publicMetadata)
+  ```
+  </Tab>
 
-clerk = Clerk::SDK.new(api_key: "your_clerk_secret_key")
-clerk.users.updateMetadata("user_xyz", public_metadata: publicMetadata)
-```
-</CodeBlockTabs>
+  <Tab>
+  ```bash filename="curl.sh"
+  curl -XPATCH -H 'Authorization: Bearer CLERK_SECRET_KEY' -H "Content-type: application/json" -d '{
+    "public_metadata": {
+      "role": "shopper"
+    }
+  }' 'https://api.clerk.com/v1/users/{user_id}/metadata'
+  ```
+  </Tab>
+</Tabs>
 
 ### Retrieving public metadata
 
@@ -294,247 +329,279 @@ The "unsafe" custom attributes can be set upon sign-up when creating or updating
 
 #### Using the Backend API
 
-<CodeBlockTabs options={['cURL', 'Pages Router', 'App Router', 'Node', 'Go','Ruby']}>
-```bash filename="curl.sh"
-curl -XPATCH -H 'Authorization: Bearer CLERK_SECRET_KEY' -H "Content-type: application/json" -d '{
-  "unsafe_metadata": {
-    "birthday": "11-30-1969"
+<Tabs type="framework" items={["Next.js", "Node", "cURL", "Go", "Ruby"]}>
+  <Tab>
+    <CodeBlockTabs type="router" options={["App Router", "Pages Router"]}>
+
+    ```ts filename="app/route/private.ts"
+    import { NextResponse } from 'next/server';
+    import { clerkClient } from "@clerk/nextjs";
+
+    export async function POST() {
+      const { stripeId, userId } = await body.json();
+      await clerkClient.users.updateUserMetadata(userId, {
+        unsafeMetadata: {
+          "birthday": "11-30-1969"
+        }
+      });
+      return NextResponse.json({ success: true });
+    }
+    ```
+
+    ```ts filename="pages/api/private.ts"
+    import { clerkClient } from "@clerk/nextjs";
+    import { NextApiRequest, NextApiResponse } from "next";
+
+    export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+
+      const { stripeId, userId } = req.body;
+
+      await clerkClient.users.updateUserMetadata(userId, {
+        unsafeMetadata: {
+          "birthday": "11-30-1969"
+        }
+      })
+
+      res.status(200).json({ success: true });
+    }
+    ```
+    </CodeBlockTabs>
+  </Tab>
+
+  <Tab>
+  ```ts filename="private.ts"
+  import { clerkClient } from "@clerk/clerk-sdk-node";
+
+  app.post('/updateStripe', (req, res) => {
+
+    const { stripeId, userId } = await body.json();
+    await clerkClient.users.updateUserMetadata(userId, {
+      unsafeMetadata: {
+        "birthday": "11-30-1969"
+      }
+    });
+    res.status(200).json({ success: true });
+  });
+
+  ```
+  </Tab>
+
+  <Tab>
+  ```ts filename="private.go"
+  var client clerk.Client
+
+  func addStripeCustomerID(user *clerk.User, stripeCustomerID string) error {
+      birthday := map[string]interface{}{
+          "birthday": "04-20-1969",
+      }
+    user, err := s.clerkClient.Users().UpdateMetadata(sess.UserID, &clerk.updateMetadataRequest{
+      UnsafeMetadata: birthday,
+    })
+
+    if err != nil {
+      panic(err)
+    }
   }
-}' 'https://api.clerk.com/v1/users/{user_id}/metadata'
-```
-```ts filename="pages/api/private.ts"
-import { clerkClient } from "@clerk/nextjs";
-import { NextApiRequest, NextApiResponse } from "next";
+  ```
+  </Tab>
 
-export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  <Tab>
+  ```ts filename="private.rb"
+  // ruby json example with a private metadata and stripe id
+  require 'clerk'
+  require 'json'
 
-  const { stripeId, userId } = req.body;
+  unsafeMetadata = {
+    "birthday": "04-20-1969"
+  }
 
-  await clerkClient.users.updateUserMetadata(userId, {
-    unsafeMetadata: {
+  clerk = Clerk::SDK.new(api_key: "your_clerk_secret_key")
+  clerk.users.updateMetadata("user_xyz", unsafe_metadata: unsafeMetadata)
+  ```
+  </Tab>
+
+  <Tab>
+  ```bash filename="curl.sh"
+  curl -XPATCH -H 'Authorization: Bearer CLERK_SECRET_KEY' -H "Content-type: application/json" -d '{
+    "unsafe_metadata": {
       "birthday": "11-30-1969"
     }
-  })
-
-  res.status(200).json({ success: true });
-}
-```
-```ts filename="app/route/private.ts"
-import { NextResponse } from 'next/server';
-import { clerkClient } from "@clerk/nextjs";
-
-export async function POST() {
-  const { stripeId, userId } = await body.json();
-  await clerkClient.users.updateUserMetadata(userId, {
-    unsafeMetadata: {
-      "birthday": "11-30-1969"
-    }
-  });
-  return NextResponse.json({ success: true });
-}
-```
-```ts filename="private.ts"
-import { clerkClient } from "@clerk/clerk-sdk-node";
-
-app.post('/updateStripe', (req, res) => {
-
-  const { stripeId, userId } = await body.json();
-  await clerkClient.users.updateUserMetadata(userId, {
-    unsafeMetadata: {
-      "birthday": "11-30-1969"
-    }
-  });
-  res.status(200).json({ success: true });
-});
-
-```
-```ts filename="private.go"
-var client clerk.Client
-
-func addStripeCustomerID(user *clerk.User, stripeCustomerID string) error {
-    birthday := map[string]interface{}{
-        "birthday": "04-20-1969",
-    }
-	user, err := s.clerkClient.Users().UpdateMetadata(sess.UserID, &clerk.updateMetadataRequest{
-		UnsafeMetadata: birthday,
-	})
-
-	if err != nil {
-		panic(err)
-	}
-}
-```
-```ts filename="private.rb"
-// ruby json example with a private metadata and stripe id
-require 'clerk'
-require 'json'
-
-unsafeMetadata = {
-  "birthday": "04-20-1969"
-}
-
-
-clerk = Clerk::SDK.new(api_key: "your_clerk_secret_key")
-clerk.users.updateMetadata("user_xyz", unsafe_metadata: unsafeMetadata)
-```
-</CodeBlockTabs>
+  }' 'https://api.clerk.com/v1/users/{user_id}/metadata'
+  ```
+  </Tab>
+</Tabs>
 
 #### Using the Frontend SDKs
 
-<CodeBlockTabs options={['Pages Router', 'App Router', 'React', 'Remix','Gatsby', 'JavaScript']}>
+<Tabs type="framework" items={["Next.js", "React", "Remix","Gatsby", "JavaScript"]}>
+  <Tab>
+    <CodeBlockTabs type="router" options={["App Router", "Pages Router"]}>
+    ```tsx filename="app/route/unsafe.tsx"
+    "use client"
+    import {useUser} from "@clerk/nextjs";
+    import {useState} from "react";
 
-```tsx filename="pages/unsafe.tsx"
-import {useUser} from "@clerk/nextjs";
-import {useState} from "react";
-
-export default function UnSafePage() {
-  const { user } = useUser();
-  const [birthday, setBirthday] = ""
-
-
-  return(
-    <div>
-      <input type="text" value={birthday} onChange={(e) => setBirthday(e.target.value)} />
-      <button onClick={() => {
-        user.update({
-          unsafeMetadata: {
-            birthday
-          }
-        })
-      }}>Update Birthday</button>
-    </div>
-  )
-}
-```
-```tsx filename="app/route/unsafe.tsx"
-"use client"
-import {useUser} from "@clerk/nextjs";
-import {useState} from "react";
-
-export default function UnSafePage() {
-  const { user } = useUser();
-  const [birthday, setBirthday] = ""
+    export default function UnSafePage() {
+      const { user } = useUser();
+      const [birthday, setBirthday] = ""
 
 
-  return(
-    <div>
-      <input type="text" value={birthday} onChange={(e) => setBirthday(e.target.value)} />
-      <button onClick={() => {
-        user.update({
-          unsafeMetadata: {
-            birthday
-          }
-        })
-      }}>Update Birthday</button>
-    </div>
-  )
-}
-```
-```tsx filename="unsafe.tsx"
-import {useUser} from "@clerk/clerk-react";
-import {useState} from "react";
-
-export default function UnSafePage() {
-  const { user } = useUser();
-  const [birthday, setBirthday] = ""
-
-
-  return(
-    <div>
-      <input type="text" value={birthday} onChange={(e) => setBirthday(e.target.value)} />
-      <button onClick={() => {
-        user.update({
-          unsafeMetadata: {
-            birthday
-          }
-        })
-      }}>Update Birthday</button>
-    </div>
-  )
-}
-```
-```tsx filename="unsafe.tsx"
-import {useUser} from "@clerk/remix";
-import {useState} from "react";
-
-export default function UnSafePage() {
-  const { user } = useUser();
-  const [birthday, setBirthday] = ""
-  return(
-    <div>
-      <input type="text" value={birthday} onChange={(e) => setBirthday(e.target.value)} />
-      <button onClick={() => {
-        user.update({
-          unsafeMetadata: {
-            birthday
-          }
-        })
-      }}>Update Birthday</button>
-    </div>
-  )
-}
-```
-```tsx filename="unsafe.tsx"
-// use Clerk React for gatsby
-import {useUser} from "@clerk/clerk-react";
-import {useState} from "react";
-
-export default function UnSafePage() {
-  const { user } = useUser();
-  const [birthday, setBirthday] = ""
-
-
-  return(
-    <div>
-      <input type="text" value={birthday} onChange={(e) => setBirthday(e.target.value)} />
-      <button onClick={() => {
-        user.update({
-          unsafeMetadata: {
-            birthday
-          }
-        })
-      }}>Update Birthday</button>
-    </div>
-  )
-}
-```
-```html filename="unsafe.html"
-<!DOCTYPE html>
-<html lang="en">
-
-<head>
-    <meta charset="UTF-8" />
-    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Clerk Unsafe Update</title>
-</head>
-
-<body>
-    <h1>Clerk JavaScript Email + Password</h1>
-
-    <div id="birthday-update">
-        <input placeholder="your birthday" id="birthday" type="string"></input>
-        <button onclick="updateBirthday()">Update Birthday</button>
-
-    </div>
-    <script>
-        const updateBirthday = async () => {
-            const birthday = document.getElementById('birthday').value;
-            const {user} = window.Clerk;
+      return(
+        <div>
+          <input type="text" value={birthday} onChange={(e) => setBirthday(e.target.value)} />
+          <button onClick={() => {
             user.update({
-                unsafeMetadata: {
-                  "birthday": birthday
-                }
+              unsafeMetadata: {
+                birthday
+              }
             })
-        };
-    </script>
-    // Script to load Clerk up
-    <script src="src/script.js" async crossorigin="anonymous"></script>
-</body>
+          }}>Update Birthday</button>
+        </div>
+      )
+    }
+    ```
 
-</html>
-```
-</CodeBlockTabs>
+    ```tsx filename="pages/unsafe.tsx"
+    import {useUser} from "@clerk/nextjs";
+    import {useState} from "react";
+
+    export default function UnSafePage() {
+      const { user } = useUser();
+      const [birthday, setBirthday] = ""
+
+
+      return(
+        <div>
+          <input type="text" value={birthday} onChange={(e) => setBirthday(e.target.value)} />
+          <button onClick={() => {
+            user.update({
+              unsafeMetadata: {
+                birthday
+              }
+            })
+          }}>Update Birthday</button>
+        </div>
+      )
+    }
+    ```
+    </CodeBlockTabs>
+  </Tab>
+
+  <Tab>
+  ```tsx filename="unsafe.tsx"
+  import {useUser} from "@clerk/clerk-react";
+  import {useState} from "react";
+
+  export default function UnSafePage() {
+    const { user } = useUser();
+    const [birthday, setBirthday] = ""
+
+    return(
+      <div>
+        <input type="text" value={birthday} onChange={(e) => setBirthday(e.target.value)} />
+        <button onClick={() => {
+          user.update({
+            unsafeMetadata: {
+              birthday
+            }
+          })
+        }}>Update Birthday</button>
+      </div>
+    )
+  }
+  ```
+  </Tab>
+
+  <Tab>
+  ```tsx filename="unsafe.tsx"
+  import {useUser} from "@clerk/remix";
+  import {useState} from "react";
+
+  export default function UnSafePage() {
+    const { user } = useUser();
+    const [birthday, setBirthday] = ""
+    return(
+      <div>
+        <input type="text" value={birthday} onChange={(e) => setBirthday(e.target.value)} />
+        <button onClick={() => {
+          user.update({
+            unsafeMetadata: {
+              birthday
+            }
+          })
+        }}>Update Birthday</button>
+      </div>
+    )
+  }
+  ```
+  </Tab>
+
+  <Tab>
+  ```tsx filename="unsafe.tsx"
+  // use Clerk React for gatsby
+  import {useUser} from "@clerk/clerk-react";
+  import {useState} from "react";
+
+  export default function UnSafePage() {
+    const { user } = useUser();
+    const [birthday, setBirthday] = ""
+
+
+    return(
+      <div>
+        <input type="text" value={birthday} onChange={(e) => setBirthday(e.target.value)} />
+        <button onClick={() => {
+          user.update({
+            unsafeMetadata: {
+              birthday
+            }
+          })
+        }}>Update Birthday</button>
+      </div>
+    )
+  }
+  ```
+  </Tab>
+
+  <Tab>
+  ```html filename="unsafe.html"
+  <!DOCTYPE html>
+  <html lang="en">
+
+  <head>
+      <meta charset="UTF-8" />
+      <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+      <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+      <title>Clerk Unsafe Update</title>
+  </head>
+
+  <body>
+      <h1>Clerk JavaScript Email + Password</h1>
+
+      <div id="birthday-update">
+          <input placeholder="your birthday" id="birthday" type="string"></input>
+          <button onclick="updateBirthday()">Update Birthday</button>
+
+      </div>
+      <script>
+          const updateBirthday = async () => {
+              const birthday = document.getElementById('birthday').value;
+              const {user} = window.Clerk;
+              user.update({
+                  unsafeMetadata: {
+                    "birthday": birthday
+                  }
+              })
+          };
+      </script>
+      // Script to load Clerk up
+      <script src="src/script.js" async crossorigin="anonymous"></script>
+  </body>
+
+  </html>
+  ```
+  </Tab>
+</Tabs>
 
 ### Retrieving unsafe metadata
 

--- a/docs/users/sync-data.mdx
+++ b/docs/users/sync-data.mdx
@@ -69,7 +69,7 @@ Additionally messages contain an `id` string in the headers. To learn more about
 
 To get started setting up your endpoint, you will need to install the [`svix` package](https://www.npmjs.com/package/svix). Svix provides a package for verifying the webhook signature, making it easy to verify the authenticity of the webhook events.
 
-<CodeBlockTabs options={['npm', 'yarn', 'pnpm']}>
+<CodeBlockTabs type="installer" options={["npm", "yarn", "pnpm"]}>
   ```bash filename="terminal"
   npm install svix
   ```
@@ -85,236 +85,226 @@ pnpm add svix
 
 ### Create the endpoint in your application
 
-<Tabs items={["App Router","Pages Router", "Node"]}>
+<Tabs type="framework" items={["Next.js", "Node"]}>
+  <Tab>
+    Create a webhook endpoint in the `/api` directory.
 
-<Tab>
+    <CodeBlockTabs type="router" options={["App Router", "Pages Router"]}>
+    ```ts filename="app/api/webhook/route.ts"
+    import { Webhook } from 'svix'
+    import { headers } from 'next/headers'
+    import { WebhookEvent } from '@clerk/nextjs/server'
 
-If you're using Next.js with App Router, you can create a webhook endpoint in the `app/api` directory.
+    export async function POST(req: Request) {
 
-```ts filename="app/api/webhook/route.ts"
-import { Webhook } from 'svix'
-import { headers } from 'next/headers'
-import { WebhookEvent } from '@clerk/nextjs/server'
+      // You can find this in the Clerk Dashboard -> Webhooks -> choose the webhook
+      const WEBHOOK_SECRET = process.env.WEBHOOK_SECRET
 
-export async function POST(req: Request) {
+      if (!WEBHOOK_SECRET) {
+        throw new Error('Please add WEBHOOK_SECRET from Clerk Dashboard to .env or .env.local')
+      }
 
-  // You can find this in the Clerk Dashboard -> Webhooks -> choose the webhook
-  const WEBHOOK_SECRET = process.env.WEBHOOK_SECRET
+      // Get the headers
+      const headerPayload = headers();
+      const svix_id = headerPayload.get("svix-id");
+      const svix_timestamp = headerPayload.get("svix-timestamp");
+      const svix_signature = headerPayload.get("svix-signature");
 
-  if (!WEBHOOK_SECRET) {
-    throw new Error('Please add WEBHOOK_SECRET from Clerk Dashboard to .env or .env.local')
-  }
+      // If there are no headers, error out
+      if (!svix_id || !svix_timestamp || !svix_signature) {
+        return new Response('Error occured -- no svix headers', {
+          status: 400
+        })
+      }
 
-  // Get the headers
-  const headerPayload = headers();
-  const svix_id = headerPayload.get("svix-id");
-  const svix_timestamp = headerPayload.get("svix-timestamp");
-  const svix_signature = headerPayload.get("svix-signature");
+      // Get the body
+      const payload = await req.json()
+      const body = JSON.stringify(payload);
 
-  // If there are no headers, error out
-  if (!svix_id || !svix_timestamp || !svix_signature) {
-    return new Response('Error occured -- no svix headers', {
-      status: 400
+      // Create a new Svix instance with your secret.
+      const wh = new Webhook(WEBHOOK_SECRET);
+
+      let evt: WebhookEvent
+
+      // Verify the payload with the headers
+      try {
+        evt = wh.verify(body, {
+          "svix-id": svix_id,
+          "svix-timestamp": svix_timestamp,
+          "svix-signature": svix_signature,
+        }) as WebhookEvent
+      } catch (err) {
+        console.error('Error verifying webhook:', err);
+        return new Response('Error occured', {
+          status: 400
+        })
+      }
+
+      // Get the ID and type
+      const { id } = evt.data;
+      const eventType = evt.type;
+
+      console.log(`Webhook with and ID of ${id} and type of ${eventType}`)
+      console.log('Webhook body:', body)
+
+      return new Response('', { status: 200 })
+    }
+
+    ```
+
+    ```ts filename="pages/api/webhook.ts"
+    import { Webhook } from 'svix'
+    import { WebhookEvent } from '@clerk/nextjs/server'
+    import { NextApiRequest, NextApiResponse } from 'next'
+    import { buffer } from 'micro'
+
+    export const config = {
+      api: {
+        bodyParser: false,
+      }
+    }
+
+    export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+      if (req.method !== 'POST') {
+        return res.status(405)
+      }
+      // You can find this in the Clerk Dashboard -> Webhooks -> choose the webhook
+      const WEBHOOK_SECRET = process.env.WEBHOOK_SECRET
+
+      if (!WEBHOOK_SECRET) {
+        throw new Error('Please add WEBHOOK_SECRET from Clerk Dashboard to .env or .env.local')
+      }
+
+      // Get the headers
+      const svix_id = req.headers["svix-id"] as string;
+      const svix_timestamp = req.headers["svix-timestamp"] as string;
+      const svix_signature = req.headers["svix-signature"] as string;
+
+
+      // If there are no headers, error out
+      if (!svix_id || !svix_timestamp || !svix_signature) {
+        return res.status(400).json({ error: 'Error occured -- no svix headers' })
+      }
+
+      console.log('headers', req.headers, svix_id, svix_signature, svix_timestamp)
+      // Get the body
+      const body = (await buffer(req)).toString()
+
+      // Create a new Svix instance with your secret.
+      const wh = new Webhook(WEBHOOK_SECRET);
+
+      let evt: WebhookEvent
+
+      // Verify the payload with the headers
+      try {
+        evt = wh.verify(body, {
+          "svix-id": svix_id,
+          "svix-timestamp": svix_timestamp,
+          "svix-signature": svix_signature,
+        }) as WebhookEvent
+      } catch (err) {
+        console.error('Error verifying webhook:', err);
+        return res.status(400).json({ 'Error': err })
+      }
+
+      // Get the ID and type
+      const { id } = evt.data;
+      const eventType = evt.type;
+
+      console.log(`Webhook with and ID of ${id} and type of ${eventType}`)
+      console.log('Webhook body:', body)
+
+      return res.status(200).json({ response: 'Success' })
+    }
+    ```
+    </CodeBlockTabs>
+  </Tab>
+
+  <Tab>
+  The code example assumes a working Express application. Please adjust as needed for your setup and framework of choice.
+
+  ```ts
+  import bodyParser from 'body-parser'
+
+  app.post('/api/webhook', bodyParser.raw({ type: 'application/json' }), async function(req, res) {
+
+    // Check if the 'Signing Secret' from the Clerk Dashboard was correctly provided
+    const WEBHOOK_SECRET = process.env.WEBHOOK_SECRET
+    if (!WEBHOOK_SECRET) {
+        throw new Error('You need a WEBHOOK_SECRET in your .env')
+    }
+
+    // Grab the headers and body
+    const headers = req.headers;
+    const payload = req.body
+
+    // Get the Svix headers for verification
+    const svix_id = headers["svix-id"] as string;
+    const svix_timestamp = headers["svix-timestamp"] as string;
+    const svix_signature = headers["svix-signature"] as string;
+
+    // If there are missing Svix headers, error out
+    if (!svix_id || !svix_timestamp || !svix_signature) {
+        return new Response('Error occured -- no svix headers', {
+          status: 400
+        })
+    }
+
+    // Initiate Svix
+    const wh = new Webhook(WEBHOOK_SECRET)
+
+    let evt: WebhookEvent
+
+    // Attempt to verify the incoming webhook
+    // If successful, the payload will be available from 'evt'
+    // If the verification fails, error out and  return error code
+    try {
+        evt = wh.verify(payload, {
+          "svix-id": svix_id,
+          "svix-timestamp": svix_timestamp,
+          "svix-signature": svix_signature,
+        }) as WebhookEvent
+    } catch (err: any) {
+        // Console log and return errro
+        console.log('Webhook failed to verify. Error:', err.message)
+        return res.status(400).json({
+          success: false,
+          message: err.message
+        })
+    }
+
+    // Grab the ID and TYPE of the Webhook
+    const { id } = evt.data;
+    const eventType = evt.type;
+
+    console.log(`Webhook with an ID of ${id} and type of ${eventType}`)
+    // Console log the full payload to view
+    console.log('Webhook body:', evt.data)
+
+    return res.status(200).json({
+        success: true,
+        message: 'Webhook received'
     })
-  }
-
-  // Get the body
-  const payload = await req.json()
-  const body = JSON.stringify(payload);
-
-  // Create a new Svix instance with your secret.
-  const wh = new Webhook(WEBHOOK_SECRET);
-
-  let evt: WebhookEvent
-
-  // Verify the payload with the headers
-  try {
-    evt = wh.verify(body, {
-      "svix-id": svix_id,
-      "svix-timestamp": svix_timestamp,
-      "svix-signature": svix_signature,
-    }) as WebhookEvent
-  } catch (err) {
-    console.error('Error verifying webhook:', err);
-    return new Response('Error occured', {
-      status: 400
-    })
-  }
-
-  // Get the ID and type
-  const { id } = evt.data;
-  const eventType = evt.type;
-
-  console.log(`Webhook with and ID of ${id} and type of ${eventType}`)
-  console.log('Webhook body:', body)
-
-  return new Response('', { status: 200 })
-}
-
-```
-
-</Tab>
-
-<Tab>
-
-If you're using Next.js with Pages Router, you can create a webhook endpoint in the `pages/api` directory.
-
-```ts filename="pages/api/webhook.ts"
-import { Webhook } from 'svix'
-import { WebhookEvent } from '@clerk/nextjs/server'
-import { NextApiRequest, NextApiResponse } from 'next'
-import { buffer } from 'micro'
-
-export const config = {
-  api: {
-    bodyParser: false,
-  }
-}
-
-export default async function handler(req: NextApiRequest, res: NextApiResponse) {
-  if (req.method !== 'POST') {
-    return res.status(405)
-  }
-  // You can find this in the Clerk Dashboard -> Webhooks -> choose the webhook
-  const WEBHOOK_SECRET = process.env.WEBHOOK_SECRET
-
-  if (!WEBHOOK_SECRET) {
-    throw new Error('Please add WEBHOOK_SECRET from Clerk Dashboard to .env or .env.local')
-  }
-
-  // Get the headers
-  const svix_id = req.headers["svix-id"] as string;
-  const svix_timestamp = req.headers["svix-timestamp"] as string;
-  const svix_signature = req.headers["svix-signature"] as string;
-
-
-  // If there are no headers, error out
-  if (!svix_id || !svix_timestamp || !svix_signature) {
-    return res.status(400).json({ error: 'Error occured -- no svix headers' })
-  }
-
-  console.log('headers', req.headers, svix_id, svix_signature, svix_timestamp)
-  // Get the body
-  const body = (await buffer(req)).toString()
-
-  // Create a new Svix instance with your secret.
-  const wh = new Webhook(WEBHOOK_SECRET);
-
-  let evt: WebhookEvent
-
-  // Verify the payload with the headers
-  try {
-    evt = wh.verify(body, {
-      "svix-id": svix_id,
-      "svix-timestamp": svix_timestamp,
-      "svix-signature": svix_signature,
-    }) as WebhookEvent
-  } catch (err) {
-    console.error('Error verifying webhook:', err);
-    return res.status(400).json({ 'Error': err })
-  }
-
-  // Get the ID and type
-  const { id } = evt.data;
-  const eventType = evt.type;
-
-  console.log(`Webhook with and ID of ${id} and type of ${eventType}`)
-  console.log('Webhook body:', body)
-
-  return res.status(200).json({ response: 'Success' })
-}
-```
-
-</Tab>
-
-<Tab>
-
-The code example assumes a working Express application. Please adjust as needed for your setup and framework of choice.
-
-```ts
-import bodyParser from 'body-parser'
-
-app.post('/api/webhook', bodyParser.raw({ type: 'application/json' }), async function(req, res) {
-
-   // Check if the 'Signing Secret' from the Clerk Dashboard was correctly provided
-   const WEBHOOK_SECRET = process.env.WEBHOOK_SECRET
-   if (!WEBHOOK_SECRET) {
-      throw new Error('You need a WEBHOOK_SECRET in your .env')
-   }
-
-   // Grab the headers and body
-   const headers = req.headers;
-   const payload = req.body
-
-   // Get the Svix headers for verification
-   const svix_id = headers["svix-id"] as string;
-   const svix_timestamp = headers["svix-timestamp"] as string;
-   const svix_signature = headers["svix-signature"] as string;
-
-   // If there are missing Svix headers, error out
-   if (!svix_id || !svix_timestamp || !svix_signature) {
-      return new Response('Error occured -- no svix headers', {
-         status: 400
-      })
-   }
-
-   // Initiate Svix
-   const wh = new Webhook(WEBHOOK_SECRET)
-
-   let evt: WebhookEvent
-
-   // Attempt to verify the incoming webhook
-   // If successful, the payload will be available from 'evt'
-   // If the verification fails, error out and  return error code
-   try {
-      evt = wh.verify(payload, {
-         "svix-id": svix_id,
-         "svix-timestamp": svix_timestamp,
-         "svix-signature": svix_signature,
-      }) as WebhookEvent
-   } catch (err: any) {
-      // Console log and return errro
-      console.log('Webhook failed to verify. Error:', err.message)
-      return res.status(400).json({
-         success: false,
-         message: err.message
-      })
-   }
-
-   // Grab the ID and TYPE of the Webhook
-   const { id } = evt.data;
-   const eventType = evt.type;
-
-   console.log(`Webhook with an ID of ${id} and type of ${eventType}`)
-   // Console log the full payload to view
-   console.log('Webhook body:', evt.data)
-
-   return res.status(200).json({
-      success: true,
-      message: 'Webhook received'
-   })
-})
-```
-
-</Tab>
-
+  })
+  ```
+  </Tab>
 </Tabs>
 
 ### Add your endpoint to Middleware
 
 Your Route Handler must be made public or ignored by Middleware to allow the request to succeed. The following example will make any webhooks created under `app/api/webhooks/` public. See [authMiddleware](/docs/references/nextjs/auth-middleware) for more information.
 
- ```tsx filename="middleware.tsx" {4}
- import { authMiddleware } from "@clerk/nextjs";
+```tsx filename="middleware.tsx" {4}
+import { authMiddleware } from "@clerk/nextjs";
  
 export default authMiddleware({
-    publicRoutes: ["/api/webhooks(.*)"]
-    });
+  publicRoutes: ["/api/webhooks(.*)"]
+});
  
 export const config = {
   matcher: ['/((?!.+\\.[\\w]+$|_next).*)', '/', '/(api|trpc)(.*)'],
 };
-    ```
+```
 
 
 ### Test the webhook


### PR DESCRIPTION
[PR-825 in the Marketing repo](https://github.com/clerk/clerk-marketing/pull/825) introduces logic to sync `<CodeBlockTabs />` and `<Tabs />` instances so that their active tabs are synced and persist across sessions.

This PR updates these component instances to utilize the `type` property in order to sync components where appropriate.
This PR also updates the styleguide to introduce this new feature and examples on how to use it.

> Again, note that this is related to [PR-825](https://github.com/clerk/clerk-marketing/pull/825), so the build will fail until the new property and related logic is merged to prod. To test yourself, pull both this branch and the branch from PR-825 and run locally.
> For videos on how the feature works, check the description of [PR-825](https://github.com/clerk/clerk-marketing/pull/825).