### PR TITLE
DOCS-735 fix text to accurately reference sid and sub

### DIFF
--- a/.remarkrc
+++ b/.remarkrc
@@ -4,6 +4,7 @@
     "preset-lint-markdown-style-guide",
     "preset-lint-recommended",
     "frontmatter",
+    ["remark-lint-ordered-list-marker-value", "off"],
     ["remark-lint-frontmatter-schema", {
       "schemas": {
         "./schemas/docs.schema.yml": [

--- a/docs/backend-requests/handling/manual-jwt.mdx
+++ b/docs/backend-requests/handling/manual-jwt.mdx
@@ -24,10 +24,10 @@ There are three ways to obtain your public key:
 2. Using the Frontend API in JSON Web Key Set (JWKS) format at the following endpoint `https://<YOUR_FRONTEND_API>/.well-known/jwks.json`. This can be obtained from the Clerk Dashboard on the [API Keys](https://dashboard.clerk.com/last-active?path=api-keys) page. Scroll down and click on **Advanced** and in the **JWT public key** section, copy the **JWKS URL**.
 
 <Images
-src="/docs/images/backend-requests/jwt-public-key.jpg"
-width={3024}
-height={1650}
-alt="The 'API Keys' page in the Clerk Dashboard. There is a red box around the 'JWT public key' section, with a red arrow pointing to the 'JWKS URL' tab of the code example."
+  src="/docs/images/backend-requests/jwt-public-key.jpg"
+  width={3024}
+  height={1650}
+  alt="The 'API Keys' page in the Clerk Dashboard. There is a red box around the 'JWT public key' section, with a red arrow pointing to the 'JWKS URL' tab of the code example."
 />
 
 3. Using the PEM public key provided in the Clerk Dashboard on the [API Keys](https://dashboard.clerk.com/last-active?path=api-keys) page. Scroll down and click on **Advanced** and in the **JWT public key** section, copy the **PEM public key**. This option should only be used as a fallback for when the first two options are not available.
@@ -41,6 +41,7 @@ To verify the token signature, you should:
 3. The `azp` claim in the Clerk Session JWT stands for authorized parties. If the `azp` claim exists, validate that it equals any of your known origins that are permitted to generate those tokens. This is an extra security check that we highly recommend that you do. Verifying the `azp` claim on the server side ensures that the session token is generated from the expected frontend application. For example, if you are permitting tokens retrieved from `http://localhost:3000`, then the `azp` claim should equal `http://localhost:3000`. You can also pass an array of strings like so: `['http://localhost:4003', 'https://clerk.dev']`. If the `azp` claim does not exist, then you can skip this step.
 
 If the above process is successful, it means that the user is signed in to your application and you can consider them authenticated. You can also retrieve the session ID and user ID out of the token's claims.
+
 </Steps>
 
 ## Example usage
@@ -84,7 +85,7 @@ export default async function (req: NextApiRequest, res: NextApiResponse) {
 ```
 
 {/* TO-DO: add code examples of how to validate the exp and azp claims ?? */}
-If the token is valid, the response will return a JSON object that looks similar to the one below. You can use this to validate the `exp` and `azp` claims, as mentioned in the [steps above](#verify-the-token-signature). Once the token is completely validated, you then have a valid `session` and `user_id` that you can use in your application.
+If the token is valid, the response will return a JSON object that looks similar to the one below. You can use this to validate the `exp` and `azp` claims, as mentioned in the [steps above](#verify-the-token-signature). Once the token is completely validated, you then have a valid session ID (`sid`) and user ID (`sub`) that you can use in your application.
 
 ```json
 {


### PR DESCRIPTION
[DOCS-735](https://linear.app/clerk/issue/DOCS-735/%F0%9F%98%A2-feedback-for-backend-requestshandlingmanual-jwtmanual-jwt) is a user feedback ticket that says "I can decoded token but it doesn't contain user_id."

At [the bottom of the Manual JWT docs](https://clerk.com/docs/backend-requests/handling/manual-jwt#example-usage), it mentions "Once the token is completely validated, you then have a valid `session` and `user_id` that you can use in your application." 
This is not correct; the token includes `sid` and `sub` properties, not `session` and `user_id` properties.
This PR updates the text to be accurate.

And special thank you to matko.klaic for leaving the feedback that incited these changes 💙