### PR TITLE
fix: remove undefined `user` in Apollo example

### DIFF
--- a/docs/integrations/databases/hasura.mdx
+++ b/docs/integrations/databases/hasura.mdx
@@ -109,7 +109,7 @@ export const ApolloProviderWrapper = ({ children }) => {
   const { getToken } = useAuth();
   const apolloClient = useMemo(() => {
     const authMiddleware = setContext(async (req, { headers }) => {
-      const token = await user.getToken({template: "template"});
+      const token = await getToken({template: "template"});
       return {
         headers: {
           ...headers,


### PR DESCRIPTION
Use the destructured `getToken` and remove the undefined `user` in the Apollo example for Hasura