### PR TITLE
DOCS-5325 update socialButtonsVariant type

### DIFF
--- a/docs/components/customization/layout.mdx
+++ b/docs/components/customization/layout.mdx
@@ -35,5 +35,5 @@ import { ClerkProvider } from '@clerk/nextjs';
 | `privacyPageUrl` | `string` | The URL to your privacy page. |
 | `showOptionalFields` | `boolean` | Whether to show optional fields on sign up. |
 | `socialButtonsPlacement` | `'bottom' \| 'top'` | The placement of your social buttons. |
-| `socialButtonsVariant` | `'blockButton' \| 'textButton' \| 'auto'` | The variant of your social buttons. |
+| `socialButtonsVariant` | `'blockButton' \| 'iconButton' \| 'auto'` | The variant of your social buttons. |
 | `termsPageUrl` | `string` | The URL to your terms page. |


### PR DESCRIPTION
[DOCS-5325](https://linear.app/clerk/issue/DOCS-5325/feedback-for-componentscustomizationlayout) reads:
hello, the socialButtonsVariant properties are incorrect.

It should be "auto" | "iconButton" | "blockButton"

---

This PR updates the `socialButtonsVariant` type accordingly.

and a special thank you to nirmal.patel for the feedback that incited these changes 💙