### PR TITLE
Fix mountSignIn example

### DIFF
--- a/docs/references/javascript/clerk/sign-in.mdx
+++ b/docs/references/javascript/clerk/sign-in.mdx
@@ -79,7 +79,7 @@ In the example below, the `<SignIn />` component is rendered to a `<div>` elemen
 
       const signInComponent = document.querySelector('#sign-in');
 
-      window.Clerk.openSignIn(signInComponent, {
+      window.Clerk.mountSignIn(signInComponent, {
         appearance: {
           baseTheme: dark
         }


### PR DESCRIPTION
user wrote into support:

> error in your documentation:
> 
> https://clerk.com/docs/references/javascript/clerk/sign-in#mount-sign-in-usage 
> 
> The code on line 16 should read:
> 
> `"window.Clerk.mountSignIn(signInComponent, {"`
> 
> and not
> 
> `"window.Clerk.openSignIn(signInComponent, {"`