### PR TITLE
(core1) DOCS-5394 Update React references

### DIFF
--- a/docs/guides/force-organizations.mdx
+++ b/docs/guides/force-organizations.mdx
@@ -31,7 +31,7 @@ This guide will be written for Next.js applications using App Router, but the sa
 
 ### Hide Personal Accounts from UI components
 
-To begin forcing organizations in your application, you need to remove a user's Personal Account from the UI. A user's Personal Account cannot be disabled; it can only be hidden. 
+To begin forcing organizations in your application, you need to remove a user's Personal Account from the UI. A user's Personal Account cannot be disabled; it can only be hidden.
 
 If you have an application set up to use organizations, you might have the [`<OrganizationList />`](/docs/components/organization/organization-list) and [`<OrganizationSwitcher />`](/docs/components/organization/organization-switcher) components in your application. These components will show a user's Personal Account by default, but you can hide it by passing the `hidePersonal` prop.
 
@@ -67,7 +67,7 @@ If you have an application set up to use organizations, you might have the [`<Or
 
 ### Detect and set an active organization
 
-With Clerk, a user can have many organization memberships, but only one of them can be active at a time. 
+With Clerk, a user can have many organization memberships, but only one of them can be active at a time.
 
 #### Detect an active organization
 
@@ -93,7 +93,7 @@ A session will always include an `orgId` via the [`Authentication` object](/docs
   <Tab>
 
     The [`useAuth()`](/docs/references/react/use-auth) hook can be used to get the `orgId` from the session *client-side*. If the `orgId` is `null`, then the user does not have an active organization.
-  
+
     ```tsx
     "use client"
     import { useAuth } from '@clerk/nextjs'
@@ -110,7 +110,7 @@ A session will always include an `orgId` via the [`Authentication` object](/docs
 
 #### Set an active organization
 
-In the case of [Clerk components](/docs/components/overview), an organization will *automatically* be set as active each time the user creates an organization, accepts an invitation, or selects a membership from the organization switcher. In the case of custom flows, you will need to provide the logic for setting an organization as active. Don't worry, Clerk's [`useOrganizationList`](/docs/references/react/use-organization-list) hook provides a `setActive` method to help you with this.
+In the case of [Clerk components](/docs/components/overview), an organization will *automatically* be set as active each time the user creates an organization, accepts an invitation, or selects a membership from the organization switcher. In the case of custom flows, you will need to provide the logic for setting an organization as active. Don't worry, Clerk's [`useOrganizationList()`](/docs/references/react/use-organization-list) hook provides a `setActive` method to help you with this.
 
 In the example below, a custom organization switcher is created. It allows a user to select an organization from a list of their memberships. The `useOrganizationList()` hook is used to fetch a list of the user's memberships, and the `setActive` method is used to set the selected organization as active.
 
@@ -122,18 +122,18 @@ In the example below, a custom organization switcher is created. It allows a use
 "use client"
 
 import { useOrganizationList } from "@clerk/nextjs";
- 
+
 export const CustomOrgSwitcher = () => {
   const { isLoaded, setActive, userMemberships } = useOrganizationList({
     userMemberships: {
       infinite: true,
     },
   });
- 
+
   if (!isLoaded) {
     return <>Loading</>;
   }
- 
+
   return (
     <>
       <ul>
@@ -148,7 +148,7 @@ export const CustomOrgSwitcher = () => {
           </li>
         ))}
       </ul>
- 
+
       <button
         disabled={!userMemberships.hasNextPage}
         onClick={() => userMemberships.fetchNext()}
@@ -239,7 +239,7 @@ Based on your use case, you can decide to limit users either in the entire app o
 
 #### Limit access using the `authMiddleware` helper
 
-Clerk's `authMiddleware` helper can be used in both App Router and Pages Router applications to limit access to users with active organizations only. 
+Clerk's `authMiddleware` helper can be used in both App Router and Pages Router applications to limit access to users with active organizations only.
 
 To limit access to the entire application, your middleware can be configured as follows:
 
@@ -276,15 +276,15 @@ To limit access to a specific part of the application, you can check if the path
       if(
         auth.userId &&
         !auth.orgId &&
-        req.nextUrl.pathname.startsWith('/dashboard') && 
+        req.nextUrl.pathname.startsWith('/dashboard') &&
         req.nextUrl.pathname !== "/dashboard/org-selection"
         ){
       const searchParams = new URLSearchParams({
         redirectUrl: req.url
       })
- 
+
       const orgSelection = new URL(`/dashboard/org-selection?${searchParams.toString()}`, req.url);
- 
+
       return NextResponse.redirect(orgSelection)
       }
       ...
@@ -325,7 +325,7 @@ Now that you have configured your middleware to redirect users to the `/org-sele
     }
     ```
   </Tab>
-  
+
   <Tab>
     ```tsx filename="pages/org-selection.tsx"
     import { OrganizationList } from "@clerk/nextjs"

--- a/docs/guides/force-organizations.mdx
+++ b/docs/guides/force-organizations.mdx
@@ -110,7 +110,7 @@ A session will always include an `orgId` via the [`Authentication` object](/docs
 
 #### Set an active organization
 
-In the case of [Clerk components](/docs/components/overview), an organization will *automatically* be set as active each time the user creates an organization, accepts an invitation, or selects a membership from the organization switcher. In the case of custom flows, you will need to provide the logic for setting an organization as active. Don't worry, Clerk's [`useOrganizationList()`](/docs/references/react/use-organization-list) hook provides a `setActive` method to help you with this.
+In the case of [Clerk components](/docs/components/overview), an organization will *automatically* be set as active each time the user creates an organization, accepts an invitation, or selects a membership from the organization switcher. In the case of custom flows, you will need to implement the logic for setting an organization as active. Clerk's [`useOrganizationList()`](/docs/references/react/use-organization-list) hook provides a `setActive` method to help you with this.
 
 In the example below, a custom organization switcher is created. It allows a user to select an organization from a list of their memberships. The `useOrganizationList()` hook is used to fetch a list of the user's memberships, and the `setActive` method is used to set the selected organization as active.
 

--- a/docs/references/react/use-auth.mdx
+++ b/docs/references/react/use-auth.mdx
@@ -7,105 +7,47 @@ description: Clerk's useAuth() hook is a convenient way to access the current au
 
 The `useAuth()` hook is a convenient way to access the current auth state. This hook provides the minimal information needed for data-loading and helper methods to manage the current active session.
 
-## Usage
+## `useAuth()` returns
 
-<Tabs type="framework" items={["Next.js", "React"]}>
-  <Tab>
-    <CodeBlockTabs type="router" options={["App Router", "Pages Router"]}>
-      ```tsx filename="/app/pageWithData/clientComponent.tsx"
-      "use client";
+| Name | Type | Description |
+| --- | --- | --- |
+| `isSignedIn` | `boolean` | A boolean that returns true if the user is signed in. |
+| `isLoaded` | `boolean` | A boolean that until Clerk loads and initializes, will be set to `false`. Once Clerk loads, `isLoaded` will be set to `true`. |
+| `userId` | `string` | The current user's ID. |
+| `sessionId` | `string` | The current user's session ID. |
+| `orgId` | `string` | The current user's active organization ID. |
+| `orgRole` | `string` | The current user's active organization role. |
+| `orgSlug` | `string` | The current user's organization slug. |
+| `signOut()` | `(options?: SignOutOptions) => Promise<void>` | A function that signs the user out. See the [reference documentation](/docs/references/javascript/clerk/clerk#sign-out) for more information. |
+| `getToken()` | `(options?: GetTokenOptions) => Promise\<string \| null\>` | A function that returns a promise that resolves to the current user's session token. Can also be used to retrieve a custom JWT template. See the [reference documentation](/docs/references/javascript/session#get-token) for more information. |
+| `has()` | `(isAuthorizedParams: CheckAuthorizationParamsWithCustomPermissions) => boolean` | A function that returns a boolean based on the permission or role provided as parameter. Can be used for authorization. See the [reference documentation](https://clerk.com/docs/references/nextjs/authentication-object#has) for more information. |
 
-      import * as React from "react";
-      import { useAuth } from "@clerk/nextjs";
+## How to use the `useAuth()` hook
 
-      export default function ExternalDataPage() {
-        const [data, setData] = React.useState<object>({});
-        const { getToken, isLoaded, isSignedIn } = useAuth();
-        
-        // In this case, /api/example is a Next.js Route Handler
-        const fetchData = async () => {
-          fetch("/api/example", {
-            headers: { Authorization: `Bearer ${await getToken()}` },
-          })
-            .then((response) => response.json())
-            .then((data) => {
-              console.log("data", data);
-              setData(data);
-            });
-          return;
-        };
+The following example demonstrates how to use the `useAuth()` hook to access the current auth state, like whether the user is signed in or not. It also demonstrates a basic example of how you could use the `getToken()` method to retrieve a session token for fetching data from an external resource.
 
-        React.useEffect(() => {
-          if (!isLoaded || !isSignedIn) {
-            // You can handle the loading or signed state separately
-          }
-          
-          fetchData();
-        }, []);
+```tsx filename="external-data-page.tsx"
+import { useAuth } from '@clerk/clerk-react';
 
-        return <pre>{JSON.stringify(data, null, 2)}</pre>;
-      }
-      ```
+export default function ExternalDataPage() {
+  const { getToken, isLoaded, isSignedIn } = useAuth();
 
-      ```tsx filename="pages/index.tsx"
-      import { useAuth } from '@clerk/nextjs';
+  if (!isLoaded) {
+    // Handle loading state however you like
+    return <div>Loading...</div>;
+  }
 
-      export default function ExternalDataPage() {
-        const { getToken, isLoaded, isSignedIn } = useAuth();
+  if (!isSignedIn) {
+    // Handle signed out state however you like
+    return <div>Sign in to view this page</div>;
+  }
 
-        if (!isLoaded || !isSignedIn) {
-          // You can handle the loading or signed state separately
-          return null;
-        }
+  const fetchDataFromExternalResource = async () => {
+    const token = await getToken();
+    // Add logic to fetch your data
+    return data;
+  }
 
-        const fetchDataFromExternalResource = async () => {
-          const token = await getToken();
-          // fetch your data
-          return data;
-        };
-
-        return <div>...</div>;
-      }
-      ```
-    </CodeBlockTabs>
-  </Tab>
-
-  <Tab>
-      ```tsx filename="external-data-page.tsx"
-      import { useAuth } from '@clerk/clerk-react';
-
-      export default function ExternalDataPage() {
-        const { getToken, isLoaded, isSignedIn } = useAuth();
-
-        if (!isLoaded || !isSignedIn) {
-          // You can handle the loading or signed state separately
-          return null;
-        }
-
-        const fetchDataFromExternalResource = async () => {
-          const token = await getToken();
-          // fetch your data
-          return data;
-        }
-
-        return <div>...</div>;
-      }
-      ```
-  </Tab>
-</Tabs>
-
-## Returns
-
-| Variables | Description |
-| --- | --- |
-| `isSignedIn` | A boolean that returns true if the user is signed in. |
-| `isLoaded` | A boolean that until Clerk loads and initializes, will be set to `false`. Once Clerk loads, `isLoaded` will be set to `true`. |
-| `userId` | The current user's ID. |
-| `sessionId` | The current user's session ID. |
-| `signOut` | A function that signs the user out. |
-| `getToken` | A function that returns a promise that resolves to the current user's session token. Can also be used to retrieve a custom JWT template. |
-| `has` | A function that returns a boolean based on the [permission or role](/docs/organizations/roles-permissions) provided as parameter. Can be used for authorization. |
-| `orgId` | The current user's active organization ID. |
-| `orgRole` | The current user's active organization role. |
-| `orgPermissions` | The current user's active organization Permissions. |
-| `orgSlug` | The current user's organization slug. |
+  return <div>...</div>;
+}
+```

--- a/docs/references/react/use-auth.mdx
+++ b/docs/references/react/use-auth.mdx
@@ -1,6 +1,6 @@
 ---
 title: useAuth()
-description: The useAuth() hook is a convenient way to access the current auth state. This hook provides the minimal information needed for data-loading and helper methods to manage the current active session.
+description: Clerk's useAuth() hook is a convenient way to access the current auth state.
 ---
 
 # `useAuth()`

--- a/docs/references/react/use-clerk.mdx
+++ b/docs/references/react/use-clerk.mdx
@@ -1,6 +1,6 @@
 ---
 title: useClerk()
-description: The useClerk() hook provides access to the Clerk object, giving you the ability to build alternatives to any Clerk Component.
+description: Clerk's useClerk() hook is used to access the Clerk object, which can be used to build alternatives to any Clerk Component.
 ---
 
 # `useClerk()`
@@ -8,33 +8,24 @@ description: The useClerk() hook provides access to the Clerk object, giving you
 The `useClerk()` hook provides access to the [`Clerk`](/docs/references/javascript/clerk/clerk) object, giving you the ability to build alternatives to any Clerk Component.
 
 <Callout type="warning">
-  This is intended to be used for advanced use cases, like building a completely custom OAuth flow or as an escape hatch for getting access to the [`Clerk`](/docs/references/javascript/clerk/clerk) object.
+  This is intended to be used for advanced use cases, like building a completely custom OAuth flow or as an escape hatch for getting access to the `Clerk` object.
 </Callout>
 
-## Usage
+## `useClerk()` returns
 
-<CodeBlockTabs type="framework" options={["Next.js", "React"]}>
-  ```tsx filename="pages/index.tsx"
-  import { useClerk } from "@clerk/nextjs";
+The `useClerk()` hook returns the `Clerk` object, which includes all the methods and properties listed in the [`Clerk` reference](/docs/references/javascript/clerk/clerk).
 
-  export default function Home() {
-    const clerk = useClerk();
+## How to use the `useClerk()` hook
+
+```tsx filename="home.tsx"
+import { useClerk } from "@clerk/clerk-react";
+
+export default function Home() {
+  const clerk = useClerk();
 
   return <button onClick={() => clerk.openSignIn({})}>Sign in</button>;
-  }
-
-  ```
-
-  ```tsx filename="home.tsx"
-  import { useClerk } from "@clerk/clerk-react";
-
-  export default function Home() {
-    const clerk = useClerk();
-
-    return <button onClick={() => clerk.openSignIn({})}>Sign in</button>;
-  }
-  ```
-</CodeBlockTabs>
+};
+```
 
 
 

--- a/docs/references/react/use-organization-list.mdx
+++ b/docs/references/react/use-organization-list.mdx
@@ -95,7 +95,33 @@ type OrganizationSuggestionStatus = "pending" | "accepted";
 
 ## How to use the `useOrganizationList()` hook
 
+### Expanding and paginating attributes
+
 To keep network usage to a minimum, developers are required to opt-in by specifying which resource they need to fetch and paginate through. So by default, the `userMemberships`, `userInvitations`, and `userSuggestions` attributes are not populated. You must pass `true` or an object with the desired [properties](#shared-properties) to fetch and paginate the data.
+
+```jsx
+const { userMemberships } = useOrganizationList(); // userMemberships.data will never be populated.
+
+// Use default values to fetch userMemberships, such as initialPage = 1 and pageSize = 10
+const { userMemberships } = useOrganizationList({
+  userMemberships: true
+});
+
+// Pass your own values to fetch userMemberships
+const { userMemberships } = useOrganizationList({
+  userMemberships: {
+    pageSize: 20,
+    initialPage: 2, // skips the first page
+  }
+});
+
+// Aggregate pages in order to render an infinite list
+const { userMemberships } = useOrganizationList({
+  userMemberships: {
+    infinite: true,
+  }
+});
+```
 
 ### Infinite pagination
 

--- a/docs/references/react/use-organization-list.mdx
+++ b/docs/references/react/use-organization-list.mdx
@@ -51,13 +51,13 @@ type OrganizationSuggestionStatus = "pending" | "accepted";
 ## `useOrganizationList()` returns
 
 | Name | Type | Description |
-| --- | --- |
+| --- | --- | --- |
 | `isLoaded` | `boolean` | A boolean is set to `false` until Clerk loads and initializes. Once Clerk loads, `isLoaded` will be set to `true`. |
 | `createOrganization()` | <code>(params: [CreateOrganizationParams](#create-organization-params)) => Promise\<[OrganizationResource](/docs/references/javascript/organization/organization)\></code> | A function that returns a `Promise` which resolves to the newly created `Organization`. |
 | `setActive()` | <code>(params: [SetActiveParams](#set-active-params)) => Promise\<void\></code> | A function that sets the active session. | A function that sets the active organization. It accepts either the organization object or the organization id. |
-| `userMemberships` | [Paginated resources](#paginatedresources) | Includes a list of the user's organization memberships. |
-| `userInvitations` | [Paginated resources](#paginatedresources) | Includes a list of the user's organization invitations. |
-| `userSuggestions` | [Paginated resources](#paginatedresources) | Includes a list of suggestions for organizations that the user can join. |
+| `userMemberships` | [`PaginatedResources`](#paginatedresources) | Returns `PaginatedResources` which includes a list of the user's organization memberships. |
+| `userInvitations` | [`PaginatedResources`](#paginatedresources) | Returns `PaginatedResources` which includes a list of the user's organization invitations. |
+| `userSuggestions` | [`PaginatedResources`](#paginatedresources) | Returns `PaginatedResources` which includes a list of suggestions for organizations that the user can join. |
 
 ### `CreateOrganizationParams`
 

--- a/docs/references/react/use-organization-list.mdx
+++ b/docs/references/react/use-organization-list.mdx
@@ -1,15 +1,15 @@
 ---
 title: useOrganizationList()
-description: The useOrganizationList() hook is used to access methods for switching between active organizations and for listing the user's organization memberships, invitations, and suggestions.
+description: Clerk's useOrganizationList() hook is used to access methods for switching between active organizations and for listing the user's organization memberships, invitations, and suggestions.
 ---
 
 # `useOrganizationList()`
 
-The `useOrganizationList` hook allows you to retrieve the memberships, invitations, or suggestions for an active user. This hook also gives you the ability to create an organization and set the active organization.
+The `useOrganizationList()` hook allows you to retrieve the memberships, invitations, or suggestions for an active user. This hook also gives you the ability to create an organization and set the active organization.
 
 ## `useOrganizationList()` parameters
 
-`useOrganizationList` accepts a single object with the following properties:
+`useOrganizationList()` accepts a single object with the following properties:
 
 | Properties | Description |
 | --- | --- |

--- a/docs/references/react/use-organization-list.mdx
+++ b/docs/references/react/use-organization-list.mdx
@@ -1,64 +1,105 @@
 ---
 title: useOrganizationList()
-description: Access methods for switching between active organizations and for listing available memberships, invitations and suggestions.
+description: The useOrganizationList() hook is used to access methods for switching between active organizations and for listing the user's organization memberships, invitations, and suggestions.
 ---
 
 # `useOrganizationList()`
 
 The `useOrganizationList` hook allows you to retrieve the memberships, invitations, or suggestions for an active user. This hook also gives you the ability to create an organization and set the active organization.
 
-## Usage
+## `useOrganizationList()` parameters
 
-The `useOrganizationList` hook requires developers to opt-in by specifying which resource they need to fetch and paginate through. It is ideal for infinite lists or tables.
+`useOrganizationList` accepts a single object with the following properties:
 
-<Callout type="info">
-    Note that your component must be a descendant of [`<ClerkProvider/>`](/docs/components/clerk-provider).
-</Callout>
+| Properties | Description |
+| --- | --- |
+| `userMemberships` | `true` or an object with any of the properties described in [Shared properties](#shared-properties). If set to `true`, all default properties will be used. |
+| `userInvitations` | `true` or an object with [`status: OrganizationInvitationStatus`](#organization-invitation-status) or any of the properties described in [Shared properties](#shared-properties). If set to `true`, all default properties will be used. |
+| `userSuggestions` | `true` or an object with [`status: OrganizationSuggestionsStatus \| OrganizationSuggestionStatus[]`](#organization-suggestion-status) or any of the properties described in [Shared properties](#shared-properties). If set to `true`, all default properties will be used. |
 
-### Infinite list of joined organizations
-<CodeBlockTabs type="framework" options={["Next.js", "React"]}>
-```tsx filename="pages/joined-organizations.tsx"
-import { useOrganizationList } from "@clerk/nextjs";
-import React from "react";
+### Shared properties
 
-const JoinedOrganizationList = () => {
-  const { isLoaded, setActive, userMemberships } = useOrganizationList({
-    userMemberships: {
-      infinite: true,
-    },
-  });
+Parameters that are shared across the `invitations`, `membershipRequests`, `memberships`, and `domains` properties.
 
-  if (!isLoaded) {
-    return <>Loading</>;
-  }
+| Properties | Description |
+| --- | --- |
+| `initialPage?` | A number that can be used to skip the first n-1 pages. For example, if `initialPage` is set to 10, it is will skip the first 9 pages and will fetch the 10th page. Defaults to `1`. |
+| `pageSize?` | A number that indicates the maximum number of results that should be returned for a specific page. Defaults to `10`. |
+| `keepPreviousData?` | If `true`, it will persist the cached data until the new data has been fetched. Defaults to `false`. |
+| `infinite?` | If `true`, the new downloaded data will be appended to the list with the existing data. Ideal for infinite lists. Defaults to `false`. |
 
-  return (
-    <>
-      <ul>
-        {userMemberships.data?.map((mem) => (
-          <li key={mem.id}>
-            <span>{mem.organization.name}</span>
-            <button
-              onClick={() => setActive({ organization: mem.organization.id })}
-            >
-              Select
-            </button>
-          </li>
-        ))}
-      </ul>
+### `OrganizationInvitationStatus`
 
-      <button
-        disabled={!userMemberships.hasNextPage}
-        onClick={() => userMemberships.fetchNext()}
-      >
-        Load more
-      </button>
-    </>
-  );
-};
+`useOrganizationList()` accepts `status` as a property for the `userInvitations` parameter.
 
-export default JoinedOrganizationList;
+`status` is a string that can be one of the following:
+
+```typescript
+type OrganizationInvitationStatus = "pending" | "accepted" | "revoked";
 ```
+
+### `OrganizationSuggestionsStatus`
+
+`useOrganizationList()` accepts `status` as a property for the `userSuggestions` parameter.
+
+`status` can be a string that can be one of the following, or an array of the following:
+
+```typescript
+type OrganizationSuggestionStatus = "pending" | "accepted";
+```
+
+## `useOrganizationList()` returns
+
+| Name | Type | Description |
+| --- | --- |
+| `isLoaded` | `boolean` | A boolean is set to `false` until Clerk loads and initializes. Once Clerk loads, `isLoaded` will be set to `true`. |
+| `createOrganization()` | <code>(params: [CreateOrganizationParams](#create-organization-params)) => Promise\<[OrganizationResource](/docs/references/javascript/organization/organization)\></code> | A function that returns a `Promise` which resolves to the newly created `Organization`. |
+| `setActive()` | <code>(params: [SetActiveParams](#set-active-params)) => Promise\<void\></code> | A function that sets the active session. | A function that sets the active organization. It accepts either the organization object or the organization id. |
+| `userMemberships` | [Paginated resources](#paginatedresources) | Includes a list of the user's organization memberships. |
+| `userInvitations` | [Paginated resources](#paginatedresources) | Includes a list of the user's organization invitations. |
+| `userSuggestions` | [Paginated resources](#paginatedresources) | Includes a list of suggestions for organizations that the user can join. |
+
+### `CreateOrganizationParams`
+
+| Name | Type | Description |
+| --- | --- | --- |
+| `name` | `string` | The name of the organization. |
+| `slug?` | `string` | The slug of the organization. |
+
+### `SetActiveParams`
+
+| Name | Type | Description |
+| --- | --- | --- |
+| `session` | <code>[Session](/docs/references/javascript/session) \| string \| null</code> | The session resource or session ID (string version) to be set as active. If `null`, the current session is deleted. |
+| `organization` | <code>[Organization](/docs/references/javascript/organization/organization) \| string \| null</code> | The organization resource or organization ID (string version) to be set as active in the current session. If `null`, the currently active organization is removed as active. |
+| `beforeEmit?` | `(session?: Session \| null) => void \| Promise<any>` | Callback run just before the active session and/or organization is set to the passed object. Can be used to hook up for pre-navigation actions. |
+
+### `PaginatedResources`
+
+| Variables | Description |
+| --- | --- |
+| `data` | An array that contains the fetched data. |
+| `count` | The total count of data that exist remotely. |
+| `isLoading` | A boolean that is `true` if there is an ongoing request and there is no fetched data. |
+| `isFetching` | A boolean that is `true` if there is an ongoing request or a revalidation. |
+| `isError` | A boolean that indicates the request failed. |
+| `page` | A number that indicates the current page. |
+| `pageCount` | A number that indicates the total amount of pages. It is calculated based on `count` , `initialPage` , and `pageSize` |
+| `fetchPage` | A function that triggers a specific page to be loaded. |
+| `fetchPrevious` | A helper function that triggers the previous page to be loaded. This is the same as `fetchPage(page=> Math.max(0, page - 1))` |
+| `fetchNext` | A helper function that triggers the next page to be loaded. This is the same as `fetchPage(page=> Math.min(pageCount, page + 1))` |
+| `hasNextPage` | A boolean that indicates if there are available pages to be fetched. |
+| `hasPreviousPage` | A boolean that indicates if there are available pages to be fetched. |
+| `revalidate` | A function that triggers a revalidation of the current page. |
+| `setData` | A function that allows you to set the data manually. |
+
+## How to use the `useOrganizationList()` hook
+
+To keep network usage to a minimum, developers are required to opt-in by specifying which resource they need to fetch and paginate through. So by default, the `userMemberships`, `userInvitations`, and `userSuggestions` attributes are not populated. You must pass `true` or an object with the desired [properties](#shared-properties) to fetch and paginate the data.
+
+### Infinite pagination
+
+The following example demonstrates how to use the `infinite` property to fetch and append new data to the existing list. The `userMemberships` attribute will be populated with the first page of the user's organization memberships. When the "Load more" button is clicked, the `fetchNext` helper function will be called to append the next page of memberships to the list.
 
 ```tsx filename="joined-organizations.tsx"
 import { useOrganizationList } from "@clerk/clerk-react";
@@ -102,67 +143,15 @@ const JoinedOrganizationList = () => {
 
 export default JoinedOrganizationList;
 ```
-</CodeBlockTabs>
 
-### Table of invitations
-<CodeBlockTabs type="framework" options={["Next.js", "React"]}>
-```tsx filename="pages/joined-organizations.tsx"
-import { useOrganizationList } from "@clerk/nextjs";
-import React from "react";
+### Simple pagination
 
-const InvitationsTable = () => {
-  const { isLoaded, userInvitations } = useOrganizationList({
-    userInvitations: {
-      infinite: true,
-      keepPreviousData: true,
-    },
-  });
+The following example demonstrates how to use the `fetchPrevious` and `fetchNext` helper functions to paginate through the data. The `userInvitations` attribute will be populated with the first page of invitations. When the "Previous page" or "Next page" button is clicked, the `fetchPrevious` or `fetchNext` helper function will be called to fetch the previous or next page of invitations.
 
-  if (!isLoaded || userInvitations.isLoading) {
-    return <>Loading</>;
-  }
-
-  return (
-    <>
-      <table>
-        <thead>
-          <tr>
-            <th>Email</th>
-            <th>Org name</th>
-          </tr>
-        </thead>
-
-        <tbody>
-          {userInvitations.data?.map((inv) => (
-            <tr key={inv.id}>
-              <th>{inv.emailAddress}</th>
-              <th>{inv.publicOrganizationData.name}</th>
-            </tr>
-          ))}
-        </tbody>
-      </table>
-
-      <button
-        disabled={!userInvitations.hasPreviousPage}
-        onClick={userInvitations.fetchPrevious}
-      >
-        Prev
-      </button>
-      <button
-        disabled={!userInvitations.hasNextPage}
-        onClick={userInvitations.fetchNext}
-      >
-        Next
-      </button>
-    </>
-  );
-};
-
-export default InvitationsTable;
-```
+Notice the difference between this example's pagination and the infinite pagination example above.
 
 ```tsx filename="joined-organizations.tsx"
-import { useOrganizationList } from "@clerk/nextjs";
+import { useOrganizationList } from "@clerk/clerk-react";
 import React from "react";
 
 const InvitationsTable = () => {
@@ -215,55 +204,5 @@ const InvitationsTable = () => {
 
 export default InvitationsTable;
 ```
-</CodeBlockTabs>
 
-## Parameters
-
-`useOrganizationList` accepts a single object with the following properties:
-
-| Properties | Description |
-| --- | --- |
-| `userMemberships` | [`CommonPaginatedParams`](#commonpaginatedparams) |
-| `userInvitations` | [`CommonPaginatedParams`](#commonpaginatedparams) and `status` which describes the status of an invitation, defaults to `pending`. |
-| `userSuggestions` | [`CommonPaginatedParams`](#commonpaginatedparams) and `status` which describes the status of a suggestion, defaults to `pending`. |
-
-### `CommonPaginatedParams`
-
-`CommonPaginatedParams` can be either `true` or an object with the properties described below. If set to `true`, all of the default values will be used.
-
-| Properties | Description |
-| --- | --- |
-| `initialPage` | A number that can be used to skip the first n-1 pages. For example, if `initialPage` is set to 10, it is will skip the first 9 pages and will fetch the 10th page. Defaults to `1`. |
-| `pageSize` | A number that indicates the maximum number of results that should be returned for a specific page. Defaults to `10`. |
-| `keepPreviousData` | If `true`, it will persist the cached data until the new data has been fetched. Defaults to `false`. |
-| `infinite` | If `true`, the new downloaded data will be appended to the list with the existing data. Ideal for infinite lists. Defaults to `false`. |
-
-## Returns
-
-The `userMemberships`, `userInvitations`, and `userSuggestions` are returned as paginated lists.
-
-| Variables | Description |
-| --- | --- |
-| `isLoaded` | A boolean is set to `false` until Clerk loads and initializes. Once Clerk loads, `isLoaded` will be set to `true`. |
-| `createOrganization` | A function that returns a promise that resolves to the newly created Organization. It accepts a name and a slug |
-| `setActive` | A function that sets the active organization. It accepts either the organization object or the organization id. |
-| `userMemberships` | API for fetching [paginated resources](#paginatedresources). |
-| `userInvitations` | API for fetching [paginated resources](#paginatedresources). |
-| `userSuggestions` | API for fetching [paginated resources](#paginatedresources). |
-
-### `PaginatedResources`
-
-| Variables | Description |
-| --- | --- |
-| `data` | An array that contains the fetched data. |
-| `count` | The total count of data that exist remotely. |
-| `isLoading` | A boolean that is `true` if there is an ongoing request and there is no fetched data. |
-| `isFetching` | A boolean that is `true` if there is an ongoing request or a revalidation. |
-| `isError` | A boolean that indicates the request failed. |
-| `page` | A number that indicates the current page. |
-| `pageCount` | A number that indicates the total amount of pages. It is calculated based on `count` , `initialPage` , and `pageSize` |
-| `fetchPage` | A function that triggers a specific page to be loaded. |
-| `fetchPrevious` | A helper function that triggers the previous page to be loaded. This is the same as `fetchPage(page=> Math.max(0, page - 1))` |
-| `fetchNext` | A helper function that triggers the next page to be loaded. This is the same as `fetchPage(page=> Math.max(0, page + 1))` |
-| `hasNextPage` | A boolean that indicates if there are available pages to be fetched. |
-| `hasPreviousPage` | A boolean that indicates if there are available pages to be fetched. |
+To see the different organization features integrated into one application, take a look at our [organizations demo repository](https://github.com/clerk/organizations-demo).

--- a/docs/references/react/use-organization.mdx
+++ b/docs/references/react/use-organization.mdx
@@ -1,85 +1,142 @@
 ---
 title: useOrganization()
-description: Access attributes of the currently active organization.
+description: Clerk's useOrganization() hook retrieves attributes of the currently active organization.
 ---
 
 # `useOrganization()`
 
-The `useOrganization()` hook gives you access to the current active organization attributes.
+The `useOrganization()` hook is used to retrieve attributes of the currently active organization. 
 
-```jsx
-const { 
-  isLoaded,
-  organization,
-  membership,
-  invitations,
-  memberships,
-  membershipRequests,
-  domains,
-} = useOrganization();
+## `useOrganization()` parameters
+
+`useOrganization()` accepts a single object with the following optional properties:
+
+| Properties | Description |
+| --- | --- |
+| `invitations?` | `true` or an object with [`status: OrganizationInvitationStatus`](#organization-invitation-status) or any of the properties described in [Shared properties](#shared-properties). If set to `true`, all default properties will be used. |
+| `membershipRequests?` | `true` or an object with [`status: OrganizationInvitationStatus`](#organization-invitation-status) or any of the properties described in [Shared properties](#shared-properties). If set to `true`, all default properties will be used. |
+| `memberships?` | `true` or an object with [`role: OrganizationCustomRoleKey[]`](#organization-custome-role-key) or any of the properties described in [Shared properties](#shared-properties). If set to `true`, all default properties will be used. |
+| `domains?` | `true` or an object with [`enrollmentMode: OrganizationEnrollmentMode`](#organization-enrollment-mode) or any of the properties described in [Shared properties](#shared-properties). If set to `true`, all default properties will be used. |
+
+### Shared properties
+
+Properties that are shared across the `invitations`, `membershipRequests`, `memberships`, and `domains` properties.
+
+| Properties | Description |
+| --- | --- |
+| `initialPage?` | A number that can be used to skip the first n-1 pages. For example, if `initialPage` is set to 10, it is will skip the first 9 pages and will fetch the 10th page. Defaults to `1`. |
+| `pageSize?` | A number that indicates the maximum number of results that should be returned for a specific page. Defaults to `10`. |
+| `keepPreviousData?` | If `true`, it will persist the cached data until the new data has been fetched. Defaults to `false`. |
+| `infinite?` | If `true`, the new downloaded data will be appended to the list with the existing data. Ideal for infinite lists. Defaults to `false`. |
+
+### `OrganizationInvitationStatus`
+
+`useOrganization()` accepts `status` as a property for the `invitations` and `membershipRequests` parameters.
+
+`status` is a string that can be one of the following:
+
+```typescript
+type OrganizationInvitationStatus = "pending" | "accepted" | "revoked";
+```
+
+### `OrganizationCustomRoleKey`
+
+`useOrganization` accepts `role` as a property for the `memberships` parameter.
+
+`role` is a string that represents the user's role in the organization. Clerk provides the [default roles](/docs/organizations/roles-permissions#default-roles) `org:admin` and `org:member`. However, you can create [custom roles](/docs/organizations/create-roles-permissions) as well.
+
+### `OrganizationEnrollmentMode`
+
+`useOrganization()` accepts `enrollmentMode` as a property for the `domains` paramater.
+
+`enrollmentMode` is a string that can be one of the following:
+
+```typescript
+type OrganizationEnrollmentMode = "manual_invitation" | "automatic_invitation" | "automatic_suggestion";
 ```
 
 <Callout type="info">
   These attributes are updating automatically and will re-render their respective components whenever you set a different organization using the [`setActive({ organization })`](/docs/references/javascript/clerk/session-methods#set-active) method or update any of the memberships or invitations. No need for you to manage updating anything manually.
 </Callout>
 
-## Usage
+## `useOrganization()` returns
 
-<Callout type="warning">
-  Make sure you've followed the installation guide for [Clerk React](/docs/references/react/overview) before running the snippets below.
-</Callout>
+| Name | Type | Description |
+| --- | --- | --- |
+| `isLoaded` | `boolean` | A boolean that is set to `false` until Clerk loads and initializes. |
+| `organization` | [`Organization`](/docs/references/javascript/organization/organization) | The currently active organization. |
+| `membership` | [`OrganizationMembership`](/docs/references/javascript/organization-membership) | The current organization membership. |
+| `memberships` | [`PaginatedResources`](#paginated-resources) | Includes a paginated list of the organization's memberships. |
+| `invitations` | [`PaginatedResources`](#paginated-resources) | Includes a paginated list of the organization's invitations. |
+| `membershipRequests` | [`PaginatedResources`](#paginated-resources) | Includes a paginated list of the organization's membership requests. |
+| `domains` | [`PaginatedResources`](#paginated-resources) | Includes a paginated list of the organization's domains. |
 
-In the following example, `useOrganization()` is used to map over the `memberships` of the current active organization and present membership attributes. In addition, buttons support navigating through the paginated response.
+### `PaginatedResources`
 
-<Callout type="info">
-  Note that your component must be a descendant of [`<ClerkProvider/>`](/docs/components/clerk-provider).
-</Callout>
+| Variables | Description |
+| --- | --- |
+| `data` | An array that contains the fetched data. |
+| `count` | The total count of data that exist remotely. |
+| `isLoading` | A boolean that is `true` if there is an ongoing request and there is no fetched data. |
+| `isFetching` | A boolean that is `true` if there is an ongoing request or a revalidation. |
+| `isError` | A boolean that indicates the request failed. |
+| `page` | A number that indicates the current page. |
+| `pageCount` | A number that indicates the total amount of pages. It is calculated based on `count` , `initialPage` , and `pageSize` |
+| `fetchPage` | A function that triggers a specific page to be loaded. |
+| `fetchPrevious` | A helper function that triggers the previous page to be loaded. This is the same as `fetchPage(page=> Math.max(0, page - 1))` |
+| `fetchNext` | A helper function that triggers the next page to be loaded. This is the same as `fetchPage(page=> Math.min(pageCount, page + 1))` |
+| `hasNextPage` | A boolean that indicates if there are available pages to be fetched. |
+| `hasPreviousPage` | A boolean that indicates if there are available pages to be fetched. |
+| `revalidate` | A function that triggers a revalidation of the current page. |
+| `setData` | A function that allows you to set the data manually. |
+
+## How to use the `useOrganization()` hook
 
 ### Expanding and paginating attributes
 
-To keep network usage to a minimum, we require developers to opt-in by specifying which resource they need to fetch and paginate through.
+To keep network usage to a minimum, developers are required to opt-in by specifying which resource they need to fetch and paginate through. So by default, the `memberships`, `invitations`, `membershipRequests`, and `domains` attributes are not populated. You must pass `true` or an object with the desired [properties](#shared-properties) to fetch and paginate the data.
 
 ```jsx
-const { invitations } = useOrganization();
-// invitations.data will never be populated
+const { invitations } = useOrganization(); // invitations.data will never be populated.
 
 // Use default values to fetch invitations
 const { invitations } = useOrganization({
- invitations: true
+  invitations: true
 });
 
 // Override fetch invitations
 const { invitations } = useOrganization({
- invitations: {
+  invitations: {
     pageSize: 20,
     initialPage: 2, // skips the first page
- }
+  }
 });
 
 // Aggregate pages in order to render an infinite list
 const { invitations } = useOrganization({
- invitations: {
+  invitations: {
     infinite: true,
- }
+  }
 });
-
 ```
 
-
 ### Infinite pagination
+
+The following example demonstrates how to use the `infinite` property to fetch and append new data to the existing list. The `memberships` attribute will be populated with the first page of the organization's memberships. When the "Load more" button is clicked, the `fetchNext` helper function will be called to append the next page of memberships to the list.
+
 ```jsx
-import { useOrganization } from "@clerk/nextjs";
+import { useOrganization } from "@clerk/clerk-react";
 
 export default function MemberList() {
   const { memberships } = useOrganization({
     memberships: {
-      infinite: true,
-      keepPreviousData: true,
+      infinite: true, // Append new data to the existing list
+      keepPreviousData: true, // Persist the cached data until the new data has been fetched
     },
   });
 
   if (!memberships) {
-    // loading state
+    // Handle loading state
     return null;
   }
 
@@ -96,7 +153,7 @@ export default function MemberList() {
       </ul>
 
       <button
-        disabled={!memberships.hasNextPage}
+        disabled={!memberships.hasNextPage} // Disable the button if there are no more available pages to be fetched
         onClick={memberships.fetchNext}
       >
         Load more
@@ -107,18 +164,23 @@ export default function MemberList() {
 ```
 
 ### Simple pagination
+
+The following example demonstrates how to use the `fetchPrevious` and `fetchNext` helper functions to paginate through the data. The `memberships` attribute will be populated with the first page of the organization's memberships. When the "Previous page" or "Next page" button is clicked, the `fetchPrevious` or `fetchNext` helper function will be called to fetch the previous or next page of memberships.
+
+Notice the difference between this example's pagination and the infinite pagination example above.
+
 ```jsx
-import { useOrganization } from "@clerk/nextjs";
+import { useOrganization } from "@clerk/clerk-react";
 
 export default function MemberList() {
   const { memberships } = useOrganization({
     memberships: {
-      keepPreviousData: true,
+      keepPreviousData: true, // Persist the cached data until the new data has been fetched
     },
   });
 
   if (!memberships) {
-    // loading state
+    // Handle loading state
     return null;
   }
 
@@ -152,75 +214,4 @@ export default function MemberList() {
 }
 ```
 
-To see a demo application utilising the hook and the organizations feature, take a look at our [organizations demo repository](https://github.com/clerk/organizations-demo).
-
-## Parameters
-
-`useOrganization()` accepts a single object with the following optional properties:
-
-| Properties | Description |
-| --- | --- |
-| `invitations?` | [`CommonPaginatedParams`](#common-paginated-params) and [`OrganizationInvitationStatus[]`](#organization-invitation-status) |
-| `membershipRequests?` | [`CommonPaginatedParams`](#common-paginated-params) and [`OrganizationInvitationStatus`](#organization-invitation-status) |
-| `memberships?` | [`CommonPaginatedParams`](#common-paginated-params) and [`MembershipRole?`](#membership-role) |
-| `domains?` | [`CommonPaginatedParams`](#commonpaginated-params) and [`OrganizationEnrollmentMode`](#organization-enrollment-mode) |
-
-### `CommonPaginatedParams`
-
-`CommonPaginatedParams` can be either `true` or an object with the properties described below. If set to `true`, all of the default values will be used.
-
-| Properties | Description |
-| --- | --- |
-| `initialPage?` | A number that can be used to skip the first n-1 pages. For example, if `initialPage` is set to 10, it is will skip the first 9 pages and will fetch the 10th page. Defaults to `1`. |
-| `pageSize?` | A number that indicates the maximum number of results that should be returned for a specific page. Defaults to `10`. |
-| `keepPreviousData?` | If `true`, it will persist the cached data until the new data has been fetched. Defaults to `false`. |
-| `infinite?` | If `true`, the new downloaded data will be appended to the list with the existing data. Ideal for infinite lists. Defaults to `false`. |
-
-### `OrganizationInvitationStatus`
-
-```typescript
-type OrganizationInvitationStatus = "pending" | "accepted" | "revoked";
-```
-
-### `MembershipRole`
-
-```typescript
-type MembershipRole = "admin" | "org:member";
-```
-
-### `OrganizationEnrollmentMode`
-
-```typescript
-type OrganizationEnrollmentMode = "manual_invitation" | "automatic_invitation" | "automatic_suggestion";
-```
-
-## Returns
-
-The `memberships`, `membershipRequests`, and `domains` are returned as paginated lists.
-
-| Variables | Description |
-| --- | --- |
-| `isLoaded` | A boolean is set to `false` until Clerk loads and initializes. Once Clerk loads, `isLoaded` will be set to `true`. |
-| `organization` | The current active organization. |
-| `membership` | The current organization membership. |
-| `invitations` | API for fetching [paginated resources](#paginated-resources). |
-| `memberships` | API for fetching [paginated resources](#paginated-resources). |
-| `membershipRequests` | API for fetching [paginated resources](#paginated-resources). |
-| `domains` | API for fetching [paginated resources](#paginated-resources). |
-
-### `PaginatedResources`
-
-| Variables | Description |
-| --- | --- |
-| `data` | An array that contains the fetched data. |
-| `count` | The total count of data that exist remotely. |
-| `isLoading` | A boolean that is `true` if there is an ongoing request and there is no fetched data. |
-| `isFetching` | A boolean that is `true` if there is an ongoing request or a revalidation. |
-| `isError` | A boolean that indicates the request failed. |
-| `page` | A number that indicates the current page. |
-| `pageCount` | A number that indicates the total amount of pages. It is calculated based on `count` , `initialPage` , and `pageSize` |
-| `fetchPage` | A function that triggers a specific page to be loaded. |
-| `fetchPrevious` | A helper function that triggers the previous page to be loaded. This is the same as `fetchPage(page=> Math.max(0, page - 1))` |
-| `fetchNext` | A helper function that triggers the previous page to be loaded. This is the same as `fetchPage(page=> Math.max(0, page + 1))` |
-| `hasNextPage` | A boolean that indicates if there are available pages to be fetched. |
-| `hasPreviousPage` | A boolean that indicates if there are available pages to be fetched. |
+To see the different organization features integrated into one application, take a look at our [organizations demo repository](https://github.com/clerk/organizations-demo).

--- a/docs/references/react/use-organization.mdx
+++ b/docs/references/react/use-organization.mdx
@@ -5,7 +5,7 @@ description: Clerk's useOrganization() hook retrieves attributes of the currentl
 
 # `useOrganization()`
 
-The `useOrganization()` hook is used to retrieve attributes of the currently active organization. 
+The `useOrganization()` hook is used to retrieve attributes of the currently active organization.
 
 ## `useOrganization()` parameters
 
@@ -99,12 +99,12 @@ To keep network usage to a minimum, developers are required to opt-in by specify
 ```jsx
 const { invitations } = useOrganization(); // invitations.data will never be populated.
 
-// Use default values to fetch invitations
+// Use default values to fetch invitations, such as initialPage = 1 and pageSize = 10
 const { invitations } = useOrganization({
   invitations: true
 });
 
-// Override fetch invitations
+// Pass your own values to fetch invitations
 const { invitations } = useOrganization({
   invitations: {
     pageSize: 20,

--- a/docs/references/react/use-session-list.mdx
+++ b/docs/references/react/use-session-list.mdx
@@ -26,7 +26,7 @@ The `useSessionList()` hook returns an array of [`Session`](/docs/references/jav
 
 ## How to use the `useSessionList()` hook
 
-In the following example, the `useSessionList()` hook is used to retrieve a list of sessions that have been registered on the client device. The `isLoaded` property is used to handle the loading state, and the `sessions` property is used to display the number of times the user has visited the page.
+The following example demonstrates how to use the `useSessionList()` hook to retrieve a list of sessions that have been registered on the client device. The `isLoaded` property is used to handle the loading state, and the `sessions` property is used to display the number of times the user has visited the page.
 
 ```tsx filename="home.tsx"
 import { useSessionList } from "@clerk/clerk-react";

--- a/docs/references/react/use-session-list.mdx
+++ b/docs/references/react/use-session-list.mdx
@@ -1,40 +1,38 @@
 ---
 title: useSessionList()
-description: The useSessionList() hook returns an array of Session objects that have been registered on the client device.
+description: Clerk's useSessionList() hook retrieves a list of sessions that have been registered on the client device.
 ---
 
 # `useSessionList()`
 
 The `useSessionList()` hook returns an array of [`Session`](/docs/references/javascript/session) objects that have been registered on the client device.
 
-## Usage
+## `useSessionList()` returns
 
-<CodeBlockTabs type="framework" options={["Next.js", "React"]}>
-```tsx filename="pages/index.tsx"
-import { useSessionList } from "@clerk/nextjs";
+| Name | Type | Description |
+| --- | --- | --- |
+| `isLoaded` | `boolean` | A boolean that is set to `false` until Clerk loads and initializes. |
+| `setActive()` | <code>(params: [SetActiveParams](#set-active-params)) => Promise\<void\></code> | A function that sets the active session. | A function that sets the active organization. It accepts either the organization object or the organization id. |
+| `setSession()` (deprecated) | Deprecated in favor of `setActive()`. |
+| `sessions` | [`Session[]`](/docs/references/javascript/session) | Holds an array of `Session` objects that have been registered on the client device. |
 
-export default function Home() {
-  const { isLoaded, sessions} = useSessionList();
+### `SetActiveParams`
 
-  if (!isLoaded) {
-    // handle loading state
-    return null;
-  }
-  return (
-    <div>
-      <p>Welcome back. You have been here
-      {sessions.length} times before.
-      </p>
-    </div>
-  )
-}
-```
+| Name | Type | Description |
+| --- | --- | --- |
+| `session` | <code>[Session](/docs/references/javascript/session) \| string \| null</code> | The session resource or session ID (string version) to be set as active. If `null`, the current session is deleted. |
+| `organization` | <code>[Organization](/docs/references/javascript/organization/organization) \| string \| null</code> | The organization resource or organization ID (string version) to be set as active in the current session. If `null`, the currently active organization is removed as active. |
+| `beforeEmit?` | `(session?: Session \| null) => void \| Promise<any>` | Callback run just before the active session and/or organization is set to the passed object. Can be used to hook up for pre-navigation actions. |
+
+## How to use the `useSessionList()` hook
+
+In the following example, the `useSessionList()` hook is used to retrieve a list of sessions that have been registered on the client device. The `isLoaded` property is used to handle the loading state, and the `sessions` property is used to display the number of times the user has visited the page.
 
 ```tsx filename="home.tsx"
 import { useSessionList } from "@clerk/clerk-react";
 
 export default function Home() {
-  const { isLoaded, sessions} = useSessionList();
+  const { isLoaded, sessions } = useSessionList();
 
   if (!isLoaded) {
     // handle loading state
@@ -49,11 +47,3 @@ export default function Home() {
   )
 }
 ```
-</CodeBlockTabs>
-
-| Values | Description |
-| --- | --- |
-| `isLoaded` | A boolean that is set to `false` until Clerk loads and initializes. |
-| `setActive()` | A function that sets the active session. |
-| `setSession()` (deprecated) | Deprecated in favor of `setActive()`. |
-| `sessions` | Holds an array of [`Session`](/docs/references/javascript/session) objects that have been registered on the client device. |

--- a/docs/references/react/use-session.mdx
+++ b/docs/references/react/use-session.mdx
@@ -17,7 +17,7 @@ The `useSession()` hook provides access to the current user's [`Session`](/docs/
 
 ## How to use the `useSession()` hook
 
-In the following example, the `useSession()` hook is used to access the `SignIn` object, which has the `lastActiveAt` property on it. The `lastActiveAt` property is used to display the last active time of the current session to the user.
+The following example demonstrates how to use the `useSession()` hook to access the `SignIn` object, which has the `lastActiveAt` property on it. The `lastActiveAt` property is used to display the last active time of the current session to the user.
 
 ```tsx filename="home.tsx"
 import { useSession } from "@clerk/clerk-react";

--- a/docs/references/react/use-session.mdx
+++ b/docs/references/react/use-session.mdx
@@ -1,39 +1,23 @@
 ---
 title: useSession()
-description: The useSession() hook provides access to the the current user Session object, and helpers to set the active session.
+description: Clerk's useSession() hook provides access to the the current user Session object, as well as helpers to set the active session.
 ---
 
 # `useSession()`
 
 The `useSession()` hook provides access to the current user's [`Session`](/docs/references/javascript/session) object, as well as helpers for setting the active session.
 
-## Usage
+## `useSession()` returns
 
-<CodeBlockTabs type="framework" options={["Next.js", "React"]}>
-```tsx filename="pages/index.tsx"
-import { useSession } from "@clerk/nextjs";
+| Name | Type | Description |
+| --- | --- | --- |
+| `isLoaded` | `boolean` | A boolean that is set to `false` until Clerk loads and initializes. |
+| `isSignedIn` | `boolean` | A boolean that is set to `true` if the user is signed in. |
+| `session` | [`Session`](/docs/references/javascript/session) | Holds the current active session for the user. |
 
-export default function Home() {
-  const { isLoaded, session, isSignedIn } = useSession();
+## How to use the `useSession()` hook
 
-  if (!isLoaded) {
-    // handle loading state
-    return null;
-  }
-  if(!isSignedIn) {
-    // handle not signed in state
-    return null;
-  }
-
-  return (
-    <div>
-      <p>This session has been active
-      since {session.lastActiveAt.toLocaleString()}
-      </p>
-    </div>
-  )
-}
-```
+In the following example, the `useSession()` hook is used to access the `SignIn` object, which has the `lastActiveAt` property on it. The `lastActiveAt` property is used to display the last active time of the current session to the user.
 
 ```tsx filename="home.tsx"
 import { useSession } from "@clerk/clerk-react";
@@ -42,11 +26,11 @@ export default function Home() {
   const { isLoaded, session, isSignedIn } = useSession();
 
   if (!isLoaded) {
-    // handle loading state
+    // Add logic to handle loading state
     return null;
   }
   if(!isSignedIn) {
-    // handle not signed in state
+    // Add logic to handle not signed in state
     return null;
   }
 
@@ -59,11 +43,3 @@ export default function Home() {
   )
 }
 ```
-</CodeBlockTabs>
-
-| Values | Description |
-| --- | --- |
-| `isLoaded` | A boolean that is set to `false` until Clerk loads and initializes. |
-| `setActive()` | A function that sets the active session. |
-| `setSession()` (deprecated) | Deprecated in favor of `setActive()`. |
-| `session` | Holds the current active session for the user. |

--- a/docs/references/react/use-sign-in.mdx
+++ b/docs/references/react/use-sign-in.mdx
@@ -1,6 +1,6 @@
 ---
 title: useSignIn()
-description: The useSignIn() hook provides access to the SignIn object, which allows you to check the current state of a sign-in and for creating custom sign-in flows.
+description: Clerk's useSignIn() hook provides access to the SignIn object, which allows you to check the current state of a sign-in.
 ---
 
 # `useSignIn()`
@@ -28,23 +28,7 @@ The `useSignIn()` hook provides access to the [`SignIn`](/docs/references/javasc
 
 ### Check the current state of a sign-in with `useSignIn()`
 
-You can utilize the `useSignIn()` hook to check the current state of a sign-in.
-
-<CodeBlockTabs type="framework" options={["Next.js", "React"]}>
-  ```tsx filename="pages/index.tsx"
-  import { useSignIn } from "@clerk/nextjs";
-
-  export default function SignInStep() {
-    const { isLoaded, signIn } = useSignIn();
-
-    if (!isLoaded) {
-      // handle loading state
-      return null;
-    }
-
-    return <div>The current sign in attempt status is {signIn.status}.</div>;
-  }
-  ```
+Use the `useSignIn()` hook to check the current state of a sign-in.
 
   ```tsx filename="pages/sign-in-step.tsx"
   import { useSignIn } from "@clerk/clerk-react";
@@ -53,16 +37,15 @@ You can utilize the `useSignIn()` hook to check the current state of a sign-in.
     const { isLoaded, signIn } = useSignIn();
 
     if (!isLoaded) {
-      // handle loading state
+      // Add logic to handle loading state
       return null;
     }
 
     return <div>The current sign in attempt status is {signIn.status}.</div>;
   }
   ```
-</CodeBlockTabs>
 
-The `status` property of the `signIn` object can be one of the following values:
+The `status` property of the `SignIn` object can be one of the following values:
 
 | Values | Descriptiom |
 | --- | --- |
@@ -74,4 +57,4 @@ The `status` property of the `signIn` object can be one of the following values:
 
 ### Create a custom sign-in flow with `useSignIn()`
 
-You can also utilize the `useSignIn()` hook to build fully custom sign-in flows, if Clerk's pre-built components don't meet your specific needs or if you require more control over the authentication flow. Different sign-in flows include email and password, email and phone codes, email links, and multifactor (MFA). To learn more about using the `useSignIn()` hook to create custom flows, check out the [custom flow guides](https://clerk.com/docs/custom-flows/overview).
+The `useSignIn()` hook can also be used to build fully custom sign-in flows, if Clerk's pre-built components don't meet your specific needs or if you require more control over the authentication flow. Different sign-in flows include email and password, email and phone codes, email links, and multifactor (MFA). To learn more about using the `useSignIn()` hook to create custom flows, check out the [custom flow guides](https://clerk.com/docs/custom-flows/use-sign-up).

--- a/docs/references/react/use-sign-up.mdx
+++ b/docs/references/react/use-sign-up.mdx
@@ -1,6 +1,6 @@
 ---
 title: useSignUp()
-description: The useSignUp() hook gives you access to the SignUp object, which allows you to check the current state of a sign-up and create custom sign-up flows.
+description: Clerk's useSignUp() hook gives you access to the SignUp object, which allows you to check the current state of a sign-up.
 ---
 # `useSignUp()`
 
@@ -27,23 +27,7 @@ The `useSignUp()` hook gives you access to the [`SignUp`](/docs/references/javas
 
 ### Check the current state of a sign-up with `useSignUp()`
 
-You can utilize the `useSignUp()` hook to check the current state of a sign-up.
-
-<CodeBlockTabs type="framework" options={["Next.js", "React"]}>
-  ```tsx filename="pages/sign-up.tsx"
-  import { useSignUp } from "@clerk/nextjs";
-
-  export default function SignUpStep() {
-    const { isLoaded, signUp } = useSignUp();
-
-    if (!isLoaded) {
-      // handle loading state
-      return null;
-    }
-
-    return <div>The current sign-up attempt status is {signUp.status}.</div>;
-  }
-  ```
+Use the `useSignUp()` hook to access the `SignUp` object and check the current state of a sign-up.
 
   ```tsx filename="sign-up-step.tsx"
   import { useSignUp } from "@clerk/clerk-react";
@@ -52,16 +36,15 @@ You can utilize the `useSignUp()` hook to check the current state of a sign-up.
     const { isLoaded, signUp } = useSignUp();
 
     if (!isLoaded) {
-      // handle loading state
+      // Add logic to handle loading state
       return null;
     }
 
     return <div>The current sign-up attempt status is {signUp.status}.</div>;
   }
   ```
-</CodeBlockTabs>
 
-The `status` property of the `signIn` object can be one of the following values:
+The `status` property of the `SignUp` object can be one of the following values:
 
 | Values | Descriptiom |
 | --- | --- |
@@ -71,4 +54,4 @@ The `status` property of the `signIn` object can be one of the following values:
 
 ### Create a custom sign-up flow with `useSignUp()`
 
-You can also utilize the `useSignUp()` hook to build fully custom sign-up flows, if Clerk's pre-built components don't meet your specific needs or if you require more control over the authentication flow. Different sign-up flows include email and password, email and phone codes, email links, and multifactor (MFA). To learn more about using the `useSignUp()` hook to create custom flows, check out the [custom flow guides](https://clerk.com/docs/custom-flows/overview).
+The `useSignUp()` hook can also be used to build fully custom sign-up flows, if Clerk's pre-built components don't meet your specific needs or if you require more control over the authentication flow. Different sign-up flows include email and password, email and phone codes, email links, and multifactor (MFA). To learn more about using the `useSignUp()` hook to create custom flows, check out the [custom flow guides](https://clerk.com/docs/custom-flows/use-sign-up).

--- a/docs/references/react/use-user.mdx
+++ b/docs/references/react/use-user.mdx
@@ -7,33 +7,19 @@ description: The useUser() hook is used to get the current user object and to up
 
 The `useUser()` hook is a convenient way to access the current [`User`](/docs/references/javascript/user/user) data where you need it. This hook provides the user data and helper methods to manage the current active session.
 
-## Usage
+## `useUser()` returns
 
-<Callout type="info">
-  Note that your component must be a descendant of [`<ClerkProvider>`](/docs/components/clerk-provider).
-</Callout>
+| Name | Type | Description |
+| --- | --- | --- |
+| `isSignedIn` | `boolean` | A boolean that returns `true` if the user is signed in. |
+| `isLoaded` | `boolean` | A boolean that until Clerk loads and initializes, will be set to `false`. Once Clerk loads, `isLoaded` will be set to `true`. |
+| `user` | [`User`](/docs/references/javascript/user/user) | The `User` object for the currently active user. If the user is not signed in, `user` will be `null`. |
 
-### Retrieve the current user data
+## How to use the `useUser()` hook
 
-<CodeBlockTabs type="framework" options={["Next.js", "React"]}>
-```tsx filename="pages/index.tsx"
-import { useUser } from "@clerk/nextjs";
+### Retrieve the current user data with the `useUser()` hook
 
-export default function Home() {
-  const { isSignedIn, user, isLoaded } = useUser();
-
-  if (!isLoaded) {
-    return null;
-  }
-
-  if (isSignedIn) {
-    return <div>Hello {user.fullName}!</div>;
-  }
-
-  return <div>Not signed in</div>;
-}
-
-```
+The following example demonstrates how to use the `useUser()` hook to access the `user` object, which includes the current user's data, like the user's full name. The `isLoaded` and `isSignedIn` properties are used to handle the loading state and to check if the user is signed in, respectively.
 
 ```tsx filename="home.tsx"
 import { useUser } from "@clerk/clerk-react";
@@ -42,6 +28,7 @@ export default function Home() {
   const { isSignedIn, user, isLoaded } = useUser();
 
   if (!isLoaded) {
+    // Handle loading state however you like
     return null;
   }
 
@@ -51,25 +38,32 @@ export default function Home() {
 
   return <div>Not signed in</div>;
 }
-
 ```
-</CodeBlockTabs>
 
-### Update the current user data
+### Update the current user data with the `useUser()` hook
 
-<CodeBlockTabs type="framework" options={["Next.js", "React"]}>
-```tsx filename="app/page.tsx"
-import { useUser } from "@clerk/nextjs";
+The following example demonstrates how to use the `useUser()` hook to access the `user` object, which includes the `update` method for updating the user's data.
+
+```tsx filename="home.tsx"
+import { useUser } from "@clerk/clerk-react";
 
 export default function Home() {
-  const { user } = useUser();
+  const { isLoaded, user } = useUser();
+
+  if (!isLoaded) {
+    // Handle loading state however you like
+    return null;
+  }
+
   if (!user) return null;
+
   const updateUser = async () => {
     await user.update({
       firstName: "John",
       lastName: "Doe",
     });
   };
+
   return (
     <>
       <button onClick={updateUser}>Click me to update your name</button>
@@ -80,46 +74,33 @@ export default function Home() {
 }
 ```
 
+### Reload user data with the `useUser()` hook
+
+To retrieve the latest user data after updating the user elsewhere, use the `user.reload()` method.
+
 ```tsx filename="home.tsx"
 import { useUser } from "@clerk/clerk-react";
 
 export default function Home() {
-  const { user } = useUser();
+  const { isLoaded, user } = useUser();
+
+  if (!isLoaded) {
+    // Handle loading state however you like
+    return null;
+  }
+
   if (!user) return null;
+
   const updateUser = async () => {
-    await user.update({
-      firstName: "John",
-      lastName: "Doe",
-    });
-  };
-  return (
-    <>
-      <button onClick={updateUser}>Click me to update your name</button>
-      <p>user.firstName: {user?.firstName}</p>
-      <p>user.lastName: {user?.lastName}</p>
-    </>
-  );
-}
-```
-</CodeBlockTabs>
+    // Update data via an API endpoint
+    const updateMetadata = await fetch("/api/updateMetadata");
 
-### Reload user data
-
-If you need to retrieve the latest user data after updating the user elsewhere, use the `user.reload()` method.
-
-<CodeBlockTabs type="framework" options={["Next.js", "React"]}>
-```tsx filename="app/page.tsx"
-import { useUser } from "@clerk/nextjs";
-
-export default function Home() {
-  const { user } = useUser();
-  if (!user) return null;
-  const updateUser = async () => {
-    // updated data via an api point
-    const updateMeta = await fetch("/api/updateMetadata");
+    // Check if the update was successful
     if (!updateMeta.message == "success") {
       throw new Error("Error updating");
     }
+
+    // If the update was successful, reload the user data
     user.reload();
   };
 
@@ -131,36 +112,3 @@ export default function Home() {
   );
 }
 ```
-
-```tsx filename="home.tsx"
-import { useUser } from "@clerk/clerk-react";
-
-export default function Home() {
-  const { user } = useUser();
-  if (!user) return null;
-  const updateUser = async () => {
-    // updated data via an api point
-    const updateMeta = await fetch("/api/updateMetadata");
-    if (!updateMeta.message == "success") {
-      throw new Error("Error updating");
-    }
-    user.reload();
-  };
-
-  return (
-    <>
-      <button onClick={updateUser}>Click me to update your metadata</button>
-      <p>user role: {user?.publicMetadata.role}</p>
-    </>
-  );
-}
-```
-</CodeBlockTabs>
-
-## Return value
-
-| Variables | Description |
-| --- | --- |
-| `isSignedIn` | A boolean that returns `true` if the user is signed in. |
-| `isLoaded` | A boolean that until Clerk loads and initializes, will be set to `false`. Once Clerk loads, `isLoaded` will be set to `true`. |
-| `user` | The [`User`](/docs/references/javascript/user/user) object for the currently active user. If the user is not signed in, `user` will be `null`. |


### PR DESCRIPTION
Follow new formatting of introducing a function, its params, its returns, and THEN examples of usage. NO custom flows should be on these reference pages. And as these are React references, the Next.js examples are being removed for now.

🔎 [docs/references/react/use-auth](https://docs-preview-715.clerkpreview.com/docs/references/react/use-auth)
🔎 [docs/references/react/use-clerk](https://docs-preview-715.clerkpreview.com/docs/references/react/use-clerk)
🔎 [docs/references/react/use-organization-list](https://docs-preview-715.clerkpreview.com/docs/references/react/use-organization-list)
🔎 [docs/references/react/use-organization](https://docs-preview-715.clerkpreview.com/docs/references/react/use-organization)
🔎 [docs/references/react/use-session](https://docs-preview-715.clerkpreview.com/docs/references/react/use-session)
🔎 [docs/references/react/use-session-list](https://docs-preview-715.clerkpreview.com/docs/references/react/use-session-list)
🔎 [docs/references/react/use-sign-in](https://docs-preview-715.clerkpreview.com/docs/references/react/use-sign-in)
🔎 [docs/references/react/use-sign-up](https://docs-preview-715.clerkpreview.com/docs/references/react/use-sign-up)
🔎 [docs/references/react/use-user](https://docs-preview-715.clerkpreview.com/docs/references/react/use-user)

