### PR TITLE
fix: Add exclude list to link checker

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -65,7 +65,7 @@ Clerk employees can run the application and preview their documentation changes 
 
 Before committing your changes, run our linting checks to validate the changes you are making are correct. Currently we:
 
-- **Check for broken links.** If your change contains links that are valid but not authored inside this repository (e.g. marketing pages or other docs) the linter will fail. You'll need to add your URLs to the `EXCLUDE_LIST` inside [`check-links.mjs`](./scripts/check-links.mjs).
+- **Check for broken links.** If your change contains URLs that are not authored inside this repository (e.g. marketing pages or other docs) the linter will fail. You'll need to add your URLs to the `EXCLUDE_LIST` inside [`check-links.mjs`](./scripts/check-links.mjs).
 
 To run all linting steps:
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -65,9 +65,11 @@ Clerk employees can run the application and preview their documentation changes 
 
 Before committing your changes, run our linting checks to validate the changes you are making are correct. Currently we:
 
-* Check for broken links
+- **Check for broken links.** If your change contains links that are valid but not authored inside this repository (e.g. marketing pages or other docs) the linter will fail. You'll need to add your URLs to the `EXCLUDE_LIST` inside [`check-links.mjs`](./scripts/check-links.mjs).
 
-```
+To run all linting steps:
+
+```shell
 npm run lint
 ```
 

--- a/scripts/check-links.mjs
+++ b/scripts/check-links.mjs
@@ -35,7 +35,7 @@ const validateUrl = (url, node, file) => {
     if (!fileCheckCache.has(cleanedUrl)) {
       const isExcluded = EXCLUDE_LIST.some((excludedUrl) => cleanedUrl.startsWith(excludedUrl))
 
-      // If the URL is excluded, we don't need to check the filesystem. However, we should do the check here and not early return in the beginning because we want to cache the result still.
+      // If the URL is excluded, we don't need to check the filesystem. However, we should do the check here and not early return in the beginning because we still want to cache the result.
       if (isExcluded) {
         fileCheckCache.set(cleanedUrl, true);
       } else {


### PR DESCRIPTION
Adds an `EXCLUDE_LIST` to the link checker so that URLs that are hosted on the marketing site or that are other docs (e.g. BAPI docs) are not marked as missing.