### PR TITLE
"force organizations" guide suggestions

### DIFF
--- a/docs/guides/force-organizations.mdx
+++ b/docs/guides/force-organizations.mdx
@@ -164,7 +164,7 @@ export const CustomOrgSwitcher = () => {
 #### Set an active organization based on the URL
 
 <Callout type="warning">
-  This approach still depends one the `setActive` method which only runs on the client. Due to this limitation, during SSR it is possible that `orgId` from `auth()` returns an incorrect value that does not match the organiaztion id in the URL.
+  This approach still depends on the `setActive` method, which only runs on the client. Due to this limitation, during SSR, it is possible that `orgId` from `auth()` returns an incorrect value that does not match the organization ID in the URL.
 </Callout>
 
 In some cases, you might want to set an active organization based on the URL. For example, if you have a URL like `/organizations/org_123`, you might want to set `org_123` as the active organization.
@@ -206,7 +206,7 @@ export function SyncActiveOrganization() {
 }
 ```
 
-We can now use the helper we created above inside a Layout that is directly inside the Dynamic Route with the `orgId` param.
+Now you can place the `SyncActiveOrganization` helper that you created above in a [layout](https://nextjs.org/docs/app/building-your-application/routing/pages-and-layouts#layouts) and use the layout for all pages that require an active organization. In the example below, the `SyncActiveOrganization` component will run on every page in the `/app/[orgId]` directory.
 
 ```tsx filename="app/[orgId]/layout.tsx"
 
@@ -222,8 +222,6 @@ export default function OrganizationLayout(props: PropsWithChildren) {
   );
 }
 ```
-
-
 
 ### Limit access to users with active organizations only
 
@@ -360,7 +358,7 @@ Now that you have configured your middleware to redirect users to the `/org-sele
 
 #### Limit access using an App Router layout
 
-In Next.js App Router applications, instead of using `authMiddleware`, you also have the option to use a [layout](https://nextjs.org/docs/app/building-your-application/routing/pages-and-layouts#layouts) to limit access to users with active organizations only.
+In Next.js App Router applications, instead of using `authMiddleware`, you also have the option to use a layout to limit access to users with active organizations only.
 
 In the example below, a component called `RequiredActiveOrgLayout` is created. This component will be used as a layout for all pages that require an active organization. If the user has an active organization, the route the user is visting will be rendered. If the user does not have an active organization, the organization selection page will be rendered.
 

--- a/docs/guides/force-organizations.mdx
+++ b/docs/guides/force-organizations.mdx
@@ -21,7 +21,7 @@ description: Learn how to hide personal accounts and force organizations in your
   - Limit access to users with active organizations only
 </TutorialHero>
 
-# Force organization-only accounts in your app
+# Hide personal accounts and force organizations
 
 In this guide, you will learn how to hide a user's "personal account" in order to appear as if they only have an organization account. This is useful for applications that are built for organizations only, such as B2B applications.
 

--- a/docs/guides/force-organizations.mdx
+++ b/docs/guides/force-organizations.mdx
@@ -1,86 +1,130 @@
 ---
-title: Avoid personal account and force organizations in your app
-description: Learn how to avoid personal account and force organizations in your app
+title: Hide personal accounts and force organizations
+description: Learn how to hide personal accounts and force organizations in your Clerk application.
 ---
 
 <TutorialHero
-    beforeYouStart={[
-        {
-            title: "Set up a Next.js + Clerk application",
-            link: "https://clerk.com/docs/quickstarts/nextjs"
-        },
-        {
-            title: "Enable organizations for your instance",
-            link: "https://clerk.com/docs/organizations/overview"
-        }
-    ]}
+  beforeYouStart={[
+    {
+      title: "Set up a Next.js + Clerk application",
+      link: "https://clerk.com/docs/quickstarts/nextjs"
+    },
+    {
+      title: "Enable organizations for your instance",
+      link: "https://clerk.com/docs/organizations/overview"
+    }
+  ]}
 >
-    - Remove Personal Account from `<OrganizationList/>` and `<OrganizationSwitcher/>`.
-    - Set an active organization with `setActive`.
-    - Limit access for users with active organizations only.
+  - Hide personal accounts from UI components
+  - Detect an active organization
+  - Set an active organization
+  - Limit access to users with active organizations only
 </TutorialHero>
 
-<Callout type="info">
-    A user's personal account cannot be disabled. It can only be hidden.
-</Callout>
+# Force organization-only accounts in your app
+
+In this guide, you will learn how to hide a user's "personal account" in order to appear as if they only have an organization account. This is useful for applications that are built for organizations only, such as B2B applications.
+
+This guide will be written for Next.js applications using App Router, but the same concepts can be applied to any application using Clerk.
 
 <Steps>
 
-### Remove Personal Account from UI components
+### Hide personal accounts from UI components
 
-Our prebuilt UI components can accept props in order to hide any reference to a users personal account. Such components are [`<OrganizationList />`](/docs/components/organization/organization-list) and [`<OrganizationSwitcher />`](/docs/components/organization/organization-switcher). Both of them accept the `hidePersonal` props which accepts a boolean. For the case of forcing organizations you should pass `true` to this prop.
+To begin forcing organizations in your application, you need to remove a user's personal account from the UI. A user's personal account cannot be disabled; it can only be hidden. 
 
-<Tabs type="router" items={["OrganizationList", "OrganizationSwitcher"]}>
-    <Tab>
-```tsx
-import { OrganizationList } from '@clerk/nextjs'
+If you have an application set up to use organizations, you might have the [`<OrganizationList />`](/docs/components/organization/organization-list) and [`<OrganizationSwitcher />`](/docs/components/organization/organization-switcher) components in your application. These components will show a user's personal account by default, but you can hide it by passing the `hidePersonal` prop.
 
-export default function OrganizationListPage() {
-  return (
-    <OrganizationList
-        hidePersonal={true}
-        {...}
-    />
-  );
-};
-```
-    </Tab>
+<Tabs items={["<OrganizationList />", "<OrganizationSwitcher />"]}>
+  <Tab>
+    ```tsx filename="app/organization-list/[[...organization-list]]/page.tsx" {6}
+    import { OrganizationList } from '@clerk/nextjs'
 
-    <Tab>
-```tsx
-import { OrganizationSwitcher } from '@clerk/nextjs'
+    export default function OrganizationListPage() {
+      return (
+        <OrganizationList
+          hidePersonal={true}
+        />
+      );
+    };
+    ```
+  </Tab>
 
-export default function Sidebar() {
-  return (
-    <OrganizationSwitcher
-        hidePersonal={true}
-        {...}
-    />
-  );
-};
-```
-    </Tab>
+  <Tab>
+    ```tsx filename="app/sidebar.tsx" {5}
+    import { OrganizationSwitcher } from '@clerk/nextjs'
+
+    export default function Sidebar() {
+      return (
+        <OrganizationSwitcher
+          hidePersonal={true}
+        />
+      );
+    };
+    ```
+  </Tab>
 </Tabs>
 
-### How to set an active organization
+### Detect and set an active organization
 
-<Callout type="info">
-    Setting an active organization can only be performed in the client
+With Clerk, a user can have many organization memberships, but only one of them can be active at a time. 
+
+#### Detect an active organization
+
+A session will always include an `organizationId` via the [`Authentication` object](/docs/references/nextjs/authentication-object#example-with-active-organization). This can be used to detect if a user has an active organization.
+
+<Tabs items={["App Router Server Component", "App Router Client Component"]}>
+  <Tab>
+
+    The [`auth()`](/docs/references/nextjs/auth) helper function can be used to get the `organizationId` from the session *server-side*. If the `organizationId` is `null`, then the user does not have an active organization.
+
+    ```tsx
+    import { auth } from '@clerk/nextjs/server'
+
+    export default function Layout() {
+      const { orgId } = auth();
+
+      const hasActiveOrg = orgId !== null;
+      ...
+    }
+    ```
+  </Tab>
+
+  <Tab>
+
+    The [`useAuth()`](/docs/references/react/use-auth) hook can be used to get the `organizationId` from the session *client-side*. If the `organizationId` is `null`, then the user does not have an active organization.
+  
+    ```tsx
+    "use client"
+    import { useAuth } from '@clerk/nextjs'
+
+    export default function Layout() {
+      const { orgId } = useAuth();
+
+      const hasActiveOrg = orgId !== null;
+      ...
+    }
+    ```
+  </Tab>
+</Tabs>
+
+#### Set an active organization
+
+In the case of [Clerk components](/docs/components/overview), an organization will *automatically* be set as active each time the user creates an organization, accepts an invitation, or selects a membership from the organization switcher. In the case of custom flows, you will need to provide the logic for setting an organization as active. Don't worry, Clerk's [`useOrganizationList`](/docs/hooks/use-organization-list) hook provides a [`setActive`](/docs/references/react/use-organization-list) helper function to help you with this.
+
+In the example below, a custom organization switcher is created. It allows a user to select an organization from a list of their memberships. The `useOrganizationList()` hook is used to fetch a list of the user's memberships, and the `setActive` helper function is used to set the selected organization as active.
+
+<Callout type="warning">
+  Setting an active organization can only be performed client-side.
 </Callout>
 
-With clerk, a user can have many organization memberships. That means they can could have joined both Organization A and Organization B, but only one of them can be active at a time.
-
-Clerk UI Components will automatically set an organization as active each time the user creates an organization, accepts an invitation or selects a membership from the switcher. For custom flows when developers want to set an organization as active you can use the [`setActive`](#) utility
-
-<Tabs type="router" items={["Custom flow with setActive", "Sync with url with setActive"]}>
-    <Tab>
-```tsx
+```tsx filename="app/custom-org-switcher.tsx"
 "use client"
 
 import { useOrganizationList } from "@clerk/nextjs";
 import React from "react";
  
-export const CustomSwitcher = () => {
+export const CustomOrgSwitcher = () => {
   const { isLoaded, setActive, userMemberships } = useOrganizationList({
     userMemberships: {
       infinite: true,
@@ -117,10 +161,12 @@ export const CustomSwitcher = () => {
 };
 
 ```
-    </Tab>
 
-    <Tab>
-```tsx filename="app/[orgId]/sync-active-organization.tsx"
+#### Set an active organization based on the URL
+
+In some cases, you might want to set an active organization based on the URL. For example, if you have a URL like `/organizations/org_123`, you might want to set `org_123` as the active organization. In this case, you can use Next.js's [`useParams()`](https://nextjs.org/docs/app/api-reference/functions/use-params) hook to get the organization ID from the URL, and then use the `setActive` helper function to set the organization as active.
+
+```tsx filename="app/utils/sync-active-organization.tsx"
 "use client"
 
 import { useEffect } from "react"
@@ -128,18 +174,24 @@ import { redirect, useParams } from "next/navigation"
 import { useAuth, useOrganizationList } from "@clerk/nextjs"
 
 export function SyncActiveOrganization() {
-  const { orgId: urlOrgId } = useParams() as { orgId: string }
-  const { orgId } = useAuth()
   const { setActive, isLoaded } = useOrganizationList()
+
+  // Get the organization ID from the session
+  const { orgId } = useAuth()
+
+  // Get the organization ID from the URL
+  const { orgId: urlOrgId } = useParams() as { orgId: string }
 
   useEffect(() => {
     if (!isLoaded) return
 
+    // If the org ID in the URL is not valid, redirect to the homepage
     if (!urlOrgId?.startsWith("org_")) {
       redirect("/")
       return
     }
 
+    // If the org ID in the URL is not the same as the org ID in the session (the active organization), set the active organization to be the org ID from the URL
     if (urlOrgId && urlOrgId !== orgId) {
       void setActive({ organization: urlOrgId })
     }
@@ -148,134 +200,116 @@ export function SyncActiveOrganization() {
   return null
 }
 ```
-    </Tab>
-</Tabs>
 
-### Detect an active organization
+### Limit access to users with active organizations only
 
-A session will always include an organizationId via the [`AuthenticationObject`](/docs/references/nextjs/authentication-object#example-with-active-organization), we can use this in order to detect if a user has an "active organization".
+Now that you have hidden personal accounts from the UI and can detect and set an active organization, you can limit access to users with active organizations only.
 
-<Tabs type="router" items={["App Router Server Component", "App Router Client Component"]}>
-    <Tab>
-```tsx
-import { auth } from '@clerk/nextjs/server'
+It's possible for a user to be logged in, but not have an active organization. This can happen in two cases:
+  - The user created an account and hasn't created an organization yet
+  - The user joined or created multiple organizations, and left or deleted the active organization
 
-export default function Layout() {
-  const { orgId } = auth()
-  const hasActiveOrg = orgId !== null
-  ...
-}
-```
-    </Tab>
+Based on your use case, you can decide to limit users either in the entire app or a specific part of it. For example, a B2B application might need to limit access to only users with an active organization, whereas a B2B2C application might limit only the `/dashboard` path to users with an active organization.
 
-    <Tab>
-```tsx
-"use client"
-import { useAuth } from '@clerk/nextjs'
+#### Limit the entire application to only users with active organizations
 
-export default function Layout() {
-  const { orgId } = useAuth()
-  const hasActiveOrg = orgId !== null
-  ...
-}
-```
-    </Tab>
-</Tabs>
+In Next.js App Router applications, you can use a [layout](https://nextjs.org/docs/app/building-your-application/routing/pages-and-layouts#layouts) to limit the entire application to only users with active organizations.
 
-
-### Limit access for users with active organizations only
-
-<Callout type="info">
-  **How users can end up in this state ?**
-  - User just created an account, not by accepting an invitation, and hasn’t created an organization yet
-  - User has joined or created multiple organizations and leaves or deletes the active organization. 
-</Callout>
-
-Based on your usecase you can either decide to limit users in the entire app or a specific part of it. For example a B2B application might need to limit users with active organization for the entire app, whereas a B2B2C application would only limit the `/dashboard` path to users with active organization.
-
-We can use the [`authMiddleware`](/docs/references/nextjs/auth-middleware) or we can use an `App Router Layout` to limit our entire application for users with an active organization.
-
-<Tabs type="router" items={["App Router", "Pages Router"]}>
-    <Tab>
+In the example below, a component called `RequiredActiveOrgLayout` is created. This component will be used as a layout for all pages that require an active organization. If the user has an active organization, the children will be rendered. If the user does not have an active organization, the organization selection page will be rendered.
 
 ```tsx filename="app/(with-active-organization)/layout.tsx"
-import { OrganizationList } from "@clerk/nextjs"
-import { auth } from "@clerk/nextjs/server"
-import { PropsWithChildren } from "react"
+  import { OrganizationList } from "@clerk/nextjs"
+  import { auth } from "@clerk/nextjs/server"
+  import { PropsWithChildren } from "react"
 
-export default function RequiredActiveOrgLayout(props: PropsWithChildren) {
-  const { orgId } = auth()
+  export default function RequiredActiveOrgLayout(props: PropsWithChildren) {
+    // Get the organization ID from the session
+    const { orgId } = auth()
 
-  if (orgId) {
-    return props.children
-  }
-
-  return (
-    <section>
-      <h1>Welcome</h1>
-      <p>
-        This part of the application requires the user to select an
-        organization in order to proceed. If you are not part of an
-        organization, you can accept an invitation or create your own
-        organization
-      </p>
-      <OrganizationList hidePersonal={true} />
-    </section>
-  )
-}
-```
-
-    </Tab>
-
-    <Tab>
-
-    See the complete example of the middleware script ([here](/docs/references/nextjs/auth-middleware#use-after-auth-for-fine-grained-control))
-```tsx filename="middleware.ts"
-import { authMiddleware, redirectToSignIn } from '@clerk/nextjs';
- 
-export default authMiddleware({
-  afterAuth(auth, req, evt) {
-    ...
-    // Redirect logged in users to organization selection page if they are not active in an organization
-    if(auth.userId && !auth.orgId && req.nextUrl.pathname !== "/org-selection"){
-      const searchParams = new URLSearchParams({
-        redirectUrl: req.url
-      })
-      const orgSelection = new URL(`/org-selection?${searchParams.toString()}`, req.url);
-      return NextResponse.redirect(orgSelection)
+    // If the user has an active organization, render the children
+    if (orgId) {
+      return props.children
     }
-    ...
+
+    // If the user does not have an active organization, render the organization selection page
+    return (
+      <section>
+        <h1>Welcome to the Organization Selection page.</h1>
+        <p>
+          This part of the application requires the user to select an
+          organization in order to proceed. If you are not part of an
+          organization, you can accept an invitation or create your own
+          organization.
+        </p>
+        <OrganizationList hidePersonal={true} />
+      </section>
+    )
   }
-});
 ```
 
-```tsx filename="pages/org-selection.tsx"
-import { OrganizationList } from "@clerk/nextjs"
-import { useRouter } from "next/router";
+In Next.js Pages Router applications, Clerk's [`authMiddleware`](/docs/references/nextjs/auth-middleware) helper can be used to limit the entire application to only user's with an active organization.
 
-export default function OrganizationSelection() {
-  const { query } = useRouter()
-  return (
-    <section>
-      <h1>Welcome</h1>
-      <p>
-        This part of the application requires the user to select an
-        organization in order to proceed. If you are not part of an
-        organization, you can accept an invitation or create your own
-        organization
-      </p>
-      <OrganizationList
-        hidePersonal={true}
-        afterCreateOrganizationUrl={query.redirectUrl) ?? "/"}
-        afterSelectOrganizationUrl={query.redirectUrl) ?? "/"}
-      />
-    </section>
-  )
-}
-```
-    </Tab>
+This following example will show you how to configure the [`authMiddleware`](/docs/references/nextjs/auth-middleware) helper to redirect users to the `/org-selection` page if they are not active in an organization.
+
+<Tabs items={["Middleware", "Organization Selection page"]}>
+  <Tab>
+    ```tsx filename="middleware.ts"
+    import { authMiddleware, redirectToSignIn } from '@clerk/nextjs';
+
+    export default authMiddleware({
+      afterAuth(auth, req, evt) {
+        ...
+        // Redirect logged in users to organization selection page if they are not active in an organization
+        if(auth.userId && !auth.orgId && req.nextUrl.pathname !== "/org-selection"){
+          const searchParams = new URLSearchParams({
+            redirectUrl: req.url
+          })
+
+          const orgSelection = new URL(`/org-selection?${searchParams.toString()}`, req.url);
+
+          return NextResponse.redirect(orgSelection)
+        }
+        ...
+      }
+    });
+    ```
+  </Tab>
+
+  <Tab>
+    ```tsx filename="pages/org-selection.tsx"
+    import { OrganizationList } from "@clerk/nextjs"
+    import { useRouter } from "next/router";
+
+    export default function OrganizationSelection() {
+      const { query } = useRouter();
+
+      return (
+        <section>
+          <h1>Welcome to the Organization Selection page.</h1>
+          <p>
+            This part of the application requires the user to select an
+            organization in order to proceed. If you are not part of an
+            organization, you can accept an invitation or create your own
+            organization.
+          </p>
+          <OrganizationList
+            hidePersonal={true}
+            afterCreateOrganizationUrl={query.redirectUrl ?? "/"}
+            afterSelectOrganizationUrl={query.redirectUrl ?? "/"}
+          />
+        </section>
+      )
+    }
+    ```
+  </Tab>
 </Tabs>
+
+#### Limit parts of an application to only users with active organizations
+
+TODO: Did we want to add a section here with example functions/components for limiting specific parts of an application?
 
 </Steps>
 
 ## Finished 🎉
+
+TODO.

--- a/docs/guides/force-organizations.mdx
+++ b/docs/guides/force-organizations.mdx
@@ -163,6 +163,10 @@ export const CustomOrgSwitcher = () => {
 
 #### Set an active organization based on the URL
 
+<Callout type="warning">
+  This approach still depends one the `setActive` method which only runs on the client. Due to this limitation, during SSR it is possible that `orgId` from `auth()` returns an incorrect value that does not match the organiaztion id in the URL.
+</Callout>
+
 In some cases, you might want to set an active organization based on the URL. For example, if you have a URL like `/organizations/org_123`, you might want to set `org_123` as the active organization.
 
 In the example below, a component called `SyncActiveOrganization` is created. The Next.js [`useParams()`](https://nextjs.org/docs/app/api-reference/functions/use-params) hook is used to get the organization ID from the URL, and then the `setActive` method is used to set the organization as active.
@@ -175,32 +179,51 @@ import { redirect, useParams } from "next/navigation"
 import { useAuth, useOrganizationList } from "@clerk/nextjs"
 
 export function SyncActiveOrganization() {
-  const { setActive, isLoaded } = useOrganizationList()
+  const { setActive, isLoaded } = useOrganizationList();
 
   // Get the organization ID from the session
-  const { orgId } = useAuth()
+  const { orgId } = useAuth();
 
   // Get the organization ID from the URL
-  const { orgId: urlOrgId } = useParams() as { orgId: string }
+  const { orgId: urlOrgId } = useParams() as { orgId: string };
 
   useEffect(() => {
-    if (!isLoaded) return
+    if (!isLoaded) return;
 
     // If the org ID in the URL is not valid, redirect to the homepage
     if (!urlOrgId?.startsWith("org_")) {
-      redirect("/")
-      return
+      redirect("/");
+      return;
     }
 
     // If the org ID in the URL is not the same as the org ID in the session (the active organization), set the active organization to be the org ID from the URL
     if (urlOrgId && urlOrgId !== orgId) {
-      void setActive({ organization: urlOrgId })
+      void setActive({ organization: urlOrgId });
     }
   }, [orgId, isLoaded, setActive, urlOrgId])
 
-  return null
+  return null;
 }
 ```
+
+We can now use the helper we created above inside a Layout that is directly inside the Dynamic Route with the `orgId` param.
+
+```tsx filename="app/[orgId]/layout.tsx"
+
+import { type PropsWithChildren } from "react"
+import { SyncActiveOrganization } from '../utils/sync-active-organization'
+
+export default function OrganizationLayout(props: PropsWithChildren) {
+  return (
+    <>
+      <SyncActiveOrganization/>
+      {props.children}
+    </>
+  );
+}
+```
+
+
 
 ### Limit access to users with active organizations only
 
@@ -252,7 +275,12 @@ To limit access to a specific part of the application, you can check if the path
     afterAuth(auth, req, evt) {
       ...
       // Redirect logged in users to organization selection page if they are not active in an organization
-      if(auth.userId && !auth.orgId && req.nextUrl.pathname !== "/dashboard/org-selection"){
+      if(
+        auth.userId &&
+        !auth.orgId &&
+        req.nextUrl.pathname.startsWith('/dashboard') && 
+        req.nextUrl.pathname !== "/dashboard/org-selection"
+        ){
       const searchParams = new URLSearchParams({
         redirectUrl: req.url
       })
@@ -274,10 +302,11 @@ Now that you have configured your middleware to redirect users to the `/org-sele
     "use client"
 
     import { OrganizationList } from "@clerk/nextjs"
-    import { useRouter } from "next/router";
+    import { useSearchParams } from "next/navigation";
 
     export default function OrganizationSelection() {
-      const { query } = useRouter();
+      const searchParams = useSearchParams();
+      const redirectUrl = searchParams.get('redirectUrl') ?? "/";
 
       return (
         <section>
@@ -290,8 +319,8 @@ Now that you have configured your middleware to redirect users to the `/org-sele
           </p>
           <OrganizationList
             hidePersonal={true}
-            afterCreateOrganizationUrl={query.redirectUrl ?? "/"}
-            afterSelectOrganizationUrl={query.redirectUrl ?? "/"}
+            afterCreateOrganizationUrl={redirectUrl}
+            afterSelectOrganizationUrl={redirectUrl}
           />
         </section>
       )
@@ -306,6 +335,7 @@ Now that you have configured your middleware to redirect users to the `/org-sele
 
     export default function OrganizationSelection() {
       const { query } = useRouter();
+      const redirectUrl = query.redirectUrl ?? "/"
 
       return (
         <section>
@@ -318,8 +348,8 @@ Now that you have configured your middleware to redirect users to the `/org-sele
           </p>
           <OrganizationList
             hidePersonal={true}
-            afterCreateOrganizationUrl={query.redirectUrl ?? "/"}
-            afterSelectOrganizationUrl={query.redirectUrl ?? "/"}
+            afterCreateOrganizationUrl={redirectUrl}
+            afterSelectOrganizationUrl={redirectUrl}
           />
         </section>
       )

--- a/docs/guides/force-organizations.mdx
+++ b/docs/guides/force-organizations.mdx
@@ -1,6 +1,6 @@
 ---
-title: Hide personal accounts and force organizations
-description: Learn how to hide personal accounts and force organizations in your Clerk application.
+title: Hide Personal Accounts and force organizations
+description: Learn how to hide Personal Accounts and force organizations in your Clerk application.
 ---
 
 <TutorialHero
@@ -15,25 +15,25 @@ description: Learn how to hide personal accounts and force organizations in your
     }
   ]}
 >
-  - Hide personal accounts from UI components
+  - Hide Personal Accounts from UI components
   - Detect an active organization
   - Set an active organization
   - Limit access to users with active organizations only
 </TutorialHero>
 
-# Hide personal accounts and force organizations
+## Introduction
 
-In this guide, you will learn how to hide a user's "personal account" in order to appear as if they only have an organization account. This is useful for applications that are built for organizations only, such as B2B applications.
+In this guide, you will learn how to hide a user's Personal Account in order to appear as if they only have access to organizations. You will also learn how to limit access to your application to only users with active organizations, further enforcing organization-centric access. This is useful for applications that are built for organizations only, such as B2B applications.
 
 This guide will be written for Next.js applications using App Router, but the same concepts can be applied to any application using Clerk.
 
 <Steps>
 
-### Hide personal accounts from UI components
+### Hide Personal Accounts from UI components
 
-To begin forcing organizations in your application, you need to remove a user's personal account from the UI. A user's personal account cannot be disabled; it can only be hidden. 
+To begin forcing organizations in your application, you need to remove a user's Personal Account from the UI. A user's Personal Account cannot be disabled; it can only be hidden. 
 
-If you have an application set up to use organizations, you might have the [`<OrganizationList />`](/docs/components/organization/organization-list) and [`<OrganizationSwitcher />`](/docs/components/organization/organization-switcher) components in your application. These components will show a user's personal account by default, but you can hide it by passing the `hidePersonal` prop.
+If you have an application set up to use organizations, you might have the [`<OrganizationList />`](/docs/components/organization/organization-list) and [`<OrganizationSwitcher />`](/docs/components/organization/organization-switcher) components in your application. These components will show a user's Personal Account by default, but you can hide it by passing the `hidePersonal` prop.
 
 <Tabs items={["<OrganizationList />", "<OrganizationSwitcher />"]}>
   <Tab>
@@ -71,12 +71,12 @@ With Clerk, a user can have many organization memberships, but only one of them 
 
 #### Detect an active organization
 
-A session will always include an `organizationId` via the [`Authentication` object](/docs/references/nextjs/authentication-object#example-with-active-organization). This can be used to detect if a user has an active organization.
+A session will always include an `orgId` via the [`Authentication` object](/docs/references/nextjs/authentication-object#example-with-active-organization). This can be used to detect if a user has an active organization.
 
 <Tabs items={["App Router Server Component", "App Router Client Component"]}>
   <Tab>
 
-    The [`auth()`](/docs/references/nextjs/auth) helper function can be used to get the `organizationId` from the session *server-side*. If the `organizationId` is `null`, then the user does not have an active organization.
+    The [`auth()`](/docs/references/nextjs/auth) helper function can be used to get the `orgId` from the session *server-side*. If the `orgId` is `null`, then the user does not have an active organization.
 
     ```tsx
     import { auth } from '@clerk/nextjs/server'
@@ -92,7 +92,7 @@ A session will always include an `organizationId` via the [`Authentication` obje
 
   <Tab>
 
-    The [`useAuth()`](/docs/references/react/use-auth) hook can be used to get the `organizationId` from the session *client-side*. If the `organizationId` is `null`, then the user does not have an active organization.
+    The [`useAuth()`](/docs/references/react/use-auth) hook can be used to get the `orgId` from the session *client-side*. If the `orgId` is `null`, then the user does not have an active organization.
   
     ```tsx
     "use client"
@@ -110,9 +110,9 @@ A session will always include an `organizationId` via the [`Authentication` obje
 
 #### Set an active organization
 
-In the case of [Clerk components](/docs/components/overview), an organization will *automatically* be set as active each time the user creates an organization, accepts an invitation, or selects a membership from the organization switcher. In the case of custom flows, you will need to provide the logic for setting an organization as active. Don't worry, Clerk's [`useOrganizationList`](/docs/hooks/use-organization-list) hook provides a [`setActive`](/docs/references/react/use-organization-list) helper function to help you with this.
+In the case of [Clerk components](/docs/components/overview), an organization will *automatically* be set as active each time the user creates an organization, accepts an invitation, or selects a membership from the organization switcher. In the case of custom flows, you will need to provide the logic for setting an organization as active. Don't worry, Clerk's [`useOrganizationList`](/docs/hooks/use-organization-list) hook provides a [`setActive`](/docs/references/react/use-organization-list) method to help you with this.
 
-In the example below, a custom organization switcher is created. It allows a user to select an organization from a list of their memberships. The `useOrganizationList()` hook is used to fetch a list of the user's memberships, and the `setActive` helper function is used to set the selected organization as active.
+In the example below, a custom organization switcher is created. It allows a user to select an organization from a list of their memberships. The `useOrganizationList()` hook is used to fetch a list of the user's memberships, and the `setActive` method is used to set the selected organization as active.
 
 <Callout type="warning">
   Setting an active organization can only be performed client-side.
@@ -122,7 +122,6 @@ In the example below, a custom organization switcher is created. It allows a use
 "use client"
 
 import { useOrganizationList } from "@clerk/nextjs";
-import React from "react";
  
 export const CustomOrgSwitcher = () => {
   const { isLoaded, setActive, userMemberships } = useOrganizationList({
@@ -164,7 +163,9 @@ export const CustomOrgSwitcher = () => {
 
 #### Set an active organization based on the URL
 
-In some cases, you might want to set an active organization based on the URL. For example, if you have a URL like `/organizations/org_123`, you might want to set `org_123` as the active organization. In this case, you can use Next.js's [`useParams()`](https://nextjs.org/docs/app/api-reference/functions/use-params) hook to get the organization ID from the URL, and then use the `setActive` helper function to set the organization as active.
+In some cases, you might want to set an active organization based on the URL. For example, if you have a URL like `/organizations/org_123`, you might want to set `org_123` as the active organization.
+
+In the example below, a component called `SyncActiveOrganization` is created. The Next.js [`useParams()`](https://nextjs.org/docs/app/api-reference/functions/use-params) hook is used to get the organization ID from the URL, and then the `setActive` method is used to set the organization as active.
 
 ```tsx filename="app/utils/sync-active-organization.tsx"
 "use client"
@@ -203,19 +204,135 @@ export function SyncActiveOrganization() {
 
 ### Limit access to users with active organizations only
 
-Now that you have hidden personal accounts from the UI and can detect and set an active organization, you can limit access to users with active organizations only.
+Now that you have hidden Personal Accounts from the UI and can detect and set an active organization, you can limit access to your application to users with active organizations only. This will ensure that users without active organizations cannot access your application.
 
 It's possible for a user to be logged in, but not have an active organization. This can happen in two cases:
   - The user created an account and hasn't created an organization yet
   - The user joined or created multiple organizations, and left or deleted the active organization
 
+There are two ways to limit access to users with active organizations only:
+  - Limit access using the [`authMiddleware`](/docs/references/nextjs/auth-middleware) helper
+  - Limit access using an App Router layout
+
 Based on your use case, you can decide to limit users either in the entire app or a specific part of it. For example, a B2B application might need to limit access to only users with an active organization, whereas a B2B2C application might limit only the `/dashboard` path to users with an active organization.
 
-#### Limit the entire application to only users with active organizations
+#### Limit access using the `authMiddleware` helper
 
-In Next.js App Router applications, you can use a [layout](https://nextjs.org/docs/app/building-your-application/routing/pages-and-layouts#layouts) to limit the entire application to only users with active organizations.
+Clerk's `authMiddleware` helper can be used in both App Router and Pages Router applications to limit access to users with active organizations only. 
 
-In the example below, a component called `RequiredActiveOrgLayout` is created. This component will be used as a layout for all pages that require an active organization. If the user has an active organization, the children will be rendered. If the user does not have an active organization, the organization selection page will be rendered.
+To limit access to the entire application, your middleware can be configured as follows:
+
+```tsx filename="middleware.ts"
+  import { authMiddleware, redirectToSignIn } from '@clerk/nextjs';
+
+  export default authMiddleware({
+    afterAuth(auth, req, evt) {
+      ...
+      // Redirect logged in users to organization selection page if they are not active in an organization
+      if(auth.userId && !auth.orgId && req.nextUrl.pathname !== "/org-selection"){
+        const searchParams = new URLSearchParams({
+          redirectUrl: req.url
+        })
+
+        const orgSelection = new URL(`/org-selection?${searchParams.toString()}`, req.url);
+
+        return NextResponse.redirect(orgSelection)
+      }
+      ...
+    }
+  });
+```
+
+To limit access to a specific part of the application, you can check if the path the user is visiting is the path you want to limit access to. In this example, the `/dashboard` path is limited to users with active organizations only. If the user is not active in an organization, they will be redirected to the `/dashboard/org-selection` page.
+
+```tsx filename="middleware.ts"
+  import { authMiddleware, redirectToSignIn } from '@clerk/nextjs';
+
+  export default authMiddleware({
+    afterAuth(auth, req, evt) {
+      ...
+      // Redirect logged in users to organization selection page if they are not active in an organization
+      if(auth.userId && !auth.orgId && req.nextUrl.pathname !== "/dashboard/org-selection"){
+      const searchParams = new URLSearchParams({
+        redirectUrl: req.url
+      })
+ 
+      const orgSelection = new URL(`/dashboard/org-selection?${searchParams.toString()}`, req.url);
+ 
+      return NextResponse.redirect(orgSelection)
+      }
+      ...
+    }
+  });
+```
+
+Now that you have configured your middleware to redirect users to the `/org-selection` page if they are not active in an organization, you need to create the `/org-selection` page. This page will allow users to select an organization or create their own organization.
+
+<Tabs type="router" items={["App Router", "Pages Router"]}>
+  <Tab>
+    ```tsx filename="app/org-selection/page.tsx"
+    "use client"
+
+    import { OrganizationList } from "@clerk/nextjs"
+    import { useRouter } from "next/router";
+
+    export default function OrganizationSelection() {
+      const { query } = useRouter();
+
+      return (
+        <section>
+          <h1>Welcome to the Organization Selection page.</h1>
+          <p>
+            This part of the application requires the user to select an
+            organization in order to proceed. If you are not part of an
+            organization, you can accept an invitation or create your own
+            organization.
+          </p>
+          <OrganizationList
+            hidePersonal={true}
+            afterCreateOrganizationUrl={query.redirectUrl ?? "/"}
+            afterSelectOrganizationUrl={query.redirectUrl ?? "/"}
+          />
+        </section>
+      )
+    }
+    ```
+  </Tab>
+  
+  <Tab>
+    ```tsx filename="pages/org-selection.tsx"
+    import { OrganizationList } from "@clerk/nextjs"
+    import { useRouter } from "next/router";
+
+    export default function OrganizationSelection() {
+      const { query } = useRouter();
+
+      return (
+        <section>
+          <h1>Welcome to the Organization Selection page.</h1>
+          <p>
+            This part of the application requires the user to select an
+            organization in order to proceed. If you are not part of an
+            organization, you can accept an invitation or create your own
+            organization.
+          </p>
+          <OrganizationList
+            hidePersonal={true}
+            afterCreateOrganizationUrl={query.redirectUrl ?? "/"}
+            afterSelectOrganizationUrl={query.redirectUrl ?? "/"}
+          />
+        </section>
+      )
+    }
+    ```
+  </Tab>
+</Tabs>
+
+#### Limit access using an App Router layout
+
+In Next.js App Router applications, instead of using `authMiddleware`, you also have the option to use a [layout](https://nextjs.org/docs/app/building-your-application/routing/pages-and-layouts#layouts) to limit access to users with active organizations only.
+
+In the example below, a component called `RequiredActiveOrgLayout` is created. This component will be used as a layout for all pages that require an active organization. If the user has an active organization, the route the user is visting will be rendered. If the user does not have an active organization, the organization selection page will be rendered.
 
 ```tsx filename="app/(with-active-organization)/layout.tsx"
   import { OrganizationList } from "@clerk/nextjs"
@@ -247,69 +364,16 @@ In the example below, a component called `RequiredActiveOrgLayout` is created. T
   }
 ```
 
-In Next.js Pages Router applications, Clerk's [`authMiddleware`](/docs/references/nextjs/auth-middleware) helper can be used to limit the entire application to only user's with an active organization.
-
-This following example will show you how to configure the [`authMiddleware`](/docs/references/nextjs/auth-middleware) helper to redirect users to the `/org-selection` page if they are not active in an organization.
-
-<Tabs items={["Middleware", "Organization Selection page"]}>
-  <Tab>
-    ```tsx filename="middleware.ts"
-    import { authMiddleware, redirectToSignIn } from '@clerk/nextjs';
-
-    export default authMiddleware({
-      afterAuth(auth, req, evt) {
-        ...
-        // Redirect logged in users to organization selection page if they are not active in an organization
-        if(auth.userId && !auth.orgId && req.nextUrl.pathname !== "/org-selection"){
-          const searchParams = new URLSearchParams({
-            redirectUrl: req.url
-          })
-
-          const orgSelection = new URL(`/org-selection?${searchParams.toString()}`, req.url);
-
-          return NextResponse.redirect(orgSelection)
-        }
-        ...
-      }
-    });
-    ```
-  </Tab>
-
-  <Tab>
-    ```tsx filename="pages/org-selection.tsx"
-    import { OrganizationList } from "@clerk/nextjs"
-    import { useRouter } from "next/router";
-
-    export default function OrganizationSelection() {
-      const { query } = useRouter();
-
-      return (
-        <section>
-          <h1>Welcome to the Organization Selection page.</h1>
-          <p>
-            This part of the application requires the user to select an
-            organization in order to proceed. If you are not part of an
-            organization, you can accept an invitation or create your own
-            organization.
-          </p>
-          <OrganizationList
-            hidePersonal={true}
-            afterCreateOrganizationUrl={query.redirectUrl ?? "/"}
-            afterSelectOrganizationUrl={query.redirectUrl ?? "/"}
-          />
-        </section>
-      )
-    }
-    ```
-  </Tab>
-</Tabs>
-
-#### Limit parts of an application to only users with active organizations
-
-TODO: Did we want to add a section here with example functions/components for limiting specific parts of an application?
-
 </Steps>
 
 ## Finished 🎉
 
-TODO.
+You have configured your Clerk application to hide personal accounts and enforce organization-centric access. By following this guide, you've learned how to:
+
+- hide Personal Accounts from UI components
+- detect an active organization by using Clerk's `auth()` helper function or `useAuth()` hook
+- set an active organization automatically through Clerk components or manually using the `setActive` method
+- set an active organization based on the URL
+- limit access to your application to only users with active organizations by utilizing Clerk's `authMiddleware` helper or by implementing an App Router layout
+
+Now that you've completed these steps, your application is well-configured for organizational use, providing a streamlined experience for users associated with organizations.

--- a/docs/manifest.json
+++ b/docs/manifest.json
@@ -31,7 +31,7 @@
     },
     [
       ["Implement basic Role Based Access Control with metadata", "/guides/basic-rbac"],
-      ["Avoid personal account and force organizations in your app", "/guides/force-organizations"]
+      ["Hide personal accounts and force organizations", "/guides/force-organizations"]
     ]
   ],
   "---",

--- a/docs/manifest.json
+++ b/docs/manifest.json
@@ -31,7 +31,7 @@
     },
     [
       ["Implement basic Role Based Access Control with metadata", "/guides/basic-rbac"],
-      ["Hide personal accounts and force organizations", "/guides/force-organizations"]
+      ["Hide Personal Accounts and force organizations", "/guides/force-organizations"]
     ]
   ],
   "---",

--- a/docs/organizations/overview.mdx
+++ b/docs/organizations/overview.mdx
@@ -7,6 +7,8 @@ description: Learn about how to create and manage Clerk organizations and their 
 
 Organizations are a way of grouping your application's users. Organizations are shared accounts, useful for project and team leaders—think of GitHub Teams or the different departments of a company. Members of different organizations can usually collaborate across shared resources but might have different levels of access and permissions with different [role](/docs/organizations/overview#roles).
 
+To enable organizations, go to the Clerk Dashboard and navigate to [**Organizations Settings**](https://dashboard.clerk.com/last-active?path=organizations-settings). Select the toggle next to **Enable Organizations**.
+
 There is no limit to the number of organizations a user can be a member of. However, a user can only create up to 100 organizations in a given application instance. All members of an organization can view information about other members in the same organization.
 
 Clerk provides [prebuilt components](/docs/components/overview), [React hooks](/docs/references/react/use-organization), and [APIs](/docs/references/javascript/organization/organization) to help you integrate organizations into your application. Using the [Organizations Backend API](https://clerk.com/docs/reference/backend-api/tag/Organizations), you can provide additional [private and public metadata for the organization](/docs/organizations/metadata) and set custom attributes. 


### PR DESCRIPTION
A lengthy review/update to the Force Organizations guide that is better done in a separate PR rather than cumbersome github code review suggestions.

- reorganizes sections/renames sections to be more clear and overall editorial pass
- adds a section to organizations/overview that explains how to enable organizations.
