### PR TITLE
(core1) update protect docs

### DIFF
--- a/docs/references/nextjs/auth.mdx
+++ b/docs/references/nextjs/auth.mdx
@@ -7,7 +7,7 @@ description: Access minimal authentication data for managing sessions and data f
 
 The `auth()` helper returns the [`Authentication`](/docs/references/nextjs/authentication-object) object of the currently active user. This is the same `Authentication` object that is returned by the [`getAuth()`](/docs/references/nextjs/get-auth) hook. However, it can be used in Server Components, Route Handlers, and Server Actions.
 
-The `auth()` helper does require [Middleware](/docs/references/nextjs/auth-middleware). 
+The `auth()` helper does require [Middleware](/docs/references/nextjs/auth-middleware).
 
 A Route Handler added to [`publicRoutes`](/docs/references/nextjs/auth-middleware#making-pages-public-using-public-routes) can still use the [`auth()`](/docs/references/nextjs/auth) helper to return information about the user or their authentication state, or to control access to some or all of the Route Handler.
 
@@ -20,21 +20,25 @@ A Route Handler added to [`publicRoutes`](/docs/references/nextjs/auth-middlewar
 
 ### `protect()`
 
-You can use the `protect()` helper to check if a user is authorized to access something, such as a component or a route handler. 
-
-`protect()` will return the `Authentication` object if the user is authorized. If the user is not authorized, it will throw a `notFound` Next.js error.
-
 <Callout type="warning">
   `auth().protect()` only works for App Router and is considered experimental.
 </Callout>
+
+You can use the `protect()` helper in two ways:
+- to check if a user is authenticated
+- to check if a user is authorized to access something, such as a component or a route handler
+
+`protect()` will return the `Authentication` object if the user is authenticated or authorized. If the user is not authenticated or authorized, `protect()` will redirect the user to the sign-in page or to a custom URL that you provide as a parameter.
 
 `protect()` accepts the following parameters:
 
 | Name | Type | Description |
 | --- | --- | --- |
-| `role` | `string` | The role to check for. |
-| `permission` | `string` | The permission to check for. |
-| `has` | <code>(isAuthorizedParams: CheckAuthorizationParamsWithCustomPermissions) => boolean</code> | A function that returns a boolean based on the permission or role provided as parameter. Can be used for authorization. See the dedicated [`has()`](/docs/references/nextjs/authentication-object#has) section for more information. |
+| `role?` | `string` | The role to check for. |
+| `permission?` | `string` | The permission to check for. |
+| `has?` | <code>(isAuthorizedParams: CheckAuthorizationParamsWithCustomPermissions) => boolean</code> | A function that returns a boolean based on the permission or role provided as parameter. Can be used for authorization. See the dedicated [`has()`](/docs/references/nextjs/authentication-object#has) section for more information. |
+| `unauthorizedUrl?` | `string` | The URL to redirect the user to if they are not authorized. |
+| `unauthenticatedUrl?` | `string` | The URL to redirect the user to if they are not authenticated. |
 
 ### `redirectToSignIn()`
 
@@ -73,13 +77,32 @@ export async function GET() {
     const token = await getToken({template: "supabase"});
 
     // Add logic here to fetch data from Supabase and return it.
-  
+
     const data = { supabaseData: 'Hello World' };
-  
+
     return Response.json({ data });
   } catch (error) {
     return Response.json(error);
   }
+}
+```
+
+## Use `auth()` to check if a user is authenticated
+
+`auth().protect()` can be used in a `layout.tsx` file to protect the entire route, including all children.
+
+In the following example,
+- the `protect()` helper is used to check if a user visiting any `/dashboard` route is authenticated.
+- If the user is not authenticated, they will be redirected to the sign-in route.
+- If the user is authenticated, they can view the route and its children.
+
+```tsx filename="app/dashboard/layout.tsx"
+import { auth } from '@clerk/nextjs/server'
+
+export default async function Layout({ children }:{ children: React.ReactNode }){
+  auth().protect()
+
+  return <>{children}</>
 }
 ```
 
@@ -106,7 +129,7 @@ export default async function Page() {
 
   const canManage = has({ permission:"org:team_settings:manage" });
 
-  if(!canManage) return null;  
+  if(!canManage) return null;
 
   return <h1>Team Settings</h1>
 }
@@ -121,8 +144,8 @@ Use the [`protect()`](#protect) helper to protect a route handler from unauthori
 </Callout>
 
 In the following example:
-- `protect()` helper is used to check if a user is authorized to access a route handler. 
-- If the user is not authorized, the `protect()` helper will throw a `notFound` Next.js error. 
+- `protect()` helper is used to check if a user is authorized to access a route handler.
+- If the user is not authorized, the `protect()` helper will redirect the user to the sign-in route.
 - If the user is authorized, the `protect()` helper will return the `Authentication` object, which has the `userId` property.
 
 ```tsx filename="app/api/route.ts"
@@ -137,7 +160,7 @@ export const POST = () => {
 
 ## Use `auth()` to check your current user's role
 
-In some cases, you need to check your user's current organization role before displaying data or allowing certain actions to be performed. 
+In some cases, you need to check your user's current organization role before displaying data or allowing certain actions to be performed.
 
 Check the current user's role with the `orgRole` property of the `Authentication` object returned by `auth()`, as shown in the following example:
 

--- a/docs/references/nextjs/auth.mdx
+++ b/docs/references/nextjs/auth.mdx
@@ -94,7 +94,7 @@ export async function GET() {
 In the following example,
 - the `protect()` helper is used to check if a user visiting any `/dashboard` route is authenticated.
 - If the user is not authenticated, they will be redirected to the sign-in route.
-- If the user is authenticated, they can view the route and its children.
+- If the user is authenticated, they can view any `/dashboard` route and its children.
 
 ```tsx filename="app/dashboard/layout.tsx"
 import { auth } from '@clerk/nextjs/server'

--- a/docs/references/nextjs/authentication-object.mdx
+++ b/docs/references/nextjs/authentication-object.mdx
@@ -17,10 +17,10 @@ Both [`auth()`](/docs/references/nextjs/auth) and  [`getAuth()`](/docs/reference
 | `orgRole` | <code>[OrganizationCustomRoleKey](#organization-custom-role-key) \| undefined</code> | The current user's active organization role. |
 | `orgSlug` | `string \|undefined` | The current user's active organization slug. |
 | `orgPermissions` | <code>[OrganizationCustomPermissionKey[]](#organization-custom-role-key) \| undefined</code> | The current user's active organization permissions. |
-| [`has`](#has) | <code>(isAuthorizedParams: [CheckAuthorizationParamsWithCustomPermissions](#check-authorization-params-with-custom-permissions)) => boolean</code> | A function that returns a boolean based on the permission or role provided as parameter. Can be used for authorization. |
-| [`getToken`](#get-token) | [`ServerGetToken`](#server-get-token) | A function that returns a promise that resolves to the current user's session token. Can also be used to retrieve a custom JWT template. |
-| `claims` | `JwtPayload` | The current user's [session claims](/docs/backend-requests/resources/session-tokens#default-session-claims). |
+| `sessionClaims` | `JwtPayload` | The current user's [session claims](/docs/backend-requests/resources/session-tokens#default-session-claims). |
 | `actor` | `ActClaim \| undefined` | Holds identifier for the user that is impersonating the current user. |
+| [`has()`](#has) | <code>(isAuthorizedParams: [CheckAuthorizationParamsWithCustomPermissions](#check-authorization-params-with-custom-permissions)) => boolean</code> | A function that returns a boolean based on the permission or role provided as parameter. Can be used for authorization. |
+| [`getToken()`](#get-token) | [`ServerGetToken`](#server-get-token) | A function that returns a promise that resolves to the current user's session token. Can also be used to retrieve a custom JWT template. |
 | `debug` | `AuthObjectDebug` | Used to help debug issues when using Clerk in development. |
 
 ### `OrganizationCustomRoleKey`
@@ -62,7 +62,7 @@ function has(isAuthorizedParams: CheckAuthorizationParamsWithCustomPermissions) 
 
 #### `has()` example
 
-You can use `has()` to check if a user is authorized to access a component. 
+You can use `has()` to check if a user is authorized to access a component.
 
 In the following example:
 - `has()` is used to check if the user has the `org:team_settings:manage` permission.
@@ -76,7 +76,7 @@ export default async function Page() {
 
   const canManage = has({ permission:"org:team_settings:manage" });
 
-  if(!canManage) return null;  
+  if(!canManage) return null;
 
   return <h1>Team Settings</h1>
 }
@@ -112,7 +112,7 @@ The following is an example of the `Authentication` object without an active org
   orgRole: null,
   orgSlug: null,
   orgPermissions: null,
-  has: [Function (anonymous)], 
+  has: [Function (anonymous)],
   getToken: [AsyncFunction (anonymous)],
   claims: {
     azp: 'http://localhost:3000',
@@ -138,7 +138,7 @@ The following is an example of the `Authentication` object with an active organi
   orgRole: 'org:admin',
   orgSlug: undefined,
   orgPermissions: ['org:team_settings:manage'], // Custom permissions
-  has: [Function (anonymous)], 
+  has: [Function (anonymous)],
   getToken: [AsyncFunction (anonymous)],
   claims: {
     azp: 'http://localhost:3000',


### PR DESCRIPTION
- update incorrect information - `protect()` doesn't throw an error, it redirects users to the sign-in page
- add missing information
- add missing example for demonstrating an authentication check