### PR TITLE
fix: jwt templates example consistency on has_verified_contact_info

### DIFF
--- a/docs/backend-requests/making/jwt-templates.mdx
+++ b/docs/backend-requests/making/jwt-templates.mdx
@@ -186,7 +186,7 @@ As an example, given the following template (comments added for clarity):
 
 ```json
 {
-  "has_contact_info": "{{user.has_verified_email || user.has_verified_phone}}",
+  "has_verified_contact_info": "{{user.has_verified_email || user.has_verified_phone}}",
 
   // fallback to a string value
   "full_name": "{{user.full_name || 'Awesome User'}}",


### PR DESCRIPTION
Fixes the example for [conditional expressions](https://clerk.com/docs/backend-requests/making/jwt-templates#conditional-expressions) so that it uses the same key: `has_verified_contact_info`

![Screenshot 2024-02-16 at 9 06 39 AM](https://github.com/clerk/clerk-docs/assets/69559/4e1cceff-a8c4-4089-a303-48b60742c899)
