### PR TITLE
DOCS-5150 update SignIn and useSignIn docs

### DIFF
--- a/docs/references/javascript/sign-in/sign-in.mdx
+++ b/docs/references/javascript/sign-in/sign-in.mdx
@@ -21,7 +21,7 @@ The `SignIn` object's properties can be split into logical groups, with each gro
 
 | Name | Type | Description |
 | --- | --- | --- |
-| `status` | `string` | The current status of the sign-in.<br/>The following values are supported:<br/><ul><li>`needs_identifier`: The authentication identifier hasn't been provided.</li><li>`needs_first_factor`: First factor verification for the provided identifier needs to be prepared and verified.</li><li>`needs_second_factor`: Second factor verification (2FA) for the provided identifier needs to be prepared and verified.</li><li>`complete`: The sign-in is complete and the user is authenticated.</li><li>`abandoned`: The sign-in has been inactive for a long period of time, thus it's considered as abandoned and need to start over.</li></ul> |
+| `status` | `string` | The current status of the sign-in.<br/>The following values are supported:<br/><ul><li>`needs_identifier`: The authentication identifier hasn't been provided.</li><li>`needs_first_factor`: First factor verification for the provided identifier needs to be prepared and verified. See [First Factor](/docs/references/javascript/sign-in/first-factor) for details.</li><li>`needs_second_factor`: Second factor verification (2FA) for the provided identifier needs to be prepared and verified. See [Second Factor](/docs/references/javascript/sign-in/second-factor) for details.</li><li>`needs_new_password`: The user needs to set a new password.</li><li>`complete`: The sign-in is complete and the user is authenticated.</li></ul> |
 | `supportedIdentifiers` | `string[]` | Array of all the authentication identifiers that are supported for this sign in.<br/>Examples of this could be: <ul><li>`email_address`</li><li>`phone_number`</li><li>`web3_wallet`</li><li>`username`</li></ul> |
 | `identifier` | `string \| null` | The authentication identifier value for the current sign-in. |
 | `supportedExternalAccounts` | `string[]` | Array of all the external accounts that can be used in this sign in.<br />For example:<br /><code>["oauth_google", "oauth_facebook"]</code> |
@@ -29,7 +29,7 @@ The `SignIn` object's properties can be split into logical groups, with each gro
 | `supportedSecondFactors` | `SignInFactor[]` | Array of the second factors that are supported in the current sign-in. Each factor contains information about the verification strategy that can be used.<br/>For example: <ul><li>`email_code` for email addresses</li><li>`phone_code` for phone numbers</li></ul> As well as the identifier that the factor refers to. Please note that this property is populated only when the first factor is verified. |
 | `firstFactorVerification` | `Verification` | The state of the verification process for the selected first factor. Please note that this property contains an empty verification object initially, since there is no first factor selected. You need to call the [`prepareFirstFactor`](/docs/references/javascript/sign-in/first-factor#prepare-first-factor) method in order to start the verification process. |
 | `secondFactorVerification` | `Verification` | The state of the verification process for the selected second factor. Similar to `firstFactorVerification`, this property contains an empty verification object initially, since there is no second factor selected. For the `phone_code` strategy, you need to call the [`prepareSecondFactor`](/docs/references/javascript/sign-in/second-factor#prepare-second-factor) method in order to start the verification process. For the `totp` strategy, you can directly attempt. |
-| `userData` | `UserData` | An object containing information about the user of the current sign-in. This property is populated only once an identifier is given to the [`SignIn`][signin-ref] object. |
+| `userData` | `UserData` | An object containing information about the user of the current sign-in. This property is populated only once an identifier is given to the `SignIn` object. |
 | `createdSessionId` | `string \| null` | The identifier of the session that was created upon completion of the current sign-in. The value of this property is `null` if the sign-in status is not `complete`. |
 
 ## Methods
@@ -40,7 +40,7 @@ The `SignIn` object's properties can be split into logical groups, with each gro
 function create(params: SignInCreateParams): Promise<SignIn>;
 ```
 
-Use this method to kick-off the sign in flow. It creates a [`SignIn`][signin-ref] object and stores the sign-in lifecycle state.
+Use this method to kick-off the sign in flow. It creates a `SignIn` object and stores the sign-in lifecycle state.
 
 Depending on the use-case and the `params` you pass to the `create` method, it can either complete the sign-in process in one go, or simply collect part of the necessary data for completing authentication at a later stage.
 
@@ -60,7 +60,7 @@ Depending on the use-case and the `params` you pass to the `create` method, it c
 
 | Type | Description |
 | --- | --- |
-| <code>Promise\<[SignIn][signin-ref]\></code> | This method returns a `Promise` which resolves with a [`SignIn`][signin-ref] object. Check the `status` attribute to see if the sign-in has been completed or a hint on what needs to happen next. |
+| `Promise<SignIn>` | This method returns a `Promise` which resolves with a `SignIn` object. Check the `status` attribute to see if the sign-in has been completed or a hint on what needs to happen next. |
 
 ### `resetPassword()`
 
@@ -96,7 +96,7 @@ The second function can be used to stop polling at any time, allowing for full c
 
 | Name | Type | Description |
 | --- | --- | --- |
-| `startMagicLinkFlow` | <code>(params: [SignInStartMagicLinkFlowParams](#sign-in-start-magic-link-flow-params)) => Promise\<[SignIn][signin-ref]\></code> | Function to start the magic link flow. It prepares a magic link verification and polls for the verification result. |
+| `startMagicLinkFlow` | <code>(params: [SignInStartMagicLinkFlowParams](#sign-in-start-magic-link-flow-params)) => Promise\<SignIn\></code> | Function to start the magic link flow. It prepares a magic link verification and polls for the verification result. |
 | `cancelMagicLinkFlow` | `() => void` | Function to cleanup the magic link flow. Stops waiting for verification results. |
 
 #### `SignInStartMagicLinkFlowParams`
@@ -125,5 +125,3 @@ In addition to the methods listed above, the `SignIn` class also has the followi
 *   [`authenticateWithRedirect()`](/docs/references/javascript/sign-in/authenticate-with#authenticate-with-redirect)
 *   [`authenticateWithMetamask()`](/docs/references/javascript/sign-in/authenticate-with#authenticate-with-metamask)
 *   [`authenticateWithWeb3()`](/docs/references/javascript/sign-in/authenticate-with#authenticate-with-web3)
-
-[signin-ref]: /docs/references/javascript/sign-in/sign-in

--- a/docs/references/react/use-sign-in.mdx
+++ b/docs/references/react/use-sign-in.mdx
@@ -20,8 +20,8 @@ The `useSignIn()` hook provides access to the [`SignIn`](/docs/references/javasc
 
 | Name | Type | Description |
 | --- | --- | --- |
-| `session` | [`Session`](/docs/references/javascript/session) \| `string` \| `null` | The session resource or session ID (string version) to be set as active. If `null`, the current session is deleted. |
-| `organization` | [`Organization`](/docs/references/javascript/organization/organization) \| `string` \| `null` | The organization resource or organization ID (string version) to be set as active in the current session. If `null`, the currently active organization is removed as active. |
+| `session` | <code>[Session](/docs/references/javascript/session) \| string \| null</code> | The session resource or session ID (string version) to be set as active. If `null`, the current session is deleted. |
+| `organization` | <code>[Organization](/docs/references/javascript/organization/organization) \| string \| null</code> | The organization resource or organization ID (string version) to be set as active in the current session. If `null`, the currently active organization is removed as active. |
 | `beforeEmit?` | `(session?: Session \| null) => void \| Promise<any>` | Callback run just before the active session and/or organization is set to the passed object. Can be used to hook up for pre-navigation actions. |
 
 ## How to use the `useSignIn()` hook

--- a/docs/references/react/use-sign-in.mdx
+++ b/docs/references/react/use-sign-in.mdx
@@ -30,7 +30,7 @@ The `useSignIn()` hook provides access to the [`SignIn`](/docs/references/javasc
 
 You can utilize the `useSignIn()` hook to check the current state of a sign-in.
 
-<CodeBlockTabs type="framework" items={["Next.js", "React"]}>
+<CodeBlockTabs type="framework" options={["Next.js", "React"]}>
   ```tsx filename="pages/index.tsx"
   import { useSignIn } from "@clerk/nextjs";
 

--- a/docs/references/react/use-sign-in.mdx
+++ b/docs/references/react/use-sign-in.mdx
@@ -7,180 +7,71 @@ description: The useSignIn() hook provides access to the SignIn object, which al
 
 The `useSignIn()` hook provides access to the [`SignIn`](/docs/references/javascript/sign-in/sign-in) object, which allows you to check the current state of a sign-in. This is also useful for creating a custom sign-in flow.
 
-## Usage
+## `useSignIn()` returns
 
-<Tabs type="framework" items={["Next.js", "React"]}>
-  <Tab>
-    #### Check the current sign-in status
-
-    ```tsx filename="pages/index.tsx"
-    import { useSignIn } from "@clerk/nextjs";
-
-    export default function SignInStep() {
-      const { isLoaded, signIn } = useSignIn();
-
-      if (!isLoaded) {
-        // handle loading state
-        return null;
-      }
-
-      return <div>The current sign in attempt status is {signIn.status}.</div>;
-    }
-    ```
-
-    #### Sign in a user with a custom flow
-
-    ```tsx filename="pages/signin.tsx"
-    import { useSignIn } from "@clerk/nextjs";
-    import { useState } from "react";
-
-    export default function SignIn() {
-      const [email, setEmail] = useState("");
-      const [password, setPassword] = useState("");
-
-      const { isLoaded, signIn, setActive } = useSignIn();
-
-      if (!isLoaded) {
-        return null;
-      }
-
-      async function submit(e) {
-        e.preventDefault();
-        await signIn
-          .create({
-            identifier: email,
-            password,
-          })
-          .then((result) => {
-            if (result.status === "complete") {
-              console.log(result);
-              setActive({ session: result.createdSessionId });
-            } else {
-              console.log(result);
-            }
-          })
-          .catch((err) => console.error("error", err.errors[0].longMessage));
-      }
-
-      return (
-        <form onSubmit={submit}>
-          <div>
-            <label htmlFor="email">Email</label>
-            <input
-              type="email"
-              value={email}
-              onChange={(e) => setEmail(e.target.value)}
-            />
-          </div>
-          <div>
-            <label htmlFor="password">Password</label>
-            <input
-              type="password"
-              value={password}
-              onChange={(e) => setPassword(e.target.value)}
-            />
-          </div>
-          <div>
-            <button>Sign in</button>
-          </div>
-        </form>
-      );
-    }
-    ```
-  </Tab>
-
-  <Tab>
-    #### Check the current sign-in status
-
-    ```tsx filename="pages/sign-in-step.tsx"
-    import { useSignIn } from "@clerk/clerk-react";
-
-    export default function SignInStep() {
-      const { isLoaded, signIn } = useSignIn();
-
-      if (!isLoaded) {
-        // handle loading state
-        return null;
-      }
-
-      return <div>The current sign in attempt status is {signIn.status}.</div>;
-    }
-    ```
-
-    #### Sign in a user with a custom flow
-
-    ```tsx filename="pages/signin.tsx"
-    import { useSignIn } from "@clerk/clerk-react";
-    import { useState } from "react";
-
-    export default function SignIn() {
-      const [email, setEmail] = useState("");
-      const [password, setPassword] = useState("");
-
-      const { isLoaded, signIn, setActive } = useSignIn();
-
-      if (!isLoaded) {
-        return null;
-      }
-
-      async function submit(e) {
-        e.preventDefault();
-        await signIn
-          .create({
-            identifier: email,
-            password,
-          })
-          .then((result) => {
-            if (result.status === "complete") {
-              console.log(result);
-              setActive({ session: result.createdSessionId });
-            } else {
-              console.log(result);
-            }
-          })
-          .catch((err) => console.error("error", err.errors[0].longMessage));
-      }
-
-      return (
-        <form onSubmit={submit}>
-          <div>
-            <label htmlFor="email">Email</label>
-            <input
-              type="email"
-              value={email}
-              onChange={(e) => setEmail(e.target.value)}
-            />
-          </div>
-          <div>
-            <label htmlFor="password">Password</label>
-            <input
-              type="password"
-              value={password}
-              onChange={(e) => setPassword(e.target.value)}
-            />
-          </div>
-          <div>
-            <button>Sign in</button>
-          </div>
-        </form>
-      );
-    }
-    ```
-  </Tab>
-</Tabs>
-
-| Values | Description |
+| Name | Type | Description |
 | --- | --- |
-| `isLoaded` | A boolean that is set to `false` until Clerk loads and initializes. |
-| `setActive()` | A function that sets the active session. |
-| `setSession()` (deprecated) | Deprecated in favor of `setActive()`. |
-| `signIn` | An object that contains the current sign-in attempt status and methods to create a new sign-in attempt. |
+| `isLoaded` | `boolean` | A boolean that is set to `false` until Clerk loads and initializes. |
+| `setActive()` | <code>(params: [SetActiveParams](#set-active-params)) => Promise\<void\></code> | A function that sets the active session. |
+| `setSession()` (deprecated) |  Deprecated. | Deprecated in favor of `setActive()`. |
+| `signIn` | [`SignIn`](/docs/references/javascript/sign-in/sign-in) | An object that contains the current sign-in attempt status and methods to create a new sign-in attempt. |
 
-### Result status
+### `SetActiveParams`
+
+| Name | Type | Description |
+| --- | --- | --- |
+| `session` | [`Session`](/docs/references/javascript/session) \| `string` \| `null` | The session resource or session ID (string version) to be set as active. If `null`, the current session is deleted. |
+| `organization` | [`Organization`](/docs/references/javascript/organization/organization) \| `string` \| `null` | The organization resource or organization ID (string version) to be set as active in the current session. If `null`, the currently active organization is removed as active. |
+| `beforeEmit?` | `(session?: Session \| null) => void \| Promise<any>` | Callback run just before the active session and/or organization is set to the passed object. Can be used to hook up for pre-navigation actions. |
+
+## How to use the `useSignIn()` hook
+
+### Check the current state of a sign-in
+
+You can utilize the `useSignIn()` hook to check the current state of a sign-in.
+
+<CodeBlockTabs type="framework" items={["Next.js", "React"]}>
+  ```tsx filename="pages/index.tsx"
+  import { useSignIn } from "@clerk/nextjs";
+
+  export default function SignInStep() {
+    const { isLoaded, signIn } = useSignIn();
+
+    if (!isLoaded) {
+      // handle loading state
+      return null;
+    }
+
+    return <div>The current sign in attempt status is {signIn.status}.</div>;
+  }
+  ```
+
+  ```tsx filename="pages/sign-in-step.tsx"
+  import { useSignIn } from "@clerk/clerk-react";
+
+  export default function SignInStep() {
+    const { isLoaded, signIn } = useSignIn();
+
+    if (!isLoaded) {
+      // handle loading state
+      return null;
+    }
+
+    return <div>The current sign in attempt status is {signIn.status}.</div>;
+  }
+  ```
+</CodeBlockTabs>
+
+The `status` property of the `signIn` object can be one of the following values:
 
 | Values | Descriptiom |
 | --- | --- |
 | `complete` | The user has been signed in and custom flow can proceed to `setActive()` to create session. |
-| `needs_factor_one` | The First Factor verification is missing. One of `email_link`, `email_code`, `phone_code`, `web3_metamask_signature` or `oauth_provider` is required to verify user. See [First Factor](/docs/references/javascript/sign-in/first-factor) for details. |
-| `needs_factor_two` | The Second Factor verification is missing. The Second Factor is an optional step to provide additional verification and includes `phone_code` and `totp`. See [Second Factor](/docs/references/javascript/sign-in/second-factor) for details.|
-| `needs_identifier` | The unqiue identifier for the user was missing. | 
+| `needs_first_factor` | The First Factor verification is missing. One of `email_link`, `email_code`, `phone_code`, `web3_metamask_signature` or `oauth_provider` is required to verify user. See [First Factor](/docs/references/javascript/sign-in/first-factor) for details. |
+| `needs_second_factor` | The Second Factor verification is missing. The Second Factor is an optional step to provide additional verification and includes `phone_code` and `totp`. See [Second Factor](/docs/references/javascript/sign-in/second-factor) for details. |
+| `needs_identifier` | The user's identifier (email address, phone number, username, etc.) hasn't been provided. |
+| `needs_new_password` | The user needs to set a new password. |
+
+### Create a custom sign-in flow
+
+You can also utilize the `useSignIn()` hook to build fully custom sign-in flows, if Clerk's pre-built components don't meet your specific needs or if you require more control over the authentication flow. Different sign-in flows include email and password, email and phone codes, email links, and multifactor (MFA). To learn more about using the `useSignIn()` hook to create custom flows, check out the [custom flow guides](https://clerk.com/docs/custom-flows/overview).

--- a/docs/references/react/use-sign-in.mdx
+++ b/docs/references/react/use-sign-in.mdx
@@ -10,7 +10,7 @@ The `useSignIn()` hook provides access to the [`SignIn`](/docs/references/javasc
 ## `useSignIn()` returns
 
 | Name | Type | Description |
-| --- | --- |
+| --- | --- | --- |
 | `isLoaded` | `boolean` | A boolean that is set to `false` until Clerk loads and initializes. |
 | `setActive()` | <code>(params: [SetActiveParams](#set-active-params)) => Promise\<void\></code> | A function that sets the active session. |
 | `setSession()` (deprecated) |  Deprecated. | Deprecated in favor of `setActive()`. |

--- a/docs/references/react/use-sign-in.mdx
+++ b/docs/references/react/use-sign-in.mdx
@@ -26,7 +26,7 @@ The `useSignIn()` hook provides access to the [`SignIn`](/docs/references/javasc
 
 ## How to use the `useSignIn()` hook
 
-### Check the current state of a sign-in
+### Check the current state of a sign-in with `useSignIn()`
 
 You can utilize the `useSignIn()` hook to check the current state of a sign-in.
 
@@ -72,6 +72,6 @@ The `status` property of the `signIn` object can be one of the following values:
 | `needs_identifier` | The user's identifier (email address, phone number, username, etc.) hasn't been provided. |
 | `needs_new_password` | The user needs to set a new password. |
 
-### Create a custom sign-in flow
+### Create a custom sign-in flow with `useSignIn()`
 
 You can also utilize the `useSignIn()` hook to build fully custom sign-in flows, if Clerk's pre-built components don't meet your specific needs or if you require more control over the authentication flow. Different sign-in flows include email and password, email and phone codes, email links, and multifactor (MFA). To learn more about using the `useSignIn()` hook to create custom flows, check out the [custom flow guides](https://clerk.com/docs/custom-flows/overview).


### PR DESCRIPTION
[This user feedback ticket](https://linear.app/clerk/issue/DOCS-5150/double-check-that-referencesreactuse-sign-in-works) claimed our useSignIn docs were not working/outdated

Taking a look at the [useSignIn](https://clerk.com/docs/references/react/use-sign-in) doc, I have updated it's overall structure to introduce the hook and its returns first so that users can understand the hook before taking a look at its usage. Its "Usage" section got reorganized as well, removing redundant code examples that already exist in our "Custom flows" docs. Now, this "Usage" section will link to the appropriate place in the docs, so that users can be guided to the entire section for building custom flows, and understand custom flows fully in their context instead of viewing an incomplete, dead end code example.
The [SignIn](https://clerk.com/docs/references/javascript/sign-in/sign-in) doc also needed updating. Some properties on the object were missing.

🔎 [useSignIn](https://docs-preview-681.clerkpreview.com/docs/references/react/use-sign-in)
🔎 [SignIn](https://docs-preview-681.clerkpreview.com/docs/references/javascript/sign-in/sign-in#sign-in)