### PR TITLE
DOCS-778 differentiate between the component reference and JS reference for the SignIn component

### DIFF
--- a/docs/components/authentication/sign-in.mdx
+++ b/docs/components/authentication/sign-in.mdx
@@ -86,12 +86,66 @@ Below is basic implementation of the `<SignIn />` component. You can use this as
   </Tab>
 
   <Tab>
-    ```js filename="sign-in.js"
-    window.Clerk.mountSignIn(
-      document.getElementById("sign-in")
-    );
-    window.Clerk.openSignIn();
-    ```
+    In the example below, the [`mountSignIn()`](/docs/references/javascript/clerk/sign-in#mount-sign-in) method is used to render the `<SignIn />` component to a `<div>` element with `id="sign-in"`.
+
+    To learn more about the methods available for rendering and controlling the `<SignIn />` component in a JavaScript application, see the [JavaScript reference docs](/docs/references/javascript/clerk/sign-in).
+
+    <InjectKeys>
+
+    <CodeBlockTabs type="npm-script" options={['NPM Module', 'window.Clerk']}>
+      ```typescript
+      import Clerk from '@clerk/clerk-js';
+      import { dark } from "@clerk/themes";
+
+      // Add a <div> element with id="sign-in" to your HTML
+      document.querySelector<HTMLDivElement>('#app')!.innerHTML = `
+        <div
+          id="sign-in"
+        >
+        </div>
+      `;
+
+      const signInComponent = document.querySelector<HTMLDivElement>('#sign-in')!;
+
+      // Initialize Clerk with your Clerk publishable key
+      const clerk = new Clerk(`{{pub_key}}`);
+      await clerk.load();
+
+      clerk.mountSignIn(signInComponent, {
+        appearance: {
+          baseTheme: dark
+        }
+      });
+      ```
+
+      ```html
+      <!-- Add a <div> element with id="sign-in" to your HTML -->
+      <div id="sign-in"></div>
+
+      <script>
+        const script = document.createElement('script');
+        // Set your Clerk publishable key
+        script.setAttribute('data-clerk-publishable-key', `{{pub_key}}`);
+        script.async = true;
+        script.src = `https://[your-domain].clerk.accounts.dev/npm/@clerk/clerk-js@latest/dist/clerk.browser.js`;
+
+        script.addEventListener('load', async function () {
+          await window.Clerk.load();
+
+          const signInComponent = document.querySelector('#sign-in');
+
+          window.Clerk.openSignIn(signInComponent, {
+            appearance: {
+              baseTheme: dark
+            }
+          });
+        });
+        document.body.appendChild(script);
+      </script>
+      ```
+    </CodeBlockTabs>
+
+    </InjectKeys>
   </Tab>  
 </Tabs>
 

--- a/docs/references/javascript/clerk/sign-in.mdx
+++ b/docs/references/javascript/clerk/sign-in.mdx
@@ -20,6 +20,17 @@ The following methods available on an instance of the [`Clerk`](/docs/references
 
 Render the `<SignIn />` component to an HTML `<div>` element.
 
+### `mountSignIn()` properties
+
+```typescript
+function mountSignIn(node: HTMLDivElement, props?: SignInProps): void;
+```
+
+| Name | Type | Description |
+| --- | --- | --- |
+| `node` | [`HTMLDivElement`](https://developer.mozilla.org/en-US/docs/Web/API/HTMLDivElement) | The container `<div>` element used to render in the `<SignIn />` component |
+| `props?` | [`SignInProps`](#sign-in-props) | The properties to pass to the `<SignIn />` component |
+
 ### `mountSignIn()` usage
 
 In the example below, the `<SignIn />` component is rendered to a `<div>` element with `id="sign-in"`. The `<SignIn />` component will be rendered with the default settings specified in your [Clerk Dashboard](https://dashboard.clerk.com).
@@ -81,20 +92,19 @@ In the example below, the `<SignIn />` component is rendered to a `<div>` elemen
 
 </InjectKeys>
 
-### `mountSignIn()` properties
+## `unmountSignIn()`
+
+Unmount and run cleanup on an existing `<SignIn />` component instance.
+
+### `unmountSignIn()` properties
 
 ```typescript
-function mountSignIn(node: HTMLDivElement, props?: SignInProps): void;
+function unmountSignIn(node: HTMLDivElement): void;
 ```
 
 | Name | Type | Description |
 | --- | --- | --- |
-| `node` | [`HTMLDivElement`](https://developer.mozilla.org/en-US/docs/Web/API/HTMLDivElement) | The container `<div>` element used to render in the `<SignIn />` component |
-| `props?` | [`SignInProps`](#sign-in-props) | The properties to pass to the `<SignIn />` component |
-
-## `unmountSignIn()`
-
-Unmount and run cleanup on an existing `<SignIn />` component instance.
+| `node` | [`HTMLDivElement`](https://developer.mozilla.org/en-US/docs/Web/API/HTMLDivElement) | The container `<div>` element with a rendered `<SignIn />` component instance |
 
 ### `unmountSignIn()` usage
 
@@ -145,19 +155,19 @@ Unmount and run cleanup on an existing `<SignIn />` component instance.
   ```
 </CodeBlockTabs>
 
-### `unmountSignIn()` properties
-
-```typescript
-function unmountSignIn(node: HTMLDivElement): void;
-```
-
-| Name | Type | Description |
-| --- | --- | --- |
-| `node` | [`HTMLDivElement`](https://developer.mozilla.org/en-US/docs/Web/API/HTMLDivElement) | The container `<div>` element with a rendered `<SignIn />` component instance |
-
 ## `openSignIn()`
 
 Opens the `<SignIn />` component as an overlay at the root of your HTML `body` element.
+
+### `openSignIn()` properties
+
+```typescript
+function openSignIn(props?: SignInProps): void;
+```
+
+| Name | Type | Desciption |
+| --- | --- | --- |
+| `props?` | [`SignInProps`](#sign-in-props) | The properties to pass to the `<SignIn />` component |
 
 ### `openSignIn()` usage
 
@@ -197,19 +207,15 @@ Opens the `<SignIn />` component as an overlay at the root of your HTML `body` e
   ```
 </CodeBlockTabs>
 
-### `openSignIn()` properties
-
-```typescript
-function openSignIn(props?: SignInProps): void;
-```
-
-| Name | Type | Desciption |
-| --- | --- | --- |
-| `props?` | [`SignInProps`](#sign-in-props) | The properties to pass to the `<SignIn />` component |
-
 ## `closeSignIn()`
 
 Closes the sign in overlay.
+
+### `closeSignIn()` properties
+
+```typescript
+function closeSignIn(): void;
+```
 
 ### `closeSignIn()` usage
 
@@ -248,12 +254,6 @@ Closes the sign in overlay.
   </script>
   ```
 </CodeBlockTabs>
-
-### `closeSignIn()` properties
-
-```typescript
-function closeSignIn(): void;
-```
 
 ## `SignInProps`
 

--- a/docs/references/javascript/clerk/sign-in.mdx
+++ b/docs/references/javascript/clerk/sign-in.mdx
@@ -1,36 +1,48 @@
 ---
 title: <SignIn /> component
-description: The <SignIn /> component renders a UI for signing in users. The functionality of the <SignIn /> component are controlled by the instance settings you specify in your Clerk Dashboard. You can further customize your <SignIn /> component by passing additional properties at the time of rendering.
+description: This reference describes the properties and methods related to Clerk's <SignIn /> component for a JavaScript application.
 ---
 
 # `<SignIn />` component
 
 <Images width={496} height={564} src="/docs/images/ui-components/component-sign_in.svg" alt="Sign in component example" />
 
-The [`<SignIn />`][signin-ref] component renders a UI for signing in users. The functionality of the [`<SignIn />`][signin-ref] component are controlled by the instance settings you specify in your [Clerk Dashboard](https://dashboard.clerk.com). You can further customize your [`<SignIn />`][signin-ref] component by passing additional properties at the time of rendering.
+The [`<SignIn />`](/docs/components/authentication/sign-in) component renders a UI for signing in users. The functionality of the `<SignIn />` component are controlled by the instance settings you specify in your [Clerk Dashboard](https://dashboard.clerk.com), such as [sign-up options](/docs/authentication/configuration/sign-up-options) and [social connections](/docs/authentication/social-connections/overview). You can further customize your `<SignIn />` component by passing additional properties at the time of rendering.
 
-> All of these are methods on [an instance of the `Clerk` class](/docs/references/javascript/clerk/clerk).
+The following methods available on an instance of the [`Clerk`](/docs/references/javascript/clerk/clerk) class are used to render and control the `<SignIn />` component:
+
+- [`mountSignIn()`](#mount-sign-in)
+- [`unmountSignIn()`](#unmount-sign-in)
+- [`openSignIn()`](#open-sign-in)
+- [`closeSignIn()`](#close-sign-in)
 
 ## `mountSignIn()`
 
-Render the [`<SignIn />`][signin-ref] component to an HTML `<div>` element.
+Render the `<SignIn />` component to an HTML `<div>` element.
 
-### Usage
+### `mountSignIn()` usage
+
+In the example below, the `<SignIn />` component is rendered to a `<div>` element with `id="sign-in"`. The `<SignIn />` component will be rendered with the default settings specified in your [Clerk Dashboard](https://dashboard.clerk.com).
+
+<InjectKeys>
 
 <CodeBlockTabs type="npm-script" options={['NPM Module', 'window.Clerk']}>
-  ```typescript {15-19}
+  ```typescript
   import Clerk from '@clerk/clerk-js';
   import { dark } from "@clerk/themes";
 
+  // Add a <div> element with id="sign-in" to your HTML
   document.querySelector<HTMLDivElement>('#app')!.innerHTML = `
     <div
       id="sign-in"
-    ></div>
+    >
+    </div>
   `;
 
   const signInComponent = document.querySelector<HTMLDivElement>('#sign-in')!;
 
-  const clerk = new Clerk('pk_[publishable_key]');
+  // Initialize Clerk with your Clerk publishable key
+  const clerk = new Clerk(`{{pub_key}}`);
   await clerk.load();
 
   clerk.mountSignIn(signInComponent, {
@@ -40,11 +52,14 @@ Render the [`<SignIn />`][signin-ref] component to an HTML `<div>` element.
   });
   ```
 
-  ```html {13-17}
+  ```html
+  <!-- Add a <div> element with id="sign-in" to your HTML -->
   <div id="sign-in"></div>
+
   <script>
     const script = document.createElement('script');
-    script.setAttribute('data-clerk-publishable-key', 'pk_[publishable_key]');
+    // Set your Clerk publishable key
+    script.setAttribute('data-clerk-publishable-key', `{{pub_key}}`);
     script.async = true;
     script.src = `https://[your-domain].clerk.accounts.dev/npm/@clerk/clerk-js@latest/dist/clerk.browser.js`;
 
@@ -64,7 +79,9 @@ Render the [`<SignIn />`][signin-ref] component to an HTML `<div>` element.
   ```
 </CodeBlockTabs>
 
-### Properties
+</InjectKeys>
+
+### `mountSignIn()` properties
 
 ```typescript
 function mountSignIn(node: HTMLDivElement, props?: SignInProps): void;
@@ -72,14 +89,14 @@ function mountSignIn(node: HTMLDivElement, props?: SignInProps): void;
 
 | Name | Type | Description |
 | --- | --- | --- |
-| `node` | [`HTMLDivElement`](https://developer.mozilla.org/en-US/docs/Web/API/HTMLDivElement) | The container `<div>` element used to render in the [`<SignIn />`][signin-ref] component |
-| `props?` | [`SignInProps`](#sign-in-props) | The properties to pass to the [`<SignIn />`][signin-ref] component |
+| `node` | [`HTMLDivElement`](https://developer.mozilla.org/en-US/docs/Web/API/HTMLDivElement) | The container `<div>` element used to render in the `<SignIn />` component |
+| `props?` | [`SignInProps`](#sign-in-props) | The properties to pass to the `<SignIn />` component |
 
 ## `unmountSignIn()`
 
-Unmount and run cleanup on an existing [`<SignIn />`][signin-ref] component instance.
+Unmount and run cleanup on an existing `<SignIn />` component instance.
 
-### Usage
+### `unmountSignIn()` usage
 
 <CodeBlockTabs type="npm-script" options={['NPM Module', 'window.Clerk']}>
   ```typescript {19}
@@ -128,7 +145,7 @@ Unmount and run cleanup on an existing [`<SignIn />`][signin-ref] component inst
   ```
 </CodeBlockTabs>
 
-### Properties
+### `unmountSignIn()` properties
 
 ```typescript
 function unmountSignIn(node: HTMLDivElement): void;
@@ -142,7 +159,7 @@ function unmountSignIn(node: HTMLDivElement): void;
 
 Opens the `<SignIn />` component as an overlay at the root of your HTML `body` element.
 
-### Usage
+### `openSignIn()` usage
 
 <CodeBlockTabs type="npm-script" options={['NPM Module', 'window.Clerk']}>
   ```typescript {7-11}
@@ -180,7 +197,7 @@ Opens the `<SignIn />` component as an overlay at the root of your HTML `body` e
   ```
 </CodeBlockTabs>
 
-### Properties
+### `openSignIn()` properties
 
 ```typescript
 function openSignIn(props?: SignInProps): void;
@@ -194,7 +211,7 @@ function openSignIn(props?: SignInProps): void;
 
 Closes the sign in overlay.
 
-### Usage
+### `closeSignIn()` usage
 
 <CodeBlockTabs type="npm-script" options={['NPM Module', 'window.Clerk']}>
   ```typescript {11}
@@ -232,7 +249,7 @@ Closes the sign in overlay.
   ```
 </CodeBlockTabs>
 
-### Properties
+### `closeSignIn()` properties
 
 ```typescript
 function closeSignIn(): void;
@@ -251,5 +268,3 @@ All props below are optional.
 | `signUpUrl` | `string` | Full URL or path to the sign up page. Use this property to provide the target of the 'Sign Up' link that's rendered. |
 | `afterSignUpUrl` | `string` | The full URL or path to navigate after a successful sign up. |
 | `initialValues` | [`SignInInitialValues`](/docs/references/javascript/types/sign-in-initial-values) | The values used to prefill the sign-in fields with. |
-
-[signin-ref]: /docs/components/authentication/sign-in


### PR DESCRIPTION
[DOCS-778](https://linear.app/clerk/issue/DOCS-778/feedback-for-referencesjavascriptclerksign-in) is a user feedback ticket that states: 

> Pretty confusing that this component is only documented under the JavaScript SDK and not under React, Next.js etc. Of course, these are also based on JavaScript, but my first instinct is to look in the Next.js docs rather than JavaScript, as there are often more specialised solutions for these frameworks.
I only noticed this change in the docs because a new employee couldn't find this component without me telling him about it.

This PR serves to more clearly differentiate between the two references. In this PR:

[SignIn component reference preview]()
- adds the JS reference examples for mounting the SignIn component to the component reference docs (consistency)
- adds copy that references and leads users to the JS reference docs
    - "To learn more about the methods available for rendering and controlling the `<SignIn />` component in a JavaScript application, see the [JavaScript reference docs](/docs/references/javascript/clerk/sign-in)."

[SignIn JavaScript reference preview]()
- reorders sections: properties of a method should get introduced before usage
- removes duplicate headings
- removes duplicate links on a page (removes the [sign-in-ref] reference link in order to dedupe the reference link)
- adds comments to the examples for better clarity