### PR TITLE
chore(backend,types): Introduce PaginatedRequest type to re-use across javascript docs

### DIFF
--- a/docs/manifest.json
+++ b/docs/manifest.json
@@ -583,6 +583,7 @@
           ["OAuthProvider", "/references/javascript/types/oauth-provider"],
           ["OAuthStrategy", "/references/javascript/types/oauth-strategy"],
           ["PaginatedResponse", "/references/javascript/types/paginated-response"],
+          ["PaginatedRequest", "/references/javascript/types/paginated-request"],
           ["CustomPage", "/references/javascript/types/custom-page"]
         ]
       ]

--- a/docs/references/javascript/organization/domains.mdx
+++ b/docs/references/javascript/organization/domains.mdx
@@ -19,8 +19,7 @@ function getDomains(params?: GetDomainsParams): Promise<PaginatedResources<Organ
 
 | Name | Type | Description |
 | --- | --- | --- |
-| `initialPage?` | `number` | A number that can be used to skip the first n-1 pages. For example, if `initialPage` is set to 10, it is will skip the first 9 pages and will fetch the 10th page. |
-| `pageSize?` | `number` | A number that indicates the maximum number of results that should be returned for a specific page. |
+(TODO: extend PaginatedRequest)
 | `enrollmentMode?` | `'manual_invitation' \| 'automatic_invitation' \| 'automatic_suggestion'` | An [enrollment mode][enrollment-mode-ref] will change how new users join an organization. |
 
 ### Returns

--- a/docs/references/javascript/organization/invitations.mdx
+++ b/docs/references/javascript/organization/invitations.mdx
@@ -19,8 +19,7 @@ function getInvitations(params?: GetInvitationsParams): Promise<PaginatedResourc
 
 | Name | Type | Description |
 | --- | --- | --- |
-| `initialPage?` | `number` | A number that can be used to skip the first n-1 pages. For example, if `initialPage` is set to 10, it is will skip the first 9 pages and will fetch the 10th page. |
-| `pageSize?` | `number` | A number that indicates the maximum number of results that should be returned for a specific page. |
+(TODO: extend PaginatedRequest)
 | `status?` | `'pending' \| 'accepted' \| 'revoked'` | The status an invitation can have. |
 
 ### Returns

--- a/docs/references/javascript/organization/members.mdx
+++ b/docs/references/javascript/organization/members.mdx
@@ -19,8 +19,7 @@ Retrieve the members of the currently active organization.
 
 | Name | Type | Description |
 | --- | --- | --- |
-| `initialPage?` | `number` | A number that can be used to skip the first n-1 pages. For example, if `initialPage` is set to 10, it is will skip the first 9 pages and will fetch the 10th page. |
-| `pageSize?` | `number` | A number that indicates the maximum number of results that should be returned for a specific page. |
+(TODO: extend PaginatedRequest)
 | `role?` | `('admin' \| 'basic_member' \| 'guest_member')[]` | The roles of memberships that will be included in the response. |
 
 <Callout type="danger">

--- a/docs/references/javascript/types/paginated-request.mdx
+++ b/docs/references/javascript/types/paginated-request.mdx
@@ -9,7 +9,7 @@ An interface that describes the request params of a method that returns a pagina
 
 ## Properties
 
-| Properties | Type | Description |
+| Name | Type | Description |
 | --- | --- | --- |
 | `initialPage?` | `number` |  A number that can be used to skip the first n-1 pages. For example, if `initialPage` is set to 10, it will skip the first 9 pages and will fetch the 10th page. Defaults to `1`.|
 | `pageSize?` | `number` |  A number that indicates the maximum number of results that should be returned for a specific page. Defaults to `10`.|

--- a/docs/references/javascript/types/paginated-request.mdx
+++ b/docs/references/javascript/types/paginated-request.mdx
@@ -11,5 +11,5 @@ An interface that describes the request params of a method that returns a pagina
 
 | Properties | Type | Description |
 | --- | --- | --- |
-| `initialPage?` | `number` |  A number that can be used to skip the first n-1 pages. For example, if `initialPage` is set to 10, it is will skip the first 9 pages and will fetch the 10th page. Defaults to `1`.|
+| `initialPage?` | `number` |  A number that can be used to skip the first n-1 pages. For example, if `initialPage` is set to 10, it will skip the first 9 pages and will fetch the 10th page. Defaults to `1`.|
 | `pageSize?` | `number` |  A number that indicates the maximum number of results that should be returned for a specific page. Defaults to `10`.|

--- a/docs/references/javascript/types/paginated-request.mdx
+++ b/docs/references/javascript/types/paginated-request.mdx
@@ -1,0 +1,15 @@
+---
+title: PaginatedRequest
+description: An interface that describes the request params of a method that returns a paginated list of resources.
+---
+
+# `PaginatedRequest<T>`
+
+An interface that describes the request params of a method that returns a paginated list of resources.
+
+## Properties
+
+| Properties | Type | Description |
+| --- | --- | --- |
+| `initialPage?` | `number` |  A number that can be used to skip the first n-1 pages. For example, if `initialPage` is set to 10, it is will skip the first 9 pages and will fetch the 10th page. Defaults to `1`.|
+| `pageSize?` | `number` |  A number that indicates the maximum number of results that should be returned for a specific page. Defaults to `10`.|

--- a/docs/references/react/use-organization.mdx
+++ b/docs/references/react/use-organization.mdx
@@ -172,8 +172,7 @@ To see a demo application utilising the hook and the organizations feature, take
 
 | Properties | Description |
 | --- | --- |
-| `initialPage?` | A number that can be used to skip the first n-1 pages. For example, if `initialPage` is set to 10, it is will skip the first 9 pages and will fetch the 10th page. Defaults to `1`. |
-| `pageSize?` | A number that indicates the maximum number of results that should be returned for a specific page. Defaults to `10`. |
+(TODO: extend PaginatedRequest)
 | `keepPreviousData?` | If `true`, it will persist the cached data until the new data has been fetched. Defaults to `false`. |
 | `infinite?` | If `true`, the new downloaded data will be appended to the list with the existing data. Ideal for infinite lists. Defaults to `false`. |
 


### PR DESCRIPTION
## TODOs
- [] find a way to replace `(TODO: extend PaginatedRequest)` with an indication that the type extends the `PaginatedRequest`
- [] Improve PR description