### PR TITLE
chore: Add Bun.js to add @clerk package to different projects.

### DIFF
--- a/docs/quickstarts/expo.mdx
+++ b/docs/quickstarts/expo.mdx
@@ -17,7 +17,7 @@ Learn how to use Clerk to quickly and easily add secure authentication and user 
 
 Once you have an Expo application ready, you need to install Clerk's Expo SDK.
 
-<CodeBlockTabs type="installer" options={["npm", "yarn", "pnpm"]}>
+<CodeBlockTabs type="installer" options={["npm", "yarn", "pnpm", "bun"]}>
   ```bash filename="terminal"
   npm install @clerk/clerk-expo
   ```
@@ -28,6 +28,10 @@ Once you have an Expo application ready, you need to install Clerk's Expo SDK.
 
   ```bash filename="terminal"
   pnpm add @clerk/clerk-expo
+  ```
+
+  ```bash filename="terminal"
+  bun add @clerk/clerk-expo
   ```
 </CodeBlockTabs>
 

--- a/docs/quickstarts/fastify.mdx
+++ b/docs/quickstarts/fastify.mdx
@@ -17,7 +17,7 @@ If you're looking for a more complete example, check out our [Fastify example ap
 <Steps>
 ### Install `@clerk/fastify`
 
-<CodeBlockTabs type="installer" options={["npm", "yarn", "pnpm"]}>
+<CodeBlockTabs type="installer" options={["npm", "yarn", "pnpm", "bun"]}>
   ```bash filename="terminal"
   npm install @clerk/fastify
   ```
@@ -28,6 +28,10 @@ If you're looking for a more complete example, check out our [Fastify example ap
 
   ```bash filename="terminal"
   pnpm add @clerk/fastify
+  ```
+
+  ```bash filename="terminal"
+  bun add @clerk/fastify
   ```
 </CodeBlockTabs>
 

--- a/docs/quickstarts/gatsby.mdx
+++ b/docs/quickstarts/gatsby.mdx
@@ -12,7 +12,7 @@ Learn how to use Clerk to quickly and easily add secure authentication and user 
 
 Once you have a React application ready, you need to install Clerk's React SDK. This gives you access to our prebuilt components and hooks for React applications.
 
-<CodeBlockTabs type="installer" options={["npm", "yarn", "pnpm"]}>
+<CodeBlockTabs type="installer" options={["npm", "yarn", "pnpm", "bun"]}>
   ```bash filename="terminal"
   npm install gatsby-plugin-clerk
   ```
@@ -23,6 +23,10 @@ Once you have a React application ready, you need to install Clerk's React SDK. 
 
   ```bash filename="terminal"
   pnpm add gatsby-plugin-clerk
+  ```
+
+  ```bash filename="terminal"
+  bun add gatsby-plugin-clerk
   ```
 </CodeBlockTabs>
 

--- a/docs/quickstarts/javascript.mdx
+++ b/docs/quickstarts/javascript.mdx
@@ -20,7 +20,7 @@ To use the ClerkJS package, you have two options:
 
 At the root of your project, install the ClerkJS package using your package manager of choice:
 
-<CodeBlockTabs type="installer" options={["npm", "yarn", "pnpm"]}>
+<CodeBlockTabs type="installer" options={["npm", "yarn", "pnpm", "bun"]}>
   ```bash filename="terminal"
   npm install @clerk/clerk-js
   ```
@@ -31,6 +31,10 @@ At the root of your project, install the ClerkJS package using your package mana
 
   ```bash filename="terminal"
   pnpm add @clerk/clerk-js
+  ```
+
+  ```bash filename="terminal"
+  bun add @clerk/clerk-js
   ```
 </CodeBlockTabs>
 

--- a/docs/quickstarts/nextjs.mdx
+++ b/docs/quickstarts/nextjs.mdx
@@ -31,7 +31,7 @@ description: Learn how to use Clerk to quickly and easily add secure authenticat
 
 Clerk's Next.js SDK gives you access to prebuilt [components](/docs/components/overview), [hooks](/docs/references/nextjs/overview#client-side-helpers), and [helpers](/docs/references/nextjs/overview) for Next.js Server Components, Route Handlers and Middleware. Install it by running the following command in your terminal:
 
-<CodeBlockTabs type="installer" options={["npm", "yarn", "pnpm"]}>
+<CodeBlockTabs type="installer" options={["npm", "yarn", "pnpm", "bun"]}>
   ```bash filename="terminal"
   npm install @clerk/nextjs
   ```
@@ -44,6 +44,9 @@ yarn add @clerk/nextjs
 pnpm add @clerk/nextjs
 ```
 
+```bash filename="terminal"
+bun add @clerk/nextjs
+```
 </CodeBlockTabs>
 
 ### Set environment keys

--- a/docs/quickstarts/react.mdx
+++ b/docs/quickstarts/react.mdx
@@ -35,7 +35,7 @@ description: Learn how to use Clerk to quickly and easily add secure authenticat
 
 Scaffold your new React application using [Vite](https://vitejs.dev/guide/#scaffolding-your-first-vite-project).
 
-<CodeBlockTabs type="installer" options={["npm", "yarn", "pnpm"]}>
+<CodeBlockTabs type="installer" options={["npm", "yarn", "pnpm", "bun"]}>
   ```bash filename="terminal"
   npm create vite@latest clerk-react -- --template react-ts
   cd clerk-react
@@ -57,6 +57,12 @@ Scaffold your new React application using [Vite](https://vitejs.dev/guide/#scaff
   pnpm dev
   ```
 
+  ```bash filename="terminal"
+  bun create vite clerk-react --template react-ts
+  cd clerk-react
+  bun install
+  bun dev
+  ```
 </CodeBlockTabs>
 
 

--- a/docs/quickstarts/remix.mdx
+++ b/docs/quickstarts/remix.mdx
@@ -13,7 +13,7 @@ Learn how to use Clerk to quickly and easily add secure authentication and user 
 
 Once you have a Remix application ready, you need to install Clerk's Remix SDK. This gives you access to our prebuilt components and hooks for Remix applications.
 
-<CodeBlockTabs type="installer" options={["npm", "yarn", "pnpm"]}>
+<CodeBlockTabs type="installer" options={["npm", "yarn", "pnpm", "bun"]}>
   ```bash filename="terminal"
   npm install @clerk/remix
   ```
@@ -25,6 +25,10 @@ Once you have a Remix application ready, you need to install Clerk's Remix SDK. 
   ```bash filename="terminal"
   pnpm add @clerk/remix
   ```
+
+  ```bash filename="terminal"
+  bun add @clerk/remix
+  ``` 
 </CodeBlockTabs>
 
 ### Set environment keys


### PR DESCRIPTION
## Add Bun.js to add @clerk package to different projects.
For example: bun add @clerk/remix

## Why add Bun Js

Bun's Node.js compatible package manager is significantly faster than npm, yarn, and pnpm.