### PR TITLE
update quickstarts overview

### DIFF
--- a/docs/authentication/social-connections/linkedin-oidc.mdx
+++ b/docs/authentication/social-connections/linkedin-oidc.mdx
@@ -1,34 +1,22 @@
 ---
-title: Set up a social connection with LinkedIn OpenID Connect
+title: LinkedIn OpenID Connect
 description: Learn how to set up a social connection with LinkedIn in your Clerk application.
 ---
 
-<TutorialHero 
-  beforeYouStart={[
-    {
-      title: 'Create a Clerk application in your Clerk Dashboard',
-      link: 'https://clerk.com/docs/quickstarts/setup-clerk',
-    },
-    {
-      title: 'Create a LinkedIn developer account',
-      link: 'https://developer.linkedin.com/',
-    },
-  ]}
->
-- Create a LinkedIn application
-- Enable LinkedIn as a social connection
-- Set the Authorized Redirect URI in your LinkedIn application
-- Set the Client ID and Client Secret in your Clerk Dashboard
-- Enable OpenID Connect in your LinkedIn application
-</TutorialHero>
+# LinkedIn
 
-## Introduction
+Learn how to set up a social connection with LinkedIn in your Clerk application.
 
 To make the development flow as smooth as possible, Clerk uses preconfigured shared OAuth credentials and redirect URIs for development instances - no other configuration is needed. Simply navigate to the [Social Connections page](https://dashboard.clerk.dev/last-active?path=user-authentication/social-connections) in your Clerk Dashboard, toggle on the LinkedIn option, and click **Save**.
 
-In production instances, you must provide custom credentials, which includes generating your own Client ID and Client Secret using your LinkedIn Developer account. Don't worry, this tutorial will walk you through that process in just a few simple steps.
+In production instances, you must provide custom credentials, which includes generating your own Client ID and Client Secret using your LinkedIn Developer account. Don't worry, this guide will walk you through that process in just a few simple steps.
 
-## Tutorial
+## Before you start
+
+- You need to create a Clerk Application in your [Clerk Dashboard](https://dashboard.clerk.dev/). For more information, check out our [Set up your application guide](/docs/quickstarts/setup-clerk).
+- You need to have a LinkedIn account. To create one, [click here](https://developer.linkedin.com/).
+
+## Configuration
 
 <Steps>
 
@@ -53,9 +41,11 @@ Once redirected to the application creation form, you need to set a name, associ
   alt="The 'Create new app' form in the Linkedin Developer portal."
 />
 
-### Enable LinkedIn as a social connection
+### LinkedIn + your Clerk app
 
-To enable LinkedIn as a social connection for your Clerk application, go to the Clerk Dashboard. Navigate to **User & Authentication > [Social Connections](https://dashboard.clerk.com/last-active?path=user-authentication/social-connections)**. From the list of OAuth vendors, toggle on the LinkedIn option.
+You need to enable LinkedIn as a social connection for your Clerk application.
+
+In the Clerk Dashboard, go to **User & Authentication > [Social Connections](https://dashboard.clerk.com/last-active?path=user-authentication/social-connections)**. From the list of OAuth vendors, toggle on the LinkedIn option.
 
 <Images
   width={3024}
@@ -73,15 +63,13 @@ In the modal that opened, copy **Authorized redirect URI**. Keep this modal and 
   alt="The LinkedIn settings modal in the Clerk Dashboard. A red arrow is pointing to the 'Redirect URI' copy button."
 />
 
-### Set the Authorized Redirect URI in your LinkedIn application
+### Configure LinkedIn application
 
 Navigate back to your LinkedIn app and go to the **Auth** tab.
 
-Scroll to the **OAuth 2.0 settings** section. In the **Authorized redirect URLs for your app** input, paste the **Authorized Redirect URI** value you copied from the Clerk Dashboard in the last step.
+Paste the **Redirect URL** value you copied from the Clerk Dashboard into the **Authorized redirect URLs for your app** input in the **OAuth 2.0 settings** section.
 
-### Set the Client ID and Client Secret in your Clerk Dashboard
-
-In your LinkedIn app, navigate to the **Application credentials** section and copy the **Client ID** and **Client Secret**. Go back to the Clerk Dashboard, where the modal should still be open, and paste these values into the respective fields.
+Above that section, copy the **Client ID** and **Client Secret** from the **Application credentials** section. Go back to the Clerk Dashboard, where the modal should still be open, and paste these values into the respective fields.
 
 <Callout type="info">
   If the modal or page is not still open, go to the Clerk Dashboard and navigate to **User & Authentication > [Social Connections](https://dashboard.clerk.com/last-active?path=user-authentication/social-connections)**. Click on the settings cog icon next to the LinkedIn option. You can now paste the **Client ID** and **Client Secret** into their respective fields.
@@ -94,7 +82,7 @@ In your LinkedIn app, navigate to the **Application credentials** section and co
   alt="The 'Auth' tab in the Linkedin Developer dashboard for a user's application. There is a red box around the 'Authentication keys' section, which contains the 'Client ID' and 'Client Secret' values. There is also a red box around the 'Authorized redirect URLs for your app' section."
 />
 
-### Enable OpenID Connect in your LinkedIn application
+### Enable OpenID Connect
 
 In the LinkedIn Developer portal for your application, go to the **Products** tab. Enable the **Sign In with LinkedIn using OpenID Connect** product for your OAuth application.
 
@@ -111,6 +99,6 @@ In the LinkedIn Developer portal for your application, go to the **Products** ta
 
 ### Finished 🎉
 
-Congratulations! Social connection with LinkedIn is now configured for your Clerk application.
+Congratulations! Social connection with LinkedIn is now configured for your instance.
 
 </Steps>

--- a/docs/authentication/social-connections/linkedin-oidc.mdx
+++ b/docs/authentication/social-connections/linkedin-oidc.mdx
@@ -1,22 +1,34 @@
 ---
-title: LinkedIn OpenID Connect
+title: Set up a social connection with LinkedIn OpenID Connect
 description: Learn how to set up a social connection with LinkedIn in your Clerk application.
 ---
 
-# LinkedIn
+<TutorialHero 
+  beforeYouStart={[
+    {
+      title: 'Create a Clerk application in your Clerk Dashboard',
+      link: 'https://clerk.com/docs/quickstarts/setup-clerk',
+    },
+    {
+      title: 'Create a LinkedIn developer account',
+      link: 'https://developer.linkedin.com/',
+    },
+  ]}
+>
+- Create a LinkedIn application
+- Enable LinkedIn as a social connection
+- Set the Authorized Redirect URI in your LinkedIn application
+- Set the Client ID and Client Secret in your Clerk Dashboard
+- Enable OpenID Connect in your LinkedIn application
+</TutorialHero>
 
-Learn how to set up a social connection with LinkedIn in your Clerk application.
+## Introduction
 
 To make the development flow as smooth as possible, Clerk uses preconfigured shared OAuth credentials and redirect URIs for development instances - no other configuration is needed. Simply navigate to the [Social Connections page](https://dashboard.clerk.dev/last-active?path=user-authentication/social-connections) in your Clerk Dashboard, toggle on the LinkedIn option, and click **Save**.
 
-In production instances, you must provide custom credentials, which includes generating your own Client ID and Client Secret using your LinkedIn Developer account. Don't worry, this guide will walk you through that process in just a few simple steps.
+In production instances, you must provide custom credentials, which includes generating your own Client ID and Client Secret using your LinkedIn Developer account. Don't worry, this tutorial will walk you through that process in just a few simple steps.
 
-## Before you start
-
-- You need to create a Clerk Application in your [Clerk Dashboard](https://dashboard.clerk.dev/). For more information, check out our [Set up your application guide](/docs/quickstarts/setup-clerk).
-- You need to have a LinkedIn account. To create one, [click here](https://developer.linkedin.com/).
-
-## Configuration
+## Tutorial
 
 <Steps>
 
@@ -41,11 +53,9 @@ Once redirected to the application creation form, you need to set a name, associ
   alt="The 'Create new app' form in the Linkedin Developer portal."
 />
 
-### LinkedIn + your Clerk app
+### Enable LinkedIn as a social connection
 
-You need to enable LinkedIn as a social connection for your Clerk application.
-
-In the Clerk Dashboard, go to **User & Authentication > [Social Connections](https://dashboard.clerk.com/last-active?path=user-authentication/social-connections)**. From the list of OAuth vendors, toggle on the LinkedIn option.
+To enable LinkedIn as a social connection for your Clerk application, go to the Clerk Dashboard. Navigate to **User & Authentication > [Social Connections](https://dashboard.clerk.com/last-active?path=user-authentication/social-connections)**. From the list of OAuth vendors, toggle on the LinkedIn option.
 
 <Images
   width={3024}
@@ -63,13 +73,15 @@ In the modal that opened, copy **Authorized redirect URI**. Keep this modal and 
   alt="The LinkedIn settings modal in the Clerk Dashboard. A red arrow is pointing to the 'Redirect URI' copy button."
 />
 
-### Configure LinkedIn application
+### Set the Authorized Redirect URI in your LinkedIn application
 
 Navigate back to your LinkedIn app and go to the **Auth** tab.
 
-Paste the **Redirect URL** value you copied from the Clerk Dashboard into the **Authorized redirect URLs for your app** input in the **OAuth 2.0 settings** section.
+Scroll to the **OAuth 2.0 settings** section. In the **Authorized redirect URLs for your app** input, paste the **Authorized Redirect URI** value you copied from the Clerk Dashboard in the last step.
 
-Above that section, copy the **Client ID** and **Client Secret** from the **Application credentials** section. Go back to the Clerk Dashboard, where the modal should still be open, and paste these values into the respective fields.
+### Set the Client ID and Client Secret in your Clerk Dashboard
+
+In your LinkedIn app, navigate to the **Application credentials** section and copy the **Client ID** and **Client Secret**. Go back to the Clerk Dashboard, where the modal should still be open, and paste these values into the respective fields.
 
 <Callout type="info">
   If the modal or page is not still open, go to the Clerk Dashboard and navigate to **User & Authentication > [Social Connections](https://dashboard.clerk.com/last-active?path=user-authentication/social-connections)**. Click on the settings cog icon next to the LinkedIn option. You can now paste the **Client ID** and **Client Secret** into their respective fields.
@@ -82,7 +94,7 @@ Above that section, copy the **Client ID** and **Client Secret** from the **Appl
   alt="The 'Auth' tab in the Linkedin Developer dashboard for a user's application. There is a red box around the 'Authentication keys' section, which contains the 'Client ID' and 'Client Secret' values. There is also a red box around the 'Authorized redirect URLs for your app' section."
 />
 
-### Enable OpenID Connect
+### Enable OpenID Connect in your LinkedIn application
 
 In the LinkedIn Developer portal for your application, go to the **Products** tab. Enable the **Sign In with LinkedIn using OpenID Connect** product for your OAuth application.
 
@@ -99,6 +111,6 @@ In the LinkedIn Developer portal for your application, go to the **Products** ta
 
 ### Finished 🎉
 
-Congratulations! Social connection with LinkedIn is now configured for your instance.
+Congratulations! Social connection with LinkedIn is now configured for your Clerk application.
 
 </Steps>

--- a/docs/manifest.json
+++ b/docs/manifest.json
@@ -3,7 +3,7 @@
   "# Learning",
   [
     {
-      "title": "Quickstarts & Tutorials",
+      "title": "Quickstarts",
       "icon": "lightning-bolt",
       "root": "quickstarts"
     },

--- a/docs/manifest.json
+++ b/docs/manifest.json
@@ -9,7 +9,7 @@
     },
     [
       ["Overview", "/quickstarts/overview"],
-      ["Setup Clerk", "/quickstarts/setup-clerk"],
+      ["Set up Clerk", "/quickstarts/setup-clerk"],
       "# Full Stack",
       ["Next.js", "/quickstarts/nextjs"],
       ["Remix", "/quickstarts/remix"],

--- a/docs/quickstarts/nextjs.mdx
+++ b/docs/quickstarts/nextjs.mdx
@@ -4,7 +4,7 @@ description: Learn how to use Clerk to quickly and easily add secure authenticat
 ---
 
 <TutorialHero 
-  quickstart="nextjs"
+  framework="nextjs"
   beforeYouStart={[
     {
       title: "Set up a Clerk application",

--- a/docs/quickstarts/nextjs.mdx
+++ b/docs/quickstarts/nextjs.mdx
@@ -4,7 +4,7 @@ description: Learn how to use Clerk to quickly and easily add secure authenticat
 ---
 
 <TutorialHero 
-  framework="nextjs"
+  quickstart="nextjs"
   beforeYouStart={[
     {
       title: "Set up a Clerk application",

--- a/docs/quickstarts/overview.mdx
+++ b/docs/quickstarts/overview.mdx
@@ -1,4 +1,4 @@
 ---
-title: Quickstarts & Tutorials
+title: Quickstarts
 description: Check out our Clerk getting started guides and tutorials.
 ---

--- a/docs/quickstarts/setup-clerk.mdx
+++ b/docs/quickstarts/setup-clerk.mdx
@@ -1,9 +1,9 @@
 ---
-title: Setup Clerk
+title: Set up Clerk
 description: Set up a new Clerk account and integrate it into a new application.
 ---
 
-# Setup your Clerk account
+# Set up your Clerk account
 
 ## You will learn how to
 

--- a/docs/troubleshooting/overview.mdx
+++ b/docs/troubleshooting/overview.mdx
@@ -9,7 +9,7 @@ We hope that our documentation is thorough and transparent enough that you won't
 
 Refer to the [Backend API](https://clerk.com/docs/reference/backend-api) and Frontend API reference docs for questions about object structures, requests, and responses.
 
-Are you looking for a place to get started? Check out our [Quickstarts & Tutorials](/docs/quickstarts/overview) section.
+Are you looking for a place to get started? Check out our [Quickstarts](/docs/quickstarts/overview) section.
 
 ## Discord community
 


### PR DESCRIPTION
Related to [PR-847 in the marketing repo](https://github.com/clerk/clerk-marketing/pull/847). 

Noticed that these changes should be made:
- Our quickstarts can simply be named "Quickstarts" instead of "Quickstarts and Tutorials". It seems misleading because it's not where all of our tutorials are withheld.
- Setup Clerk should be Set up Clerk. Setup is a noun and Set up is a verb.