### PR TITLE
update trpc guide to specify its for nextjs pages router

### DIFF
--- a/docs/references/nextjs/trpc.mdx
+++ b/docs/references/nextjs/trpc.mdx
@@ -1,11 +1,11 @@
 ---
-title: Integrate Clerk into your Next.js app with tRPC
+title: Integrate Clerk into your Next.js Pages Router app with tRPC
 description: Learn how to integrate Clerk into your Next.js application using tRPC. tRPC can be used with Clerk, but requires a few tweaks from a traditional Clerk + Next.js setup.
 ---
 
-# Integrate Clerk into your Next.js app with tRPC
+# Integrate Clerk into your Next.js Pages Router app with tRPC
 
-Learn how to integrate Clerk into your Next.js application using [tRPC](https://trpc.io/). tRPC can be used with Clerk, but requires a few tweaks from a traditional Clerk + Next.js setup.
+Learn how to integrate Clerk into your Next.js Pages Router application using [tRPC](https://trpc.io/). tRPC can be used with Clerk, but requires a few tweaks from a traditional Clerk + Next.js setup.
 
 <Callout>
   Prefer to get started quickly? Check out the following [repo](https://github.com/perkinsjr/t3-app-clerk-minimal) which implements the essentials.


### PR DESCRIPTION
We get complaints about it not being clear that tRPC guide is for pages router only. this is a quick fix until we update the guide & add the app router version