### PR TITLE
Revert "Update use-sign-up.mdx"

### DIFF
--- a/docs/custom-flows/use-sign-up.mdx
+++ b/docs/custom-flows/use-sign-up.mdx
@@ -46,7 +46,7 @@ The more involved example below shows an approach for creating a custom form for
 ```jsx
 import { useState } from "react";
 import { useSignUp } from "@clerk/nextjs";
-import { useRouter } from "next/navigation";
+import { useRouter } from "next/router";
 
 export default function SignUpForm() {
   const { isLoaded, signUp, setActive } = useSignUp();
@@ -176,7 +176,7 @@ The more involved example below shows an approach for creating a custom form for
 ```jsx
 import { useState } from "react";
 import { useSignIn } from "@clerk/nextjs";
-import { useRouter } from "next/navigation";
+import { useRouter } from "next/router";
 
 export default function SignInForm() {
   const { isLoaded, signIn, setActive } = useSignIn();


### PR DESCRIPTION
Reverts clerk/clerk-docs#530

Accidentally merged [PR-530](https://github.com/clerk/clerk-docs/pull/530) which switched `next/router` to `next/navigation`
This is incorrect, as `next/navigation` is used in App Router, and these are Pages Router examples (so the original code was correct).