### PR TITLE
Fix broken image for Google block email subaddresses

### DIFF
--- a/docs/authentication/social-connections/google.mdx
+++ b/docs/authentication/social-connections/google.mdx
@@ -52,7 +52,12 @@ Finally, click **Save** so that the settings are applied. Congratulations! Socia
 
 ### Block email subaddresses
 
-![Block email subaddresses enabled for Google social connection.](/docs/images/authentication-providers/google/google-block-email-subaddresses.webp)
+<Images
+  width={3024}
+  height={1652}
+  src="/docs/images/authentication-providers/google/google-block-email-subaddresses.webp"
+  alt="Block email subaddresses enabled for Google social connection."
+/>
 
 In the Clerk Dashboard configuration screen, you also have an option to block email subaddresses. With this setting on, any Google account with an email address that contains the characters `+`, `=` or `#` will not be able to sign in, sign up, or be added to existing accounts. By default, this setting will be enabled for new Google social connections. 
 


### PR DESCRIPTION
I think this was the issue but lmk if not

image broken here: https://clerk.com/docs/authentication/social-connections/google#block-email-subaddresses