### PR TITLE
Update custom-signup-signin-pages.mdx

### DIFF
--- a/docs/references/nextjs/custom-signup-signin-pages.mdx
+++ b/docs/references/nextjs/custom-signup-signin-pages.mdx
@@ -37,7 +37,7 @@ export default function Page() {
 
 ### Build your sign-in page
 
-Create a new file that will be used to render the sign-up page. In the file, import the [`<SignIn />`](/docs/components/authentication/sign-in) component from `@clerk/nextjs` and render it.
+Create a new file that will be used to render the sign-in page. In the file, import the [`<SignIn />`](/docs/components/authentication/sign-in) component from `@clerk/nextjs` and render it.
 
 <CodeBlockTabs type="router" options={["App Router", "Pages Router"]}>
 ```tsx filename="app/sign-in/[[...sign-in]]/page.tsx"


### PR DESCRIPTION
A typo error under the section "Build your sign-in page" where it says sign-_up_ which actually should have been sign-**_in_**.