### PR TITLE
Remove gendered pronoun from example

### DIFF
--- a/docs/custom-flows/user-impersonation.mdx
+++ b/docs/custom-flows/user-impersonation.mdx
@@ -24,7 +24,7 @@ Clerk allows developers or admins of an application to sign in as different user
 
 Actor tokens are similar to [sign-in tokens](https://clerk.com/docs/reference/backend-api/tag/Sign-in-Tokens#operation/CreateSignInToken). They can be used for one-time logins, but they result in impersonated sessions. You can obtain an actor token from our [Backend API](https://clerk.com/docs/reference/backend-api/tag/Actor-Tokens#operation/CreateActorToken).
 
-Actor tokens need to declare the impersonator user (**actor**) and the impersonated user (**subject**). When Alice decides to impersonate Bob, she will issue an actor token. Alice is the actor and Bob is the subject of the Impersonation.
+Actor tokens need to declare the impersonator user (**actor**) and the impersonated user (**subject**). When Alice decides to impersonate Bob, they will issue an actor token. Alice is the actor and Bob is the subject of the Impersonation.
 
 You can also configure the validity duration of an actor token by setting an expiration time, but you can revoke it at any time.
 


### PR DESCRIPTION
Super quick fix - our policy is to use neutral pronouns in examples like this in Clerk's docs