### PR TITLE
DOCS-674 fix incorrect text in sign-out button

### DIFF
--- a/docs/components/unstyled/sign-out-button.mdx
+++ b/docs/components/unstyled/sign-out-button.mdx
@@ -105,7 +105,7 @@ You can create a custom button by wrapping your own button, or button text, in t
           <div>
           <h1> Sign out </h1>
             <SignOutButton>
-              <button>Sign in with Clerk</button>
+              <button>Sign out</button>
             </SignOutButton>
           </div>
         );
@@ -120,7 +120,7 @@ You can create a custom button by wrapping your own button, or button text, in t
           <div>
           <h1> Sign out </h1>
             <SignOutButton>
-              <button>Sign in with Clerk</button>
+              <button>Sign out</button>
             </SignOutButton>
           </div>
         );
@@ -138,7 +138,7 @@ You can create a custom button by wrapping your own button, or button text, in t
         <div>
         <h1> Sign out </h1>
           <SignOutButton>
-            <button>Sign in with Clerk</button>
+            <button>Sign out</button>
           </SignOutButton>
         </div>
       );
@@ -155,7 +155,7 @@ You can create a custom button by wrapping your own button, or button text, in t
         <div>
         <h1> Sign in </h1>
           <SignOutButton>
-            <button>Sign in with Clerk</button>
+            <button>Sign out</button>
           </SignOutButton>
         </div>
       );
@@ -172,7 +172,7 @@ You can create a custom button by wrapping your own button, or button text, in t
         <div>
         <h1> Sign out </h1>
           <SignOutButton>
-            <button>Sign in with Clerk</button>
+            <button>Sign out</button>
           </SignOutButton>
         </div>
       );


### PR DESCRIPTION
[DOCS-674](https://linear.app/clerk/issue/DOCS-674/feedback-for-componentsunstyledsign-out-button) is a user feedback ticket that states 

"minor typo in code examples:

CURRENT (with typo):
<SignOutButton>
<button>Sign in with Clerk</button>
</SignOutButton>

DESIRED (fixed)
<SignOutButton>
<button>Sign out with Clerk</button>
</SignOutButton>"

The user suggested we update it to "Sign out with Clerk". I would like to update it to simply "Sign out" because the user would have already "signed in with Clerk" and it seems redundant to say "with Clerk" again.

This PR fixes all instances where the text is incorrect for a sign-out button.

And thank you to Greg for leaving the feedback that incited these changes 💙