### PR TITLE
docs: typo fix

### DIFF
--- a/docs/references/react/add-react-router.mdx
+++ b/docs/references/react/add-react-router.mdx
@@ -156,7 +156,7 @@ export default function InvoicesPage() {
 
 You're going to create two layouts for your application. One will mount [`<ClerkProvider>`](/docs/components/clerk-provider) and act as a top level layout. It will also be a place for a header, footer, and other standard elements for your application.
 
-The second layout will be non-rendering and will protect everything in the `/dashboard` route. This avoids the need for per-page auth checks or for using Clerk's control componnets.
+The second layout will be non-rendering and will protect everything in the `/dashboard` route. This avoids the need for per-page auth checks or for using Clerk's control components.
 
 <CodeBlockTabs options={["Root Layout", "Dashboard Layout"]}>
 


### PR DESCRIPTION
At create layouts session, there is a typo at 'componnets',