### PR TITLE
Add link to FAPI API docs

### DIFF
--- a/docs/manifest.json
+++ b/docs/manifest.json
@@ -872,4 +872,5 @@
     ]
   ],
   ["Backend API", "https://clerk.com/docs/reference/backend-api"]
+  ["Frontend API", "https://clerk.com/docs/reference/frontend-api"]
 ]


### PR DESCRIPTION
Add a link pointing to the FAPI OpenAPI documentation hosted in Redocly.  The Clerk Marketing Site will reverse proxy this URL back to Redocly. 

This is an absolute URL since reverse proxying will only work in production.