### PR TITLE
fix: Go SDK import path

### DIFF
--- a/docs/references/go/overview.mdx
+++ b/docs/references/go/overview.mdx
@@ -8,13 +8,13 @@ description: Learn how to integrate Go into your Clerk application.
 Clerk's Go SDK is a thin wrapper over the Clerk Backend API. Add the following import statement:
 
 ```go
-import "github.com/clerk/clerk-sdk-go/clerk"
+import "github.com/clerkinc/clerk-sdk-go/clerk"
 ```
 
 Go doesn't automatically add the module. You can explicitly add it with:
 
 ```go
-$ go get github.com/clerk/clerk-sdk-go
+$ go get github.com/clerkinc/clerk-sdk-go
 ```
 
 ## `Clerk` client


### PR DESCRIPTION
The install/import path cannot be yet changed since the [`go.mod` file uses the previous path](https://github.com/clerk/clerk-sdk-go/blob/2f041fef8d673473d84d5b8360b0650d43b11ae3/go.mod#L1).

See also: https://github.com/clerk/clerk-sdk-go/issues/196