### PR TITLE
update references to components to use appropriate tag format

### DIFF
--- a/STYLEGUIDE.md
+++ b/STYLEGUIDE.md
@@ -83,11 +83,11 @@ Clerk is the entity writing these docs and providing these services. The learner
 
 #### Do
 
-> Clerk's `<ClerkProvider />` provides active session and user context to Clerk's hooks and other components. Import it into your app by adding `import { ClerkProvider } from '@clerk/nextjs'` at the top of your file.
+> Clerk's `<ClerkProvider>` provides active session and user context to Clerk's hooks and other components. Import it into your app by adding `import { ClerkProvider } from '@clerk/nextjs'` at the top of your file.
 
 #### Don't 
 
-> Our `<ClerkProvider />` provides active session and user context to our hooks and other components. Let's import it into our app by adding `import { ClerkProvider } from '@clerk/nextjs'` at the top of the file.
+> Our `<ClerkProvider>` provides active session and user context to our hooks and other components. Let's import it into our app by adding `import { ClerkProvider } from '@clerk/nextjs'` at the top of the file.
 
 ### 2.2 "Users" are people logging in/out with Clerk. "Developers" are the audience we’re writing for.
 
@@ -195,13 +195,13 @@ Use as little [jargon](https://dictionary.cambridge.org/dictionary/english/jargo
 
 #### Do
 
-> You can authenticate your app with Clerk in three steps. Install Clerk with `npm install @clerk/nextjs`, add your environment keys, and then wrap your app in `<ClerkProvider />`, and add [control components](https://clerk.com/docs/components/overview). Visit our [Quickstarts](https://clerk.com/docs/quickstarts/overview) for a step-by-step guide written for your framework.
+> You can authenticate your app with Clerk in three steps. Install Clerk with `npm install @clerk/nextjs`, add your environment keys, and then wrap your app in `<ClerkProvider>`, and add [control components](https://clerk.com/docs/components/overview). Visit our [Quickstarts](https://clerk.com/docs/quickstarts/overview) for a step-by-step guide written for your framework.
 
 > Clerk supports offline mode, a feature that lets users use an app without being connected to data or wifi. This means Clerk works great with progressive web apps, apps built with web platform technologies that provide similar experiences to platform-specific apps. You can use the [dynamic import pattern](https://www.patterns.dev/vanilla/dynamic-import) to improve loading speeds.
 
 #### Don't
 
-> It's easy to authenticate your app with Clerk! Just install Clerk with `npm install @clerk/nextjs`, add your environment keys, wrap your app in `<ClerkProvider />`, and simply add [control components](https://clerk.com/docs/components/overview).
+> It's easy to authenticate your app with Clerk! Just install Clerk with `npm install @clerk/nextjs`, add your environment keys, wrap your app in `<ClerkProvider>`, and simply add [control components](https://clerk.com/docs/components/overview).
 
 > Clerk works great with PWA as it supports offline mode. You can use the dynamic import pattern to improve loading speeds.
 
@@ -365,13 +365,15 @@ Next.js is a platform with two different implementations grouped underneath it.
 
 Next.js's two implementations are given equal weight to the other members of the tab bar. Someone unfamiliar with Next.js may become confused, and the ever growing tab bar is harder to navigate at smaller sizes.
 
-### 4.7 Wrap component references in `< />`
+### 4.7 Wrap component references in the appropriate tags
 
-Component references should be wrapped in `< />`.
+Component references should be wrapped in `< />` if they are self closing. Otherwise, they should be wrapped in `< >`.
 
 #### Do
 
 > Use the `<SignIn />` component.
+
+> Use the `<ClerkProvider>` component.
 
 #### Don't 
 
@@ -380,6 +382,14 @@ Component references should be wrapped in `< />`.
 > Use the "SignIn component".
 
 > Use the `SignIn` component.
+
+> Use the `<SignIn>` component.
+
+The last case is incorrect because the `<SignIn />` component will never wrap children, and therefore, should have a self-closing tag.
+
+> Use the `<ClerkProvider />` component.
+
+The last case is incorrect because the `<ClerkProvider>` component will always wrap children and will never be self-closing. 
 
 ### 4.8 Specify syntax and filename for terminal commands
 

--- a/docs/account-portal/custom-redirects.mdx
+++ b/docs/account-portal/custom-redirects.mdx
@@ -98,12 +98,12 @@ function App() {
 </CodeBlockTabs>
 
 <Callout type="info" emoji="💡">
-  `<RedirectToSignIn />` or `<RedirectToSignUp />` child components will always take precedence over `<ClerkProvider />`. 
+  `<RedirectToSignIn />` or `<RedirectToSignUp />` child components will always take precedence over `<ClerkProvider>`. 
 </Callout>
 
 ### Button components
 
-In the case that you are using a [`<SignInButton />`](/docs/components/unstyled/sign-in-button) or [`<SignUpButton />`](/docs/components/unstyled/sign-up-button), you can also pass the properties into those components. We recommend defining both `afterSignInUrl` and `afterSignUpUrl` redirects in each button as some users may choose to sign up instead after attempting to sign in.
+In the case that you are using a [`<SignInButton>`](/docs/components/unstyled/sign-in-button) or [`<SignUpButton>`](/docs/components/unstyled/sign-up-button), you can also pass the properties into those components. We recommend defining both `afterSignInUrl` and `afterSignUpUrl` redirects in each button as some users may choose to sign up instead after attempting to sign in.
 
 <CodeBlockTabs type="framework" options={["Next.js", "React", "Remix", "Gatsby"]}>
   ```jsx filename="pages/index.js"

--- a/docs/advanced-usage/satellite-domains.mdx
+++ b/docs/advanced-usage/satellite-domains.mdx
@@ -86,7 +86,7 @@ The `URL` mentioned above is the request url for server side usage or the curren
   <Tab>
     You can embed the [`<SignIn />`][signin] component using the [Next.js optional catch-all route](https://nextjs.org/docs/pages/building-your-application/routing/dynamic-routes#optional-catch-all-routes). This allows you to redirect the user inside your application. The [`<SignIn />`][signin] component should be mounted on a public page.
 
-    <CodeBlockTabs options={["<ClerkProvider />", "Middleware"]}>
+    <CodeBlockTabs options={["<ClerkProvider>", "Middleware"]}>
     ```jsx filename="_app.tsx"
     import { ClerkProvider } from "@clerk/nextjs";
     import Head from "next/head";

--- a/docs/components/clerk-provider.mdx
+++ b/docs/components/clerk-provider.mdx
@@ -1,24 +1,24 @@
 ---
-title: <ClerkProvider />
-description: The <ClerkProvider /> component wraps your React application to provide active session and user context to Clerk's hooks and other components.
+title: <ClerkProvider>
+description: The <ClerkProvider> component wraps your React application to provide active session and user context to Clerk's hooks and other components.
 ---
 
-# `<ClerkProvider />`
+# `<ClerkProvider>`
 
-The `<ClerkProvider />` component wraps your React application to provide active session and user context to Clerk's hooks and other components.
+The `<ClerkProvider>` component wraps your React application to provide active session and user context to Clerk's hooks and other components.
 
 ## Usage
 
-The `<ClerkProvider />` component must be added to your React entrypoint.
+The `<ClerkProvider>` component must be added to your React entrypoint.
 
 <Tabs type="framework" items={["Next.js", "React"]}>
   <Tab>
-  The `<ClerkProvider />` component needs to access headers to authenticate correctly. This means anything wrapped by the provider will be opted into dynamic rendering at request time. If you have static-optimized or ISR pages that you would prefer not to be opted into dynamic rendering, make sure they are not wrapped by `<ClerkProvider />`.
+  The `<ClerkProvider>` component needs to access headers to authenticate correctly. This means anything wrapped by the provider will be opted into dynamic rendering at request time. If you have static-optimized or ISR pages that you would prefer not to be opted into dynamic rendering, make sure they are not wrapped by `<ClerkProvider>`.
 
-  This is easiest to accomplish by ensuring that `<ClerkProvider />` is added further down the tree to wrap route groups that explicitly need authentication instead of having the provider wrap your application root as recommended above. For example, if your project includes a set of landing/marketing pages as well as a dashboard that requires login, you would create separate (marketing) and (dashboard) route groups. Adding `<ClerkProvider />` to the (dashboard)/layout.jsx layout file will ensure that only those routes are opted into dynamic rendering, allowing the marketing routes to be statically optimized.
+  This is easiest to accomplish by ensuring that `<ClerkProvider>` is added further down the tree to wrap route groups that explicitly need authentication instead of having the provider wrap your application root as recommended above. For example, if your project includes a set of landing/marketing pages as well as a dashboard that requires login, you would create separate (marketing) and (dashboard) route groups. Adding `<ClerkProvider>` to the (dashboard)/layout.jsx layout file will ensure that only those routes are opted into dynamic rendering, allowing the marketing routes to be statically optimized.
 
   <Callout type="info">
-    The root layout is a server component. If you plan to use the `<ClerkProvider />` outside the root layout, it will need to be a server component as well.
+    The root layout is a server component. If you plan to use the `<ClerkProvider>` outside the root layout, it will need to be a server component as well.
   </Callout>
 
     <CodeBlockTabs type="router" options={["App Router", "Pages Router"]}>
@@ -87,7 +87,7 @@ The `<ClerkProvider />` component must be added to your React entrypoint.
 </Tabs>
 
 {/* TODO: Make dedicated docs pages for these meta-frameworks */}
-> Other meta-frameworks, like [Remix](/docs/quickstarts/remix#configure-clerk-app) and [Gatsby](/docs/quickstarts/gatsby#update-gatsby-config-ts), have wrappers around `<ClerkProvider />` to make their integrations tighter.
+> Other meta-frameworks, like [Remix](/docs/quickstarts/remix#configure-clerk-app) and [Gatsby](/docs/quickstarts/gatsby#update-gatsby-config-ts), have wrappers around `<ClerkProvider>` to make their integrations tighter.
 
 ## Properties
 

--- a/docs/components/control/clerk-loaded.mdx
+++ b/docs/components/control/clerk-loaded.mdx
@@ -1,11 +1,11 @@
 ---
-title: <ClerkLoaded />
-description: The `<ClerkLoaded />` component guarantees that the Clerk object has loaded and will be available under `window.Clerk`. This allows you to wrap child components to access the Clerk object without the need to check it exists.
+title: <ClerkLoaded>
+description: The `<ClerkLoaded>` component guarantees that the Clerk object has loaded and will be available under `window.Clerk`. This allows you to wrap child components to access the Clerk object without the need to check it exists.
 ---
 
-# `<ClerkLoaded />`
+# `<ClerkLoaded>`
 
-The `<ClerkLoaded />` component guarantees that the Clerk object has loaded and will be available under `window.Clerk`. This allows you to wrap child components to access the `Clerk` object without the need to check it exists.
+The `<ClerkLoaded>` component guarantees that the Clerk object has loaded and will be available under `window.Clerk`. This allows you to wrap child components to access the `Clerk` object without the need to check it exists.
 
 ## Usage
 
@@ -30,7 +30,7 @@ The `<ClerkLoaded />` component guarantees that the Clerk object has loaded and 
   export default MyApp;
   ```
 
-  Once you have wrapped your app with `<ClerkLoaded />`, you can access the `Clerk` object without the need to check if it exists.
+  Once you have wrapped your app with `<ClerkLoaded>`, you can access the `Clerk` object without the need to check if it exists.
 
   ```tsx filename="pages/index.tsx"
   declare global {

--- a/docs/components/control/clerk-loading.mdx
+++ b/docs/components/control/clerk-loading.mdx
@@ -1,11 +1,11 @@
 ---
-title: <ClerkLoading />
-description: The `<ClerkLoading />` renders its children while Clerk is loading, and is helpful for showing a custom loading state.
+title: <ClerkLoading>
+description: The `<ClerkLoading>` renders its children while Clerk is loading, and is helpful for showing a custom loading state.
 ---
 
-# `<ClerkLoading />`
+# `<ClerkLoading>`
 
-The `<ClerkLoading />` renders its children while Clerk is loading, and is helpful for showing a custom loading state.
+The `<ClerkLoading>` renders its children while Clerk is loading, and is helpful for showing a custom loading state.
 
 ## Usage
 

--- a/docs/components/control/multi-session.mdx
+++ b/docs/components/control/multi-session.mdx
@@ -1,11 +1,11 @@
 ---
-title: <MultisessionAppSupport />
-description: The `<MultisessionAppSupport />` provides a wrapper for your React application that guarantees a full rerendering cycle everytime the current session and user changes.
+title: <MultisessionAppSupport>
+description: The `<MultisessionAppSupport>` provides a wrapper for your React application that guarantees a full rerendering cycle everytime the current session and user changes.
 ---
 
-# `<MultisessionAppSupport />`
+# `<MultisessionAppSupport>`
 
-The `<MultisessionAppSupport />` provides a wrapper for your React application that guarantees a full rerendering cycle everytime the current session and user changes.
+The `<MultisessionAppSupport>` provides a wrapper for your React application that guarantees a full rerendering cycle everytime the current session and user changes.
 
 ## Usage
 

--- a/docs/components/control/signed-in.mdx
+++ b/docs/components/control/signed-in.mdx
@@ -1,12 +1,12 @@
 ---
-title: <SignedIn />
+title: <SignedIn>
 description: Conditionally render content only when a user is signed in.
 ---
 
-# `<SignedIn />`
+# `<SignedIn>`
 
 ## Overview
-The `<SignedIn />` component offers authentication checks as a cross-cutting concern. Any children components wrapped by a `<SignedIn />` component will be rendered only if there's a User with an active Session signed in your application.
+The `<SignedIn>` component offers authentication checks as a cross-cutting concern. Any children components wrapped by a `<SignedIn>` component will be rendered only if there's a User with an active Session signed in your application.
 
 ## Usage
 <Tabs type="framework" items={["Next.js", "React", "Remix"]}>
@@ -84,7 +84,7 @@ The `<SignedIn />` component offers authentication checks as a cross-cutting con
 
 ### Usage with React Router
 
-Below is an example of how to use `<SignedIn />` with React Router. The `<SignedIn />` component can be used as a child of a `<Route />` component to render content only to signed in users.
+Below is an example of how to use `<SignedIn>` with React Router. The `<SignedIn>` component can be used as a child of a `<Route />` component to render content only to signed in users.
 
 ```tsx filename="app.tsx"
 import { Routes, Route } from 'react-router-dom';

--- a/docs/components/control/signed-out.mdx
+++ b/docs/components/control/signed-out.mdx
@@ -1,11 +1,11 @@
 ---
-title: <SignedOut />
+title: <SignedOut>
 description: Conditionally render content only when a user is signed out.
 ---
 
-# `<SignedOut />`
+# `<SignedOut>`
 
-The `<SignedOut />` component offers authentication checks as a cross-cutting concern. Any child nodes wrapped by a `<SignedOut />` component will be rendered only if there's no User signed in to your application.
+The `<SignedOut>` component offers authentication checks as a cross-cutting concern. Any child nodes wrapped by a `<SignedOut>` component will be rendered only if there's no User signed in to your application.
 
 ## Usage
 <Tabs type="framework" items={["Next.js", "React", "Remix"]}>
@@ -58,7 +58,7 @@ The `<SignedOut />` component offers authentication checks as a cross-cutting co
 
   ### Usage with React Router
 
-  Below is an example of how to use `<SignedOut />` with React Router. The `<SignedOut />` component can be used as a child of a `<Route />` component to render content only to signed in users.
+  Below is an example of how to use `<SignedOut>` with React Router. The `<SignedOut>` component can be used as a child of a `<Route />` component to render content only to signed in users.
 
   ```tsx filename="app.tsx"
   import { Routes, Route } from 'react-router-dom';

--- a/docs/components/customization/localization.mdx
+++ b/docs/components/customization/localization.mdx
@@ -59,7 +59,7 @@ To get started, install the `@clerk/localizations` package.
   ```
 </CodeBlockTabs>
 
-Once the `@clerk/localizations` package is installed, you can import the localizations you need by removing the "-" from the locale. In this example, the fr-FR locale is imported as `frFR`. The imported localization is then passed to the `localization` prop on the [`<ClerkProvider />`](/docs/components/clerk-provider).
+Once the `@clerk/localizations` package is installed, you can import the localizations you need by removing the "-" from the locale. In this example, the fr-FR locale is imported as `frFR`. The imported localization is then passed to the `localization` prop on the [`<ClerkProvider>`](/docs/components/clerk-provider).
 
 ```tsx filename="_app.tsx"
 import { ClerkProvider } from "@clerk/nextjs";

--- a/docs/components/customization/overview.mdx
+++ b/docs/components/customization/overview.mdx
@@ -5,7 +5,7 @@ description: Utilize Clerk's appearance property in order to share styles across
 
 # Appearance prop
 
-The appearance prop can be applied to [React's `<ClerkProvider />`](/docs/components/clerk-provider) to share styles across every component, or individually to any of the Clerk components.
+The appearance prop can be applied to [React's `<ClerkProvider>`](/docs/components/clerk-provider) to share styles across every component, or individually to any of the Clerk components.
 
 This applies to all of the React-based packages, like [Next.js](/docs/quickstarts/nextjs) and [Gatsby](/docs/quickstarts/gatsby), as well as [the pure JavaScript ClerkJS package](/docs/references/javascript/overview).
 
@@ -29,13 +29,13 @@ Clerk offers [a set of themes that can be used with the `appearance` prop](/docs
 
 ### Usage
 
-To use a theme, import it from `@clerk/themes` and pass it to the `appearance` prop of a Clerk component. You can pass it to the [`<ClerkProvider />`](/docs/components/clerk-provider) component to apply it to all Clerk components in your app or you can pass it to a single Clerk component.
+To use a theme, import it from `@clerk/themes` and pass it to the `appearance` prop of a Clerk component. You can pass it to the [`<ClerkProvider>`](/docs/components/clerk-provider) component to apply it to all Clerk components in your app or you can pass it to a single Clerk component.
 
 > [Visit the Themes docs to see a list of the themes that Clerk offers.](/docs/components/customization/themes)
 
-#### Pass a theme to `<ClerkProvider />`
+#### Pass a theme to `<ClerkProvider>`
 
-To apply a theme to all Clerk components, pass the `appearance` prop to the `<ClerkProvider />` component. The `appearance` prop accepts the property `baseTheme`, which can be set to a theme.
+To apply a theme to all Clerk components, pass the `appearance` prop to the `<ClerkProvider>` component. The `appearance` prop accepts the property `baseTheme`, which can be set to a theme.
 
 In the example below, the `dark` theme is applied to all Clerk components.
 
@@ -301,7 +301,7 @@ In the example below, the `dark` theme is applied first, then the `neobrutalism`
   </Tab>
 </Tabs>
 
-You can apply a theme to all instances of a Clerk component by passing the component to the `appearance` prop of the `<ClerkProvider />`. The `appearance` prop accepts the name of the Clerk component you want to style as a key.
+You can apply a theme to all instances of a Clerk component by passing the component to the `appearance` prop of the `<ClerkProvider>`. The `appearance` prop accepts the name of the Clerk component you want to style as a key.
 
 In the example below, the `neobrutalism` theme is applied to all instances of the [`<SignIn />`](/docs/components/authentication/sign-in) component.
 

--- a/docs/components/customization/themes.mdx
+++ b/docs/components/customization/themes.mdx
@@ -30,7 +30,7 @@ To get started, install the `@clerk/themes` package.
   ```
 </CodeBlockTabs>
 
-To use a theme, import it from `@clerk/themes` and pass it to the `appearance` prop of a Clerk component. You can pass it to the [`<ClerkProvider />`](/docs/components/clerk-provider) component to apply it to all Clerk components in your app or you can pass it to a single Clerk component. For guided examples and to learn further about how to use themes, see the [Appearance prop](/docs/components/customization/overview#using-a-pre-built-theme) documentiation.
+To use a theme, import it from `@clerk/themes` and pass it to the `appearance` prop of a Clerk component. You can pass it to the [`<ClerkProvider>`](/docs/components/clerk-provider) component to apply it to all Clerk components in your app or you can pass it to a single Clerk component. For guided examples and to learn further about how to use themes, see the [Appearance prop](/docs/components/customization/overview#using-a-pre-built-theme) documentiation.
 
 ### Default theme
 

--- a/docs/components/customization/variables.mdx
+++ b/docs/components/customization/variables.mdx
@@ -9,13 +9,13 @@ The `variables` property is used to adjust the general styles of the component's
 
 ## Usage
 
-You can customize Clerk components by passing an object of variables to the `variables` property of the [`appearance`](/docs/components/customization/overview) prop. You can pass it to the [`<ClerkProvider />`](/docs/components/clerk-provider) component to apply it to all Clerk components in your app or you can pass it to a single Clerk component.
+You can customize Clerk components by passing an object of variables to the `variables` property of the [`appearance`](/docs/components/customization/overview) prop. You can pass it to the [`<ClerkProvider>`](/docs/components/clerk-provider) component to apply it to all Clerk components in your app or you can pass it to a single Clerk component.
 
-### Pass `variables` to `<ClerkProvider />`
+### Pass `variables` to `<ClerkProvider>`
 
-To customize all Clerk components, pass the `variables` property to the `appearance` prop to the `<ClerkProvider />` component.
+To customize all Clerk components, pass the `variables` property to the `appearance` prop to the `<ClerkProvider>` component.
 
-In the example below, the primary color is set to red and the text color is set to white. Because these styles are applied to the `<ClerkProvider />`, which wraps the entire application, these styles will be applied to all Clerk components that use the primary color and text color.
+In the example below, the primary color is set to red and the text color is set to white. Because these styles are applied to the `<ClerkProvider>`, which wraps the entire application, these styles will be applied to all Clerk components that use the primary color and text color.
 
 <Tabs type="framework" items={["Next.js", "React", "Remix"]}>
   <Tab>
@@ -154,7 +154,7 @@ In the example below, the primary color is set to red and the text color is set 
   </Tab>
 </Tabs>
 
-You can customize all instances of a Clerk component by passing the component to the `appearance` prop of the `<ClerkProvider />`. The `appearance` prop accepts the name of the Clerk component you want to style as a key. 
+You can customize all instances of a Clerk component by passing the component to the `appearance` prop of the `<ClerkProvider>`. The `appearance` prop accepts the name of the Clerk component you want to style as a key. 
 
 In the example below, the primary color is set to red and the text color is set to white for all instances of the [`<SignIn />`](/docs/components/authentication/sign-in) component. 
 

--- a/docs/components/protect.mdx
+++ b/docs/components/protect.mdx
@@ -11,7 +11,7 @@ The `<Protect>` component is used for authorization. It only renders its childre
 
 You can pass either a `permission` or `role` key to `<Protect>` to limit who can see the content it renders. The recommended approach is to use `permission` because this lets you modify Roles without breaking your application. Permissions can be assigned to different Roles with ease.
 
-If you do not pass either prop, `<Protect>` behaves the same as [`<SignedIn />`](/docs/components/control/signed-in) and will render its children if the user is signed in, regardless of their Role or its Permissions.
+If you do not pass either prop, `<Protect>` behaves the same as [`<SignedIn>`](/docs/components/control/signed-in) and will render its children if the user is signed in, regardless of their Role or its Permissions.
 
 For more complex authorization logic, pass conditional logic to the `condition` prop.
 

--- a/docs/components/protect.mdx
+++ b/docs/components/protect.mdx
@@ -1,5 +1,5 @@
 ---
-title: <Protect />
+title: <Protect>
 description: The Protect component is used for authorization. It only renders its children when the current user has the specified permission or role in the organization.
 ---
 

--- a/docs/components/unstyled/sign-in-button.mdx
+++ b/docs/components/unstyled/sign-in-button.mdx
@@ -1,11 +1,11 @@
 ---
-title: <SignInButton />
-description: The <SignInButton /> component is a button that links to the sign-in page or displays the sign-in modal.
+title: <SignInButton>
+description: The <SignInButton> component is a button that links to the sign-in page or displays the sign-in modal.
 ---
 
-# `<SignInButton />`
+# `<SignInButton>`
 
-The `<SignInButton />` component is a button that links to the sign-in page or displays the sign-in modal.
+The `<SignInButton>` component is a button that links to the sign-in page or displays the sign-in modal.
 
 ## Usage
 
@@ -19,7 +19,7 @@ The `<SignInButton />` component is a button that links to the sign-in page or d
     return (
       <div>
       <h1> Sign in </h1>
-        <SignInButton />
+        <SignInButton>
       </div>
     );
   }
@@ -32,7 +32,7 @@ The `<SignInButton />` component is a button that links to the sign-in page or d
     return (
       <div>
       <h1> Sign in </h1>
-        <SignInButton />
+        <SignInButton>
       </div>
     );
   }
@@ -45,7 +45,7 @@ The `<SignInButton />` component is a button that links to the sign-in page or d
     return (
       <div>
       <h1> Sign in </h1>
-        <SignInButton />
+        <SignInButton>
       </div>
     );
   }
@@ -58,7 +58,7 @@ The `<SignInButton />` component is a button that links to the sign-in page or d
     return (
       <div>
       <h1> Sign in </h1>
-        <SignInButton />
+        <SignInButton>
       </div>
     );
   }
@@ -138,5 +138,5 @@ In some cases you will want to use your own button, or button text. You can do t
 | `redirectUrl` | `string` | Full URL or path to navigate after successful sign in or sign up.<br /> The same as setting `afterSignInUrl` and `afterSignUpUrl` to the same value. |
 | `afterSignInUrl` | `string` | The full URL or path to navigate after a successful sign in. |
 | `afterSignUpUrl` | `string` | The full URL or path to navigate after a successful sign up. |
-| `mode` | `'redirect' \| 'modal'` | Determines what happens when a user clicks on the `<SignInButton />`. Setting this to `'redirect'` will redirect the user to the sign-in route. Setting this to `'modal'` will open a modal on the current route.<br />Defaults to 'redirect'`
+| `mode` | `'redirect' \| 'modal'` | Determines what happens when a user clicks on the `<SignInButton>`. Setting this to `'redirect'` will redirect the user to the sign-in route. Setting this to `'modal'` will open a modal on the current route.<br />Defaults to 'redirect'`
 

--- a/docs/components/unstyled/sign-in-with-metamask.mdx
+++ b/docs/components/unstyled/sign-in-with-metamask.mdx
@@ -1,11 +1,11 @@
 ---
-title: <SignInWithMetamaskButton />
-description: The `<SignInWithMetamaskButton />` component is used to complete a one-click, cryptographically-secure login flow using MetaMask.
+title: <SignInWithMetamaskButton>
+description: The `<SignInWithMetamaskButton>` component is used to complete a one-click, cryptographically-secure login flow using MetaMask.
 ---
 
-# `<SignInWithMetamaskButton />`
+# `<SignInWithMetamaskButton>`
 
-The `<SignInWithMetamaskButton />` component is used to complete a one-click, cryptographically-secure login flow using MetaMask.
+The `<SignInWithMetamaskButton>` component is used to complete a one-click, cryptographically-secure login flow using MetaMask.
 
 ## Usage
 
@@ -19,7 +19,7 @@ The `<SignInWithMetamaskButton />` component is used to complete a one-click, cr
     return (
       <div>
       <h1> Sign in </h1>
-        <SignInWithMetamaskButton />
+        <SignInWithMetamaskButton>
       </div>
     );
   }
@@ -32,7 +32,7 @@ The `<SignInWithMetamaskButton />` component is used to complete a one-click, cr
     return (
       <div>
       <h1> Sign in </h1>
-        <SignInWithMetamaskButton />
+        <SignInWithMetamaskButton>
       </div>
     );
   }
@@ -45,7 +45,7 @@ The `<SignInWithMetamaskButton />` component is used to complete a one-click, cr
     return (
       <div>
       <h1> Sign in </h1>
-        <SignInWithMetamaskButton />
+        <SignInWithMetamaskButton>
       </div>
     );
   }
@@ -58,7 +58,7 @@ The `<SignInWithMetamaskButton />` component is used to complete a one-click, cr
     return (
       <div>
       <h1> Sign in </h1>
-        <SignInWithMetamaskButton />
+        <SignInWithMetamaskButton>
       </div>
     );
   }

--- a/docs/components/unstyled/sign-out-button.mdx
+++ b/docs/components/unstyled/sign-out-button.mdx
@@ -1,17 +1,17 @@
 ---
-title: <SignOutButton />
-description: The `<SignOutButton />` component is a button that signs a user out.
+title: <SignOutButton>
+description: The `<SignOutButton>` component is a button that signs a user out.
 ---
 
-# `<SignOutButton />`
+# `<SignOutButton>`
 
-The `<SignOutButton />` component is a button that signs a user out. By default, it is a `<button>` tag that says **Sign Out**, but it is completely customizable by passing children.
+The `<SignOutButton>` component is a button that signs a user out. By default, it is a `<button>` tag that says **Sign Out**, but it is completely customizable by passing children.
 
 ## Usage
 
 ### Basic usage
 
-The example below shows how to use the `<SignOutButton />` component. 
+The example below shows how to use the `<SignOutButton>` component. 
 
 <Tabs type="framework" items={["Next.js", "React", "Remix", "Gatsby"]}>
   <Tab>
@@ -23,7 +23,7 @@ The example below shows how to use the `<SignOutButton />` component.
         return (
           <div>
           <h1> Sign out </h1>
-            <SignOutButton />
+            <SignOutButton>
           </div>
         );
       }
@@ -36,7 +36,7 @@ The example below shows how to use the `<SignOutButton />` component.
         return (
           <div>
           <h1> Sign out </h1>
-            <SignOutButton />
+            <SignOutButton>
           </div>
         );
       }
@@ -52,7 +52,7 @@ The example below shows how to use the `<SignOutButton />` component.
       return (
         <div>
         <h1> Sign out </h1>
-          <SignOutButton />
+          <SignOutButton>
         </div>
       );
     }
@@ -67,7 +67,7 @@ The example below shows how to use the `<SignOutButton />` component.
       return (
         <div>
         <h1> Sign out </h1>
-          <SignOutButton />
+          <SignOutButton>
         </div>
       );
     }
@@ -82,7 +82,7 @@ The example below shows how to use the `<SignOutButton />` component.
       return (
         <div>
         <h1> Sign out </h1>
-          <SignOutButton />
+          <SignOutButton>
         </div>
       );
     }
@@ -92,7 +92,7 @@ The example below shows how to use the `<SignOutButton />` component.
 
 ### Custom usage
 
-You can create a custom button by wrapping your own button, or button text, in the `<SignOutButton />` component.
+You can create a custom button by wrapping your own button, or button text, in the `<SignOutButton>` component.
 
 <Tabs type="framework" items={["Next.js", "React", "Remix", "Gatsby"]}>
   <Tab>
@@ -204,7 +204,7 @@ In the example below, the `sessionId` is retrieved from the [`useAuth()`](/docs/
           return (
             <div>
               <h1> Sign in </h1>
-              <SignInButton />
+              <SignInButton>
             </div>
           );
         }
@@ -228,7 +228,7 @@ In the example below, the `sessionId` is retrieved from the [`useAuth()`](/docs/
           return (
             <div>
               <h1> Sign in </h1>
-              <SignInButton />
+              <SignInButton>
             </div>
           );
         }
@@ -255,7 +255,7 @@ In the example below, the `sessionId` is retrieved from the [`useAuth()`](/docs/
         return (
           <div>
             <h1> Sign in </h1>
-            <SignInButton />
+            <SignInButton>
           </div>
         );
       }
@@ -281,7 +281,7 @@ In the example below, the `sessionId` is retrieved from the [`useAuth()`](/docs/
         return (
           <div>
             <h1> Sign in </h1>
-            <SignInButton />
+            <SignInButton>
           </div>
         );
       }
@@ -307,7 +307,7 @@ In the example below, the `sessionId` is retrieved from the [`useAuth()`](/docs/
         return (
           <div>
             <h1> Sign in </h1>
-            <SignInButton />
+            <SignInButton>
           </div>
         );
       }
@@ -423,5 +423,5 @@ In the example below, the `signOut()` method is retrieved from the [`useClerk()`
 | Name | Type | Description |
 | --- | --- | --- |
 | `signOutCallback?` | <code>{`() => (void \| Promise<any>)`}</code> | A promise to handle after the sign out has successfully happened. |
-| `children?` | `React.ReactNode` | children you want to wrap the `<SignOutButton />` in. |
+| `children?` | `React.ReactNode` | children you want to wrap the `<SignOutButton>` in. |
 | `signOutOptions?` | `SignOutOptions` | Object that has a `sessionId` property. The `sessionId` can be passed in to sign out a specific session, which is useful for multisession applications. |

--- a/docs/components/unstyled/sign-up-button.mdx
+++ b/docs/components/unstyled/sign-up-button.mdx
@@ -1,11 +1,11 @@
 ---
-title: <SignUpButton />
-description: The <SignUpButton /> component is a button that links to the sign-up page or displays the sign-up modal.
+title: <SignUpButton>
+description: The <SignUpButton> component is a button that links to the sign-up page or displays the sign-up modal.
 ---
 
-# `<SignUpButton />`
+# `<SignUpButton>`
 
-The `<SignUpButton />` component is a button that links to the sign-up page or displays the sign-up modal.
+The `<SignUpButton>` component is a button that links to the sign-up page or displays the sign-up modal.
 
 ## Usage
 
@@ -19,7 +19,7 @@ The `<SignUpButton />` component is a button that links to the sign-up page or d
     return (
       <div>
       <h1> Sign up </h1>
-        <SignUpButton />
+        <SignUpButton>
       </div>
     );
   }
@@ -32,7 +32,7 @@ The `<SignUpButton />` component is a button that links to the sign-up page or d
     return (
       <div>
       <h1> Sign up </h1>
-        <SignUpButton />
+        <SignUpButton>
       </div>
     );
   }
@@ -45,7 +45,7 @@ The `<SignUpButton />` component is a button that links to the sign-up page or d
     return (
       <div>
       <h1> Sign up </h1>
-        <SignUpButton />
+        <SignUpButton>
       </div>
     );
   }
@@ -58,7 +58,7 @@ The `<SignUpButton />` component is a button that links to the sign-up page or d
     return (
       <div>
       <h1> Sign up </h1>
-        <SignUpButton />
+        <SignUpButton>
       </div>
     );
   }
@@ -147,5 +147,5 @@ In some cases you will want to use your own button, or button text. You can do t
 | `redirectUrl` | `string` | Full URL or path to navigate after successful sign in or sign up.<br /> The same as setting `afterSignInUrl` and `afterSignUpUrl` to the same value. |
 | `afterSignInUrl` | `string` | The full URL or path to navigate after a successful sign in. |
 | `afterSignUpUrl` | `string` | The full URL or path to navigate after a successful sign up. |
-| `mode` | `'redirect' \| 'modal'` | Determines what happens when a user clicks on the `<SignUpButton />`. Setting this to `'redirect'` will redirect the user to the sign-up route. Setting this to `'modal'` will open a modal on the current route.<br />Defaults to 'redirect'`
+| `mode` | `'redirect' \| 'modal'` | Determines what happens when a user clicks on the `<SignUpButton>`. Setting this to `'redirect'` will redirect the user to the sign-up route. Setting this to `'modal'` will open a modal on the current route.<br />Defaults to 'redirect'`
 

--- a/docs/components/user/user-button.mdx
+++ b/docs/components/user/user-button.mdx
@@ -37,7 +37,7 @@ In this example, `<UserButton />` is mounted inside a header component, which is
             </SignedIn>
             <SignedOut>
               {/* Signed out users get sign in button */}
-              <SignInButton />
+              <SignInButton>
             </SignedOut>
           </header>
         );
@@ -74,7 +74,7 @@ In this example, `<UserButton />` is mounted inside a header component, which is
             </SignedIn>
             <SignedOut>
               {/* Signed out users get sign in button */}
-              <SignInButton />
+              <SignInButton>
             </SignedOut>
           </header>
       );

--- a/docs/custom-flows/use-sign-up.mdx
+++ b/docs/custom-flows/use-sign-up.mdx
@@ -18,7 +18,7 @@ Getting access to the [`SignUp`][signup-ref] object from inside one of your comp
 The following example accesses the [`SignUp`][signup-ref] object to check the current sign-up attempt's status.
 
 <Callout type="info">
-  The [`useSignUp()`][use-signup-ref] hook can only be used inside a [`<ClerkProvider />`](/docs/components/clerk-provider) context.
+  The [`useSignUp()`][use-signup-ref] hook can only be used inside a [`<ClerkProvider>`](/docs/components/clerk-provider) context.
 </Callout>
 
 ```jsx
@@ -148,7 +148,7 @@ Getting access to the [`SignIn`][signin-ref] object from inside one of your comp
 The following example accesses the [`SignIn`][signin-ref] object to check the current sign-in attempt's status.
 
 <Callout type="info">
-  The [`useSignIn()`][use-signin-ref] hook can only be used inside a [`<ClerkProvider />`](/docs/components/clerk-provider) context.
+  The [`useSignIn()`][use-signin-ref] hook can only be used inside a [`<ClerkProvider>`](/docs/components/clerk-provider) context.
 </Callout>
 
 ```jsx

--- a/docs/deployments/overview.mdx
+++ b/docs/deployments/overview.mdx
@@ -31,7 +31,7 @@ In most cases, you will want to clone your development instance. This will copy 
 
 A common mistake when deploying to production is forgetting to change your API keys to your production instances keys. The best way to set this up is to make use of environment variables. All modern hosting providers, such as AWS, GCP, Vercel, Heroku, and Render, make it easy to add these values. Locally, you should use a `.env` file. This way, these values are being set dynamically depending on your environment. Here's a list of Clerk variables you'll need to change:
 
-1. **Publishable Key:** Formatted as `pk_test_` in development and `pk_live_` in production. This is passed to the `<ClerkProvider />` during initialization.
+1. **Publishable Key:** Formatted as `pk_test_` in development and `pk_live_` in production. This is passed to the `<ClerkProvider>` during initialization.
 
 2. **Secret Key:** Formatted as `sk_test_` in development and `sk_live_` in production. These values are used to access Clerk's Backend API.
 

--- a/docs/manifest.json
+++ b/docs/manifest.json
@@ -176,7 +176,7 @@
     },
     [
       ["Overview", "/components/overview"],
-      ["<ClerkProvider />", "/components/clerk-provider"],
+      ["<ClerkProvider>", "/components/clerk-provider"],
       "# Authentication Components",
       ["<SignIn />", "/components/authentication/sign-in"],
       ["<SignUp />", "/components/authentication/sign-up"],
@@ -223,10 +223,10 @@
         "<AuthenticateWithRedirectCallback />",
         "/components/control/authenticate-with-callback"
       ],
-      ["<ClerkLoaded />", "/components/control/clerk-loaded"],
-      ["<ClerkLoading />", "/components/control/clerk-loading"],
+      ["<ClerkLoaded>", "/components/control/clerk-loaded"],
+      ["<ClerkLoading>", "/components/control/clerk-loading"],
       ["<Protect>", "/components/protect"],
-      ["<MultisessionAppSupport />", "/components/control/multi-session"],
+      ["<MultisessionAppSupport>", "/components/control/multi-session"],
       ["<RedirectToSignIn />", "/components/control/redirect-to-signin"],
       ["<RedirectToSignUp />", "/components/control/redirect-to-signup"],
       [
@@ -241,16 +241,16 @@
         "<RedirectToCreateOrganization />",
         "/components/control/redirect-to-createorganization"
       ],
-      ["<SignedIn />", "/components/control/signed-in"],
-      ["<SignedOut />", "/components/control/signed-out"],
+      ["<SignedIn>", "/components/control/signed-in"],
+      ["<SignedOut>", "/components/control/signed-out"],
       "# Unstyled Components",
-      ["<SignInButton />", "/components/unstyled/sign-in-button"],
+      ["<SignInButton>", "/components/unstyled/sign-in-button"],
       [
-        "<SignInWithMetamaskButton />",
+        "<SignInWithMetamaskButton>",
         "/components/unstyled/sign-in-with-metamask"
       ],
-      ["<SignUpButton />", "/components/unstyled/sign-up-button"],
-      ["<SignOutButton />", "/components/unstyled/sign-out-button"]
+      ["<SignUpButton>", "/components/unstyled/sign-up-button"],
+      ["<SignOutButton>", "/components/unstyled/sign-out-button"]
     ]
   ],
   [

--- a/docs/quickstarts/expo.mdx
+++ b/docs/quickstarts/expo.mdx
@@ -50,9 +50,9 @@ module.exports = {
 </Callout>
 
 
-### Mount `<ClerkProvider />`
+### Mount `<ClerkProvider>`
 
-Update your app entry file to include the `<ClerkProvider />` wrapper. The `<ClerkProvider />` component wraps your Expo application to provide active session and user context to Clerk's hooks and other components. It is recommended that the `<ClerkProvider />` wraps everything else to enable the context to be accessible anywhere within the app.
+Update your app entry file to include the `<ClerkProvider>` wrapper. The `<ClerkProvider>` component wraps your Expo application to provide active session and user context to Clerk's hooks and other components. It is recommended that the `<ClerkProvider>` wraps everything else to enable the context to be accessible anywhere within the app.
 
 ```tsx filename="app.tsx"
 import React from "react";
@@ -82,7 +82,7 @@ const styles = StyleSheet.create({
 
 ### Protecting your pages
 
-Clerk offers Control Components that allow you to protect your pages. In the example below, [`<SignedIn />`](/docs/components/control/signed-in) and [`<SignedOut />`](/docs/components/control/signed-out) control components are used.
+Clerk offers Control Components that allow you to protect your pages. In the example below, [`<SignedIn>`](/docs/components/control/signed-in) and [`<SignedOut>`](/docs/components/control/signed-out) control components are used.
 
 ```tsx filename="app.tsx"
 import React from "react";
@@ -248,7 +248,7 @@ export default function SignUpScreen() {
   Now would be good a time to test your sign up flow.
 </Callout>
 
-Make sure you update your `app` file to use the component that you have created. To keep it simple, this example adds the `<SignUpScreen />` to the `<SignedOut />` component.
+Make sure you update your `app` file to use the component that you have created. To keep it simple, this example adds the `<SignUpScreen />` to the `<SignedOut>` component.
 
 ```tsx filename="app.tsx"
 import React from "react";
@@ -343,7 +343,7 @@ export default function SignInScreen() {
   Now would be good a time to test your sign in flow. Restart your server to remove the session.
 </Callout>
 
-Make sure you update your `app` file to use the component that you have created. In the `<SignedOut />` component, replace the `<SignUpScreen />` with the `<SignInScreen />`.
+Make sure you update your `app` file to use the component that you have created. In the `<SignedOut>` component, replace the `<SignUpScreen />` with the `<SignInScreen />`.
 
 ```tsx filename="app.tsx"
 import React from "react";
@@ -439,7 +439,7 @@ export default SignInWithOAuth;
   Now would be a good time to test your OAuth flow. Restart your server to remove the session.
 </Callout>
 
-Make sure you update your `app` file to use the component that you have created. Replace the `<SignInScreen />` with the `<SignInWithOAuth />` to the `<SignedOut />` component.
+Make sure you update your `app` file to use the component that you have created. Replace the `<SignInScreen />` with the `<SignInWithOAuth />` to the `<SignedOut>` component.
 
 ```tsx filename="app.tsx"
 import React from "react";
@@ -478,7 +478,7 @@ A token cache is important for persisting your JWT. By default, Clerk holds it i
 
 Expo provides a way to encrypt and securely store key–value pairs locally on the device via [`expo-secure-store`](https://docs.expo.dev/versions/v47.0.0/sdk/securestore/).
 
-You can use it as your client JWT storage by setting the `tokenCache` prop in your `<ClerkProvider />` as shown below.
+You can use it as your client JWT storage by setting the `tokenCache` prop in your `<ClerkProvider>` as shown below.
 
 #### Install expo-secure-store
 

--- a/docs/quickstarts/nextjs.mdx
+++ b/docs/quickstarts/nextjs.mdx
@@ -63,9 +63,9 @@ CLERK_SECRET_KEY={{secret}}
 
 This sets your public and secret keys.
 
-### Wrap your app in `<ClerkProvider />`
+### Wrap your app in `<ClerkProvider>`
 
-The [`<ClerkProvider />`](/docs/components/clerk-provider) component provides active session and user context to Clerk's hooks and other components. Import it into your app by adding `import { ClerkProvider } from '@clerk/nextjs'` at the top of your file. 
+The [`<ClerkProvider>`](/docs/components/clerk-provider) component provides active session and user context to Clerk's hooks and other components. Import it into your app by adding `import { ClerkProvider } from '@clerk/nextjs'` at the top of your file. 
 
 <Tabs type="router" items={["App Router", "Pages Router"]}>
   <Tab>
@@ -73,7 +73,7 @@ The [`<ClerkProvider />`](/docs/components/clerk-provider) component provides ac
       The `app/layout.tsx` file might be in your `src` folder if it isn't in your root folder.
     </Callout>
 
-    For this project, it makes sense to wrap the `<html />` element with `<ClerkProvider />`. This makes the active session and user context accessible anywhere within the app.
+    For this project, it makes sense to wrap the `<html />` element with `<ClerkProvider>`. This makes the active session and user context accessible anywhere within the app.
 
     ```tsx filename="/src/app/layout.tsx" {1,10,14}
     import { ClerkProvider } from '@clerk/nextjs'
@@ -96,7 +96,7 @@ The [`<ClerkProvider />`](/docs/components/clerk-provider) component provides ac
   </Tab>
 
   <Tab>
-    For this project, it makes sense to wrap the `<Component />` element with `<ClerkProvider />`. This makes the active session and user context accessible anywhere within `MyApp`.
+    For this project, it makes sense to wrap the `<Component />` element with `<ClerkProvider>`. This makes the active session and user context accessible anywhere within `MyApp`.
 
     ```tsx filename="_app.tsx" {2,6,8}
       import '@/styles/globals.css'
@@ -142,7 +142,7 @@ export const config = {
 
 Clerk offers a set of [prebuilt components](/docs/components/overview) to add functionality to your app with minimal effort. The [`<UserButton />`](/docs/components/user/user-button) allows users to manage their account information and log out, completing the full authentication circle.
 
-Add the `<UserButton />` anywhere inside `<ClerkProvider />` in your app. First, add `import { UserButton } from "@clerk/nextjs";` to the top of your file. Then, add `<UserButton afterSignOutUrl="/"/>`. The `afterSignOutUrl` prop lets you customize what page the user will be redirected to after sign out.
+Add the `<UserButton />` anywhere inside `<ClerkProvider>` in your app. First, add `import { UserButton } from "@clerk/nextjs";` to the top of your file. Then, add `<UserButton afterSignOutUrl="/"/>`. The `afterSignOutUrl` prop lets you customize what page the user will be redirected to after sign out.
 
 <CodeBlockTabs type="router" options={["App Router", "Pages Router"]}>
 ```tsx filename="app/page.tsx" {1,6}

--- a/docs/quickstarts/react.mdx
+++ b/docs/quickstarts/react.mdx
@@ -46,9 +46,9 @@ REACT_APP_CLERK_PUBLISHABLE_KEY={{pub_key}}
 
 </InjectKeys>
 
-### Configure `<ClerkProvider />`
+### Configure `<ClerkProvider>`
 
-Clerk requires your React application to be wrapped in the [`<ClerkProvider />`](/docs/components/clerk-provider) component. The `<ClerkProvider />` component provides active session and user context to Clerk's hooks and other components.
+Clerk requires your React application to be wrapped in the [`<ClerkProvider>`](/docs/components/clerk-provider) component. The `<ClerkProvider>` component provides active session and user context to Clerk's hooks and other components.
 
 ```tsx filename="app.tsx"
 import React from "react";

--- a/docs/references/react/use-organizations.mdx
+++ b/docs/references/react/use-organizations.mdx
@@ -22,7 +22,7 @@ For now the available methods are: `createOrganization()`, `getOrganizationMembe
 The examples below illustrates simple usage of the methods available. 
 
 <Callout type="info">
-  Note that your component must be a descendant of the [`<SignedIn />`](/docs/components/control/signed-in) component, which in turn needs to be wrapped inside the [`<ClerkProvider />`](/docs/components/clerk-provider).
+  Note that your component must be a descendant of the [`<SignedIn>`](/docs/components/control/signed-in) component, which in turn needs to be wrapped inside the [`<ClerkProvider>`](/docs/components/clerk-provider).
 </Callout>
 
 <CodeBlockTabs options={["createOrganization", "getMemberships", "getOrganization"]}>

--- a/docs/references/react/use-user.mdx
+++ b/docs/references/react/use-user.mdx
@@ -10,7 +10,7 @@ The `useUser()` hook is a convenient way to access the current [`User`](/docs/re
 ## Usage
 
 <Callout type="info">
-  Note that your component must be a descendant of [`<ClerkProvider />`](/docs/components/clerk-provider).
+  Note that your component must be a descendant of [`<ClerkProvider>`](/docs/components/clerk-provider).
 </Callout>
 
 ### Retrieve the current user data

--- a/docs/upgrade-guides/v3-client-side-changes.mdx
+++ b/docs/upgrade-guides/v3-client-side-changes.mdx
@@ -38,7 +38,7 @@ The [`useAuth()`][use-auth] hook unifies the way you access common auth operatio
 - `useSession()` to access `getToken()` or the `sessionId`
 - `useUser()` to access `getToken()` for integrations
 - `useClerk()` to access `signOut()`
-- `<SignedIn />` and `<SignedOut />` in a way that requires extra components
+- `<SignedIn>` and `<SignedOut>` in a way that requires extra components
 
 ## Hook and component API changes
 
@@ -46,7 +46,7 @@ Version 3 changes several APIs for improved consistency and usability.
 
 ### `useUser()` and `useSession()`
 
-Previously, `useUser` and `useSession` could only be called from inside the `<SignedIn />` component. This restriction has been relaxed, but now developers must manually handle the possibility the user and session objects may not be loaded when the hook is called.
+Previously, `useUser` and `useSession` could only be called from inside the `<SignedIn>` component. This restriction has been relaxed, but now developers must manually handle the possibility the user and session objects may not be loaded when the hook is called.
 
 In a future version, we plan to support React `<Suspense />` to make this even easier.
 
@@ -89,7 +89,7 @@ Props which take URLs (absolute or relative) have been standardized to use the U
 
 ### `useSignUp()` & `useSignIn()`
 
-`useSignUp()` and `useSignIn()` are no longer required to be contained in `<SignedOut />` or `<ClerkLoaded />`. Instead, they have been updated to include a loading state.
+`useSignUp()` and `useSignIn()` are no longer required to be contained in `<SignedOut>` or `<ClerkLoaded>`. Instead, they have been updated to include a loading state.
 
 | Old API | New API |
 | --- | --- |

--- a/docs/users/web3.mdx
+++ b/docs/users/web3.mdx
@@ -52,7 +52,7 @@ export default function Home() {
           Address:{" "}
           {primaryWeb3Wallet ? primaryWeb3Wallet.web3Wallet : "Not found"}
         </p>
-        <SignOutButton />
+        <SignOutButton>
       </main>
     </>
   );

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,6 +7,9 @@
     "": {
       "name": "clerk-docs-2023",
       "version": "0.1.0",
+      "dependencies": {
+        "remark-frontmatter": "^5.0.0"
+      },
       "devDependencies": {
         "eslint-plugin-mdx": "^2.1.0",
         "eslint-plugin-prettier": "^4.2.1",
@@ -544,7 +547,6 @@
       "version": "4.1.8",
       "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.8.tgz",
       "integrity": "sha512-/vPO1EPOs306Cvhwv7KfVfYvOJqA/S/AXjaHQiJboCZzcNDb+TIJFN9/2C9DZ//ijSKWioNyUxD792QmDJ+HKQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/ms": "*"
@@ -598,7 +600,6 @@
       "version": "0.7.31",
       "resolved": "https://registry.npmjs.org/@types/ms/-/ms-0.7.31.tgz",
       "integrity": "sha512-iiUgKzV9AuaEkZqkOLDIvlQiL6ltuZd9tGcW3gwpnX8JbuiuhFlEGmmFXEXkN50Cvq7Os88IY2v0dkDqXYWVgA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/node": {
@@ -709,7 +710,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/bail/-/bail-2.0.2.tgz",
       "integrity": "sha512-0xO6mYd7JB2YesxDKplafRpsiOzPt9V02ddPCLbY1xYGPOX24NTyN50qnUxgCPcSoYMhKpAuBTjQoRZCAkUDRw==",
-      "dev": true,
       "license": "MIT",
       "funding": {
         "type": "github",
@@ -817,7 +817,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/character-entities/-/character-entities-2.0.2.tgz",
       "integrity": "sha512-shx7oQ0Awen/BRIdkjkvz54PnEEI/EjwXDSIZp86/KKdbafHh1Df/RYGBhn4hbe2+uKC9FnT5UCEdyPz3ai9hQ==",
-      "dev": true,
       "license": "MIT",
       "funding": {
         "type": "github",
@@ -935,7 +934,6 @@
       "version": "4.3.4",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
       "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ms": "2.1.2"
@@ -953,7 +951,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/decode-named-character-reference/-/decode-named-character-reference-1.0.2.tgz",
       "integrity": "sha512-O8x12RzrUF8xyVcY0KJowWsmaJxQbmy0/EtnNtHRpsOcT7dFk5W598coHqBVpmWo1oQQfsCqfCmkZN5DJrZVdg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "character-entities": "^2.0.0"
@@ -1023,10 +1020,21 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
       "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/devlop": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/devlop/-/devlop-1.1.0.tgz",
+      "integrity": "sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA==",
+      "dependencies": {
+        "dequal": "^2.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/diff": {
@@ -1633,7 +1641,6 @@
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
       "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/fast-deep-equal": {
@@ -1695,7 +1702,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/fault/-/fault-2.0.1.tgz",
       "integrity": "sha512-WtySTkS4OKev5JtpHXnib4Gxiurzh5NCGvWrFaZ34m6JehfTUhKZvn9njTfw48t6JumVQOmrKqpmGcdwxnhqBQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "format": "^0.2.0"
@@ -1803,7 +1809,6 @@
       "version": "0.2.2",
       "resolved": "https://registry.npmjs.org/format/-/format-0.2.2.tgz",
       "integrity": "sha512-wzsgA6WOq+09wrU1tsJ09udeR/YZRaeArL9e1wPbFg3GG2yDnC2ldKpxs4xunpFF9DgqCqOIra3bc1HWrJ37Ww==",
-      "dev": true,
       "engines": {
         "node": ">=0.4.x"
       }
@@ -2200,7 +2205,6 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-4.1.0.tgz",
       "integrity": "sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=12"
@@ -2378,7 +2382,6 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/longest-streak/-/longest-streak-3.1.0.tgz",
       "integrity": "sha512-9Ri+o0JYgehTaVBBDoMqIl8GXtbWg711O3srftcHhZ0dqnETqLaoIK0x17fUw9rFSlK/0NlsKe0Ahhyl5pXE2g==",
-      "dev": true,
       "license": "MIT",
       "funding": {
         "type": "github",
@@ -2432,6 +2435,559 @@
         "micromark-util-types": "^1.0.0",
         "unist-util-stringify-position": "^3.0.0",
         "uvu": "^0.5.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-frontmatter": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/mdast-util-frontmatter/-/mdast-util-frontmatter-2.0.1.tgz",
+      "integrity": "sha512-LRqI9+wdgC25P0URIJY9vwocIzCcksduHQ9OF2joxQoyTNVduwLAFUzjoopuRJbJAReaKrNQKAZKL3uCMugWJA==",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.0.0",
+        "escape-string-regexp": "^5.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0",
+        "micromark-extension-frontmatter": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-frontmatter/node_modules/@types/mdast": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/@types/mdast/-/mdast-4.0.3.tgz",
+      "integrity": "sha512-LsjtqsyF+d2/yFOYaN22dHZI1Cpwkrj+g06G8+qtUKlhovPW89YhqSnfKtMbkgmEtYpH2gydRNULd6y8mciAFg==",
+      "dependencies": {
+        "@types/unist": "*"
+      }
+    },
+    "node_modules/mdast-util-frontmatter/node_modules/@types/unist": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/unist/-/unist-3.0.2.tgz",
+      "integrity": "sha512-dqId9J8K/vGi5Zr7oo212BGii5m3q5Hxlkwy3WpYuKPklmBEvsbMYYyLxAQpSffdLl/gdW0XUpKWFvYmyoWCoQ=="
+    },
+    "node_modules/mdast-util-frontmatter/node_modules/escape-string-regexp": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-5.0.0.tgz",
+      "integrity": "sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/mdast-util-frontmatter/node_modules/mdast-util-from-markdown": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-from-markdown/-/mdast-util-from-markdown-2.0.0.tgz",
+      "integrity": "sha512-n7MTOr/z+8NAX/wmhhDji8O3bRvPTV/U0oTCaZJkjhPSKTPhS3xufVhKGF8s1pJ7Ox4QgoIU7KHseh09S+9rTA==",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "@types/unist": "^3.0.0",
+        "decode-named-character-reference": "^1.0.0",
+        "devlop": "^1.0.0",
+        "mdast-util-to-string": "^4.0.0",
+        "micromark": "^4.0.0",
+        "micromark-util-decode-numeric-character-reference": "^2.0.0",
+        "micromark-util-decode-string": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0",
+        "unist-util-stringify-position": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-frontmatter/node_modules/mdast-util-phrasing": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-phrasing/-/mdast-util-phrasing-4.0.0.tgz",
+      "integrity": "sha512-xadSsJayQIucJ9n053dfQwVu1kuXg7jCTdYsMK8rqzKZh52nLfSH/k0sAxE0u+pj/zKZX+o5wB+ML5mRayOxFA==",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "unist-util-is": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-frontmatter/node_modules/mdast-util-to-markdown": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-to-markdown/-/mdast-util-to-markdown-2.1.0.tgz",
+      "integrity": "sha512-SR2VnIEdVNCJbP6y7kVTJgPLifdr8WEU440fQec7qHoHOUz/oJ2jmNRqdDQ3rbiStOXb2mCDGTuwsK5OPUgYlQ==",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "@types/unist": "^3.0.0",
+        "longest-streak": "^3.0.0",
+        "mdast-util-phrasing": "^4.0.0",
+        "mdast-util-to-string": "^4.0.0",
+        "micromark-util-decode-string": "^2.0.0",
+        "unist-util-visit": "^5.0.0",
+        "zwitch": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-frontmatter/node_modules/mdast-util-to-string": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-to-string/-/mdast-util-to-string-4.0.0.tgz",
+      "integrity": "sha512-0H44vDimn51F0YwvxSJSm0eCDOJTRlmN0R1yBh4HLj9wiV1Dn0QoXGbvFAWj2hSItVTlCmBF1hqKlIyUBVFLPg==",
+      "dependencies": {
+        "@types/mdast": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-frontmatter/node_modules/micromark": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/micromark/-/micromark-4.0.0.tgz",
+      "integrity": "sha512-o/sd0nMof8kYff+TqcDx3VSrgBTcZpSvYcAHIfHhv5VAuNmisCxjhx6YmxS8PFEpb9z5WKWKPdzf0jM23ro3RQ==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "dependencies": {
+        "@types/debug": "^4.0.0",
+        "debug": "^4.0.0",
+        "decode-named-character-reference": "^1.0.0",
+        "devlop": "^1.0.0",
+        "micromark-core-commonmark": "^2.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-combine-extensions": "^2.0.0",
+        "micromark-util-decode-numeric-character-reference": "^2.0.0",
+        "micromark-util-encode": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0",
+        "micromark-util-resolve-all": "^2.0.0",
+        "micromark-util-sanitize-uri": "^2.0.0",
+        "micromark-util-subtokenize": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/mdast-util-frontmatter/node_modules/micromark-core-commonmark": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/micromark-core-commonmark/-/micromark-core-commonmark-2.0.0.tgz",
+      "integrity": "sha512-jThOz/pVmAYUtkroV3D5c1osFXAMv9e0ypGDOIZuCeAe91/sD6BoE2Sjzt30yuXtwOYUmySOhMas/PVyh02itA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "dependencies": {
+        "decode-named-character-reference": "^1.0.0",
+        "devlop": "^1.0.0",
+        "micromark-factory-destination": "^2.0.0",
+        "micromark-factory-label": "^2.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-factory-title": "^2.0.0",
+        "micromark-factory-whitespace": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-classify-character": "^2.0.0",
+        "micromark-util-html-tag-name": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0",
+        "micromark-util-resolve-all": "^2.0.0",
+        "micromark-util-subtokenize": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/mdast-util-frontmatter/node_modules/micromark-factory-destination": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/micromark-factory-destination/-/micromark-factory-destination-2.0.0.tgz",
+      "integrity": "sha512-j9DGrQLm/Uhl2tCzcbLhy5kXsgkHUrjJHg4fFAeoMRwJmJerT9aw4FEhIbZStWN8A3qMwOp1uzHr4UL8AInxtA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/mdast-util-frontmatter/node_modules/micromark-factory-label": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/micromark-factory-label/-/micromark-factory-label-2.0.0.tgz",
+      "integrity": "sha512-RR3i96ohZGde//4WSe/dJsxOX6vxIg9TimLAS3i4EhBAFx8Sm5SmqVfR8E87DPSR31nEAjZfbt91OMZWcNgdZw==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/mdast-util-frontmatter/node_modules/micromark-factory-space": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/micromark-factory-space/-/micromark-factory-space-2.0.0.tgz",
+      "integrity": "sha512-TKr+LIDX2pkBJXFLzpyPyljzYK3MtmllMUMODTQJIUfDGncESaqB90db9IAUcz4AZAJFdd8U9zOp9ty1458rxg==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/mdast-util-frontmatter/node_modules/micromark-factory-title": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/micromark-factory-title/-/micromark-factory-title-2.0.0.tgz",
+      "integrity": "sha512-jY8CSxmpWLOxS+t8W+FG3Xigc0RDQA9bKMY/EwILvsesiRniiVMejYTE4wumNc2f4UbAa4WsHqe3J1QS1sli+A==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "dependencies": {
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/mdast-util-frontmatter/node_modules/micromark-factory-whitespace": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/micromark-factory-whitespace/-/micromark-factory-whitespace-2.0.0.tgz",
+      "integrity": "sha512-28kbwaBjc5yAI1XadbdPYHX/eDnqaUFVikLwrO7FDnKG7lpgxnvk/XGRhX/PN0mOZ+dBSZ+LgunHS+6tYQAzhA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "dependencies": {
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/mdast-util-frontmatter/node_modules/micromark-util-character": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-character/-/micromark-util-character-2.0.1.tgz",
+      "integrity": "sha512-3wgnrmEAJ4T+mGXAUfMvMAbxU9RDG43XmGce4j6CwPtVxB3vfwXSZ6KhFwDzZ3mZHhmPimMAXg71veiBGzeAZw==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "dependencies": {
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/mdast-util-frontmatter/node_modules/micromark-util-chunked": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/micromark-util-chunked/-/micromark-util-chunked-2.0.0.tgz",
+      "integrity": "sha512-anK8SWmNphkXdaKgz5hJvGa7l00qmcaUQoMYsBwDlSKFKjc6gjGXPDw3FNL3Nbwq5L8gE+RCbGqTw49FK5Qyvg==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "dependencies": {
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/mdast-util-frontmatter/node_modules/micromark-util-classify-character": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/micromark-util-classify-character/-/micromark-util-classify-character-2.0.0.tgz",
+      "integrity": "sha512-S0ze2R9GH+fu41FA7pbSqNWObo/kzwf8rN/+IGlW/4tC6oACOs8B++bh+i9bVyNnwCcuksbFwsBme5OCKXCwIw==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/mdast-util-frontmatter/node_modules/micromark-util-combine-extensions": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/micromark-util-combine-extensions/-/micromark-util-combine-extensions-2.0.0.tgz",
+      "integrity": "sha512-vZZio48k7ON0fVS3CUgFatWHoKbbLTK/rT7pzpJ4Bjp5JjkZeasRfrS9wsBdDJK2cJLHMckXZdzPSSr1B8a4oQ==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "dependencies": {
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/mdast-util-frontmatter/node_modules/micromark-util-decode-numeric-character-reference": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-decode-numeric-character-reference/-/micromark-util-decode-numeric-character-reference-2.0.1.tgz",
+      "integrity": "sha512-bmkNc7z8Wn6kgjZmVHOX3SowGmVdhYS7yBpMnuMnPzDq/6xwVA604DuOXMZTO1lvq01g+Adfa0pE2UKGlxL1XQ==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "dependencies": {
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/mdast-util-frontmatter/node_modules/micromark-util-decode-string": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/micromark-util-decode-string/-/micromark-util-decode-string-2.0.0.tgz",
+      "integrity": "sha512-r4Sc6leeUTn3P6gk20aFMj2ntPwn6qpDZqWvYmAG6NgvFTIlj4WtrAudLi65qYoaGdXYViXYw2pkmn7QnIFasA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "dependencies": {
+        "decode-named-character-reference": "^1.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-decode-numeric-character-reference": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/mdast-util-frontmatter/node_modules/micromark-util-encode": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/micromark-util-encode/-/micromark-util-encode-2.0.0.tgz",
+      "integrity": "sha512-pS+ROfCXAGLWCOc8egcBvT0kf27GoWMqtdarNfDcjb6YLuV5cM3ioG45Ys2qOVqeqSbjaKg72vU+Wby3eddPsA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ]
+    },
+    "node_modules/mdast-util-frontmatter/node_modules/micromark-util-html-tag-name": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/micromark-util-html-tag-name/-/micromark-util-html-tag-name-2.0.0.tgz",
+      "integrity": "sha512-xNn4Pqkj2puRhKdKTm8t1YHC/BAjx6CEwRFXntTaRf/x16aqka6ouVoutm+QdkISTlT7e2zU7U4ZdlDLJd2Mcw==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ]
+    },
+    "node_modules/mdast-util-frontmatter/node_modules/micromark-util-normalize-identifier": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/micromark-util-normalize-identifier/-/micromark-util-normalize-identifier-2.0.0.tgz",
+      "integrity": "sha512-2xhYT0sfo85FMrUPtHcPo2rrp1lwbDEEzpx7jiH2xXJLqBuy4H0GgXk5ToU8IEwoROtXuL8ND0ttVa4rNqYK3w==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "dependencies": {
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/mdast-util-frontmatter/node_modules/micromark-util-resolve-all": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/micromark-util-resolve-all/-/micromark-util-resolve-all-2.0.0.tgz",
+      "integrity": "sha512-6KU6qO7DZ7GJkaCgwBNtplXCvGkJToU86ybBAUdavvgsCiG8lSSvYxr9MhwmQ+udpzywHsl4RpGJsYWG1pDOcA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "dependencies": {
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/mdast-util-frontmatter/node_modules/micromark-util-sanitize-uri": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/micromark-util-sanitize-uri/-/micromark-util-sanitize-uri-2.0.0.tgz",
+      "integrity": "sha512-WhYv5UEcZrbAtlsnPuChHUAsu/iBPOVaEVsntLBIdpibO0ddy8OzavZz3iL2xVvBZOpolujSliP65Kq0/7KIYw==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-encode": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/mdast-util-frontmatter/node_modules/micromark-util-subtokenize": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/micromark-util-subtokenize/-/micromark-util-subtokenize-2.0.0.tgz",
+      "integrity": "sha512-vc93L1t+gpR3p8jxeVdaYlbV2jTYteDje19rNSS/H5dlhxUYll5Fy6vJ2cDwP8RnsXi818yGty1ayP55y3W6fg==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/mdast-util-frontmatter/node_modules/micromark-util-symbol": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/micromark-util-symbol/-/micromark-util-symbol-2.0.0.tgz",
+      "integrity": "sha512-8JZt9ElZ5kyTnO94muPxIGS8oyElRJaiJO8EzV6ZSyGQ1Is8xwl4Q45qU5UOg+bGH4AikWziz0iN4sFLWs8PGw==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ]
+    },
+    "node_modules/mdast-util-frontmatter/node_modules/micromark-util-types": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/micromark-util-types/-/micromark-util-types-2.0.0.tgz",
+      "integrity": "sha512-oNh6S2WMHWRZrmutsRmDDfkzKtxF+bc2VxLC9dvtrDIRFln627VsFP6fLMgTryGDljgLPjkrzQSDcPrjPyDJ5w==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ]
+    },
+    "node_modules/mdast-util-frontmatter/node_modules/unist-util-is": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-6.0.0.tgz",
+      "integrity": "sha512-2qCTHimwdxLfz+YzdGfkqNlH0tLi9xjTnHddPmJwtIG9MGsdbutfTc4P+haPD7l7Cjxf/WZj+we5qfVPvvxfYw==",
+      "dependencies": {
+        "@types/unist": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-frontmatter/node_modules/unist-util-stringify-position": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/unist-util-stringify-position/-/unist-util-stringify-position-4.0.0.tgz",
+      "integrity": "sha512-0ASV06AAoKCDkS2+xw5RXJywruurpbC4JZSm7nr7MOt1ojAzvyyaO+UxZf18j8FCF6kmzCZKcAgN/yu2gm2XgQ==",
+      "dependencies": {
+        "@types/unist": "^3.0.0"
       },
       "funding": {
         "type": "opencollective",
@@ -2779,6 +3335,70 @@
         "micromark-util-types": "^1.0.1",
         "uvu": "^0.5.0"
       }
+    },
+    "node_modules/micromark-extension-frontmatter": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-frontmatter/-/micromark-extension-frontmatter-2.0.0.tgz",
+      "integrity": "sha512-C4AkuM3dA58cgZha7zVnuVxBhDsbttIMiytjgsM2XbHAB2faRVaHRle40558FBN+DJcrLNCoqG5mlrpdU4cRtg==",
+      "dependencies": {
+        "fault": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-frontmatter/node_modules/micromark-util-character": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-character/-/micromark-util-character-2.0.1.tgz",
+      "integrity": "sha512-3wgnrmEAJ4T+mGXAUfMvMAbxU9RDG43XmGce4j6CwPtVxB3vfwXSZ6KhFwDzZ3mZHhmPimMAXg71veiBGzeAZw==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "dependencies": {
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-extension-frontmatter/node_modules/micromark-util-symbol": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/micromark-util-symbol/-/micromark-util-symbol-2.0.0.tgz",
+      "integrity": "sha512-8JZt9ElZ5kyTnO94muPxIGS8oyElRJaiJO8EzV6ZSyGQ1Is8xwl4Q45qU5UOg+bGH4AikWziz0iN4sFLWs8PGw==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ]
+    },
+    "node_modules/micromark-extension-frontmatter/node_modules/micromark-util-types": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/micromark-util-types/-/micromark-util-types-2.0.0.tgz",
+      "integrity": "sha512-oNh6S2WMHWRZrmutsRmDDfkzKtxF+bc2VxLC9dvtrDIRFln627VsFP6fLMgTryGDljgLPjkrzQSDcPrjPyDJ5w==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ]
     },
     "node_modules/micromark-extension-mdx-expression": {
       "version": "1.0.8",
@@ -3397,7 +4017,6 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
       "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/natural-compare": {
@@ -3858,6 +4477,52 @@
         "remark-parse": "^10.0.0",
         "remark-stringify": "^10.0.0",
         "unified": "^10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/remark-frontmatter": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/remark-frontmatter/-/remark-frontmatter-5.0.0.tgz",
+      "integrity": "sha512-XTFYvNASMe5iPN0719nPrdItC9aU0ssC4v14mH1BCi1u0n1gAocqcujWUrByftZTbLhRtiKRyjYTSIOcr69UVQ==",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "mdast-util-frontmatter": "^2.0.0",
+        "micromark-extension-frontmatter": "^2.0.0",
+        "unified": "^11.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/remark-frontmatter/node_modules/@types/mdast": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/@types/mdast/-/mdast-4.0.3.tgz",
+      "integrity": "sha512-LsjtqsyF+d2/yFOYaN22dHZI1Cpwkrj+g06G8+qtUKlhovPW89YhqSnfKtMbkgmEtYpH2gydRNULd6y8mciAFg==",
+      "dependencies": {
+        "@types/unist": "*"
+      }
+    },
+    "node_modules/remark-frontmatter/node_modules/@types/unist": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/unist/-/unist-3.0.2.tgz",
+      "integrity": "sha512-dqId9J8K/vGi5Zr7oo212BGii5m3q5Hxlkwy3WpYuKPklmBEvsbMYYyLxAQpSffdLl/gdW0XUpKWFvYmyoWCoQ=="
+    },
+    "node_modules/remark-frontmatter/node_modules/unified": {
+      "version": "11.0.4",
+      "resolved": "https://registry.npmjs.org/unified/-/unified-11.0.4.tgz",
+      "integrity": "sha512-apMPnyLjAX+ty4OrNap7yumyVAMlKx5IWU2wlzzUdYJO9A8f1p9m/gywF/GM2ZDFcjQPrx59Mc90KwmxsoklxQ==",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "bail": "^2.0.0",
+        "devlop": "^1.0.0",
+        "extend": "^3.0.0",
+        "is-plain-obj": "^4.0.0",
+        "trough": "^2.0.0",
+        "vfile": "^6.0.0"
       },
       "funding": {
         "type": "opencollective",
@@ -6830,7 +7495,6 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/trough/-/trough-2.1.0.tgz",
       "integrity": "sha512-AqTiAOLcj85xS7vQ8QkAV41hPDIJ71XJB4RCUrzo/1GM2CQwhkJGaf9Hgr7BOugMRpgGUrqRg/DrBDl4H40+8g==",
-      "dev": true,
       "license": "MIT",
       "funding": {
         "type": "github",
@@ -7265,7 +7929,6 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-5.0.0.tgz",
       "integrity": "sha512-MR04uvD+07cwl/yhVuVWAtw+3GOR/knlL55Nd/wAdblk27GCVt3lqpTivy/tkJcZoNPzTwS1Y+KMojlLDhoTzg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/unist": "^3.0.0",
@@ -7281,7 +7944,6 @@
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/unist-util-visit-parents/-/unist-util-visit-parents-6.0.1.tgz",
       "integrity": "sha512-L/PqWzfTP9lzzEa6CKs0k2nARxTdZduw3zyh8d2NVBnsyvHjSX4TWse388YrrQKbvI8w20fGjGlhgT96WwKykw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/unist": "^3.0.0",
@@ -7296,14 +7958,12 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/@types/unist/-/unist-3.0.0.tgz",
       "integrity": "sha512-MFETx3tbTjE7Uk6vvnWINA/1iJ7LuMdO4fcq8UfF0pRbj01aGLduVvQcRyswuACJdpnHgg8E3rQLhaRdNEJS0w==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/unist-util-visit-parents/node_modules/unist-util-is": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-6.0.0.tgz",
       "integrity": "sha512-2qCTHimwdxLfz+YzdGfkqNlH0tLi9xjTnHddPmJwtIG9MGsdbutfTc4P+haPD7l7Cjxf/WZj+we5qfVPvvxfYw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/unist": "^3.0.0"
@@ -7317,14 +7977,12 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/@types/unist/-/unist-3.0.0.tgz",
       "integrity": "sha512-MFETx3tbTjE7Uk6vvnWINA/1iJ7LuMdO4fcq8UfF0pRbj01aGLduVvQcRyswuACJdpnHgg8E3rQLhaRdNEJS0w==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/unist-util-visit/node_modules/unist-util-is": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-6.0.0.tgz",
       "integrity": "sha512-2qCTHimwdxLfz+YzdGfkqNlH0tLi9xjTnHddPmJwtIG9MGsdbutfTc4P+haPD7l7Cjxf/WZj+we5qfVPvvxfYw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/unist": "^3.0.0"
@@ -7384,7 +8042,6 @@
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/vfile/-/vfile-6.0.1.tgz",
       "integrity": "sha512-1bYqc7pt6NIADBJ98UiG0Bn/CHIVOoZ/IyEkqIruLg0mE1BKzkOXY2D6CSqQIcKqgadppE5lrxgWXJmXd7zZJw==",
-      "dev": true,
       "dependencies": {
         "@types/unist": "^3.0.0",
         "unist-util-stringify-position": "^4.0.0",
@@ -7639,14 +8296,12 @@
     "node_modules/vfile/node_modules/@types/unist": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/@types/unist/-/unist-3.0.0.tgz",
-      "integrity": "sha512-MFETx3tbTjE7Uk6vvnWINA/1iJ7LuMdO4fcq8UfF0pRbj01aGLduVvQcRyswuACJdpnHgg8E3rQLhaRdNEJS0w==",
-      "dev": true
+      "integrity": "sha512-MFETx3tbTjE7Uk6vvnWINA/1iJ7LuMdO4fcq8UfF0pRbj01aGLduVvQcRyswuACJdpnHgg8E3rQLhaRdNEJS0w=="
     },
     "node_modules/vfile/node_modules/unist-util-stringify-position": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/unist-util-stringify-position/-/unist-util-stringify-position-4.0.0.tgz",
       "integrity": "sha512-0ASV06AAoKCDkS2+xw5RXJywruurpbC4JZSm7nr7MOt1ojAzvyyaO+UxZf18j8FCF6kmzCZKcAgN/yu2gm2XgQ==",
-      "dev": true,
       "dependencies": {
         "@types/unist": "^3.0.0"
       },
@@ -7659,7 +8314,6 @@
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/vfile-message/-/vfile-message-4.0.2.tgz",
       "integrity": "sha512-jRDZ1IMLttGj41KcZvlrYAaI3CfqpLpfpf+Mfig13viT6NKvRzWZ+lXz0Y5D60w6uJIBAOGq9mSHf0gktF0duw==",
-      "dev": true,
       "dependencies": {
         "@types/unist": "^3.0.0",
         "unist-util-stringify-position": "^4.0.0"
@@ -7752,7 +8406,6 @@
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/zwitch/-/zwitch-2.0.4.tgz",
       "integrity": "sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==",
-      "dev": true,
       "license": "MIT",
       "funding": {
         "type": "github",

--- a/package.json
+++ b/package.json
@@ -21,5 +21,8 @@
     "unist-util-visit": "^5.0.0",
     "vfile": "^6.0.1",
     "vfile-reporter": "^8.0.0"
+  },
+  "dependencies": {
+    "remark-frontmatter": "^5.0.0"
   }
 }

--- a/scripts/check-links.mjs
+++ b/scripts/check-links.mjs
@@ -5,10 +5,15 @@ import remarkMdx from "remark-mdx";
 import { remark } from "remark";
 import reporter from "vfile-reporter";
 import { visit } from "unist-util-visit";
+import remarkFrontmatter from "remark-frontmatter";
 
 // Some URLs are valid (e.g. they link to marketing sites or docs that are not hosted through clerk-docs) so they should be excluded from the check.
 // These URLs will be used with the .startsWith() method, so they should be specific enough to not match any URLs that should be checked.
-const EXCLUDE_LIST = ['/pricing', '/docs/reference/backend-api', '/docs/reference/frontend-api']
+const EXCLUDE_LIST = [
+  "/pricing",
+  "/docs/reference/backend-api",
+  "/docs/reference/frontend-api",
+];
 
 const ERRORS = {
   RELATIVE_LINK(url) {
@@ -33,7 +38,9 @@ const validateUrl = (url, node, file) => {
     const cleanedUrl = url.split("#")[0];
 
     if (!fileCheckCache.has(cleanedUrl)) {
-      const isExcluded = EXCLUDE_LIST.some((excludedUrl) => cleanedUrl.startsWith(excludedUrl))
+      const isExcluded = EXCLUDE_LIST.some((excludedUrl) =>
+        cleanedUrl.startsWith(excludedUrl)
+      );
 
       // If the URL is excluded, we don't need to check the filesystem. However, we should do the check here and not early return in the beginning because we still want to cache the result.
       if (isExcluded) {
@@ -80,7 +87,10 @@ const remarkPluginValidateLinks = () => (tree, file) => {
   );
 };
 
-const processor = remark().use(remarkMdx).use(remarkPluginValidateLinks);
+const processor = remark()
+  .use(remarkFrontmatter)
+  .use(remarkMdx)
+  .use(remarkPluginValidateLinks);
 
 async function main() {
   console.log("🔎 Checking for broken links...");


### PR DESCRIPTION
Previously, we referred to components by using the `< />` format.
However, some of our components are not self-closing and will sometimes or always wrap children. In the case that a component is not self-closing, we will refer to the component using the `< >` format.
This PR updates the styleguide to reflect this new "rule" and updates all component references within text to follow this new rule.