### PR TITLE
DOCS-653 update copy to clarify that allowlists allow/block sign-ups

### DIFF
--- a/docs/authentication/configuration/restrictions.mdx
+++ b/docs/authentication/configuration/restrictions.mdx
@@ -11,9 +11,9 @@ Clerk provides a set of restriction options designed to provide you with enhance
 
 <Callout type="info">
   Allowlist is a premium feature and is not available on the Free plan. [Upgrade your plan](https://clerk.com/pricing) to enable this feature.
- </Callout>
+</Callout>
 
-The Allowlist feature allows you to control who can get access to your application. It can restrict sign-ups to only a certain set of email addresses or phone numbers that you define. This can be used in a way that acts as a reverse blocklist, only allowing the users added to access your application and blocking all others.
+The Allowlist feature allows you to control who can get access to your application. It can restrict sign-ups to only a certain set of email addresses or phone numbers that you define. This can be used in a way that acts as a reverse blocklist, only allowing the users added to sign-up for your application and blocking all others.
 
 To enable this feature, in the Clerk Dashboard, go to **User & Authentication > [Restrictions](https://dashboard.clerk.com/last-active?path=user-authentication/restrictions)** and go to the **Allowlist** section. Turn on the **Enable allowlist** toggle.
 


### PR DESCRIPTION
[DOCS-653](https://linear.app/clerk/issue/DOCS-653/clarify-that-allow-and-block-lists-block-sign-up-and-sign-ins) reports user complaints on the copy not being clear.

Roy stated "The part you highlighted @nabors does say 'access' but other areas, like the previous sentence, explicitly say "sign-up". This seems to be the confusion with customers."

This PR updates the copy accordingly