### PR TITLE
Fix typo in code comment in documentation

### DIFF
--- a/docs/users/sync-data.mdx
+++ b/docs/users/sync-data.mdx
@@ -272,7 +272,7 @@ app.post(
         "svix-signature": svix_signature,
       }) as WebhookEvent;
     } catch (err: any) {
-      // Console log and return errro
+      // Console log and return error
       console.log("Webhook failed to verify. Error:", err.message);
       return res.status(400).json({
         success: false,


### PR DESCRIPTION
This PR aims to fix a typo in a code comment located on the sync-data page. The typo was in a comment in the catch block of the code sample on creating an endpoint in the user's application.