### PR TITLE
fix organization typos

### DIFF
--- a/docs/references/backend/organization/get-organization-membership-list.mdx
+++ b/docs/references/backend/organization/get-organization-membership-list.mdx
@@ -25,7 +25,7 @@ const memberships = await clerkClient.organizations.getOrganizationMembershipLis
 
 ### `getOrganizationMembershipList({ limit })`
 
-Retrieves orgnanization membership list that is filtered by the number of results.
+Retrieves organization membership list that is filtered by the number of results.
 
 ```tsx
 const organizationId = 'my-organization-id';
@@ -39,7 +39,7 @@ const memberships = await clerkClient.organizations.getOrganizationMembershipLis
 
 ### `getOrganizationMembershipList({ offset })`
 
-Retrieves orgnanization membership list that is filtered by the number of results to skip.
+Retrieves organizaiton membership list that is filtered by the number of results to skip.
 
 ```tsx
 const organizationId = 'my-organization-id';

--- a/docs/references/backend/organization/get-pending-organization-invitation-list.mdx
+++ b/docs/references/backend/organization/get-pending-organization-invitation-list.mdx
@@ -25,7 +25,7 @@ const invitations = await clerkClient.organizations.getPendingOrganizationInvita
 
 ### `getPendingOrganizationInvitationList({ limit })`
 
-Retrieves orgnanization invitation list that is filtered by the number of results.
+Retrieves organization invitation list that is filtered by the number of results.
 
 ```tsx
 const organizationId = 'my-organization-id';
@@ -39,7 +39,7 @@ const invitations = await clerkClient.organizations.getPendingOrganizationInvita
 
 ### `getPendingOrganizationInvitationList({ offset })`
 
-Retrieves orgnanization invitation list that is filtered by the number of results to skip.
+Retrieves organization invitation list that is filtered by the number of results to skip.
 
 ```tsx
 const organizationId = 'my-organization-id';


### PR DESCRIPTION
[DOCS-5155](https://linear.app/clerk/issue/DOCS-5155/fix-a-typo) points out a typo on the [webhooks](https://clerk.com/docs/integrations/webhooks?_gl=1*ymomuh*_gcl_au*NTAyODk3MTk3LjE3MDMyNDYwNDY.*_ga*MTA0MTczOTc4My4xNzAzMjQ2MDQ2*_ga_1WMF5X234K*MTcwNDM1MjkzMC4zLjEuMTcwNDM1NDYxOC4wLjAuMA) page.

I couldn't find it, but ctrl + f'ing "orgna" I found other typos.