### PR TITLE
Fix spelling error

### DIFF
--- a/docs/references/backend/sessions/authenticate-request.mdx
+++ b/docs/references/backend/sessions/authenticate-request.mdx
@@ -22,7 +22,7 @@ const authStatus = await clerkClient.authenticateRequest();
 | `isSatellite?` | `boolean` | Set to `true` if the instance is a satellite domain in a multi-domain setup. |
 | `proxyUrl?` | `string` | The proxy URL from a multi-domain setup. |
 | `signInUrl?` | `string` | The sign-in URL from a multi-domain setup. |  
-| `jwtKey?` | `string` | The PRM public key from the **[API Keys](https://dashboard.clerk.com/last-active?path=api-keys) page -> Advanced -> JWT public key** section of the Clerk Dashboard.  |
+| `jwtKey?` | `string` | The PEM public key from the **[API Keys](https://dashboard.clerk.com/last-active?path=api-keys) page -> Advanced -> JWT public key** section of the Clerk Dashboard.  |
 | `audience?` | `string \| string[]` | A string of list of audiences. |
 | `frontendApi?` | `string` | The Clerk publishable key (deprecated in favor of `publishableKey`) | 
 | `apiKey?` | `string` | The Clerk API key (deprecated in favor of `secretKey`) |


### PR DESCRIPTION
Found a small spelling error while browsing the docs. Should refer to the `PEM` public key. not ~~PRM~~.