### PR TITLE
fix missing links in auth() docs

### DIFF
--- a/docs/references/nextjs/auth.mdx
+++ b/docs/references/nextjs/auth.mdx
@@ -5,7 +5,7 @@ description: Access minimal authentication data for managing sessions and data f
 
 # `auth()`
 
-The `auth()` helper returns the [`Authentication`][auth-object] object of the currently active user. This is the same [`Authentication`][auth-object] object that is returned by the [`getAuth()`](/docs/references/nextjs/get-auth) hook. However, it can be used in Server Components, Route Handlers, and Server Actions.
+The `auth()` helper returns the [`Authentication`](/docs/references/nextjs/authentication-object) object of the currently active user. This is the same `Authentication` object that is returned by the [`getAuth()`](/docs/references/nextjs/get-auth) hook. However, it can be used in Server Components, Route Handlers, and Server Actions.
 
 The `auth()` helper does require [Middleware](/docs/references/nextjs/auth-middleware). 
 


### PR DESCRIPTION
Fixes missing links in the [`auth()`](https://clerk.com/docs/references/nextjs/auth) docs.

🔎 [Updated auth() page](https://docs-preview-576.clerkpreview.com/docs/references/nextjs/auth#auth)

Screenshot of the issue before this PR (notice the [auth-object] instead of a link):
<img width="875" alt="Screenshot 2023-12-19 at 10 48 56" src="https://github.com/clerk/clerk-docs/assets/98043211/6ff2279e-6bee-4492-b98e-5893bf85a499">
