### PR TITLE
Update list of Localizations

### DIFF
--- a/docs/components/customization/localization.mdx
+++ b/docs/components/customization/localization.mdx
@@ -16,7 +16,7 @@ Clerk offers the ability to override the strings for all of the elements in each
 The `@clerk/localizations` package contains predefined localizations for the Clerk Components. Clerk currently supports:
 
 *   ar-SA
-*   cz-CZ
+*   cs-CZ
 *   da-DK
 *   de-DE
 *   el-GR
@@ -31,6 +31,7 @@ The `@clerk/localizations` package contains predefined localizations for the Cle
 *   nl-NL
 *   pl-PL
 *   pt-BR
+*   pt-PT
 *   ru-RU
 *   sk-SK
 *   sv-SE


### PR DESCRIPTION
Fixed a typo in Czech locale and added missing Portuguese locale according to: https://github.com/clerk/javascript/blob/main/packages/localizations/src/index.ts