### PR TITLE
minor docs fixes found during content audit

### DIFF
--- a/docs/components/control/authenticate-with-callback.mdx
+++ b/docs/components/control/authenticate-with-callback.mdx
@@ -9,6 +9,8 @@ The `<AuthenticateWithRedirectCallback />` is used to complete a custom OAuth fl
 
 ## Usage
 
+<InjectKeys>
+
 <Tabs type="framework" items={["Next.js", "React"]}>
   <Tab>
   This example below uses built in Next.js pages, but you could use any routing library you want.
@@ -86,7 +88,7 @@ The `<AuthenticateWithRedirectCallback />` is used to complete a custom OAuth fl
 
   function App() {
     return (
-      <ClerkProvider publishableKey="pk_test_••••••••••••••••••••••••••••••••••">
+      <ClerkProvider publishableKey={{pub_key}}>
         {/* Define a / route that displays the OAuth button */}
         <Routes>
           <Route path="/" element={<HomePages />} />
@@ -132,6 +134,8 @@ The `<AuthenticateWithRedirectCallback />` is used to complete a custom OAuth fl
 
   </Tab>
 </Tabs>
+
+</InjectKeys>
 
 ## Properties
 

--- a/docs/components/control/clerk-loaded.mdx
+++ b/docs/components/control/clerk-loaded.mdx
@@ -9,6 +9,8 @@ The `<ClerkLoaded />` component guarantees that the Clerk object has loaded and 
 
 ## Usage
 
+<InjectKeys>
+
 <Tabs type="framework" items={["Next.js", "React", "Remix"]}>
   <Tab>
   ```tsx filename="pages/_app.tsx"
@@ -58,7 +60,7 @@ The `<ClerkLoaded />` component guarantees that the Clerk object has loaded and 
 
   function App() {
     return (
-      <ClerkProvider publishableKey="pk_test_••••••••••••••••••••••••••••••••••">
+      <ClerkProvider publishableKey={{pub_key}}>
         <ClerkLoaded>
           <Page />
         </ClerkLoaded>
@@ -99,3 +101,5 @@ The `<ClerkLoaded />` component guarantees that the Clerk object has loaded and 
   ```
   </Tab>
 </Tabs>
+
+</InjectKeys>

--- a/docs/components/control/clerk-loading.mdx
+++ b/docs/components/control/clerk-loading.mdx
@@ -9,6 +9,8 @@ The `<ClerkLoading />` renders its children while Clerk is loading, and is helpf
 
 ## Usage
 
+<InjectKeys>
+
 <Tabs type="framework" items={["Next.js", "React", "Remix"]}>
   <Tab>
   ```tsx filename="pages/_app.tsx"
@@ -40,7 +42,7 @@ The `<ClerkLoading />` renders its children while Clerk is loading, and is helpf
 
   function App() {
     return (
-      <ClerkProvider publishableKey="pk_test_.........................">
+      <ClerkProvider publishableKey={{pub_key}}>
         <ClerkLoading>
           <div>Clerk is loading</div>
         </ClerkLoading>
@@ -77,3 +79,5 @@ The `<ClerkLoading />` renders its children while Clerk is loading, and is helpf
   ```
   </Tab>
 </Tabs>
+
+</InjectKeys>

--- a/docs/components/control/multi-session.mdx
+++ b/docs/components/control/multi-session.mdx
@@ -9,6 +9,8 @@ The `<MultisessionAppSupport />` provides a wrapper for your React application t
 
 ## Usage
 
+<InjectKeys>
+
 <Tabs type="framework" items={["Next.js", "React"]}>
   <Tab>
   ```tsx filename="pages/_app.tsx"
@@ -36,7 +38,7 @@ The `<MultisessionAppSupport />` provides a wrapper for your React application t
 
   function App() {
     return (
-      <ClerkProvider publishableKey="pk_test_••••••••••••••••••••••••••••••••••">
+      <ClerkProvider publishableKey={{pub_key}}>
         <MultisessionAppSupport>
           <Page />
         </MultisessionAppSupport>
@@ -53,3 +55,5 @@ The `<MultisessionAppSupport />` provides a wrapper for your React application t
   ```
   </Tab>
 </Tabs>
+
+</InjectKeys>

--- a/docs/components/control/redirect-to-createorganization.mdx
+++ b/docs/components/control/redirect-to-createorganization.mdx
@@ -9,6 +9,8 @@ The `<RedirectToCreateOrganization />` component will navigate to the create org
 
 ## Usage
 
+<InjectKeys>
+
 <Tabs type="framework" items={["Next.js", "React", "Remix"]}>
   <Tab>
   ```tsx filename="pages/_app.tsx"
@@ -49,7 +51,7 @@ The `<RedirectToCreateOrganization />` component will navigate to the create org
 
   function PrivatePage() {
     return (
-      <ClerkProvider publishableKey="pk_test_••••••••••••••••••••••••••••••••••">
+      <ClerkProvider publishableKey={{pub_key}}>
         <SignedIn>
           <RedirectToCreateOrganization/>
         </SignedIn>
@@ -85,3 +87,5 @@ The `<RedirectToCreateOrganization />` component will navigate to the create org
   ```
   </Tab>
 </Tabs>
+
+</InjectKeys>

--- a/docs/components/control/redirect-to-organizationprofile.mdx
+++ b/docs/components/control/redirect-to-organizationprofile.mdx
@@ -9,6 +9,8 @@ The `<RedirectToOrganizationProfile />` component will navigate to the organizat
 
 ## Usage
 
+<InjectKeys>
+
 <Tabs type="framework" items={["Next.js", "React", "Remix"]}>
   <Tab>
   ```tsx filename="pages/_app.tsx"
@@ -49,7 +51,7 @@ The `<RedirectToOrganizationProfile />` component will navigate to the organizat
 
   function PrivatePage() {
     return (
-      <ClerkProvider publishableKey="pk_test_••••••••••••••••••••••••••••••••••">
+      <ClerkProvider publishableKey={{pub_key}}>
         <SignedIn>
           <RedirectToOrganizationProfile/>
         </SignedIn>
@@ -85,3 +87,5 @@ The `<RedirectToOrganizationProfile />` component will navigate to the organizat
   ```
   </Tab>
 </Tabs>
+
+</InjectKeys>

--- a/docs/components/control/redirect-to-signin.mdx
+++ b/docs/components/control/redirect-to-signin.mdx
@@ -9,6 +9,8 @@ The `<RedirectToSignIn />` component will navigate to the sign in URL which has 
 
 ## Usage
 
+<InjectKeys>
+
 <Tabs type="framework" items={["Next.js", "React", "Remix"]}>
   <Tab>
   ```tsx filename="pages/_app.tsx"
@@ -48,7 +50,7 @@ The `<RedirectToSignIn />` component will navigate to the sign in URL which has 
 
   function PrivatePage() {
     return (
-      <ClerkProvider publishableKey="pk_test_••••••••••••••••••••••••••••••••••">
+      <ClerkProvider publishableKey={{pub_key}}>
         <SignedIn>
           Content that is displayed to signed in
           users.
@@ -89,6 +91,8 @@ The `<RedirectToSignIn />` component will navigate to the sign in URL which has 
   ```
   </Tab>
 </Tabs>
+
+</InjectKeys>
 
 ## Properties
 

--- a/docs/components/control/redirect-to-signup.mdx
+++ b/docs/components/control/redirect-to-signup.mdx
@@ -9,6 +9,8 @@ The `<RedirectToSignUp />` component will navigate to the sign up URL which has 
 
 ## Usage
 
+<InjectKeys>
+
 <Tabs type="framework" items={["Next.js", "React", "Remix"]}>
   <Tab>
   ```tsx filename="pages/_app.tsx"
@@ -48,7 +50,7 @@ The `<RedirectToSignUp />` component will navigate to the sign up URL which has 
 
   function PrivatePage() {
     return (
-      <ClerkProvider publishableKey="pk_test_••••••••••••••••••••••••••••••••••">
+      <ClerkProvider publishableKey={{pub_key}}>
         <SignedIn>
           Content that is displayed to signed in
           users.
@@ -88,6 +90,8 @@ The `<RedirectToSignUp />` component will navigate to the sign up URL which has 
   ```
   </Tab>
 </Tabs>
+
+</InjectKeys>
 
 ## Properties
 

--- a/docs/components/control/redirect-to-userprofile.mdx
+++ b/docs/components/control/redirect-to-userprofile.mdx
@@ -9,6 +9,8 @@ The `<RedirectToUserProfile />` component will navigate to the user profile URL 
 
 ## Usage
 
+<InjectKeys>
+
 <Tabs type="framework" items={["Next.js", "React", "Remix"]}>
   <Tab>
   ```tsx filename="pages/_app.tsx"
@@ -49,7 +51,7 @@ The `<RedirectToUserProfile />` component will navigate to the user profile URL 
 
   function PrivatePage() {
     return (
-      <ClerkProvider publishableKey="pk_test_••••••••••••••••••••••••••••••••••">
+      <ClerkProvider publishableKey={{pub_key}}>
         <SignedIn>
           <RedirectToUserProfile/>
         </SignedIn>
@@ -85,3 +87,5 @@ The `<RedirectToUserProfile />` component will navigate to the user profile URL 
   ```
   </Tab>
 </Tabs>
+
+</InjectKeys>

--- a/docs/components/control/signed-in.mdx
+++ b/docs/components/control/signed-in.mdx
@@ -9,6 +9,9 @@ description: Conditionally render content only when a user is signed in.
 The `<SignedIn />` component offers authentication checks as a cross-cutting concern. Any children components wrapped by a `<SignedIn />` component will be rendered only if there's a User with an active Session signed in your application.
 
 ## Usage
+
+<InjectKeys>
+
 <Tabs type="framework" items={["Next.js", "React", "Remix"]}>
   <Tab>
   ```tsx filename="app.tsx"
@@ -42,7 +45,7 @@ The `<SignedIn />` component offers authentication checks as a cross-cutting con
 
   function Page() {
     return (
-      <ClerkProvider publishableKey="pk_test_••••••••••••••••••••••••••••••••••">
+      <ClerkProvider publishableKey={{pub_key}}>
         <section>
           <div>
             This content is always visible.
@@ -82,6 +85,8 @@ The `<SignedIn />` component offers authentication checks as a cross-cutting con
   </Tab>
 </Tabs>
 
+</InjectKeys>
+
 ### Usage with React Router
 
 Below is an example of how to use `<SignedIn />` with React Router. The `<SignedIn />` component can be used as a child of a `<Route />` component to render content only to signed in users.
@@ -95,7 +100,7 @@ import {
 
 function App() {
   return (
-      <ClerkProvider publishableKey="pk_test_••••••••••••••••••••••••••••••••••">
+      <ClerkProvider publishableKey={{pub_key}}>
         <Routes>
         <Route
           path="/"

--- a/docs/components/control/signed-out.mdx
+++ b/docs/components/control/signed-out.mdx
@@ -8,6 +8,9 @@ description: Conditionally render content only when a user is signed out.
 The `<SignedOut />` component offers authentication checks as a cross-cutting concern. Any child nodes wrapped by a `<SignedOut />` component will be rendered only if there's no User signed in to your application.
 
 ## Usage
+
+<InjectKeys>
+
 <Tabs type="framework" items={["Next.js", "React", "Remix"]}>
   <Tab>
   ```tsx filename="app.tsx"
@@ -40,7 +43,7 @@ The `<SignedOut />` component offers authentication checks as a cross-cutting co
 
   function Page() {
     return (
-      <ClerkProvider publishableKey="pk_test_••••••••••••••••••••••••••••••••••">
+      <ClerkProvider publishableKey={{pub_key}}>
         <section>
           <div>
             This content is always visible.
@@ -70,7 +73,7 @@ The `<SignedOut />` component offers authentication checks as a cross-cutting co
 
   function App() {
     return (
-      <ClerkProvider publishableKey="pk_test_••••••••••••••••••••••••••••••••••">
+      <ClerkProvider publishableKey={{pub_key}}>
         <Routes>
         <Route
           path="/"
@@ -116,3 +119,5 @@ The `<SignedOut />` component offers authentication checks as a cross-cutting co
   ```
   </Tab>
 </Tabs>
+
+</InjectKeys>

--- a/docs/integrations/databases/supabase.mdx
+++ b/docs/integrations/databases/supabase.mdx
@@ -56,11 +56,15 @@ Reveal the JWT secret to copy it and then paste it in the **Signing key field** 
 
 To configure your client, you need to set some local environment variables. Assuming a React application, set the following:
 
+<InjectKeys>
+
 ```js filename=".env.local"
-NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY=pk_test_aGFuZHktZ251LTIwLmNsZXJrLmFjY291bnRzLmRldiQ
+NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY={{pub_key}}
 NEXT_PUBLIC_SUPABASE_URL=your-supabase-url
 NEXT_PUBLIC_SUPABASE_KEY=your-supabase-anon-key
 ```
+
+</InjectKeys>
 
 You can find your Frontend API value in the Clerk Dashboard on the **[API keys](https://dashboard.clerk.com/last-active?path=api-keys)** page. It will be the **Publishable key**.
 

--- a/docs/references/react/use-session-list.mdx
+++ b/docs/references/react/use-session-list.mdx
@@ -42,7 +42,7 @@ export default function Home() {
   }
   return (
     <div>
-      <p>Welcome back. You've been here
+      <p>Welcome back. You have been here
       {sessions.length} times before.
       </p>
     </div>

--- a/docs/testing/postman-or-insomnia.mdx
+++ b/docs/testing/postman-or-insomnia.mdx
@@ -33,8 +33,8 @@ Give your template a unique name, such as *'testing-template'*. Set the **Token 
 
 Visit your frontend that is using the same Clerk Application and instance that you want to test. Log in as a user. The user that you log in as will be the user you test with in Postman or Insomnia. You can create several tokens for several different users. Once you have logged in, open your Dev Tools and go to the **Console** tab. Enter the following command:
 
-```
-await window.Clerk.session.getToken({template: '<the template name you chose above>'})
+```js
+  await window.Clerk.session.getToken({template: '<the template name you chose above>'})
 ```
 
 <Images


### PR DESCRIPTION
During the content audit (visually scanning each page), I found inconsistencies and mistakes.

This PR
- adds `<InjectKeys />` where necessary in order to expose publishable keys
- updates text to be consistent across examples
- assigns syntax to a code snippet (was missing one altogether)