### PR TITLE
DOCS-676 abstract types from references pages

### DIFF
--- a/docs/manifest.json
+++ b/docs/manifest.json
@@ -611,6 +611,7 @@
         { "title": "Types" },
         [
           ["PublicUserData", "/references/javascript/types/public-user-data"],
+          ["SessionStatus", "/references/javascript/types/session-status"],
           ["RedirectOptions", "/references/javascript/types/redirect-options"],
           ["SignInRedirectOptions", "/references/javascript/types/sign-in-redirect-options"],
           ["SignUpRedirectOptions", "/references/javascript/types/sign-up-redirect-options"],

--- a/docs/manifest.json
+++ b/docs/manifest.json
@@ -610,6 +610,7 @@
       [
         { "title": "Types" },
         [
+          ["Overview", "/references/javascript/types/overview"],
           ["PublicUserData", "/references/javascript/types/public-user-data"],
           ["SessionStatus", "/references/javascript/types/session-status"],
           ["RedirectOptions", "/references/javascript/types/redirect-options"],

--- a/docs/references/backend/sessions/get-session-list.mdx
+++ b/docs/references/backend/sessions/get-session-list.mdx
@@ -17,23 +17,7 @@ const sessions = await clerkClient.sessions.getSessionList();
 | --- | --- | --- |
 | `clientId?` | `string` | The client ID to retrieve the list of sessions for. |
 | `userId?` | `string` | The user ID to retrieve the list of sessions for. |
-| `status?` | `[SessionStatus](#session-status)` | The status of the session. |
-
-### `SessionStatus`
-
-```tsx
-type SessionStatus = "abandoned" | "active" | "ended" | "expired" | "removed" | "replaced" | "revoked";
-```
-
-| Value | Description |
-| --- | --- |
-| `abandoned`	| The session was abandoned client-side. |
-| `active` | The session is valid and all activity is allowed. |
-| `ended`	| The user signed out of the session, but the `Session` remains in the `Client` object. |
-| `expired` | The period of allowed activity for this session has passed. |
-| `removed` | The user signed out of the session and the `Session` was removed from the `Client` object. |
-| `replaced` | The session has been replaced by another one, but the `Session` remains in the `Client` object. |
-| `revoked` | The application ended the session and the `Session` was removed from the `Client` object. |
+| `status?` | `[SessionStatus](/docs/references/javascript/types/session-status)` | The status of the session. |
 
 ## Example
 

--- a/docs/references/javascript/organization-domain.mdx
+++ b/docs/references/javascript/organization-domain.mdx
@@ -14,8 +14,8 @@ The `OrganizationDomain` object is the model around an organization domain.
 | `id` | `string` | A unique identifier for this organization domain. |
 | `name` | `string` | The name for this organization domain (e.g. example.com). |
 | `organizationId` | `string` | The organization ID of the organization this domain is for. |
-| `enrollmentMode` | `'manual_invitation' \| 'automatic_invitation' \| 'automatic_suggestion'` | An [enrollment mode][enrollment-mode-ref] will change how new users join an organization. |
-| `verification` | [`OrganizationDomainVerification`][org-domain-ver-ref] | The object that describes the status of the verification process of the domain. |
+| `enrollmentMode` | `'manual_invitation' \| 'automatic_invitation' \| 'automatic_suggestion'` | An [enrollment mode](/docs/organizations/verified-domains#enrollment-modes) will change how new users join an organization. |
+| `verification` | [`OrganizationDomainVerification`](#organization-domain-verification) | The object that describes the status of the verification process of the domain. |
 | `affiliationEmailAddress` | `string \| null` | The email address that was used to verify this organization domain. |
 | `totalPendingInvitations` | `number` | The number of total pending invitations sent to emails that match the domain name. |
 | `totalPendingSuggestions` | `number` | The number of total pending suggestions sent to emails that match the domain name. |
@@ -85,7 +85,3 @@ function attemptAffiliationVerification(params: AttemptAffiliationVerificationPa
 | Type | Description |
 | --- | --- |
 | `Promise<OrganizationDomain>` | This method returns a `Promise` which resolves with an `OrganizationDomain` object. |
-
-
-[enrollment-mode-ref]: /docs/organizations/verified-domains#enrollment-modes
-[org-domain-ver-ref]: #organization-domain-verification

--- a/docs/references/javascript/session-with-activities.mdx
+++ b/docs/references/javascript/session-with-activities.mdx
@@ -16,7 +16,7 @@ While the `SessionWithActivities` object wraps the most important information ar
 | Name | Type | Description |
 | --- | --- | --- |
 | `id` | `string` | A unique identifier for the session. |
-| `status` | [`SessionStatus`](#session-status) | The current state of the session. |
+| `status` | [`SessionStatus`](/docs/references/javascript/types/session-status) | The current state of the session. |
 | `lastActiveAt` | `Date` | The time the session was last active on the [`Client`][client-ref]. |
 | `abandonAt` | `Date` | The time when the session was abandoned by the user. |
 | `expireAt` | `Date` | The time the session expires and will seize to be active. |
@@ -49,23 +49,3 @@ Users can revoke only their own sessions.
 | `city` | `string \| undefined` | The city from which this session activity occurred. Resolved by IP address geo-location. |
 | `country` | `string \| undefined` | The country from which this session activity occurred. Resolved by IP address geo-location. |
 | `isMobile` | `boolean \| undefined` | Will be set to `true` if the session activity came from a mobile device. Set to `false` otherwise. |
-
-
-### `SessionStatus`
-
-```typescript
-type SessionStatus = "abandoned" | "active" | "ended" | "expired" | "removed" | "replaced" | "revoked";
-```
-
-| Value | Description |
-| --- | --- |
-| `abandoned` | The session was abandoned client-side. |
-| `active` | The session is valid and all activity is allowed. |
-| `ended` | The user signed out of the session, but the [`Session`][session-ref] remains in the [`Client`][client-ref] object. |
-| `expired` | The period of allowed activity for this session has passed. |
-| `removed` | The user signed out of the session and the [`Session`][session-ref] was removed from the [`Client`][client-ref] object. |
-| `replaced` | The session has been replaced by another one, but the [`Session`][session-ref] remains in the [`Client`][client-ref] object. |
-| `revoked` | The application ended the session and the [`Session`][session-ref] was removed from the [`Client`][client-ref] object. |
-
-[session-ref]: /docs/references/javascript/session
-[client-ref]: /docs/references/javascript/client

--- a/docs/references/javascript/session.mdx
+++ b/docs/references/javascript/session.mdx
@@ -24,8 +24,8 @@ All sessions that are **expired**, **removed**, **replaced**, **ended** or **aba
 | --- | --- | --- |
 | `id` | `string` | A unique identifier for the session. |
 | `user` | [`User`](/docs/references/javascript/user/user) | The user associated with the session. |
-| `publicUserData` | [`PublicUserData`](#public-user-data) | Public information about the user that this session belongs to. |
-| `status` | [`SessionStatus`](#session-status) | The current state of the session. |
+| `publicUserData` | [`PublicUserData`](/docs/references/javascript/types/public-user-data) | Public information about the user that this session belongs to. |
+| `status` | [`SessionStatus`](/docs/references/javascript/types/session-status) | The current state of the session. |
 | `lastActiveAt` | `Date` | The time the session was last active on the [`Client`][client-ref]. |
 | `abandonAt` | `Date` | The time when the session was abandoned by the user. |
 | `expireAt` | `Date` | The time the session expires and will cease to be active. |
@@ -133,33 +133,5 @@ type CheckAuthorizationParams =
 | Type | Description |
 | --- | --- |
 | `boolean` | A boolean that indicates if a user is authorized for the specified role or permission. |
-
-## Types
-
-### `PublicUserData`
-
-| Name | Type | Description |
-| --- | --- | --- |
-| `firstName` | `string \| null` | The user's first name. This attribute will only be populated if name is enabled in instance settings. |
-| `lastName` | `string \| null` | The user's last name. This attribute will only be populated if name is enabled in instance settings. |
-| `imageUrl` | `string` | A getter boolean to check if the user has uploaded an image or one was copied from OAuth. Returns `false` if Clerk is displaying an avatar for the user. |
-| `hasImage` | `boolean` | Whether the user has a profile image. |
-| `identifier` | `string` | The user's identifier (email address, phone number, username, etc) that was used for authentication when this session was created. |
-
-### `SessionStatus`
-
-```typescript
-type SessionStatus = "abandoned" | "active" | "ended" | "expired" | "removed" | "replaced" | "revoked";
-```
-
-| Value | Description |
-| --- | --- |
-| `abandoned` | The session was abandoned client-side. |
-| `active` | The session is valid and all activity is allowed. |
-| `ended` | The user signed out of the session, but the `Session` remains in the [`Client`][client-ref] object. |
-| `expired` | The period of allowed activity for this session has passed. |
-| `removed` | The user signed out of the session and the `Session` was removed from the [`Client`][client-ref] object. |
-| `replaced` | The session has been replaced by another one, but the `Session` remains in the [`Client`][client-ref] object. |
-| `revoked` | The application ended the session and the `Session` was removed from the [`Client`][client-ref] object. |
 
 [client-ref]: /docs/references/javascript/client

--- a/docs/references/javascript/types/overview.mdx
+++ b/docs/references/javascript/types/overview.mdx
@@ -1,0 +1,24 @@
+---
+title: Clerk types
+description: Explore the different types available for typing your application.
+---
+
+# Clerk types
+
+Types are a powerful tool for adding type-safety to your application. They can help you catch bugs early, make your code easier to understand, and make your code easier to refactor. Clerk provides a number of types to help you add type-safety to your application.
+
+To get access to Clerk types, you need to add the `@clerk/types` package to your project. Install it by running the following command in your terminal:
+
+<CodeBlockTabs type="installer" options={["npm", "yarn", "pnpm"]}>
+```bash filename="terminal"
+npm install @clerk/types
+```
+
+```bash filename="terminal"
+yarn add @clerk/types
+```
+
+```bash filename="terminal"
+pnpm add @clerk/types
+```
+</CodeBlockTabs>

--- a/docs/references/javascript/types/session-status.mdx
+++ b/docs/references/javascript/types/session-status.mdx
@@ -1,0 +1,27 @@
+---
+title: SessionStatus
+description: The SessionStatus enum is used to indicate the status of a session.
+---
+
+# `SessionStatus`
+
+The `SessionStatus` enum is used to indicate the status of a session.
+
+```tsx
+type SessionStatus = "abandoned" | "active" | "ended" | "expired" | "removed" | "replaced" | "revoked";
+```
+
+## Properties
+
+| Value | Description |
+| --- | --- |
+| `abandoned` | The session was abandoned client-side. |
+| `active` | The session is valid and all activity is allowed. |
+| `ended` | The user signed out of the session, but the [`Session`][session-ref] remains in the [`Client`][client-ref] object. |
+| `expired` | The period of allowed activity for this session has passed. |
+| `removed` | The user signed out of the session and the [`Session`][session-ref] was removed from the [`Client`][client-ref] object. |
+| `replaced` | The session has been replaced by another one, but the [`Session`][session-ref] remains in the [`Client`][client-ref] object. |
+| `revoked` | The application ended the session and the [`Session`][session-ref] was removed from the [`Client`][client-ref] object. |
+
+[session-ref]: /docs/references/javascript/session
+[client-ref]: /docs/references/javascript/client

--- a/docs/references/javascript/user/create-metadata.mdx
+++ b/docs/references/javascript/user/create-metadata.mdx
@@ -1,11 +1,11 @@
 ---
 title: Create User Metadata
-description: These are the methods on the User object that help you create data for the user, such as createEmailAddress() and createPhoneNumber().
+description: Learn about the methods on the User object that help you create data for the user, such as createEmailAddress() and createPhoneNumber().
 ---
 
 # Create user metadata
 
-These are the methods on the [`User`](/docs/references/javascript/user/user) object that help you create data for the user, such as `createEmailAddress()` and `createPhoneNumber()`.
+The [`User`](/docs/references/javascript/user/user) object has methods that help you create data for the user, such as `createEmailAddress()` and `createPhoneNumber()`.
 
 ## `createEmailAddress()`
 

--- a/docs/references/javascript/user/create-metadata.mdx
+++ b/docs/references/javascript/user/create-metadata.mdx
@@ -1,9 +1,11 @@
 ---
 title: Create User Metadata
-description: These are the methods that help you create data for the user, such as createEmailAddress() and createPhoneNumber().
+description: These are the methods on the User object that help you create data for the user, such as createEmailAddress() and createPhoneNumber().
 ---
 
 # Create user metadata
+
+These are the methods on the [`User`](/docs/javascript/user/user) object that help you create data for the user, such as `createEmailAddress()` and `createPhoneNumber()`.
 
 ## `createEmailAddress()`
 

--- a/docs/references/javascript/user/create-metadata.mdx
+++ b/docs/references/javascript/user/create-metadata.mdx
@@ -5,7 +5,7 @@ description: These are the methods on the User object that help you create data 
 
 # Create user metadata
 
-These are the methods on the [`User`](/docs/javascript/user/user) object that help you create data for the user, such as `createEmailAddress()` and `createPhoneNumber()`.
+These are the methods on the [`User`](/docs/references/javascript/user/user) object that help you create data for the user, such as `createEmailAddress()` and `createPhoneNumber()`.
 
 ## `createEmailAddress()`
 

--- a/docs/references/javascript/user/password-management.mdx
+++ b/docs/references/javascript/user/password-management.mdx
@@ -5,7 +5,7 @@ description: These are the methods on the User object that help you manage a use
 
 # User password management
 
-These are the methods on the [`User`](/docs/javascript/user/user) object that help you manage a user's password.
+These are the methods on the [`User`](/docs/references/javascript/user/user) object that help you manage a user's password.
 
 ## `updatePassword()`
 

--- a/docs/references/javascript/user/password-management.mdx
+++ b/docs/references/javascript/user/password-management.mdx
@@ -1,11 +1,11 @@
 ---
 title: User Password Management
-description: These are the methods on the User object that help you manage a user's password.
+description: Learn about the methods on the User object that help you manage a user's password.
 ---
 
 # User password management
 
-These are the methods on the [`User`](/docs/references/javascript/user/user) object that help you manage a user's password.
+The [`User`](/docs/references/javascript/user/user) object has methods that help you manage a user's password.
 
 ## `updatePassword()`
 

--- a/docs/references/javascript/user/password-management.mdx
+++ b/docs/references/javascript/user/password-management.mdx
@@ -1,9 +1,11 @@
 ---
 title: User Password Management
-description: These are the methods that help you manage a user's password.
+description: These are the methods on the User object that help you manage a user's password.
 ---
 
 # User password management
+
+These are the methods on the [`User`](/docs/javascript/user/user) object that help you manage a user's password.
 
 ## `updatePassword()`
 

--- a/docs/references/javascript/user/totp.mdx
+++ b/docs/references/javascript/user/totp.mdx
@@ -1,9 +1,11 @@
 ---
 title: Time-based One-time Password
-description: These are the methods and types related to Time-based One-time Password (TOTP) functionality that allow you to generate and verify TOTP secrets, disable TOTP, and manage backup codes for user authentication.
+description: These are the methods on the User object that are related to Time-based One-time Password (TOTP) functionality. These methods allow you to generate and verify TOTP secrets, disable TOTP, and manage backup codes for user authentication.
 ---
 
 # Time-based one-time password (TOTP)
+
+These are the methods on the [`User`](/docs/javascript/user/user) object that are related to Time-based One-time Password (TOTP) functionality. These methods allow you to generate and verify TOTP secrets, disable TOTP, and manage backup codes for user authentication.
 
 ## Methods
 

--- a/docs/references/javascript/user/totp.mdx
+++ b/docs/references/javascript/user/totp.mdx
@@ -5,7 +5,7 @@ description: These are the methods on the User object that are related to Time-b
 
 # Time-based one-time password (TOTP)
 
-These are the methods on the [`User`](/docs/javascript/user/user) object that are related to Time-based One-time Password (TOTP) functionality. These methods allow you to generate and verify TOTP secrets, disable TOTP, and manage backup codes for user authentication.
+These are the methods on the [`User`](/docs/references/javascript/user/user) object that are related to Time-based One-time Password (TOTP) functionality. These methods allow you to generate and verify TOTP secrets, disable TOTP, and manage backup codes for user authentication.
 
 ## Methods
 

--- a/docs/references/javascript/user/totp.mdx
+++ b/docs/references/javascript/user/totp.mdx
@@ -1,11 +1,11 @@
 ---
 title: Time-based One-time Password
-description: These are the methods on the User object that are related to Time-based One-time Password (TOTP) functionality. These methods allow you to generate and verify TOTP secrets, disable TOTP, and manage backup codes for user authentication.
+description: Learn about the methods on the User object that allow you to generate and verify TOTP secrets, disable TOTP, and manage backup codes for user authentication.
 ---
 
 # Time-based one-time password (TOTP)
 
-These are the methods on the [`User`](/docs/references/javascript/user/user) object that are related to Time-based One-time Password (TOTP) functionality. These methods allow you to generate and verify TOTP secrets, disable TOTP, and manage backup codes for user authentication.
+There are a number of methods on the [`User`](/docs/references/javascript/user/user) object that are related to Time-based One-time Password (TOTP) functionality. These methods allow you to generate and verify TOTP secrets, disable TOTP, and manage backup codes for user authentication.
 
 ## Methods
 

--- a/docs/references/javascript/web3-wallet/verification.mdx
+++ b/docs/references/javascript/web3-wallet/verification.mdx
@@ -1,11 +1,11 @@
 ---
 title: Web3Wallet Verification
-description: These are all methods on the Web3Wallet class that allow you to verify a user's web3 wallet.
+description: These are all methods on the Web3Wallet object that allow you to verify a user's web3 wallet.
 ---
 
 # `Web3Wallet` verification
 
-These are all methods on the [`Web3Wallet`](/docs/references/javascript/web3-wallet/web3-wallet) class that allow you to verify a user's web3 wallet.
+These are the methods on the [`Web3Wallet`](/docs/references/javascript/web3-wallet/web3-wallet) object that allow you to verify a user's web3 wallet.
 
 ## `prepareVerification()`
 

--- a/docs/references/javascript/web3-wallet/verification.mdx
+++ b/docs/references/javascript/web3-wallet/verification.mdx
@@ -1,11 +1,11 @@
 ---
 title: Web3Wallet Verification
-description: These are all methods on the Web3Wallet object that allow you to verify a user's web3 wallet.
+description: Learn about the methods on the Web3Wallet object that allow you to verify a user's web3 wallet.
 ---
 
 # `Web3Wallet` verification
 
-These are the methods on the [`Web3Wallet`](/docs/references/javascript/web3-wallet/web3-wallet) object that allow you to verify a user's web3 wallet.
+The [`Web3Wallet`](/docs/references/javascript/web3-wallet/web3-wallet) object has methods that allow you to verify a user's web3 wallet.
 
 ## `prepareVerification()`
 


### PR DESCRIPTION
[DOCS-676](https://linear.app/clerk/issue/DOCS-676/types-section-on-javascript-reference-pages-need-to-be-consolidated) reads:
Many of the JavaScript reference pages have a "Types" section that has redundant information. We have /references/javascript/types to house types references. For example, https://clerk.com/docs/references/javascript/session#types has PublicUserData and SessionStatus sections, yet the /references/javascript/types context has a dedicated page for PublicUserData that we can simply link to. And SessionStatus is used on other reference pages, so a dedicated page for this type can be created and then also linked to.

We should ensure that types *that are reused on multiple different pages* have a dedicated page under `/references/javascript/types`.

We should also create an overview page for /references/javascript/types that talks about installing the @clerk/types package, and gives examples on how to navigate type information.

---

This PR
- abstract types from references pages to dedicated pages in the types section of docs
- adds an overview page to the types section of the docs
- adds missing introductory paragraphs to pages such as docs/references/javascript/user/create-metadata and docs/references/javascript/user/password-management