### PR TITLE
DOCS-670 fix broken image

### DIFF
--- a/docs/authentication/saml-at-clerk.mdx
+++ b/docs/authentication/saml-at-clerk.mdx
@@ -16,7 +16,7 @@ Clerk supports Enterprise SSO via the SAML protocol so that you can create authe
 <Images 
   width={3024}
   height={1652}
-  src="/docs/images/authentication/email-address.webp"
+  src="/docs/images/authentication/email-address-configuration.jpg"
   alt="The Email, Phone, Username page in the Clerk Dashboard. There is a red arrow pointing to the toggle next to 'Email address', and it is toggled on."
 />
 


### PR DESCRIPTION
Fixes a broken image on the [SAML at Clerk](https://clerk.com/docs/authentication/saml-at-clerk#saml-at-clerk-beta) page, under "[Prerequisites](https://clerk.com/docs/authentication/saml-at-clerk#prerequisites)".

Before fix ([link to broken page](https://clerk.com/docs/authentication/saml-at-clerk#prerequisites)):
<img width="1512" alt="Screenshot 2023-11-20 at 17 11 51" src="https://github.com/clerk/clerk-docs/assets/98043211/c980716a-5cc0-4d78-84e6-2a9a27cd44f1">

After fix ([link to updated page](https://docs-preview-505.clerkpreview.com/docs/authentication/saml-at-clerk#saml-at-clerk-beta)):
<img width="1512" alt="Screenshot 2023-11-21 at 12 09 56" src="https://github.com/clerk/clerk-docs/assets/98043211/7d647735-bfa1-4a7c-bf04-7bdd70b50cad">
