### PR TITLE
DOCS-649 remove use of 'API' from SDK reference overview

### DIFF
--- a/docs/references/overview.mdx
+++ b/docs/references/overview.mdx
@@ -1,4 +1,4 @@
 ---
-title: API & SDK Reference
-description: Learn about the Clerk APIs and the available SDKs.
+title: SDK References
+description: Learn about the Clerk and community SDK's available for integrating Clerk into your application.
 ---


### PR DESCRIPTION
[DOCS-649](https://linear.app/clerk/issue/DOCS-649/%F0%9F%98%A2-feedback-for-referencesoverview) is a user feedback ticket for the [References Overview page](https://clerk.com/docs/references/overview) and it says "It’s a page for api reference but there’s literally no api docs here, just language SDKs, madness".

This PR updates the overview page to not mention "APIs" at all.