### PR TITLE
Add C# to Community SDKs

### DIFF
--- a/docs/manifest.json
+++ b/docs/manifest.json
@@ -749,6 +749,17 @@
       ["Hono", "https://github.com/honojs/middleware/tree/main/packages/clerk-auth"]
     ]
   ],
+  [
+    {
+      "title": "C#",
+      "icon": "csharp",
+      "root": "references/csharp",
+      "tag": "Community"
+    },
+    [
+      ["C#", "https://github.com/Hawxy/Clerk.Net"]
+    ]
+  ],
   "# API References",
   [
     { "title": "Backend SDK", "icon": "", "root": "/references/backend" },


### PR DESCRIPTION
Adds [Clerk.Net](https://github.com/Hawxy/Clerk.Net) to the SDK list.

Most recent C# logo is https://commons.wikimedia.org/wiki/File:C_Sharp_Logo_2023.svg if you don't already have one :)