### PR TITLE
Update Go imports

### DIFF
--- a/docs/references/go/overview.mdx
+++ b/docs/references/go/overview.mdx
@@ -8,13 +8,13 @@ description: Learn how to integrate Go into your Clerk application.
 Clerk's Go SDK is a thin wrapper over the Clerk Backend API. Add the following import statement:
 
 ```go
-import "github.com/clerk/clerk-sdk-go/clerk"
+import "github.com/clerkinc/clerk-sdk-go/clerk"
 ```
 
 Go doesn't automatically add the module. You can explicitly add it with:
 
 ```go
-$ go get github.com/clerk/clerk-sdk-go
+$ go get github.com/clerkinc/clerk-sdk-go
 ```
 
 ## `Clerk` client


### PR DESCRIPTION
a user wrote into support stating: 
_The Go example page on your main site contains an incorrect URL for the go module "clerk" instead of "clerkinc". This was a headache to figure out and actually fix, as it really gave a confusing error and I had to purge some directories to get Go to forget the mistake. (The GitHub repo Readme has the correct URL)._

changed the import and module to `import "github.com/clerkinc/clerk-sdk-go/clerk"` and `$ go get github.com/clerkinc/clerk-sdk-go`, respectively so it matches the [Go SDK README ](https://github.com/clerk/clerk-sdk-go)