### PR TITLE
documented notify and ignoreExisting for createInvitation

### DIFF
--- a/docs/references/backend/invitations/create-invitation.mdx
+++ b/docs/references/backend/invitations/create-invitation.mdx
@@ -7,7 +7,7 @@ description: Creates a new invitation for the given email address and sends the 
 
 Creates a new invitation for the given email address and sends the invitation email.
 
-If an email address has already been invited or already exists in you application, trying to create a new invitation will return an error. To create a new invitation anyways, set `ignoreExisting` to `true`.
+If an email address has already been invited or already exists in your application, trying to create a new invitation will return an error. To bypass this error and create a new invitation anyways, set `ignoreExisting` to `true`.
 
 ```tsx
 const invitation = await clerkClient.invitations.createInvitation({
@@ -29,5 +29,5 @@ const invitation = await clerkClient.invitations.createInvitation({
 | `emailAddress` | `string` | The email address of the user to invite. |
 | `redirectUrl?` | `string` | The URL to redirect the user to after they accept the invitation. |
 | `publicMetadata?` | `Record<string, unknown>` | Metadata saved on the invitation that is visible to both your Frontend and Backend APIs. | 
-| `notify?` | `boolean` | Optional flag to denote whether an email invitation should be sent to the given email address. Defaults to true. | 
-| `ignoreExisting?` | `boolean` | Whether an invitation should be created if there is already an existing invitation for this email address, or it's claimed by another user. | 
+| `notify?` | `boolean` | Optional flag to denote whether an email invitation should be sent to the given email address. Defaults to `true`. | 
+| `ignoreExisting?` | `boolean` | Optional flag to denote whether an invitation should be created if there is already an existing invitation for this email address, or if the email address already exists in the application. Defaults to `false`. | 

--- a/docs/references/backend/invitations/create-invitation.mdx
+++ b/docs/references/backend/invitations/create-invitation.mdx
@@ -7,7 +7,7 @@ description: Creates a new invitation for the given email address and sends the 
 
 Creates a new invitation for the given email address and sends the invitation email.
 
-Keep in mind that you cannot create an invitation if there is already one for the given email address. Also, trying to create an invitation for an email address that already exists in your application will result in an error.
+If an email address has already been invited or already exists in you application, trying to create a new invitation will return an error. To create a new invitation anyways, set `ignoreExisting` to `true`.
 
 ```tsx
 const invitation = await clerkClient.invitations.createInvitation({
@@ -29,3 +29,5 @@ const invitation = await clerkClient.invitations.createInvitation({
 | `emailAddress` | `string` | The email address of the user to invite. |
 | `redirectUrl?` | `string` | The URL to redirect the user to after they accept the invitation. |
 | `publicMetadata?` | `Record<string, unknown>` | Metadata saved on the invitation that is visible to both your Frontend and Backend APIs. | 
+| `notify?` | `boolean` | Optional flag to denote whether an email invitation should be sent to the given email address. Defaults to true. | 
+| `ignoreExisting?` | `boolean` | Whether an invitation should be created if there is already an existing invitation for this email address, or it's claimed by another user. | 


### PR DESCRIPTION
Missing documentation for `clerkClient.invitations.createInvitation` params `notify` and `ignoreExisting`
Copy was copied from the [BAPI reference](https://clerk.com/docs/reference/backend-api/tag/Invitations#operation/CreateInvitation!path=notify&t=request)