### PR TITLE
DOCS-5292 add missing property to SignUp; update useSignUp

### DIFF
--- a/docs/references/javascript/sign-up/sign-up.mdx
+++ b/docs/references/javascript/sign-up/sign-up.mdx
@@ -24,6 +24,7 @@ Also, the attributes of the `SignUp` object can basically be grouped into three 
 
 | Name | Type | Description |
 | --- | --- | --- |
+| `id` | `string \| undefined` | The unique identifier of the current sign-up. |
 | `status` | `'missing_requirements' \| 'complete' \| 'abandoned' \| null` | The status of the current sign-up.<br/>The following values are supported:<br/><ul><li>`missing_requirements:` There are required fields that are either missing or they are unverified.</li><li>`complete:` All the required fields have been supplied and verified, so the sign-up is complete and a new user and a session have been created.</li><li>`abandoned:` The sign-up has been inactive for a long period of time, thus it's considered as abandoned and need to start over.</li></ul> |
 | `requiredFields` | `string[]` | An array of all the required fields that need to be supplied and verified in order for this sign-up to be marked as complete and converted into a user. |
 | `optionalFields` | `string[]` | An array of all the fields that can be supplied to the sign-up, but their absence does not prevent the sign-up from being marked as complete. |

--- a/docs/references/react/use-sign-up.mdx
+++ b/docs/references/react/use-sign-up.mdx
@@ -9,7 +9,7 @@ The `useSignUp()` hook gives you access to the [`SignUp`](/docs/references/javas
 ## `useSignUp()` returns
 
 | Name | Type | Description |
-| --- | --- |
+| --- | --- | --- |
 | `isLoaded` | `boolean` | A boolean that is set to `false` until Clerk loads and initializes. |
 | `setActive()` | <code>(params: [SetActiveParams](#set-active-params)) => Promise\<void\></code> | A function that sets the active session. |
 | `setSession()` (deprecated) |  Deprecated. | Deprecated in favor of `setActive()`. |

--- a/docs/references/react/use-sign-up.mdx
+++ b/docs/references/react/use-sign-up.mdx
@@ -6,182 +6,62 @@ description: The useSignUp() hook gives you access to the SignUp object, which a
 
 The `useSignUp()` hook gives you access to the [`SignUp`](/docs/references/javascript/sign-up/sign-up) object, which allows you to check the current state of a sign-up. This is also useful for creating a custom sign-up flow.
 
-## Usage
+## `useSignUp()` returns
 
-<Tabs type="framework" items={["Next.js", "React"]}>
-  <Tab>
-    #### Check the current sign-up status
-
-    ```tsx filename="pages/sign-up.tsx"
-    import { useSignUp } from "@clerk/nextjs";
-
-    export default function SignUpStep() {
-      const { isLoaded, signUp } = useSignUp();
-
-      if (!isLoaded) {
-        // handle loading state
-        return null;
-      }
-
-      return <div>The current sign-up attempt status is {signUp.status}.</div>;
-    }
-    ```
-
-    #### Sign up a user with a custom flow
-
-    ```tsx filename="pages/signup.tsx"
-    import { useSignUp } from "@clerk/nextjs";
-    import { useState } from "react";
-
-    export default function SignUp() {
-      const [emailAddress, setEmailAddress] = useState("");
-      const [password, setPassword] = useState("");
-
-      const { isLoaded, signUp, setActive } = useSignUp();
-
-      if (!isLoaded) {
-        // handle loading state
-        return null;
-      }
-
-      async function submit(e) {
-        e.preventDefault();
-        // Check the sign up response to
-        // decide what to do next.
-        await signUp
-          .create({
-            emailAddress,
-            password,
-          })
-          .then((result) => {
-            if (result.status === "complete") {
-              console.log(result);
-              setActive({ session: result.createdSessionId });
-            } else {
-              console.log(result);
-            }
-          })
-          .catch((err) => console.error("error", err.errors[0].longMessage));
-      }
-
-      return (
-        <form onSubmit={submit}>
-          <div>
-            <label htmlFor="email">Email</label>
-            <input
-              type="email"
-              value={emailAddress}
-              onChange={(e) => setEmailAddress(e.target.value)}
-            />
-          </div>
-          <div>
-            <label htmlFor="password">Password</label>
-            <input
-              type="password"
-              value={password}
-              onChange={(e) => setPassword(e.target.value)}
-            />
-          </div>
-          <div>
-            <button>Sign up</button>
-          </div>
-        </form>
-      );
-    }
-    ```
-  </Tab>
-
-  <Tab>
-    #### Check the current sign-up status
-
-    ```tsx filename="sign-up-step.tsx"
-    import { useSignUp } from "@clerk/clerk-react";
-
-    export default function SignUpStep() {
-      const { isLoaded, signUp } = useSignUp();
-
-      if (!isLoaded) {
-        // handle loading state
-        return null;
-      }
-
-      return <div>The current sign-up attempt status is {signUp.status}.</div>;
-    }
-    ```
-
-    #### Sign up a user with a custom flow
-
-    ```tsx filename="signup.tsx"
-    import { useSignUp } from "@clerk/clerk-react";
-    import { useState } from "react";
-
-    export default function SignUp() {
-      const [emailAddress, setEmailAddress] = useState("");
-      const [password, setPassword] = useState("");
-
-      const { isLoaded, signUp, setActive } = useSignUp();
-
-      if (!isLoaded) {
-        // handle loading state
-        return null;
-      }
-
-      async function submit(e) {
-        e.preventDefault();
-        // Check the sign up response to
-        // decide what to do next.
-        await signUp
-          .create({
-            emailAddress,
-            password,
-          })
-          .then((result) => {
-            if (result.status === "complete") {
-              console.log(result);
-              setActive({ session: result.createdSessionId });
-            } else {
-              console.log(result);
-            }
-          })
-          .catch((err) => console.error("error", err.errors[0].longMessage));
-      }
-
-      return (
-        <form onSubmit={submit}>
-          <div>
-            <label htmlFor="email">Email</label>
-            <input
-              type="email"
-              value={emailAddress}
-              onChange={(e) => setEmailAddress(e.target.value)}
-            />
-          </div>
-          <div>
-            <label htmlFor="password">Password</label>
-            <input
-              type="password"
-              value={password}
-              onChange={(e) => setPassword(e.target.value)}
-            />
-          </div>
-          <div>
-            <button>Sign up</button>
-          </div>
-        </form>
-      );
-    }
-    ```
-  </Tab>
-</Tabs>
-
-| Values | Description |
+| Name | Type | Description |
 | --- | --- |
-| `isLoaded` | A boolean that is set to `false` until Clerk loads and initializes. |
-| `setActive()` | A function that sets the active session. |
-| `setSession()` (deprecated) | Deprecated in favor of `setActive()`. |
-| `signUp` | An object that contains the current sign-up attempt status and methods to create a new sign-up attempt. |
+| `isLoaded` | `boolean` | A boolean that is set to `false` until Clerk loads and initializes. |
+| `setActive()` | <code>(params: [SetActiveParams](#set-active-params)) => Promise\<void\></code> | A function that sets the active session. |
+| `setSession()` (deprecated) |  Deprecated. | Deprecated in favor of `setActive()`. |
+| `signUp` | [`SignUp`](/docs/references/javascript/sign-up/sign-up) | An object that contains the current sign-up attempt status and methods to create a new sign-up attempt. |
 
-### Result status
+### `SetActiveParams`
+
+| Name | Type | Description |
+| --- | --- | --- |
+| `session` | <code>[Session](/docs/references/javascript/session) \| string \| null</code> | The session resource or session ID (string version) to be set as active. If `null`, the current session is deleted. |
+| `organization` | <code>[Organization](/docs/references/javascript/organization/organization) \| string \| null</code> | The organization resource or organization ID (string version) to be set as active in the current session. If `null`, the currently active organization is removed as active. |
+| `beforeEmit?` | `(session?: Session \| null) => void \| Promise<any>` | Callback run just before the active session and/or organization is set to the passed object. Can be used to hook up for pre-navigation actions. |
+
+## How to use the `useSignUp()` hook
+
+### Check the current state of a sign-up with `useSignUp()`
+
+You can utilize the `useSignUp()` hook to check the current state of a sign-up.
+
+<CodeBlockTabs type="framework" options={["Next.js", "React"]}>
+  ```tsx filename="pages/sign-up.tsx"
+  import { useSignUp } from "@clerk/nextjs";
+
+  export default function SignUpStep() {
+    const { isLoaded, signUp } = useSignUp();
+
+    if (!isLoaded) {
+      // handle loading state
+      return null;
+    }
+
+    return <div>The current sign-up attempt status is {signUp.status}.</div>;
+  }
+  ```
+
+  ```tsx filename="sign-up-step.tsx"
+  import { useSignUp } from "@clerk/clerk-react";
+
+  export default function SignUpStep() {
+    const { isLoaded, signUp } = useSignUp();
+
+    if (!isLoaded) {
+      // handle loading state
+      return null;
+    }
+
+    return <div>The current sign-up attempt status is {signUp.status}.</div>;
+  }
+  ```
+</CodeBlockTabs>
+
+The `status` property of the `signIn` object can be one of the following values:
 
 | Values | Descriptiom |
 | --- | --- |
@@ -189,3 +69,6 @@ The `useSignUp()` hook gives you access to the [`SignUp`](/docs/references/javas
 | `abandoned` | The sign-up attempt will be abandoned if it was started more than 24 hours previously. |
 | `missing_requirements` | A requirement from the [Email, Phone, Username](https://dashboard.clerk.com/last-active?path=user-authentication/email-phone-username) settings is missing. For example, in the Clerk Dashboard, the Password setting is required but a password was not provided in the custom flow. |
 
+### Create a custom sign-up flow with `useSignUp()`
+
+You can also utilize the `useSignUp()` hook to build fully custom sign-up flows, if Clerk's pre-built components don't meet your specific needs or if you require more control over the authentication flow. Different sign-up flows include email and password, email and phone codes, email links, and multifactor (MFA). To learn more about using the `useSignUp()` hook to create custom flows, check out the [custom flow guides](https://clerk.com/docs/custom-flows/overview).


### PR DESCRIPTION
[This user feedback ticket](https://linear.app/clerk/issue/DOCS-5292/%F0%9F%98%A2-feedback-for-referencesreactuse-sign-upuse-sign-up) wrote, "needs to attempt verify email code before creating a user"

Taking a look at the [useSignUp](https://clerk.com/docs/references/react/use-sign-up) doc, I have updated it's overall structure to introduce the hook and its returns first so that users can understand the hook before taking a look at its usage. Its "Usage" section got reorganized as well, removing redundant code examples that already exist in our "Custom flows" docs. Now, this "Usage" section will link to the appropriate place in the docs, so that users can be guided to the entire section for building custom flows, and understand custom flows fully in their context instead of viewing an incomplete, dead end code example.
The [SignUp](https://clerk.com/docs/references/javascript/sign-up/sign-up) doc also needed updating; the `id` property was missing.

🔎 [useSignUp](https://docs-preview-689.clerkpreview.com/docs/references/react/use-sign-up)
🔎 [SignUp](https://docs-preview-689.clerkpreview.com/docs/references/javascript/sign-up/sign-up)

and special thanks to ramy.alashmawy for leaving the feedback that incited these changes 💙