### PR TITLE
remove broken link and updated deprecated backend resource

### DIFF
--- a/docs/references/ruby/available-methods.mdx
+++ b/docs/references/ruby/available-methods.mdx
@@ -100,7 +100,11 @@ Verify whether a session with a given ID corresponds to the provided session tok
 sdk.sessions.verify_token("sess_xyz", "jwt")
 ```
 
-## [SMS Messages](https://clerk.com/docs/reference/backend-api/tag/SMS-Messages)
+## SMS Messages (deprecated)
+
+<Callout type="danger">
+  This resource is deprecated. Clerk no longer supports sending SMS messages through Clerk's backend API.
+</Callout>
 
 Send an SMS message to a phone number ID belonging to another user.
 


### PR DESCRIPTION
Our broken link checker in Slack notified us that we had a broken link on the Ruby "Available methods" page under the section "SMS Messages". This is because the SMS POST endpoint from the backend API is now fully removed.

This PR removes the broken link and updates the resource to be marked as deprecated.

🔎 [Link to the exact section](https://clerk.com/docs/references/ruby/available-methods#sms-messages)
🔎 [New page]()