### PR TITLE
DOCS-699 fix broken injectkeys instances; add copy that explains injectkeys usage

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -427,7 +427,7 @@ The `<InjectKeys />` component is used to inject the user's current Clerk instan
 ````mdx
   Add the following code to your `.env.local` file to set your public and secret keys.
 
-  **Pro tip!** If you are signed into your [Clerk Dashboard](https://dashboard.clerk.com/), your secret key should become visible by clicking on the eye icon.
+  **Pro tip!** If you are signed into your Clerk Dashboard, your secret key should become visible by clicking on the eye icon. Otherwise, you can find your keys in the Clerk Dashboard on the [API Keys](https://dashboard.clerk.com/last-active?path=api-keys) page.
 
   <InjectKeys>
 

--- a/docs/advanced-usage/using-proxies.mdx
+++ b/docs/advanced-usage/using-proxies.mdx
@@ -142,6 +142,8 @@ In order to enable proxying, you need to set a proxy URL for your Clerk instance
 
 You can configure your proxy setup via environment variables or via properties.
 
+**Pro tip!** If you are signed into your Clerk Dashboard, your secret key should become visible by clicking on the eye icon. Otherwise, you can find your keys in the Clerk Dashboard on the [API Keys](https://dashboard.clerk.com/last-active?path=api-keys) page.
+
 <Tabs items={["Environment Variables", "Properties"]}>
   <Tab>
     <InjectKeys>

--- a/docs/backend-requests/handling/go.mdx
+++ b/docs/backend-requests/handling/go.mdx
@@ -7,7 +7,11 @@ description: Learn how to handle authenticated requests with Go middleware using
 
 ## Go Middleware
 
-The Clerk Go SDK provides an easy-to-use middleware that adds the active session to the request’s context.
+The Clerk Go SDK provides an easy-to-use middleware that adds the active session to the request's context.
+
+**Pro tip!** If you are signed into your Clerk Dashboard, your secret key should become visible by clicking on the eye icon. Otherwise, you can find your keys in the Clerk Dashboard on the [API Keys](https://dashboard.clerk.com/last-active?path=api-keys) page.
+
+{/* TODO: Is the filename of this code example supposed to be .env? */}
 
 <InjectKeys>
 
@@ -20,7 +24,8 @@ import (
 )
 
 func main() {
-	client, _ := clerk.NewClient({{secret}})
+	// Create a new Clerk client with your secret key from the Clerk Dashboard
+	client, _ := clerk.NewClient(`{{secret}}`)
 
 	mux := http.NewServeMux()
 

--- a/docs/components/control/authenticate-with-callback.mdx
+++ b/docs/components/control/authenticate-with-callback.mdx
@@ -88,7 +88,7 @@ The `<AuthenticateWithRedirectCallback />` is used to complete a custom OAuth fl
 
   function App() {
     return (
-      <ClerkProvider publishableKey={{pub_key}}>
+      <ClerkProvider publishableKey={`{{pub_key}}`}>
         {/* Define a / route that displays the OAuth button */}
         <Routes>
           <Route path="/" element={<HomePages />} />

--- a/docs/components/control/clerk-loaded.mdx
+++ b/docs/components/control/clerk-loaded.mdx
@@ -60,7 +60,7 @@ The `<ClerkLoaded>` component guarantees that the Clerk object has loaded and wi
 
   function App() {
     return (
-      <ClerkProvider publishableKey={{pub_key}}>
+      <ClerkProvider publishableKey={`{{pub_key}}`}>
         <ClerkLoaded>
           <Page />
         </ClerkLoaded>

--- a/docs/components/control/clerk-loading.mdx
+++ b/docs/components/control/clerk-loading.mdx
@@ -42,7 +42,7 @@ The `<ClerkLoading>` renders its children while Clerk is loading, and is helpful
 
   function App() {
     return (
-      <ClerkProvider publishableKey={{pub_key}}>
+      <ClerkProvider publishableKey={`{{pub_key}}`}>
         <ClerkLoading>
           <div>Clerk is loading</div>
         </ClerkLoading>

--- a/docs/components/control/multi-session.mdx
+++ b/docs/components/control/multi-session.mdx
@@ -38,7 +38,7 @@ The `<MultisessionAppSupport>` provides a wrapper for your React application tha
 
   function App() {
     return (
-      <ClerkProvider publishableKey={{pub_key}}>
+      <ClerkProvider publishableKey={`{{pub_key}}`}>
         <MultisessionAppSupport>
           <Page />
         </MultisessionAppSupport>

--- a/docs/components/control/redirect-to-createorganization.mdx
+++ b/docs/components/control/redirect-to-createorganization.mdx
@@ -51,7 +51,7 @@ The `<RedirectToCreateOrganization />` component will navigate to the create org
 
   function PrivatePage() {
     return (
-      <ClerkProvider publishableKey={{pub_key}}>
+      <ClerkProvider publishableKey={`{{pub_key}}`}>
         <SignedIn>
           <RedirectToCreateOrganization/>
         </SignedIn>

--- a/docs/components/control/redirect-to-organizationprofile.mdx
+++ b/docs/components/control/redirect-to-organizationprofile.mdx
@@ -51,7 +51,7 @@ The `<RedirectToOrganizationProfile />` component will navigate to the organizat
 
   function PrivatePage() {
     return (
-      <ClerkProvider publishableKey={{pub_key}}>
+      <ClerkProvider publishableKey={`{{pub_key}}`}>
         <SignedIn>
           <RedirectToOrganizationProfile/>
         </SignedIn>

--- a/docs/components/control/redirect-to-signin.mdx
+++ b/docs/components/control/redirect-to-signin.mdx
@@ -50,7 +50,7 @@ The `<RedirectToSignIn />` component will navigate to the sign in URL which has 
 
   function PrivatePage() {
     return (
-      <ClerkProvider publishableKey={{pub_key}}>
+      <ClerkProvider publishableKey={`{{pub_key}}`}>
         <SignedIn>
           Content that is displayed to signed in
           users.

--- a/docs/components/control/redirect-to-signup.mdx
+++ b/docs/components/control/redirect-to-signup.mdx
@@ -50,7 +50,7 @@ The `<RedirectToSignUp />` component will navigate to the sign up URL which has 
 
   function PrivatePage() {
     return (
-      <ClerkProvider publishableKey={{pub_key}}>
+      <ClerkProvider publishableKey={`{{pub_key}}`}>
         <SignedIn>
           Content that is displayed to signed in
           users.

--- a/docs/components/control/redirect-to-userprofile.mdx
+++ b/docs/components/control/redirect-to-userprofile.mdx
@@ -51,7 +51,7 @@ The `<RedirectToUserProfile />` component will navigate to the user profile URL 
 
   function PrivatePage() {
     return (
-      <ClerkProvider publishableKey={{pub_key}}>
+      <ClerkProvider publishableKey={`{{pub_key}}`}>
         <SignedIn>
           <RedirectToUserProfile/>
         </SignedIn>

--- a/docs/components/control/signed-in.mdx
+++ b/docs/components/control/signed-in.mdx
@@ -45,7 +45,7 @@ The `<SignedIn>` component offers authentication checks as a cross-cutting conce
 
   function Page() {
     return (
-      <ClerkProvider publishableKey={{pub_key}}>
+      <ClerkProvider publishableKey={`{{pub_key}}`}>
         <section>
           <div>
             This content is always visible.
@@ -100,7 +100,7 @@ import {
 
 function App() {
   return (
-      <ClerkProvider publishableKey={{pub_key}}>
+      <ClerkProvider publishableKey={`{{pub_key}}`}>
         <Routes>
         <Route
           path="/"

--- a/docs/components/control/signed-out.mdx
+++ b/docs/components/control/signed-out.mdx
@@ -43,7 +43,7 @@ The `<SignedOut>` component offers authentication checks as a cross-cutting conc
 
   function Page() {
     return (
-      <ClerkProvider publishableKey={{pub_key}}>
+      <ClerkProvider publishableKey={`{{pub_key}}`}>
         <section>
           <div>
             This content is always visible.
@@ -73,7 +73,7 @@ The `<SignedOut>` component offers authentication checks as a cross-cutting conc
 
   function App() {
     return (
-      <ClerkProvider publishableKey={{pub_key}}>
+      <ClerkProvider publishableKey={`{{pub_key}}`}>
         <Routes>
         <Route
           path="/"

--- a/docs/integrations/databases/convex.mdx
+++ b/docs/integrations/databases/convex.mdx
@@ -111,7 +111,7 @@ Install Clerk's React SDK by running the following command in your terminal:
 
 ### Set environment keys
 
-In your React project's root folder, you may have an `.env.local` file alongside `package.json` and other configuration files. If you don't see it, create it.
+In your React project's root folder, you may have a `.env.local` file alongside `package.json` and other configuration files. If you don't see it, create it.
 
 Add the following code to your `.env.local` file to set your public key.
 

--- a/docs/integrations/databases/convex.mdx
+++ b/docs/integrations/databases/convex.mdx
@@ -115,7 +115,7 @@ In your React project's root folder, you may have an `.env.local` file alongside
 
 Add the following code to your `.env.local` file to set your public key.
 
-**Pro tip!** If you are signed into your [Clerk Dashboard](https://dashboard.clerk.com/last-active?path=api-keys), you can copy your publishable key below.
+**Pro tip!** If you are signed into your Clerk Dashboard, you can copy your publishable key below. Otherwise, you can find it in the Clerk Dashboard on the [API Keys](https://dashboard.clerk.com/last-active?path=api-keys) page.
 
 <InjectKeys>
 

--- a/docs/integrations/databases/supabase.mdx
+++ b/docs/integrations/databases/supabase.mdx
@@ -54,7 +54,9 @@ Reveal the JWT secret to copy it and then paste it in the **Signing key field** 
 
 ## Configure your client
 
-To configure your client, you need to set some local environment variables. Assuming a React application, set the following:
+To configure your client, you need to set some local environment variables. Assuming a React application, set the following.
+
+**Pro tip!** If you are signed into your Clerk Dashboard, you can copy your Clerk publishable key below. Otherwise, you can find it in the Clerk Dashboard on the [API Keys](https://dashboard.clerk.com/last-active?path=api-keys) page.
 
 <InjectKeys>
 

--- a/docs/quickstarts/fastify.mdx
+++ b/docs/quickstarts/fastify.mdx
@@ -34,7 +34,7 @@ If you're looking for a more complete example, check out our [Fastify example ap
 
 ### Set environment keys
 
-Below is an example of an `.env.local` file. 
+Below is an example of a `.env.local` file. 
 
 **Pro tip!** If you are signed into your Clerk Dashboard, your secret key should become visible by clicking on the eye icon. Otherwise, you can find your keys in the Clerk Dashboard on the [API Keys](https://dashboard.clerk.com/last-active?path=api-keys) page.
 

--- a/docs/quickstarts/fastify.mdx
+++ b/docs/quickstarts/fastify.mdx
@@ -34,11 +34,13 @@ If you're looking for a more complete example, check out our [Fastify example ap
 
 ### Set environment keys
 
-Below is an example of an `.env` file. If you are signed into your Clerk Dashboard, your keys should become visible by clicking on the eye icon.
+Below is an example of an `.env.local` file. 
+
+**Pro tip!** If you are signed into your Clerk Dashboard, your secret key should become visible by clicking on the eye icon. Otherwise, you can find your keys in the Clerk Dashboard on the [API Keys](https://dashboard.clerk.com/last-active?path=api-keys) page.
 
 <InjectKeys>
 
-```env filename=".env"
+```env filename=".env.local"
 CLERK_PUBLISHABLE_KEY={{pub_key}}
 CLERK_SECRET_KEY={{secret}}
 ```

--- a/docs/quickstarts/gatsby.mdx
+++ b/docs/quickstarts/gatsby.mdx
@@ -28,7 +28,9 @@ Once you have a React application ready, you need to install Clerk's React SDK. 
 
 ### Set environment keys
 
-Below is an example of your `.env.development` file. If you are signed into your Clerk Dashboard, your keys should become visible by clicking on the eye icon.
+Below is an example of your `.env.development` file. 
+
+**Pro tip!** If you are signed into your Clerk Dashboard, your secret key should become visible by clicking on the eye icon. Otherwise, you can find your keys in the Clerk Dashboard on the [API Keys](https://dashboard.clerk.com/last-active?path=api-keys) page.
 
 <InjectKeys>
 

--- a/docs/quickstarts/javascript.mdx
+++ b/docs/quickstarts/javascript.mdx
@@ -54,7 +54,7 @@ At the root of your project, install the ClerkJS package using your package mana
 
 ### Set environment keys
 
-To use the ClerkJS package, you'll need your **Publishable Key** and your **Frontend API URL**. If you are signed into your Clerk Dashboard, your **Publishable key** should be visible below. However, both of these values can be found in the Clerk Dashboard on the **[API Keys](https://dashboard.clerk.com/last-active?path=api-keys)** page. On this page, click on the **Advanced** dropdown to find your **Frontend API URL**. 
+To use the ClerkJS package, you'll need your **Publishable Key** and your **Frontend API URL**. If you are signed into your Clerk Dashboard, your **Publishable key** should be visible below. Otherwise, you can find these values in the Clerk Dashboard on the **[API Keys](https://dashboard.clerk.com/last-active?path=api-keys)** page. On this page, click on the **Advanced** dropdown to find your **Frontend API URL**. 
 
 <InjectKeys>
 
@@ -137,7 +137,7 @@ This example uses [the `<UserButton />` component](/docs/references/javascript/c
 
   const userButtonComponent = document.querySelector<HTMLDivElement>('#user-button')!;
 
-  const clerk = new Clerk({{pub_key}});
+  const clerk = new Clerk(`{{pub_key}}`);
   await clerk.load();
 
   clerk.mountUserButton(userButtonComponent);
@@ -147,7 +147,7 @@ This example uses [the `<UserButton />` component](/docs/references/javascript/c
   <div id="user-button"></div>
   <script>
     const script = document.createElement('script');
-    script.setAttribute('data-clerk-publishable-key', {{pub_key}});
+    script.setAttribute('data-clerk-publishable-key', `{{pub_key}}`);
     script.async = true;
     script.src = `https://[your-domain].clerk.accounts.dev/npm/@clerk/clerk-js@latest/dist/clerk.browser.js`;
 

--- a/docs/quickstarts/javascript.mdx
+++ b/docs/quickstarts/javascript.mdx
@@ -65,7 +65,7 @@ CLERK_FRONTEND_API=[your-domain].clerk.accounts.dev
 
 </InjectKeys>
 
-> We suggest storing these keys in environment variables using an `.env` file or equivalent.
+> We suggest storing these keys in environment variables using a `.env` file or equivalent.
 
 ### Setup the Clerk class
 

--- a/docs/quickstarts/nextjs.mdx
+++ b/docs/quickstarts/nextjs.mdx
@@ -48,11 +48,11 @@ pnpm add @clerk/nextjs
 
 ### Set environment keys
 
-In your Next.js project's root folder, you may have an `.env.local` file alongside `package.json` and other configuration files. If you don't see it, create it.
+In your Next.js project's root folder, you may have a `.env.local` file alongside `package.json` and other configuration files. If you don't see it, create it.
 
 Add the following code to your `.env.local` file to set your public and secret keys.
 
-**Pro tip!** If you are signed into your Clerk Dashboard, your secret key should become visible by clicking on the eye icon. Otherwise, you can find your keys in the Clerk Dashboard on the [API Keys](https://dashboard.clerk.com/last-active?path=api-keys) page.
+**Pro tip!** If you are signed into your [Clerk Dashboard](https://dashboard.clerk.com/last-active?path=api-keys), your secret key should become visible by clicking on the eye icon.
 
 <InjectKeys>
 

--- a/docs/quickstarts/nextjs.mdx
+++ b/docs/quickstarts/nextjs.mdx
@@ -52,7 +52,7 @@ In your Next.js project's root folder, you may have an `.env.local` file alongsi
 
 Add the following code to your `.env.local` file to set your public and secret keys.
 
-**Pro tip!** If you are signed into your [Clerk Dashboard](https://dashboard.clerk.com/last-active?path=api-keys), your secret key should become visible by clicking on the eye icon.
+**Pro tip!** If you are signed into your Clerk Dashboard, your secret key should become visible by clicking on the eye icon. Otherwise, you can find your keys in the Clerk Dashboard on the [API Keys](https://dashboard.clerk.com/last-active?path=api-keys) page.
 
 <InjectKeys>
 

--- a/docs/quickstarts/react.mdx
+++ b/docs/quickstarts/react.mdx
@@ -84,7 +84,7 @@ In your React project's root folder, you may have an `.env` file alongside `pack
 
 Add the following code to your `.env.local` file to set your public key.
 
-**Pro tip!** If you are signed into your [Clerk Dashboard](https://dashboard.clerk.com/last-active?path=api-keys), you can copy your publishable key below.
+**Pro tip!** If you are signed into your Clerk Dashboard, you can copy your publishable key below. Otherwise, you can find it in the Clerk Dashboard on the [API Keys](https://dashboard.clerk.com/last-active?path=api-keys) page.
 
 <InjectKeys>
 

--- a/docs/quickstarts/react.mdx
+++ b/docs/quickstarts/react.mdx
@@ -80,7 +80,7 @@ Clerk's React SDK gives you access to prebuilt [components](/docs/components/ove
 
 ### Set environment keys
 
-In your React project's root folder, you may have an `.env` file alongside `package.json` and other configuration files. If you don't see it, create it.
+In your React project's root folder, create a `.env.local` file alongside `package.json` and other configuration files.
 
 Add the following code to your `.env.local` file to set your public key.
 
@@ -88,7 +88,7 @@ Add the following code to your `.env.local` file to set your public key.
 
 <InjectKeys>
 
-```sh filename=".env"
+```sh filename=".env.local"
 VITE_CLERK_PUBLISHABLE_KEY={{pub_key}}
 ```
 

--- a/docs/quickstarts/redwood.mdx
+++ b/docs/quickstarts/redwood.mdx
@@ -16,7 +16,7 @@ yarn create redwood-app my-redwood-project --typescript
 
 ### Set environment keys
 
-Below is an example of an `.env.local` file. 
+Below is an example of a `.env.local` file. 
 
 **Pro tip!** If you are signed into your Clerk Dashboard, your secret key should become visible by clicking on the eye icon. Otherwise, you can find your keys in the Clerk Dashboard on the [API Keys](https://dashboard.clerk.com/last-active?path=api-keys) page.
 

--- a/docs/quickstarts/redwood.mdx
+++ b/docs/quickstarts/redwood.mdx
@@ -16,11 +16,13 @@ yarn create redwood-app my-redwood-project --typescript
 
 ### Set environment keys
 
-Below is an example of an .env file. If you are signed into your Clerk Dashboard, your keys should become visible by clicking on the eye icon.
+Below is an example of an `.env.local` file. 
+
+**Pro tip!** If you are signed into your Clerk Dashboard, your secret key should become visible by clicking on the eye icon. Otherwise, you can find your keys in the Clerk Dashboard on the [API Keys](https://dashboard.clerk.com/last-active?path=api-keys) page.
 
 <InjectKeys>
 
-```sh filename=".env"
+```sh filename=".env.local"
 CLERK_PUBLISHABLE_KEY={{pub_key}}
 CLERK_SECRET_KEY={{secret}}
 ```

--- a/docs/quickstarts/remix.mdx
+++ b/docs/quickstarts/remix.mdx
@@ -29,7 +29,7 @@ Once you have a Remix application ready, you need to install Clerk's Remix SDK. 
 
 ### Set environment keys
 
-Below is an example of an `.env.local` file. 
+Below is an example of a `.env.local` file. 
 
 **Pro tip!** If you are signed into your Clerk Dashboard, your secret key should become visible by clicking on the eye icon. Otherwise, you can find your keys in the Clerk Dashboard on the [API Keys](https://dashboard.clerk.com/last-active?path=api-keys) page.
 

--- a/docs/quickstarts/remix.mdx
+++ b/docs/quickstarts/remix.mdx
@@ -29,11 +29,13 @@ Once you have a Remix application ready, you need to install Clerk's Remix SDK. 
 
 ### Set environment keys
 
-Below is an example of an `.env` file. If you are signed into your Clerk Dashboard, your keys should become visible by clicking on the eye icon.
+Below is an example of an `.env.local` file. 
+
+**Pro tip!** If you are signed into your Clerk Dashboard, your secret key should become visible by clicking on the eye icon. Otherwise, you can find your keys in the Clerk Dashboard on the [API Keys](https://dashboard.clerk.com/last-active?path=api-keys) page.
 
 <InjectKeys>
 
-```sh filename=".env"
+```sh filename=".env.local"
 CLERK_PUBLISHABLE_KEY={{pub_key}}
 CLERK_SECRET_KEY={{secret}}
 ```

--- a/docs/references/go/overview.mdx
+++ b/docs/references/go/overview.mdx
@@ -19,7 +19,7 @@ $ go get github.com/clerkinc/clerk-sdk-go
 
 ## `Clerk` client
 
-Now, you can create a `Clerk` client by calling the `clerk.NewClient` function. This function requires your Clerk secret key. If you are signed into your Clerk Dashboard, your secret key should become visible by clicking on the eye icon. Otherwise, you can retrieve your Clerk secret key from the Clerk Dashboard on the **[API Keys](https://dashboard.clerk.com/last-active?path=api-keys)** page.
+Now, you can create a `Clerk` client by calling the `clerk.NewClient()` function. This function requires your Clerk secret key. If you are signed into your Clerk Dashboard, your secret key should become visible by clicking on the eye icon. Otherwise, you can retrieve your Clerk secret key from the Clerk Dashboard on the **[API Keys](https://dashboard.clerk.com/last-active?path=api-keys)** page.
 
 With your Clerk secret key, create a `Client` object to use the various services Clerk provides.
 

--- a/docs/references/go/overview.mdx
+++ b/docs/references/go/overview.mdx
@@ -19,14 +19,14 @@ $ go get github.com/clerkinc/clerk-sdk-go
 
 ## `Clerk` client
 
-Now, you can create a `Clerk` client by calling the `clerk.NewClient` function. This function requires your Clerk secret key. If you are signed into your Clerk Dashboard, your keys should become visible by clicking on the eye icon. You can also retrieve your Clerk secret key from the Clerk Dashboard on the **[API Keys](https://dashboard.clerk.com/last-active?path=api-keys)** page.
+Now, you can create a `Clerk` client by calling the `clerk.NewClient` function. This function requires your Clerk secret key. If you are signed into your Clerk Dashboard, your secret key should become visible by clicking on the eye icon. Otherwise, you can retrieve your Clerk secret key from the Clerk Dashboard on the **[API Keys](https://dashboard.clerk.com/last-active?path=api-keys)** page.
 
 With your Clerk secret key, create a `Client` object to use the various services Clerk provides.
 
 <InjectKeys>
 
 ```go filename=".env"
-client, err := clerk.NewClient({{secret}})
+client, err := clerk.NewClient(`{{secret}}`)
 if err != nil {
     // handle error
 } 

--- a/docs/references/go/verifying-sessions.mdx
+++ b/docs/references/go/verifying-sessions.mdx
@@ -22,7 +22,7 @@ import (
 )
 
 func main() {
-	client, _ := clerk.NewClient({{secret}})
+	client, _ := clerk.NewClient(`{{secret}}`)
 
 	http.HandleFunc("/hello", func(w http.ResponseWriter, r *http.Request) {
 		// get session token from Authorization header
@@ -68,7 +68,7 @@ import (
 )
 
 func main() {
-	client, _ := clerk.NewClient({{secret}})
+	client, _ := clerk.NewClient(`{{secret}}`)
 
 	mux := http.NewServeMux()
 

--- a/docs/references/javascript/overview.mdx
+++ b/docs/references/javascript/overview.mdx
@@ -39,7 +39,7 @@ Once you have installed the package, you will need to import the ClerkJS object 
 ```js
 import Clerk from '@clerk/clerk-js';
 
-const clerkPublishableKey = {{pub_key}};
+const clerkPublishableKey = `{{pub_key}}`;
 const clerk = new Clerk(clerkPublishableKey);
 await clerk.load({
   // Set load options here...
@@ -65,7 +65,7 @@ Add the following script to your site's `<body>` element:
 ```html
 <script>
   // Get this URL and Publishable Key from the Clerk Dashboard
-  const clerkPublishableKey = "{{pub_key}}";
+  const clerkPublishableKey = `{{pub_key}}`;
   const frontendApi = '[your-domain].clerk.accounts.dev';
   const version = '@latest'; // Set to appropriate version
 

--- a/docs/references/nextjs/trpc.mdx
+++ b/docs/references/nextjs/trpc.mdx
@@ -35,7 +35,9 @@ Clerk's Next.js SDK gives you access to prebuilt components and hooks, as well a
 
 ### Set environment keys
 
-Below is an example of an `.env.local` file. If you are signed into your Clerk Dashboard, your keys should become visible by clicking on the eye icon.
+Below is an example of an `.env.local` file. 
+
+**Pro tip!** If you are signed into your Clerk Dashboard, your secret key should become visible by clicking on the eye icon. Otherwise, you can find your keys in the Clerk Dashboard on the [API Keys](https://dashboard.clerk.com/last-active?path=api-keys) page.
 
 <InjectKeys>
 

--- a/docs/references/nextjs/trpc.mdx
+++ b/docs/references/nextjs/trpc.mdx
@@ -35,7 +35,7 @@ Clerk's Next.js SDK gives you access to prebuilt components and hooks, as well a
 
 ### Set environment keys
 
-Below is an example of an `.env.local` file. 
+Below is an example of a `.env.local` file. 
 
 **Pro tip!** If you are signed into your Clerk Dashboard, your secret key should become visible by clicking on the eye icon. Otherwise, you can find your keys in the Clerk Dashboard on the [API Keys](https://dashboard.clerk.com/last-active?path=api-keys) page.
 

--- a/docs/references/nodejs/overview.mdx
+++ b/docs/references/nodejs/overview.mdx
@@ -33,7 +33,7 @@ pnpm add @clerk/clerk-sdk-node
 
 ### Set environment keys
 
-Below is an example of an `.env.local` file. 
+Below is an example of a `.env.local` file. 
 
 **Pro tip!** If you are signed into your Clerk Dashboard, your secret key should become visible by clicking on the eye icon. Otherwise, you can find your keys in the Clerk Dashboard on the [API Keys](https://dashboard.clerk.com/last-active?path=api-keys) page.
 

--- a/docs/references/nodejs/overview.mdx
+++ b/docs/references/nodejs/overview.mdx
@@ -33,7 +33,9 @@ pnpm add @clerk/clerk-sdk-node
 
 ### Set environment keys
 
-Below is an example of an `.env.local` file. If you are signed into your Clerk Dashboard, your keys should become visible by clicking on the eye icon.
+Below is an example of an `.env.local` file. 
+
+**Pro tip!** If you are signed into your Clerk Dashboard, your secret key should become visible by clicking on the eye icon. Otherwise, you can find your keys in the Clerk Dashboard on the [API Keys](https://dashboard.clerk.com/last-active?path=api-keys) page.
 
 <InjectKeys>
 

--- a/docs/references/ruby/overview.mdx
+++ b/docs/references/ruby/overview.mdx
@@ -44,7 +44,7 @@ This examples shows how to instantiate an instance of `Clerk::SDK` with your sec
 <InjectKeys>
 
 ```ruby
-clerk = Clerk::SDK.new(secret_key: {{secret}})
+clerk = Clerk::SDK.new(secret_key: `{{secret}}`)
 
 # List all users
 clerk.users.all
@@ -82,11 +82,13 @@ You can customize each instance of the `Clerk::SDK` object by passing keyword ar
 
 ```ruby
 clerk = Clerk::SDK.new(
-    secret_key: {{secret}},
+    secret_key: `{{secret}}`,
     base_url: "Y",
     logger: Logger.new()
 )
 ```
+
+</InjectKeys>
 
 #### Configuration object
 
@@ -96,14 +98,12 @@ If an argument is not provided, the configuration object is looked up, which fal
 
 ```ruby
 Clerk.configure do |c|
-  c.api_key = {{secret}} # if omitted: ENV["CLERK_SECRET_KEY"] - API calls will fail if unset
+  c.api_key = `{{secret}}` # if omitted: ENV["CLERK_SECRET_KEY"] - API calls will fail if unset
   c.base_url = "https://..." # if omitted: "https://api.clerk.com/v1/"
   c.logger = Logger.new(STDOUT) # if omitted, no logging
   c.middleware_cache_store = Rails.cache # if omitted: no caching
 end
 ```
-
-</InjectKeys>
 
 </InjectKeys>
 


### PR DESCRIPTION
[DOCS-699](https://linear.app/clerk/issue/DOCS-699/revisit-copy-for-environment-keys) reads:
- [ ] Some of our examples for environment keys say "If you are signed into your Clerk Dashboard, your keys should become visible by clicking on the eye icon." but some examples only have the publishable key (eye icon isn't necessary, so this piece of copy isn't necessary). We should also link them to the API Keys page, in case they aren't signed in.
So something like, "If you are signed into your Clerk Dashboard, you can copy your keys below. Otherwise, you can find your keys in the Clerk Dashboard on the [API Keys](link) page."
- [ ] Make sure .env is a code snippet.

---

This PR
- fixes broken injectkeys instances
- adds copy wherever injectkeys is used that explains its usage