### PR TITLE
Removed organization property -- no longer present

### DIFF
--- a/docs/references/nextjs/authentication-object.mdx
+++ b/docs/references/nextjs/authentication-object.mdx
@@ -17,7 +17,6 @@ Both [`auth()`](/docs/references/nextjs/auth) and  [`getAuth()`](/docs/reference
 | `orgId` | The current user's currently active organization ID. |
 | `orgRole` | The current user's currently active organization role. |
 | `orgSlug` | The current user's currently active organization slug. |
-| `organization` | The current user's currently active organization object. |
 | `sessionClaim` | The current user's session claim. |
 | `sessionId` | The current user's session ID. |
 | `userId` | The current user's unique identifier. |


### PR DESCRIPTION
The `organization` object was still present in the doc for the Authentication Object. This is no longer present on the object, so removed from the docs.