### PR TITLE
DOCS-5339 create references for has and protect helpers

### DIFF
--- a/docs/backend-requests/resources/session-tokens.mdx
+++ b/docs/backend-requests/resources/session-tokens.mdx
@@ -18,13 +18,13 @@ Below are the default session claims that Clerk generates for you:
 * `nbf`: not before - the time before which the token is considered invalid, as a Unix timestamp. Determined using the **Allowed Clock Skew** JWT template setting in the [Clerk Dashboard](https://dashboard.clerk.com/last-active?path=jwt-templates).
 * `sid`: session ID - the ID of the current session (e.g. `sess_123`).
 * `sub`: subject - the ID of the current user of the session (e.g. `user_123`).
+* `act`: actor - will only be included if the user is impersonating another user. See [user impersonation](/docs/custom-flows/user-impersonation#jwt-claims) for more information.
 
 The following claims are only included if the user is part of an organization:
 
 * `org_id`: organization ID - the ID of the currently active organization that the user belongs to.
 * `org_slug`: organization slug - the slug of the currently active organization that the user belongs to.
 * `org_role`: organization role - the role of the user in the currently active organization.
-* `act`: actor - will only be included if the user is impersonating another user. See [user impersonation](/docs/custom-flows/user-impersonation#jwt-claims) for more information.
 
 <Images
   width={894}

--- a/docs/backend-requests/resources/session-tokens.mdx
+++ b/docs/backend-requests/resources/session-tokens.mdx
@@ -18,7 +18,7 @@ Below are the default session claims that Clerk generates for you:
 * `nbf`: not before - the time before which the token is considered invalid, as a Unix timestamp. Determined using the **Allowed Clock Skew** JWT template setting in the [Clerk Dashboard](https://dashboard.clerk.com/last-active?path=jwt-templates).
 * `sid`: session ID - the ID of the current session (e.g. `sess_123`).
 * `sub`: subject - the ID of the current user of the session (e.g. `user_123`).
-* `act`: actor - will only be included if the user is impersonating another user. See [user impersonation](/docs/custom-flows/user-impersonation#jwt-claims) for more information.
+* `act`: actor - will only be included if the user is impersonating another user. See [user impersonation](/docs/custom-flows/user-impersonation) for more information. 
 
 The following claims are only included if the user is part of an organization:
 

--- a/docs/guides/force-organizations.mdx
+++ b/docs/guides/force-organizations.mdx
@@ -71,7 +71,7 @@ With Clerk, a user can have many organization memberships, but only one of them 
 
 #### Detect an active organization
 
-A session will always include an `orgId` via the [`Authentication` object](/docs/references/nextjs/authentication-object#example-with-active-organization). This can be used to detect if a user has an active organization.
+A session will always include an `orgId` via the [`Authentication` object](/docs/references/nextjs/authentication-object#authentication-object-example-with-active-organization). This can be used to detect if a user has an active organization.
 
 <Tabs items={["App Router Server Component", "App Router Client Component"]}>
   <Tab>

--- a/docs/organizations/create-roles-permissions.mdx
+++ b/docs/organizations/create-roles-permissions.mdx
@@ -14,7 +14,7 @@ In the Clerk Dashboard, you can create roles, assign permissions to them, and ch
 3. Give the role a name, a key to reference it by in the format `org:<role>`, and a description.
 4. Select **Create role**.
 
-## Assign permissions to a role
+## Create a new permission for your organization
 
 1. In your Clerk Dashboard, navigate to [**Organization Settings**](https://dashboard.clerk.com/last-active?path=organizations-settings) and select the **Permissions** tab. 
 2. Select **Create new permission**.

--- a/docs/organizations/verify-user-permissions.mdx
+++ b/docs/organizations/verify-user-permissions.mdx
@@ -9,12 +9,15 @@ description: A collection of utility functions and components in order to allow 
   The following authorization checks are predicated on a user having an active organization. Without this, they will likely always evaluate to false by default. Clerk's built-in [`<OrganizationSwitcher/>`](/docs/components/organization/organization-switcher) component and[`useOrganizationList().setActive({ organization: <orgId> })`](/docs/references/react/use-organization-list) method are two available options to set an organization as active for a user.
 </Callout>
 
-Clerk provides two kinds of helpers for authorization:
+In general, you should always verify whether or not a user is authorized to access sensitive information, important content, or exclusive features. The most secure way to implement authorization is by checking the active user's [role or permissions](/docs/organizations/roles-permissions#permissions).
 
-- `protect()` helpers are opinionated and will block additional processing for unauthorized users, either by not rendering children or by throwing errors. The [`<Protect>` component](/docs/components/protect) and the experimental [`auth().protect()`](/docs/references/nextjs/auth#protect) method fall into this category.
-- [`has()` helpers](/docs/references/nextjs/authentication-object#has) are more composable and flexible. They allow you to check and see what permissions a user *has*. You can decide what to do if the user lacks the permission.
+Clerk enables two broad approaches to role and permissions-based authorization:
 
-Both kinds of helpers can check a user's role and permissions. The recommended approach is to verify a user's permissions. Roles can be added and removed and their permissions changed. Authorizing by permissions is explicit.
+1. **Immediately blocking unauthorized users**.
+  - Use the [`<Protect>`](/docs/components/protect) component to prevent content from rendering if the active user is unauthorized.
+  - Call [`auth().protect()`](/docs/references/nextjs/auth#protect) to throw an error if the active user is unauthorized.
+2. **Configuring custom behavior for unauthorized users*.
+  - The [`has()`](/docs/references/nextjs/authentication-object#has) helper returns `false` if the active user lacks the role or permissions you're checking for. You can choose how your app responds without immediately throwing an error or preventing content from rendering.
 
 ## Authorization in Client Components
 

--- a/docs/organizations/verify-user-permissions.mdx
+++ b/docs/organizations/verify-user-permissions.mdx
@@ -6,7 +6,7 @@ description: A collection of utility functions and components in order to allow 
 # Verify the active user's permissions in an organization
 
 <Callout type="info">
-  The following authorization checks are predicated on a user having an active organization. Without this, they will likely always evaluate to false by default. Clerk's built-in [`<OrganizationSwitcher/>`](/docs/components/organization/organization-switcher) component and `[useOrganizationList()](/docs/references/react/use-organization-list).setActive({ organization: <orgId> })` method are two available options to set an organization as active for a user.
+  The following authorization checks are predicated on a user having an active organization. Without this, they will likely always evaluate to false by default. Clerk's built-in [`<OrganizationSwitcher/>`](/docs/components/organization/organization-switcher) component and[`useOrganizationList().setActive({ organization: <orgId> })`](/docs/references/react/use-organization-list) method are two available options to set an organization as active for a user.
 </Callout>
 
 Clerk provides two kinds of helpers for authorization:

--- a/docs/organizations/verify-user-permissions.mdx
+++ b/docs/organizations/verify-user-permissions.mdx
@@ -11,20 +11,10 @@ description: A collection of utility functions and components in order to allow 
 
 Clerk provides two kinds of helpers for authorization:
 
-- **`protect` helpers** are opinionated and will block additional processing for unauthorized users, either by not rendering children or by throwing errors. The [`<Protect>` component](/docs/components/protect) and the experimental `auth().protect()` method fall into this category.
-- **`has` helpers** are more composable and flexible. They allow you to check and see what permissions a user _has_. You can decide what to do if the user lacks the permission.
+- `protect()` helpers are opinionated and will block additional processing for unauthorized users, either by not rendering children or by throwing errors. The [`<Protect>` component](/docs/components/protect) and the experimental [`auth().protect()`](/docs/references/nextjs/auth#protect) method fall into this category.
+- [`has()` helpers](/docs/references/nextjs/authentication-object#has) are more composable and flexible. They allow you to check and see what permissions a user *has*. You can decide what to do if the user lacks the permission.
 
 Both kinds of helpers can check a user's role and permissions. The recommended approach is to verify a user's permissions. Roles can be added and removed and their permissions changed. Authorizing by permissions is explicit.
-
-## `has()`
-
-Clerk's `has()` function can be used on both the frontend and the backend to determine if the user _has_ a role or permission.
-
-`has()` can be used anywhere that Clerk returns an [`Authentication` object](/docs/references/nextjs/authentication-object):
-
-- [`auth()`](/docs/references/nextjs/auth) in Next.js App Router
-- [`useAuth()`](/docs/references/react/use-auth) in Client Components, including during SSR
-- [`getAuth(request)`](/docs/references/nextjs/get-auth) in server contexts outside of the App Router and SSR (Remix Loaders, Node, Express, Fastify, etc)
 
 ## Authorization in Client Components
 
@@ -167,7 +157,7 @@ The examples below work for both SSR and CSR. Examples are written for Next.js A
       `auth().protect()` will throw a `notFound` Next.js error if authorization checks fail.
     </Callout>
 
-    #### Using `auth().protect()`
+    ### Using `auth().protect()`
 
     ```tsx
       import { useAuth } from "@clerk/nextjs";
@@ -180,7 +170,7 @@ The examples below work for both SSR and CSR. Examples are written for Next.js A
       }
     ```
 
-    #### Using `has()`
+    ### Using `has()`
 
     ```tsx
       import { useAuth } from "@clerk/nextjs";

--- a/docs/references/nextjs/auth.mdx
+++ b/docs/references/nextjs/auth.mdx
@@ -17,8 +17,8 @@ A Route Handler added to [`publicRoutes`](/docs/references/nextjs/auth-middlewar
 
 | Name | Type | Description |
 | --- | --- | --- |
-| `protect` | Function | Accepts a permission or a role key or a function with `has` as the first parameter. It will throw a `notFound` Next.js error if the user is unauthorized. Otherwise, it returns an `Authentication` object. |
-| `redirectToSignIn` | <code>(params?: [RedirectToParams](#redirect-to-params)) => ReturnType</code> | Redirects the user to the sign-in page. |
+| [`protect`](#protect) | Function | Accepts a permission or a role key or a function with `has` as the first parameter. It will throw a `notFound` Next.js error if the user is unauthorized. Otherwise, it returns an `Authentication` object. |
+| [`redirectToSignIn`](#redirect-to-sign-in) | Function | Redirects the user to the sign-in page. |
 
 ### `protect()`
 
@@ -36,15 +36,15 @@ You can use the `protect()` helper to check if a user is authorized to access a 
 | `permission` | `string` | The permission to check for. |
 | `has` | <code>(isAuthorizedParams: CheckAuthorizationParamsWithCustomPermissions) => boolean</code> | A function that returns a boolean based on the permission or role provided as parameter. Can be used for authorization. See the dedicated [`has()`](/docs/references/nextjs/authentication-object#has) section for more information. |
 
-### `RedirectToParams`
+### `redirectToSignIn()`
 
-Parameter for `redirectToSignIn`, a method accessible on the `auth()` helper.
+`redirectToSignIn()` is a method that redirects the user to the sign-in page. It accepts the following parameters:
 
 | Name | Type | Description |
 | --- | --- | --- |
 | `returnBackUrl?` | `string \| URL` | The URL to redirect the user back to after they sign in. |
 
-## Retrieve `userId`
+## Use `auth()` to retrieve `userId`
 
 ```tsx filename="app/page.[jsx/tsx]"
 import { auth } from '@clerk/nextjs';
@@ -55,7 +55,7 @@ const { userId } : { userId: string | null } = auth();
 }
 ```
 
-## Data fetching
+## Use `auth()` for data fetching
 
 When using a Clerk integration, or if you need to send a JWT along to a server, you can use the `getToken` function.
 
@@ -80,9 +80,17 @@ export async function GET() {
 }
 ```
 
-## Authorization with `has()`
+## Use `auth()` to check if a user is authorized
+
+`auth()` returns the `Authentication` object, which includes the `has()` helper. `auth()` also returns the `protect()` helper. 
+
+`has()` and `protect()` can be used to check if a user is authorized to access certain parts of your application.
+
+### Use `has()` to check if a user is authorized
 
 Use the [`has()`](/docs/references/nextjs/authentication-object#has) helper in order to check if a user is authorized to access a component.
+
+In the following example, the `has()` helper is used to check if a user has the `org:team_settings:manage` permission. If the user does not have the permission, `null` is returned. If the user has the permission, the component will return the "Team Settings" heading.
 
 ```tsx filename="app/page.tsx"
 import { auth } from '@clerk/nextjs';
@@ -98,15 +106,17 @@ export default async function Page() {
 }
 ```
 
-## Authorization with `protect()`
+### Use `protect()` to check if a user is authorized
 
-Use the [`protect()`](#protect) helper to check if a user is authorized to access a component.
+Use the [`protect()`](#protect) helper to protect a route handler from unauthorized access.
 
 <Callout type="warning">
   `auth().protect()` only works for App Router and is considered experimental.
 </Callout>
 
-```tsx filename="app/api/route.[js/ts]"
+In the following example, the `protect()` helper is used to check if a user is authorized to access a route handler. If the user is not authorized, the `protect()` helper will throw a `notFound` Next.js error. If the user is authorized, the `protect()` helper will return the `Authentication` object, which has the `userId` property.
+
+```tsx filename="app/api/route.ts"
 import { auth } from "@clerk/nextjs";
 
 export const POST = () => {
@@ -116,9 +126,11 @@ export const POST = () => {
 }
 ```
 
-## Check your current user's role
+## Use `auth()` to check your current user's role
 
-In some cases, you need to check your user's current organization role before displaying data or allowing certain actions to be performed.
+In some cases, you need to check your user's current organization role before displaying data or allowing certain actions to be performed. 
+
+You can use the `orgRole` property of the `Authentication` object, which is returned by the `auth()` helper, to check the user's current role.
 
 ```tsx filename="app/page.[jsx/tsx]"
 import { auth } from '@clerk/nextjs';

--- a/docs/references/nextjs/auth.mdx
+++ b/docs/references/nextjs/auth.mdx
@@ -11,7 +11,40 @@ The `auth()` helper does require [Middleware](/docs/references/nextjs/auth-middl
 
 A Route Handler added to [`publicRoutes`](/docs/references/nextjs/auth-middleware#making-pages-public-using-public-routes) can still use the [`auth()`](/docs/references/nextjs/auth) helper to return information about the user or their authentication state, or to control access to some or all of the Route Handler.
 
-## Retrieving userId
+## Return type of `auth()`
+
+`auth()` returns the [`Authentication`](/docs/references/nextjs/authentication-object) object with a few extra properties:
+
+| Name | Type | Description |
+| --- | --- | --- |
+| `protect` | Function | Accepts a permission or a role key or a function with `has` as the first parameter. It will throw a `notFound` Next.js error if the user is unauthorized. Otherwise, it returns an `Authentication` object. |
+| `redirectToSignIn` | <code>(params?: [RedirectToParams](#redirect-to-params)) => ReturnType</code> | Redirects the user to the sign-in page. |
+
+### `protect()`
+
+You can use the `protect()` helper to check if a user is authorized to access a component. It will return the `Authentication` object if the user is authorized. If the user is not authorized, it will throw a `notFound` Next.js error.
+
+<Callout type="warning">
+  `auth().protect()` only works for App Router and is considered experimental.
+</Callout>
+
+`protect()` accepts the following parameters:
+
+| Name | Type | Description |
+| --- | --- | --- |
+| `role` | `string` | The role to check for. |
+| `permission` | `string` | The permission to check for. |
+| `has` | <code>(isAuthorizedParams: CheckAuthorizationParamsWithCustomPermissions) => boolean</code> | A function that returns a boolean based on the permission or role provided as parameter. Can be used for authorization. See the dedicated [`has()`](/docs/references/nextjs/authentication-object#has) section for more information. |
+
+### `RedirectToParams`
+
+Parameter for `redirectToSignIn`, a method accessible on the `auth()` helper.
+
+| Name | Type | Description |
+| --- | --- | --- |
+| `returnBackUrl?` | `string \| URL` | The URL to redirect the user back to after they sign in. |
+
+## Retrieve `userId`
 
 ```tsx filename="app/page.[jsx/tsx]"
 import { auth } from '@clerk/nextjs';
@@ -32,37 +65,44 @@ import { auth } from '@clerk/nextjs';
 
 export async function GET() {
   const {userId, getToken} = auth();
+
   if(!userId){
     return new Response("Unauthorized", { status: 401 });
   }
+
   const token = await getToken({template: "supabase"});
-  // Fetch data from Supabase and return it.
+
+  // Add logic here to fetch data from Supabase and return it.
+  
   const data = { supabaseData: 'Hello World' };
+  
   return NextResponse.json({ data });
 }
 ```
 
-## Authorization
+## Authorization with `has()`
 
-Use `has` in order to check if a user is authorized to access a component.
+Use the [`has()`](/docs/references/nextjs/authentication-object#has) helper in order to check if a user is authorized to access a component.
 
-```tsx filename="app/page.[jsx/tsx]"
+```tsx filename="app/page.tsx"
 import { auth } from '@clerk/nextjs';
 
 export default async function Page() {
   const { has } = auth();
 
-  const canManage = has({permission:"org:team_settings:manage"});
+  const canManage = has({ permission:"org:team_settings:manage" });
 
   if(!canManage) return null;  
 
-  return <h1v>Team Settings</h1>
+  return <h1>Team Settings</h1>
 }
 ```
 
-## Authorization with `protect`
+## Authorization with `protect()`
 
-<Callout type="warning" emoji="⚠️">
+Use the [`protect()`](#protect) helper to check if a user is authorized to access a component.
+
+<Callout type="warning">
   `auth().protect()` only works for App Router and is considered experimental.
 </Callout>
 
@@ -70,12 +110,11 @@ export default async function Page() {
 import { auth } from "@clerk/nextjs";
 
 export const POST = () => {
-  const { userId } = auth().protect({permission: "org:team_settings:manage"});
+  const { userId } = auth().protect({ permission: "org:team_settings:manage" });
 
   return users.createTeam(userId);
 }
 ```
-
 
 ## Check your current user's role
 
@@ -93,14 +132,3 @@ export default async function Page() {
   )
 }
 ```
-
-
-## Return type of `auth`
-
-`auth` returns the [`Authentication`](/docs/references/nextjs/authentication-object) object with a few extra properties.
-
-### Properties
-
-| Name | Type | Description |
-| --- | --- | --- |
-| `protect` | Function | Accepts a permission or a role key or a function with `has` as the first parameter. It will throw a `notFound` Next.js error if the user is unauthorized. Otherwise, it returns an `Authentication` object. |

--- a/docs/references/nextjs/auth.mdx
+++ b/docs/references/nextjs/auth.mdx
@@ -15,14 +15,14 @@ A Route Handler added to [`publicRoutes`](/docs/references/nextjs/auth-middlewar
 
 `auth()` returns the [`Authentication`](/docs/references/nextjs/authentication-object) object with a few extra properties:
 
-| Name | Type | Description |
-| --- | --- | --- |
-| [`protect`](#protect) | Function | Accepts a permission or a role key or a function with `has` as the first parameter. It will throw a `notFound` Next.js error if the user is unauthorized. Otherwise, it returns an `Authentication` object. |
-| [`redirectToSignIn`](#redirect-to-sign-in) | Function | Redirects the user to the sign-in page. |
+- [`protect()`](#protect)
+- [`redirectToSignIn()`](#redirect-to-sign-in)
 
 ### `protect()`
 
-You can use the `protect()` helper to check if a user is authorized to access a component. It will return the `Authentication` object if the user is authorized. If the user is not authorized, it will throw a `notFound` Next.js error.
+You can use the `protect()` helper to check if a user is authorized to access something, such as a component or a route handler. 
+
+`protect()` will return the `Authentication` object if the user is authorized. If the user is not authorized, it will throw a `notFound` Next.js error.
 
 <Callout type="warning">
   `auth().protect()` only works for App Router and is considered experimental.
@@ -46,7 +46,7 @@ You can use the `protect()` helper to check if a user is authorized to access a 
 
 ## Use `auth()` to retrieve `userId`
 
-```tsx filename="app/page.[jsx/tsx]"
+```tsx filename="app/page.tsx"
 import { auth } from '@clerk/nextjs';
 
 export default function Page() {
@@ -59,8 +59,7 @@ const { userId } : { userId: string | null } = auth();
 
 When using a Clerk integration, or if you need to send a JWT along to a server, you can use the `getToken` function.
 
-```tsx filename="app/api/example/route.[jsx/tsx]"
-import { NextResponse } from 'next/server';
+```tsx filename="app/api/example/route.ts"
 import { auth } from '@clerk/nextjs';
 
 export async function GET() {
@@ -70,19 +69,23 @@ export async function GET() {
     return new Response("Unauthorized", { status: 401 });
   }
 
-  const token = await getToken({template: "supabase"});
+  try {
+    const token = await getToken({template: "supabase"});
 
-  // Add logic here to fetch data from Supabase and return it.
+    // Add logic here to fetch data from Supabase and return it.
   
-  const data = { supabaseData: 'Hello World' };
+    const data = { supabaseData: 'Hello World' };
   
-  return NextResponse.json({ data });
+    return Response.json({ data });
+  } catch (error) {
+    return Response.json(error);
+  }
 }
 ```
 
 ## Use `auth()` to check if a user is authorized
 
-`auth()` returns the `Authentication` object, which includes the `has()` helper. `auth()` also returns the `protect()` helper. 
+`auth()` returns the [`Authentication`](/docs/references/nextjs/authentication-object#authentication-object) object, which includes the `has()` helper. `auth()` also returns the `protect()` helper.
 
 `has()` and `protect()` can be used to check if a user is authorized to access certain parts of your application.
 
@@ -90,7 +93,10 @@ export async function GET() {
 
 Use the [`has()`](/docs/references/nextjs/authentication-object#has) helper in order to check if a user is authorized to access a component.
 
-In the following example, the `has()` helper is used to check if a user has the `org:team_settings:manage` permission. If the user does not have the permission, `null` is returned. If the user has the permission, the component will return the "Team Settings" heading.
+In the following example:
+- `has()` is used to check if a user has the `org:team_settings:manage` permission.
+- If the user does not have the permission, `null` is returned.
+- If the user has the permission, the component will return the "Team Settings" heading.
 
 ```tsx filename="app/page.tsx"
 import { auth } from '@clerk/nextjs';
@@ -114,7 +120,10 @@ Use the [`protect()`](#protect) helper to protect a route handler from unauthori
   `auth().protect()` only works for App Router and is considered experimental.
 </Callout>
 
-In the following example, the `protect()` helper is used to check if a user is authorized to access a route handler. If the user is not authorized, the `protect()` helper will throw a `notFound` Next.js error. If the user is authorized, the `protect()` helper will return the `Authentication` object, which has the `userId` property.
+In the following example:
+- `protect()` helper is used to check if a user is authorized to access a route handler. 
+- If the user is not authorized, the `protect()` helper will throw a `notFound` Next.js error. 
+- If the user is authorized, the `protect()` helper will return the `Authentication` object, which has the `userId` property.
 
 ```tsx filename="app/api/route.ts"
 import { auth } from "@clerk/nextjs";
@@ -130,9 +139,9 @@ export const POST = () => {
 
 In some cases, you need to check your user's current organization role before displaying data or allowing certain actions to be performed. 
 
-You can use the `orgRole` property of the `Authentication` object, which is returned by the `auth()` helper, to check the user's current role.
+Check the current user's role with the `orgRole` property of the `Authentication` object returned by `auth()`, as shown in the following example:
 
-```tsx filename="app/page.[jsx/tsx]"
+```tsx filename="app/page.tsx"
 import { auth } from '@clerk/nextjs';
 
 export default async function Page() {

--- a/docs/references/nextjs/authentication-object.mdx
+++ b/docs/references/nextjs/authentication-object.mdx
@@ -27,23 +27,25 @@ Both [`auth()`](/docs/references/nextjs/auth) and  [`getAuth()`](/docs/reference
 
 The `orgRole` property on the `Authentication` object has the type `OrganizationCustomRoleKey`.
 
-`OrganizationCustomRoleKey` is a string that represents the role of the user in the organization. Clerk provides the [default roles](/docs/organizations/roles-permissions#default-roles) `org:admin` and `org:member`. However, [custom roles can be created](/docs/organizations/create-roles-permissions) and used as well.
+`OrganizationCustomRoleKey` is a string that represents the user's role in the organization. Clerk provides the [default roles](/docs/organizations/roles-permissions#default-roles) `org:admin` and `org:member`. However, you can create [custom roles](/docs/organizations/create-roles-permissions) as well.
 
 ### `OrganizationCustomPermissionKey`
 
 The `orgPermissions` property on the `Authentication` object has the type `OrganizationCustomPermissionKey`.
 
-`OrganizationCustomPermissionKey` is a string that represents the permission of the user in the organization. Clerk provides [default System Permissions](/docs/organizations/roles-permissions#permissions). However, [custom permissions can be created](/docs/organizations/create-roles-permissions#create-a-new-permission-for-your-organization) and used as well.
+`OrganizationCustomPermissionKey` is a string that represents the permission of the user in the organization. Clerk provides [default System Permissions](/docs/organizations/roles-permissions#system-permissions), and you can create [custom permissions](/docs/organizations/create-roles-permissions#create-a-new-permission-for-your-organization).
 
 ### `has()`
 
-Clerk's `has()` helper can be used on both the frontend and the backend to determine if the user *has* a role or permission.
+`has()` can be used on both the frontend and the backend to determine if the user *has* a role or permission.
 
-`has()` can be used anywhere that Clerk returns an [`Authentication` object](/docs/references/nextjs/authentication-object):
+You can use `has()` anywhere Clerk returns an [`Authentication`](/docs/references/nextjs/authentication-object) object:
 
 - [`auth()`](/docs/references/nextjs/auth) in Next.js App Router
 - [`useAuth()`](/docs/references/react/use-auth) in Client Components, including during SSR
 - [`getAuth(request)`](/docs/references/nextjs/get-auth) in server contexts outside of the App Router and SSR (Remix Loaders, Node, Express, Fastify, etc)
+
+`has()` has the following function signature:
 
 ```typescript
 function has(isAuthorizedParams: CheckAuthorizationParamsWithCustomPermissions) => boolean;
@@ -51,7 +53,7 @@ function has(isAuthorizedParams: CheckAuthorizationParamsWithCustomPermissions) 
 
 #### `CheckAuthorizationParamsWithCustomPermissions`
 
-`has()` accepts an `isAuthorizedParams` parameter. The `isAuthorizedParams` parameter, with the type `CheckAuthorizationParamsWithCustomPermissions`, is an object with either a `role` or a `permission`, or both can be used together.
+`CheckAuthorizationParamsWithCustomPermissions` has the following properties:
 
 | Name | Type | Description |
 | --- | --- | --- |
@@ -60,7 +62,11 @@ function has(isAuthorizedParams: CheckAuthorizationParamsWithCustomPermissions) 
 
 #### `has()` example
 
-You can use `has()` in order to check if a user is authorized to access a component. In the following example, `has()` is used to check if the user has the `org:team_settings:manage` permission. If the user does not have the permission, `null` is returned and the "Team Settings" component is not rendered.
+You can use `has()` to check if a user is authorized to access a component. 
+
+In the following example:
+- `has()` is used to check if the user has the `org:team_settings:manage` permission.
+- If the user does not have the permission, `null` is returned and the "Team Settings" component is not rendered.
 
 ```tsx filename="app/page.tsx"
 import { auth } from '@clerk/nextjs';
@@ -78,7 +84,7 @@ export default async function Page() {
 
 ### `getToken()`
 
-The `getToken()` method on the `Authentication` object can be used to retrieve the current user's session token. This method can also be used to retrieve a custom JWT template. It has the type `ServerGetToken`.
+You can use `getToken()` on an `Authentication` object to retrieve the current user's session token. You can also use this method to retrieve a custom JWT template. It has the type `ServerGetToken`.
 
 #### `ServerGetToken`
 
@@ -88,7 +94,7 @@ type ServerGetToken = (options?: ServerGetTokenOptions) => Promise<string | null
 
 #### `ServerGetTokenOptions`
 
-The `getToken()` method on the `Authentication` object accepts an optional `options` parameter. The `options` parameter, with the type `ServerGetTokenOptions`, is an object with the following properties:
+`getToken()` accepts an optional `options` parameter, which has the following properties:
 
 | Name | Type | Description |
 | --- | --- | --- |
@@ -96,7 +102,7 @@ The `getToken()` method on the `Authentication` object accepts an optional `opti
 
 ## `Authentication` object example without active organization
 
-The following is an example of the `Authentication` object without an active organization.
+The following is an example of the `Authentication` object without an active organization:
 
 ```js
 {
@@ -122,7 +128,7 @@ The following is an example of the `Authentication` object without an active org
 
 ## `Authentication` object example with active organization
 
-The following is an example of the `Authentication` object with an active organization.
+The following is an example of the `Authentication` object with an active organization:
 
 ```js
 {

--- a/docs/references/nextjs/authentication-object.mdx
+++ b/docs/references/nextjs/authentication-object.mdx
@@ -5,28 +5,98 @@ description: The Authentication object contains information about the current us
 
 # `Authentication` object
 
-Both [`auth()`](/docs/references/nextjs/auth) and  [`getAuth()`](/docs/references/nextjs/get-auth) return an `Authentication` object. This JavaScript object contains important information like session data, your user's ID, as well as their active organization ID.
+Both [`auth()`](/docs/references/nextjs/auth) and  [`getAuth()`](/docs/references/nextjs/get-auth) return an `Authentication` object. This JavaScript object contains important information like the current user's session ID, user ID, and organization ID. It also contains methods to check for permissions and retrieve the current user's session token.
 
-## Properties
+## `Authentication` object properties
 
-| Name | Description |
-| --- | --- |
-| `actor` | Holds identifier for the user that is impersonating the current user. |
-| `debug` | Used to help debug issues when using Clerk in development. |
-| `getToken` | A function that returns a promise that resolves to the current user's session token. Can also be used to retrieve a custom JWT template. |
-| `has` | A function that returns a boolean based on the [permission or role](/docs/organizations/roles-permissions) provided as parameter. Can be used for authorization. |
-| `orgId` | The current user's active organization ID. |
-| `orgRole` | The current user's active organization role. |
-| `orgPermissions` | The current user's active organization permissions. |
-| `orgSlug` | The current user's active organization slug. |
-| `organization` | The current user's active organization object. |
-| `sessionClaim` | The current user's session claim. |
-| `sessionId` | The current user's session ID. |
-| `userId` | The current user's unique identifier. |
+| Name | Type | Description |
+| --- | --- | --- |
+| `sessionId` | `string` | The current user's session ID. |
+| `userId` | `string` | The current user's unique identifier. |
+| `orgId` | `string \| undefined` | The current user's active organization ID. |
+| `orgRole` | <code>[OrganizationCustomRoleKey](#organization-custom-role-key) \| undefined</code> | The current user's active organization role. |
+| `orgSlug` | `string \|undefined` | The current user's active organization slug. |
+| `orgPermissions` | <code>[OrganizationCustomPermissionKey[]](#organization-custom-role-key) \| undefined</code> | The current user's active organization permissions. |
+| [`has`](#has) | <code>(isAuthorizedParams: [CheckAuthorizationParamsWithCustomPermissions](#check-authorization-params-with-custom-permissions)) => boolean</code> | A function that returns a boolean based on the permission or role provided as parameter. Can be used for authorization. |
+| [`getToken`](#get-token) | [`ServerGetToken`](#server-get-token) | A function that returns a promise that resolves to the current user's session token. Can also be used to retrieve a custom JWT template. |
+| `claims` | `JwtPayload` | The current user's [session claims](/docs/backend-requests/resources/session-tokens#default-session-claims). |
+| `actor` | `ActClaim \| undefined` | Holds identifier for the user that is impersonating the current user. |
+| `debug` | `AuthObjectDebug` | Used to help debug issues when using Clerk in development. |
 
-## Example
+### `OrganizationCustomRoleKey`
 
-{/* TODO: Update example to include the newly added properties (has, orgPermissions, organization) */}
+The `orgRole` property on the `Authentication` object has the type `OrganizationCustomRoleKey`.
+
+`OrganizationCustomRoleKey` is a string that represents the role of the user in the organization. Clerk provides the [default roles](/docs/organizations/roles-permissions#default-roles) `org:admin` and `org:member`. However, [custom roles can be created](/docs/organizations/create-roles-permissions) and used as well.
+
+### `OrganizationCustomPermissionKey`
+
+The `orgPermissions` property on the `Authentication` object has the type `OrganizationCustomPermissionKey`.
+
+`OrganizationCustomPermissionKey` is a string that represents the permission of the user in the organization. Clerk provides [default System Permissions](/docs/organizations/roles-permissions#permissions). However, [custom permissions can be created](/docs/organizations/create-roles-permissions#create-a-new-permission-for-your-organization) and used as well.
+
+### `has()`
+
+Clerk's `has()` helper can be used on both the frontend and the backend to determine if the user *has* a role or permission.
+
+`has()` can be used anywhere that Clerk returns an [`Authentication` object](/docs/references/nextjs/authentication-object):
+
+- [`auth()`](/docs/references/nextjs/auth) in Next.js App Router
+- [`useAuth()`](/docs/references/react/use-auth) in Client Components, including during SSR
+- [`getAuth(request)`](/docs/references/nextjs/get-auth) in server contexts outside of the App Router and SSR (Remix Loaders, Node, Express, Fastify, etc)
+
+```typescript
+function has(isAuthorizedParams: CheckAuthorizationParamsWithCustomPermissions) => boolean;
+```
+
+#### `CheckAuthorizationParamsWithCustomPermissions`
+
+`has()` accepts an `isAuthorizedParams` parameter. The `isAuthorizedParams` parameter, with the type `CheckAuthorizationParamsWithCustomPermissions`, is an object with either a `role` or a `permission`, or both can be used together.
+
+| Name | Type | Description |
+| --- | --- | --- |
+| `role` | `string` | The role to check for. |
+| `permission` | `string` | The permission to check for. |
+
+#### `has()` example
+
+You can use `has()` in order to check if a user is authorized to access a component. In the following example, `has()` is used to check if the user has the `org:team_settings:manage` permission. If the user does not have the permission, `null` is returned and the "Team Settings" component is not rendered.
+
+```tsx filename="app/page.tsx"
+import { auth } from '@clerk/nextjs';
+
+export default async function Page() {
+  const { has } = auth();
+
+  const canManage = has({ permission:"org:team_settings:manage" });
+
+  if(!canManage) return null;  
+
+  return <h1>Team Settings</h1>
+}
+```
+
+### `getToken()`
+
+The `getToken()` method on the `Authentication` object can be used to retrieve the current user's session token. This method can also be used to retrieve a custom JWT template. It has the type `ServerGetToken`.
+
+#### `ServerGetToken`
+
+```typescript
+type ServerGetToken = (options?: ServerGetTokenOptions) => Promise<string | null>;
+```
+
+#### `ServerGetTokenOptions`
+
+The `getToken()` method on the `Authentication` object accepts an optional `options` parameter. The `options` parameter, with the type `ServerGetTokenOptions`, is an object with the following properties:
+
+| Name | Type | Description |
+| --- | --- | --- |
+| `template?` | `string` | The name of the custom JWT template to retrieve. |
+
+## `Authentication` object example without active organization
+
+The following is an example of the `Authentication` object without an active organization.
 
 ```js
 {
@@ -50,7 +120,9 @@ Both [`auth()`](/docs/references/nextjs/auth) and  [`getAuth()`](/docs/reference
 }
 ```
 
-## Example with active organization
+## `Authentication` object example with active organization
+
+The following is an example of the `Authentication` object with an active organization.
 
 ```js
 {


### PR DESCRIPTION
This PR
🔎 [Session tokens](https://docs-preview-688.clerkpreview.com/docs/backend-requests/resources/session-tokens)
- moves the `act` token to the appropriate section (it was under organization claims, and that's not correct!)

🔎 [Verify the active user's permissions in an organization](https://docs-preview-688.clerkpreview.com/docs/organizations/verify-user-permissions)
- adds reference links for new has() and protect() sections
- fixes incorrect heading tags (they were not incremental)

🔎 [auth()](https://docs-preview-688.clerkpreview.com/docs/references/nextjs/auth)
- move return type of `auth()` to top of page, right under `auth()`'s explanation. users should fully understand what the helper is and what it returns before exploring examples of it.
- added sections that explain the returns `protect()` and `returnToSignIn()` - pretty clear as to why. users should have the full information on these methods, how to use them, their params, etc.
- updated headings to be more clear, and for better searchability
- added explanations to code examples so that users can clearly understand what's going on the code examples

🔎 [Authentication object](https://docs-preview-688.clerkpreview.com/docs/references/nextjs/authentication-object)
- reorganized the properties to follow what an actual Authentication object would return
- updated property table accordingly (was incorrect/missing props)
- added missing information for types, such as `OrganizationCustomRoleKey` and `OrganizationCustomPermissionKey`
- added sections that fully explain the methods available on the Authentication object - `has()` and `getToken()`
- updated headings to be more clear, and for better searchability