### PR TITLE
Add callout to `OrganizationSwitcher`

### DIFF
--- a/docs/organizations/verify-user-permissions.mdx
+++ b/docs/organizations/verify-user-permissions.mdx
@@ -3,6 +3,12 @@ title: Verify the active user’s permissions
 description: A collection of utility functions and components in order to allow developers to perform authorization checks.
 ---
 
+<Callout type="info">
+  The following authorization checks are predicated on an Organization being selected. Without this, they will likely
+  always evaluate to false by default. Our built-in [`<OrganizationSwitcher/>`](docs/components/organization/organization-switcher)
+  is currently the only way to change this context.
+</Callout>
+
 # Verify the active user’s permissions
 
 Clerk provides two kinds of helpers for authorization:

--- a/docs/organizations/verify-user-permissions.mdx
+++ b/docs/organizations/verify-user-permissions.mdx
@@ -5,8 +5,7 @@ description: A collection of utility functions and components in order to allow 
 
 <Callout type="info">
   The following authorization checks are predicated on an Organization being selected. Without this, they will likely
-  always evaluate to false by default. Our built-in [`<OrganizationSwitcher/>`](docs/components/organization/organization-switcher)
-  is currently the only way to change this context.
+  always evaluate to false by default. Our built-in [`<OrganizationSwitcher/>`](docs/components/organization/organization-switcher) component and `useClerk().setActive({ organization: <orgId> })` method are two available options to handle this.
 </Callout>
 
 # Verify the active user’s permissions

--- a/docs/organizations/verify-user-permissions.mdx
+++ b/docs/organizations/verify-user-permissions.mdx
@@ -3,11 +3,11 @@ title: Verify the active user’s permissions
 description: A collection of utility functions and components in order to allow developers to perform authorization checks.
 ---
 
-<Callout type="info">
-  The following authorization checks are predicated on an Organization being selected. Without this, they will likely
-  always evaluate to false by default. Our built-in [`<OrganizationSwitcher/>`](docs/components/organization/organization-switcher) component is available as a styled option to handle this. For a headless option, our `useClerk()` and `useOrganizationList()` hooks return a `setActive({ organization: <orgId> })` method which can be used in custom components.
-</Callout>
 # Verify the active user’s permissions
+
+<Callout type="info">
+  The following authorization checks are predicated on an organization being selected. Without this, they will likely always evaluate to false by default. Our built-in [`<OrganizationSwitcher/>`](docs/components/organization/organization-switcher) component is available as a styled option to handle this. For a headless option, our `useClerk()` and `useOrganizationList()` hooks return a `setActive({ organization: <orgId> })` method which can be used in custom components.
+</Callout>
 
 Clerk provides two kinds of helpers for authorization:
 

--- a/docs/organizations/verify-user-permissions.mdx
+++ b/docs/organizations/verify-user-permissions.mdx
@@ -5,9 +5,8 @@ description: A collection of utility functions and components in order to allow 
 
 <Callout type="info">
   The following authorization checks are predicated on an Organization being selected. Without this, they will likely
-  always evaluate to false by default. Our built-in [`<OrganizationSwitcher/>`](docs/components/organization/organization-switcher) component and `useClerk().setActive({ organization: <orgId> })` method are two available options to handle this.
+  always evaluate to false by default. Our built-in [`<OrganizationSwitcher/>`](docs/components/organization/organization-switcher) component is available as a styled option to handle this. For a headless option, our `useClerk()` and `useOrganizationList()` hooks return a `setActive({ organization: <orgId> })` method which can be used in custom components.
 </Callout>
-
 # Verify the active user’s permissions
 
 Clerk provides two kinds of helpers for authorization:


### PR DESCRIPTION
### What 

This calls out a critical piece (`OrganizationSwitcher`) in the docs — AFAICT, _"basically roles n permissions will not work unless you also use `OrganizationSwitcher`"_

### Why

I was attempting to use the new roles/permissions functionality, and was very confused by what the docs were laying out, and what I was seeing in my dev app. 

And I only chanced upon this via https://organizations-demo.clerk.app/. 