### PR TITLE
/quickstarts/nextjs: fix typos; remove unnecessary card from 'more resources'

### DIFF
--- a/docs/quickstarts/nextjs.mdx
+++ b/docs/quickstarts/nextjs.mdx
@@ -52,22 +52,22 @@ pnpm add @clerk/nextjs
 ### Set your environment keys
 
 1. If you don't have a `.env.local` file in the root directory of your Next.js project, create one now.
-2. Find your secret key and publishable key. If you're signed into Clerk, the `.env.local` snippet below will contain your both. Otherwise:
-    - Navigate to your [Clerk Dashboard](https://dashboard.clerk.com/last-active?path=api-keys).
-    - Select your application, then select **🔑 API Keys** in the sidebar menu.
-    - You can copy your keys from the **Quick Copy** section.
+2. Find your publishable key and secret key. If you're signed into Clerk, the `.env.local` snippet below will contain your keys. Otherwise:
+  - Navigate to your [Clerk Dashboard](https://dashboard.clerk.com/last-active?path=api-keys).
+  - Select your application, then select **🔑 API Keys** in the sidebar menu.
+  - You can copy your keys from the **Quick Copy** section.
 3. Add your keys to your `.env.local` file. 
 
 The final result should look as follows:
 
-    <InjectKeys>
+  <InjectKeys>
 
-    ```sh filename=".env.local"
-    NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY={{pub_key}}
-    CLERK_SECRET_KEY={{secret}}
-    ```
+  ```sh filename=".env.local"
+  NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY={{pub_key}}
+  CLERK_SECRET_KEY={{secret}}
+  ```
 
-    </InjectKeys>
+  </InjectKeys>
 
 ### Add `<ClerkProvider>` to your app
 
@@ -76,38 +76,38 @@ All Clerk hooks and components must be children of the [`<ClerkProvider>`](/docs
 Select your preferred router below to learn how to make this data available across your entire app:
 
 <CodeBlockTabs type="router" options={["App Router", "Pages Router"]}>
-    ```tsx filename="/src/app/layout.tsx" {1,10-14}
-    import { ClerkProvider } from '@clerk/nextjs'
-    import './globals.css'
+  ```tsx filename="/src/app/layout.tsx" {1,10-14}
+  import { ClerkProvider } from '@clerk/nextjs'
+  import './globals.css'
 
-    export default function RootLayout({
-      children,
-    }: {
-      children: React.ReactNode
-    }) {
-      return (        
-        <ClerkProvider>
-          <html lang="en">
-            <body>{children}</body>
-          </html>
+  export default function RootLayout({
+    children,
+  }: {
+    children: React.ReactNode
+  }) {
+    return (        
+      <ClerkProvider>
+        <html lang="en">
+          <body>{children}</body>
+        </html>
+      </ClerkProvider>
+    )
+  }
+  ```
+
+  ```tsx filename="_app.tsx" {2,6-8}
+    import '@/styles/globals.css'
+    import { ClerkProvider } from "@clerk/nextjs";
+    import type { AppProps } from "next/app";
+    function MyApp({ Component, pageProps }: AppProps) {
+      return (          
+        <ClerkProvider {...pageProps}>
+          <Component {...pageProps} />
         </ClerkProvider>
-      )
+      );
     }
+    export default MyApp;
     ```
-
-    ```tsx filename="_app.tsx" {2,6-8}
-      import '@/styles/globals.css'
-      import { ClerkProvider } from "@clerk/nextjs";
-      import type { AppProps } from "next/app";
-      function MyApp({ Component, pageProps }: AppProps) {
-        return (          
-          <ClerkProvider {...pageProps}>
-            <Component {...pageProps} />
-          </ClerkProvider>
-        );
-      }
-      export default MyApp;
-      ```
 
 </CodeBlockTabs>
 
@@ -117,31 +117,31 @@ Now that Clerk is installed and mounted in your application, you can decide whic
 
 1. Create a `middleware.ts` file at the root of your project, or in your `src/` directory if you have one.
 2. In your `middleware.ts`, export Clerk's [`authMiddleware`](https://clerk.com/docs/references/nextjs/auth-middleware) helper:
-    ```tsx filename="middleware.ts"
-    import { authMiddleware } from "@clerk/nextjs";
+  ```tsx filename="middleware.ts"
+  import { authMiddleware } from "@clerk/nextjs";
 
-    export default authMiddleware({});
-    ```
+  export default authMiddleware({});
+  ```
 3. With `authMiddleware()`, authentication will be enabled by default on all routes that your Next.js middleware runs on, blocking access to all signed out visitors. You can specify valid routes using Next.js's [`matcher`](https://nextjs.org/docs/app/building-your-application/routing/middleware#matcher). Add the following code to your `middleware.ts` to protect your entire application:
 
-    ```tsx filename="middleware.ts" {15}
-    import { authMiddleware } from "@clerk/nextjs";
+  ```tsx filename="middleware.ts" {15}
+  import { authMiddleware } from "@clerk/nextjs";
 
-    export default authMiddleware({
-      // Routes that can be accessed while signed out
-      publicRoutes: ['/anyone-can-visit-this-route'],
-      // Routes that can always be accessed, and have
-      // no authentication information
-      ignoredRoutes: ['/no-auth-in-this-route'],
-    });
+  export default authMiddleware({
+    // Routes that can be accessed while signed out
+    publicRoutes: ['/anyone-can-visit-this-route'],
+    // Routes that can always be accessed, and have
+    // no authentication information
+    ignoredRoutes: ['/no-auth-in-this-route'],
+  });
 
-    export const config = {
-      // Protects all routes, including api/trpc.
-      // See https://clerk.com/docs/references/nextjs/auth-middleware
-      // for more information about configuring your Middleware
-      matcher: ["/((?!.+\\.[\\w]+$|_next).*)", "/", "/(api|trpc)(.*)"],
-    };
-    ```
+  export const config = {
+    // Protects all routes, including api/trpc.
+    // See https://clerk.com/docs/references/nextjs/auth-middleware
+    // for more information about configuring your Middleware
+    matcher: ["/((?!.+\\.[\\w]+$|_next).*)", "/", "/(api|trpc)(.*)"],
+  };
+  ```
 
 <Callout type="info">
   See the [`authMiddleware()`](/docs/references/nextjs/auth-middleware#default-behaviour) docs to learn more about `publicRoutes` and `ignoredRoutes`.
@@ -152,24 +152,23 @@ Now that Clerk is installed and mounted in your application, you can decide whic
 Access your app to verify that authentication is enabled:
 
 1. Run your project with the following terminal command from the root directory of your project:
-    <CodeBlockTabs type="installer" options={["npm", "yarn", "pnpm"]}>
-      ```bash filename="terminal"
-      npm run dev
-      ```
+  <CodeBlockTabs type="installer" options={["npm", "yarn", "pnpm"]}>
+    ```bash filename="terminal"
+    npm run dev
+    ```
 
-      ```bash filename="terminal"
-      yarn dev
-      ```
+    ```bash filename="terminal"
+    yarn dev
+    ```
 
-      ```bash filename="terminal"
-      pnpm dev
-      ```
+    ```bash filename="terminal"
+    pnpm dev
+    ```
 
-    </CodeBlockTabs>
+  </CodeBlockTabs>
 2. Visit [`http://localhost:3000`](http://localhost:3000) to access your app. The Middleware will redirect you to your Sign Up page, provided by Clerk's [Account Portal](/docs/account-portal/overview) feature.
 3. Sign up to gain access to your application.
 4. Log into your new account. You should be able to access it now.
-
 
 ### Embed the `<UserButton />`
 
@@ -234,8 +233,6 @@ To see an example application that demonstrates user authentication, and session
     <Cards title="Client Side Helpers" description="Learn more about Next.js client side helpers and how to use them." link="/docs/references/nextjs/overview#client-side-helpers" cta="Learn More" />
 
     <Cards title="Next.js SDK Reference" description="Learn more about additional Next.js methods." link="/docs/references/nextjs/overview" cta="Learn More" />
-
-    <Cards title="Use Clerk with Next.js 12 and older" description="Learn how to use Clerk with older versions of Next.js." link="/docs/references/nextjs/usage-with-older-versions" cta="Learn More" />
 
     <Cards title="Deploy to Production" description="Learn how to deploy your Clerk app to production." link="/docs/deployments/overview" cta="Learn More" />
 


### PR DESCRIPTION
- very minor update: updating order of info - publishable key is introduced first in the snippet, so i'm moving it to be introduced first in the copy.
- fixed a typo where it says "contain your both." will now say "contain your keys."
- looks like our formatters are fighting 🤭 we use tab size = 2
- removed a card about using nextjs with 12 or older. not really important for a user's learning journey.