### PR TITLE
fix: webhook/route.ts - unsafe assignment of `any` value on `const payload`

### DIFF
--- a/docs/users/sync-data.mdx
+++ b/docs/users/sync-data.mdx
@@ -122,7 +122,7 @@ pnpm add svix
       }
 
       // Get the body
-      const payload = await req.json()
+      const payload = (await req.json()) as Record<string, unknown>;
       const body = JSON.stringify(payload);
 
       // Create a new Svix instance with your secret.


### PR DESCRIPTION
After using the code provided on the [user db sync page](https://clerk.com/docs/users/sync-data#create-the-endpoint-in-your-application) in docs, I was hit with an **"Unsafe assignment of an `any` value."** error on the payload. Image attached.

![image](https://github.com/clerk/clerk-docs/assets/3331801/17d1f25a-b170-4089-806f-89c06a42953e)

Updating it to `const payload = (await req.json()) as Record<string, unknown>;` resolves this.

