### PR TITLE
DOCS-730 edit forgot password guide

### DIFF
--- a/docs/custom-flows/forgot-password.mdx
+++ b/docs/custom-flows/forgot-password.mdx
@@ -1,18 +1,23 @@
 ---
-title: Forgot password
-description: Create a custom forgot password flow for your users.
+title: Create a custom Forgot Password flow using Clerk's API
+description: Create a custom forgot password flow for your users using the lower level methods provided by the ClerkJS SDK.
 ---
 
-# Forgot password
+# Create a custom Forgot Password flow using Clerk's API
 
-Clerk's [prebuilt components](/docs/components/overview) have options that you can configure to help your users who have forgotten a password.
+Clerk's [prebuilt components](/docs/components/overview) provide a **Forgot Password** flow for your users out of the box. However, if you want more control over the user experience, you can create a custom **Forgot Password** flow using the lower-level methods provided by the [ClerkJS SDK](/docs/references/javascript/overview).
 
-If these options will not work for you, or if you want more control of your user's experience, it's possible to create a completely custom **Forgot Password** flow using lower-level methods.
+In the following example, the user is asked to provide their email address. After submitting their email, the user is asked to provide a new password and the password reset code that was sent to their email. The user is then signed in with their new password.
 
-## Example
+Note that this example does not handle error states, and does not handle 2FA (two-factor authentication). If you have 2FA enabled, you will need to handle that separately.
 
-<CodeBlockTabs type="framework" options={["React"]}>
-```jsx
+For the sake of this guide, this example is written for Next.js App Router but it is supported by any React meta framework, such as Remix or Gatsby.
+
+{/* TODO: Update this Next.js example (when reset password is complete, it just has 'You successfully changed your password'.. and that's not even in a p tag or anything.), and add JavaScript example. */}
+
+<CodeBlockTabs type="framework" options={["Next.js"]}>
+```tsx filename="app/forgot-password.tsx"
+"use client"
 import React, { SyntheticEvent, useState } from 'react';
 import { useSignIn } from '@clerk/nextjs';
 import type { NextPage } from 'next';
@@ -72,7 +77,7 @@ const SignInPage: NextPage = () => {
         maxWidth: '500px',
       }}
     >
-      <h1>Forgot Password ?</h1>
+      <h1>Forgot Password?</h1>
       <form
         style={{
           display: 'flex',
@@ -83,7 +88,7 @@ const SignInPage: NextPage = () => {
       >
         {!successfulCreation && !complete && (
           <>
-            <label htmlFor='email'>Please provide identifier</label>
+            <label htmlFor='email'>Please provide your email address</label>
             <input
               type='email'
               placeholder='e.g john@doe.com'
@@ -97,14 +102,14 @@ const SignInPage: NextPage = () => {
 
         {successfulCreation && !complete && (
           <>
-            <label htmlFor='password'>New password</label>
+            <label htmlFor='password'>Enter your new password</label>
             <input
               type='password'
               value={password}
               onChange={e => setPassword(e.target.value)}
             />
 
-            <label htmlFor='password'>Reset password code</label>
+            <label htmlFor='password'>Enter the password reset code that was sent to your email</label>
             <input
               type='text'
               value={code}
@@ -115,7 +120,7 @@ const SignInPage: NextPage = () => {
           </>
         )}
 
-        {complete && 'You successfully changed you password'}
+        {complete && 'You successfully changed your password'}
         {secondFactor && '2FA is required, this UI does not handle that'}
       </form>
     </div>

--- a/docs/custom-flows/forgot-password.mdx
+++ b/docs/custom-flows/forgot-password.mdx
@@ -9,33 +9,44 @@ Clerk's [prebuilt components](/docs/components/overview) provide a **Forgot Pass
 
 In the following example, the user is asked to provide their email address. After submitting their email, the user is asked to provide a new password and the password reset code that was sent to their email. The user is then signed in with their new password.
 
-Note that this example does not handle error states, and does not handle 2FA (two-factor authentication). If you have 2FA enabled, you will need to handle that separately.
+Note that this example does not handle 2FA (two-factor authentication). If you have 2FA enabled, you will need to handle that separately.
 
 For the sake of this guide, this example is written for Next.js App Router but it is supported by any React meta framework, such as Remix or Gatsby.
 
-{/* TODO: Update this Next.js example (when reset password is complete, it just has 'You successfully changed your password'.. and that's not even in a p tag or anything.), and add JavaScript example. */}
+{/* TODO: Add JavaScript example. */}
 
 <CodeBlockTabs type="framework" options={["Next.js"]}>
 ```tsx filename="app/forgot-password.tsx"
 "use client"
 import React, { SyntheticEvent, useState } from 'react';
-import { useSignIn } from '@clerk/nextjs';
+import { useAuth, useSignIn } from '@clerk/nextjs';
 import type { NextPage } from 'next';
+import { redirect } from 'next/navigation';
 
-const SignInPage: NextPage = () => {
+const ForgotPasswordPage: NextPage = () => {
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
   const [code, setCode] = useState('');
   const [successfulCreation, setSuccessfulCreation] = useState(false);
   const [complete, setComplete] = useState(false);
   const [secondFactor, setSecondFactor] = useState(false);
+  const [error, setError] = useState('');
 
+  const { isSignedIn } = useAuth();
   const { isLoaded, signIn, setActive } = useSignIn();
 
   if (!isLoaded) {
     return null;
   }
 
+  // If the user is already signed in, 
+  // and they haven't just completed a password reset, 
+  // redirect them to the home page
+  if (isSignedIn && !complete) {
+    redirect('/');
+  }
+
+  // Send the password reset code to the user's email
   async function create(e: SyntheticEvent) {
     e.preventDefault();
     await signIn
@@ -45,10 +56,17 @@ const SignInPage: NextPage = () => {
       })
       .then(_ => {
         setSuccessfulCreation(true);
+        setError('');
       })
-      .catch(err => console.error('error', err.errors[0].longMessage));
+      .catch(err => {
+        console.error('error', err.errors[0].longMessage);
+        setError(err.errors[0].longMessage);
+      });
   }
 
+  // Reset the user's password. 
+  // Upon successful reset, the user will be 
+  // signed in and redirected to the home page
   async function reset(e: SyntheticEvent) {
     e.preventDefault();
     await signIn
@@ -60,14 +78,21 @@ const SignInPage: NextPage = () => {
       .then(result => {
         if (result.status === 'needs_second_factor') {
           setSecondFactor(true);
+          setError('');
         } else if (result.status === 'complete') {
+          // Set the active session to 
+          // the newly created session (user is now logged in)
           setActive({ session: result.createdSessionId });
           setComplete(true);
+          setError('');
         } else {
           console.log(result);
         }
       })
-      .catch(err => console.error('error', err.errors[0].longMessage));
+      .catch(err => {
+        console.error('error', err.errors[0].longMessage)
+        setError(err.errors[0].longMessage);
+      });
   }
 
   return (
@@ -96,7 +121,8 @@ const SignInPage: NextPage = () => {
               onChange={e => setEmail(e.target.value)}
             />
 
-            <button>Sign in</button>
+            <button>Send password reset code</button>
+            {error && <p>{error}</p>}
           </>
         )}
 
@@ -117,16 +143,17 @@ const SignInPage: NextPage = () => {
             />
 
             <button>Reset</button>
+            {error && <p>{error}</p>}
           </>
         )}
 
-        {complete && 'You successfully changed your password'}
-        {secondFactor && '2FA is required, this UI does not handle that'}
+        {complete && <p>You successfully changed your password</p>}
+        {secondFactor && <p>2FA is required, this UI does not handle that</p>}
       </form>
     </div>
   );
 };
 
-export default SignInPage;
+export default ForgotPasswordPage;
 ```
 </CodeBlockTabs>

--- a/docs/custom-flows/forgot-password.mdx
+++ b/docs/custom-flows/forgot-password.mdx
@@ -9,7 +9,7 @@ Clerk's [prebuilt components](/docs/components/overview) provide a **Forgot Pass
 
 In the following example, the user is asked to provide their email address. After submitting their email, the user is asked to provide a new password and the password reset code that was sent to their email. The user is then signed in with their new password.
 
-Note that this example does not handle 2FA (two-factor authentication). If you have 2FA enabled, you will need to handle that separately.
+Note that this example's user interface does not handle 2FA (two-factor authentication). If it detects that 2FA is needed for the account trying to reset the password, it will display a message to the user that says "2FA is required, but this UI does not handle that".
 
 For the sake of this guide, this example is written for Next.js App Router but it is supported by any React meta framework, such as Remix or Gatsby.
 
@@ -18,20 +18,20 @@ For the sake of this guide, this example is written for Next.js App Router but i
 <CodeBlockTabs type="framework" options={["Next.js"]}>
 ```tsx filename="app/forgot-password.tsx"
 "use client"
-import React, { SyntheticEvent, useState } from 'react';
+import React, { useState } from 'react';
 import { useAuth, useSignIn } from '@clerk/nextjs';
 import type { NextPage } from 'next';
-import { redirect } from 'next/navigation';
+import { useRouter } from 'next/navigation';
 
 const ForgotPasswordPage: NextPage = () => {
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
   const [code, setCode] = useState('');
   const [successfulCreation, setSuccessfulCreation] = useState(false);
-  const [complete, setComplete] = useState(false);
   const [secondFactor, setSecondFactor] = useState(false);
   const [error, setError] = useState('');
 
+  const router = useRouter();
   const { isSignedIn } = useAuth();
   const { isLoaded, signIn, setActive } = useSignIn();
 
@@ -39,15 +39,14 @@ const ForgotPasswordPage: NextPage = () => {
     return null;
   }
 
-  // If the user is already signed in, 
-  // and they haven't just completed a password reset, 
+  // If the user is already signed in,
   // redirect them to the home page
-  if (isSignedIn && !complete) {
-    redirect('/');
+  if (isSignedIn) {
+    router.push('/');
   }
 
   // Send the password reset code to the user's email
-  async function create(e: SyntheticEvent) {
+  async function create(e: React.FormEvent) {
     e.preventDefault();
     await signIn
       ?.create({
@@ -67,7 +66,7 @@ const ForgotPasswordPage: NextPage = () => {
   // Reset the user's password. 
   // Upon successful reset, the user will be 
   // signed in and redirected to the home page
-  async function reset(e: SyntheticEvent) {
+  async function reset(e: React.FormEvent) {
     e.preventDefault();
     await signIn
       ?.attemptFirstFactor({
@@ -76,6 +75,7 @@ const ForgotPasswordPage: NextPage = () => {
         password,
       })
       .then(result => {
+        // Check if 2FA is required
         if (result.status === 'needs_second_factor') {
           setSecondFactor(true);
           setError('');
@@ -83,7 +83,6 @@ const ForgotPasswordPage: NextPage = () => {
           // Set the active session to 
           // the newly created session (user is now logged in)
           setActive({ session: result.createdSessionId });
-          setComplete(true);
           setError('');
         } else {
           console.log(result);
@@ -111,7 +110,7 @@ const ForgotPasswordPage: NextPage = () => {
         }}
         onSubmit={!successfulCreation ? create : reset}
       >
-        {!successfulCreation && !complete && (
+        {!successfulCreation && (
           <>
             <label htmlFor='email'>Please provide your email address</label>
             <input
@@ -126,7 +125,7 @@ const ForgotPasswordPage: NextPage = () => {
           </>
         )}
 
-        {successfulCreation && !complete && (
+        {successfulCreation && (
           <>
             <label htmlFor='password'>Enter your new password</label>
             <input
@@ -147,8 +146,7 @@ const ForgotPasswordPage: NextPage = () => {
           </>
         )}
 
-        {complete && <p>You successfully changed your password</p>}
-        {secondFactor && <p>2FA is required, this UI does not handle that</p>}
+        {secondFactor && <p>2FA is required, but this UI does not handle that</p>}
       </form>
     </div>
   );


### PR DESCRIPTION
[DOCS-730](https://linear.app/clerk/issue/DOCS-730/edit-forgot-reset-password-copy) was a user complaint about the copy in the introductory sentence of the guide. It read "Clerk's [prebuilt components](https://clerk.com/docs/components/overview) have options that you can configure to help your users who have forgotten a password." This is not true, there are no options to configure in prebuilt components - they handle forgot/reset password out of the box. Non-configurable.

As I was updating the copy, I realized this code example is also very out of date and needed some love. It's definitely rough and not perfect, but it's better.. and functional! and that's what counts :~)