### PR TITLE
Update route-handlers.mdx

### DIFF
--- a/docs/references/nextjs/route-handlers.mdx
+++ b/docs/references/nextjs/route-handlers.mdx
@@ -73,13 +73,13 @@ export async function GET() {
 The `clerkClient` helper allows you to retrieve and update data from Clerk's API. 
 
 ```ts filename="app/api/route.ts"
-import { NextResponse } from 'next/server';
+import { NextResponse, NextRequest } from 'next/server';
 import { auth, clerkClient } from '@clerk/nextjs';
 
-export async function POST() {
+export async function POST(req:NextRequest) {
   const { userId } = auth();
 
-  if (!userId) return NextResponse.redirect('/sign-in');
+  if (!userId) return NextResponse.redirect(new URL('/sign-in',req.url));
   
   const params = { firstName: 'John', lastName: 'Wick' };
 


### PR DESCRIPTION
The POST request in the clerk client tutorial code shows that  user can use NextResponse.redirect("/sign-in") to redirect to a new page which does not work and returns an error saying invalid url.

Source for the change - https://nextjs.org/docs/app/api-reference/functions/next-response#redirect

I've changed it to work in next.js