### PR TITLE
DOCS-729 remove callout about clerkprovider; other small updates

### DIFF
--- a/docs/quickstarts/nextjs.mdx
+++ b/docs/quickstarts/nextjs.mdx
@@ -50,7 +50,7 @@ In your Next.js project's root folder, you may have an `.env.local` file alongsi
 
 Add the following code to your `.env.local` file to set your public and secret keys.
 
-**Pro tip!** If you are signed into your [Clerk Dashboard](https://dashboard.clerk.com/), your keys should become visible by clicking on the eye icon.
+**Pro tip!** If you are signed into your [Clerk Dashboard](https://dashboard.clerk.com/last-active?path=api-keys), your secret key should become visible by clicking on the eye icon.
 
 <InjectKeys>
 
@@ -93,11 +93,8 @@ The [`<ClerkProvider />`](/docs/components/clerk-provider) component provides ac
       )
     }
     ```
-
-    <Callout type="warning">
-      The root layout is a server component. If you plan to use the `<ClerkProvider />` outside the root layout, it will need to be a server component as well.
-    </Callout>
   </Tab>
+
   <Tab>
     For this project, it makes sense to wrap the `<Component />` element with `<ClerkProvider />`. This makes the active session and user context accessible anywhere within `MyApp`.
 
@@ -139,13 +136,13 @@ export const config = {
 
 ```
 
-**Try accessing your app now by visiting [`http://localhost:3000`](http://localhost:3000).** The Middleware will redirect you to your Sign Up page. If you want to make other routes public, check out the [authMiddleware reference page](/docs/references/nextjs/auth-middleware). Go ahead and sign up to get access to your application. Your app is now fully protected by Clerk!
+**Try accessing your app now by visiting [`http://localhost:3000`](http://localhost:3000).** The Middleware will redirect you to your Sign Up page, provided by Clerk's [Account Portal](/docs/account-portal/overview) feature. If you want to make other routes public, check out the [`authMiddleware` reference page](/docs/references/nextjs/auth-middleware). Go ahead and sign up to get access to your application. Your app is now fully protected by Clerk!
 
 ### Embed the `<UserButton />`
 
 Clerk offers a set of [prebuilt components](/docs/components/overview) to add functionality to your app with minimal effort. The [`<UserButton />`](/docs/components/user/user-button) allows users to manage their account information and log out, completing the full authentication circle.
 
-Add it anywhere inside `<ClerkProvider />` in your app. First add `import { UserButton } from "@clerk/nextjs";` to the top of your file. Then add `<UserButton afterSignOutUrl="/"/>`. The `afterSignOutUrl` prop lets you customize what page the user will be redirected to after sign out.
+Add the `<UserButton />` anywhere inside `<ClerkProvider />` in your app. First, add `import { UserButton } from "@clerk/nextjs";` to the top of your file. Then, add `<UserButton afterSignOutUrl="/"/>`. The `afterSignOutUrl` prop lets you customize what page the user will be redirected to after sign out.
 
 <CodeBlockTabs type="router" options={["App Router", "Pages Router"]}>
 ```tsx filename="app/page.tsx" {1,6}
@@ -169,7 +166,7 @@ export default function Home() {
 			<header>
 				<UserButton afterSignOutUrl="/"/>
 			</header>
-			<div>Your page's content can go here.</div>
+			<div>Your home page's content can go here.</div>
     </>
   );
 }
@@ -178,7 +175,7 @@ export default function Home() {
 
 ### Sign out of your application
 
-Visit your Next.js application at [`localhost:3000`](http://localhost:3000), click on your avatar, and select "sign out." You are now back where you started—a sign in form.
+Visit your Next.js application at [`localhost:3000`](http://localhost:3000), click on your avatar, and select **Sign out**. You are now back where you started: a sign-in form.
 
 ### Deploy your application
 
@@ -188,9 +185,9 @@ You're ready to [deploy your app to production](/docs/deployments/overview) and 
 
 ## You're authenticated!
 
-Congratulations! Your app is now only available to authenticated users! But this is just the first step. 
+Congratulations! Your app is now only available to authenticated users. But this is just the first step. 
 
-If you would like a repository that demonstrates many of the features Clerk has to offer, such as user, session, and organization management, check out one of Clerk's showcase repositories:
+If you would like a repository that demonstrates many of the features Clerk has to offer, such as user, session, and organization management, check out one of Clerk's demo repositories:
 
 - [Clerk + Next.js App Router Demo](https://github.com/clerk/clerk-nextjs-demo-app-router)
 - [Clerk + Next.js Pages Router Demo](https://github.com/clerk/clerk-nextjs-demo-pages-router)


### PR DESCRIPTION
ClerkProvider can now render in client components as well.  We can remove this callout:
> `<Callout type="warning">`
      The root layout is a server component. If you plan to use the `<ClerkProvider />` outside the root layout, it will need to be a server component as well.
   `</Callout>`

This PR also:

- adds a direct link to the API Keys page in the Clerk Dashboard when talking about api keys.
- adds copy that mentions the account portal feature, in case users need more information about the pages that Clerk provides OOTB