### PR TITLE
Update prop for <TutorialHero /> component

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -452,13 +452,13 @@ The `<TutorialHero />` component is used at the beginning of a tutorial-type con
 
 | Property | Type | Description |
 | --- | --- | --- |
-| `quickstart` | string | Denotes the framework or platform the tutorial is for. |
+| `framework` | string | Denotes the framework or platform the tutorial is for. |
 | `beforeYouStart` | { title: string; link: string }[] | Links to things that learners should complete before the tutorial. |
 | `exampleRepo` (optional) | { title: string; link: string }[] | Links to example repositories. |
 
 ```
 <TutorialHero 
-  quickstart="react"
+  framework="react"
   beforeYouStart={[
     {
       title: "Set up a Clerk application",

--- a/docs/quickstarts/nextjs.mdx
+++ b/docs/quickstarts/nextjs.mdx
@@ -4,7 +4,7 @@ description: Learn how to use Clerk to quickly and easily add secure authenticat
 ---
 
 <TutorialHero 
-  quickstart="nextjs"
+  framework="nextjs"
   beforeYouStart={[
     {
       title: "Set up a Clerk application",


### PR DESCRIPTION
[PR-845 in the marketing repo](https://github.com/clerk/clerk-marketing/pull/845) updates the `<TutorialHero />` component to be used in non-quickstart tutorials. The PR updates a prop in the component.

This PR updates that prop where necessary.
> **Note** this build will fail until PR-845 is merged.