### PR TITLE
Verifying sessions in Go (review)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -42,7 +42,7 @@ When you're ready to submit your contribution, you're going to create a [pull re
 
 If this is your first time, or you need a refresher on how to create a PR, you can check out this video:
 
-[How to Contribute to an Open Source Project on GitHub}](https://egghead.io/courses/how-to-contribute-to-an-open-source-project-on-github)
+[How to Contribute to an Open Source Project on GitHub](https://egghead.io/courses/how-to-contribute-to-an-open-source-project-on-github)
 
 The structure of the PR should be:
 
@@ -183,9 +183,9 @@ The image below shows what this example looks like once rendered.
 
 #### `<Callout />`
 
-The `<Callout />` component draws attention to something learners should slow down and read. 
+The `<Callout />` component draws attention to something learners should slow down and read.
 
-> Callouts can be distracting when people are quickly skimming a page. So only use them if the information absolutely should not be missed! 
+> Callouts can be distracting when people are quickly skimming a page. So only use them if the information absolutely should not be missed!
 
 The `<Callout />` component accepts an optional `type` property which accepts the following strings: `'Danger' | 'Info' | 'Success' | 'Warning';`.
 
@@ -223,7 +223,7 @@ The image below shows what this example looks like once rendered.
 
 ![An example of a <CodeBlockTabs /> component with three tabs options for 'npm', 'yarn', and 'pnpm'. Each tab shows a code example of how to install the @clerk/nextjs package.](/public/images/styleguide/codeblocktabs.png)
 
-The `<CodeBlockTabs />` component also accepts an optional `type` property, which is used to sync the active tab across multiple instances by passing each instance the same exact `string` to the `type` property. 
+The `<CodeBlockTabs />` component also accepts an optional `type` property, which is used to sync the active tab across multiple instances by passing each instance the same exact `string` to the `type` property.
 
 For example, in the example below, if the user were to choose `"yarn"` as the tab they want to see, both `<CodeBlockTabs />` components would change their active tab to `"yarn"` because both components were passed `"installer"` as their `type`.
 
@@ -242,7 +242,7 @@ For example, in the example below, if the user were to choose `"yarn"` as the ta
   ```
 </CodeBlockTabs>
 
-You can also install the install the Clerk React package by running the following command in your terminal: 
+You can also install the install the Clerk React package by running the following command in your terminal:
 
 <CodeBlockTabs type="installer" options={["npm", "yarn", "pnpm"]}>
   ```sh filename="terminal"
@@ -287,7 +287,7 @@ The video below shows what this example looks like once rendered.
 
 ![An example of a <Tabs /> component. There are two tab options: 'react' and 'javascript'.](/public/images/styleguide/tabs.mov)
 
-The `<Tabs />` component also accepts an optional `type` property, which is used to sync the active tab across multiple instances by passing each instance the same exact `string` to the `type` property. 
+The `<Tabs />` component also accepts an optional `type` property, which is used to sync the active tab across multiple instances by passing each instance the same exact `string` to the `type` property.
 
 For example, in the example below, if the user were to choose "JavaScript" as the tab they want to see, both `<Tabs />` components would change their active tab to "JavaScript" because both components were passed `"framework"` as their `type`.
 
@@ -343,7 +343,7 @@ The Pages Router information is here.
 <CodeBlockTabs type="router" options={["App Router", "Pages Router"]}>
 ```tsx filename="/app/sign-in/[[...sign-in]]/page.tsx"
 import { SignIn } from "@clerk/nextjs";
- 
+
 export default function Page() {
   return <SignIn />;
 }
@@ -351,11 +351,11 @@ export default function Page() {
 
 ```tsx filename="/pages/sign-in/[[...index]].tsx"
 import { SignIn } from "@clerk/nextjs";
- 
+
 const SignInPage = () => (
   <SignIn />
 );
- 
+
 export default SignInPage;
 ```
 </CodeBlockTabs>
@@ -455,7 +455,7 @@ The `<TutorialHero />` component is used at the beginning of a tutorial-type con
 | `exampleRepoTitle` (optional) | string | The title for the example repository/repositories. Defaults to `'Example repository'`. |
 
 ```mdx
-<TutorialHero 
+<TutorialHero
   framework="react"
   beforeYouStart={[
     {
@@ -477,7 +477,7 @@ The `<TutorialHero />` component is used at the beginning of a tutorial-type con
 
 - Install `@clerk/clerk-react`
 - Set up your environment keys
-- Wrap your React app in `<ClerkProvider/>`  
+- Wrap your React app in `<ClerkProvider/>`
 - Limit access to authenticated users
 - Embed the `<UserButton/>`
 

--- a/docs/references/go/other-examples.mdx
+++ b/docs/references/go/other-examples.mdx
@@ -5,30 +5,77 @@ description: Explore different examples of how to utilize Clerk with Go.
 
 # Examples
 
-Below is a code snippet showing what you can do from your backend with Clerk. Look at the [API reference](/docs/references/backend/overview) for a full list of requests you can make from your backend.
+The following example demonstrates how to use the Clerk Go SDK to execute [Clerk Backend API](/docs/references/backend/overview) operations.
 
-## Update metadata
+By executing the code in the snippet below, you will:
+- Create an organization and update its slug.
+- Fetch all organization memberships and loop through them to get the first one.
+- Get more details about the organization's user.
 
-Add a new key/value to the private metadata stored on a user.
+<Callout type="info">
+Your Clerk secret key is required. If you are signed into your Clerk Dashboard, your secret key should become visible by clicking on the eye icon. Otherwise, you can retrieve your Clerk secret key from the Clerk Dashboard on the **[API Keys](https://dashboard.clerk.com/last-active?path=api-keys)** page.
+</Callout>
 
-```go
-var client clerk.Client
+<InjectKeys>
+```go filename="main.go"
+import (
+    "github.com/clerk/clerk-sdk-go/v2"
+    "github.com/clerk/clerk-sdk-go/v2/organization"
+    "github.com/clerk/clerk-sdk-go/v2/organizationmembership"
+    "github.com/clerk/clerk-sdk-go/v2/user"
+)
 
-func addStripeCustomerID(user *clerk.User, stripeCustomerID string) error {	
-	currPrivMetadata := user.PrivateMetadata.(map[string]interface{})	
-	currPrivMetadata["stripe_customer_id"] = stripeCustomerID
+func main() {
+  // Each API operation requires a context.Context as the first argument.
+  ctx := context.Background()
 
-	var keyValStrings []string
-	for key, value := range currPrivMetadata {
-		keyValStrings = append(keysString, fmt.Sprintf("\"%s\": \"%s\"", key, value))
-	}
-	finalStr := fmt.Sprintf("{%s}", strings.Join(keysString, ","))
-	user, err := s.clerkClient.Users().Update(sess.UserID, &clerk.UpdateUser{
-		PrivateMetadata: finalStr,
-	})
+  // Set the API key
+  clerk.SetKey(`{{secret}}`)
 
-	if err != nil {
-		panic(err)
-	}
+  // Create an organization
+  org, err := organization.Create(ctx, &organization.CreateParams{
+      Name: clerk.String("Clerk Inc"),
+  })
+  if err != nil {
+    // You can get additional information on the error, if it can
+    // be type-cast to clerk.APIErrorResponse.
+    if apiErr, ok := err.(*clerk.APIErrorResponse); ok {
+      apiErr.TraceID
+      apiErr.Error()
+      apiErr.Response.RawJSON
+    }
+    // handle the error
+    panic(err)
+  }
+
+  // Update the organization
+  org, err = organization.Update(ctx, org.ID, &organization.UpdateParams{
+      Slug: clerk.String("clerk"),
+  })
+  if err != nil {
+    // handle the error
+    panic(err)
+  }
+
+  // List organization memberships
+  listParams := organizationmembership.ListParams{}
+  listParams.Limit = clerk.Int64(10)
+  memberships, err := organizationmembership.List(ctx, params)
+  if err != nil {
+    // handle the error
+    panic(err)
+  }
+  if memberships.TotalCount < 0 {
+      return
+  }
+  membership := memberships[0]
+
+  // Get a user
+  usr, err := user.Get(ctx, membership.UserID)
+  if err != nil {
+    // handle the error
+    panic(err)
+  }
 }
 ```
+</InjectKeys>

--- a/docs/references/go/other-examples.mdx
+++ b/docs/references/go/other-examples.mdx
@@ -13,7 +13,7 @@ By executing the code in the snippet below, you will:
 - Get more details about the organization's user.
 
 <Callout type="info">
-Your Clerk secret key is required. If you are signed into your Clerk Dashboard, your secret key should become visible by clicking on the eye icon. Otherwise, you can retrieve your Clerk secret key from the Clerk Dashboard on the **[API Keys](https://dashboard.clerk.com/last-active?path=api-keys)** page.
+Your Clerk secret key is required. If you are signed into your Clerk Dashboard, your secret key should become visible by selecting the eye icon. Otherwise, you can retrieve your Clerk secret key from the Clerk Dashboard on the **[API Keys](https://dashboard.clerk.com/last-active?path=api-keys)** page.
 </Callout>
 
 <InjectKeys>

--- a/docs/references/go/overview.mdx
+++ b/docs/references/go/overview.mdx
@@ -5,32 +5,113 @@ description: Learn how to integrate Go into your Clerk application.
 
 # Go
 
-Clerk's Go SDK is a thin wrapper over the Clerk Backend API. Add the following import statement:
+Clerk's [Go SDK](https://github.com/clerk/clerk-sdk-go) is a wrapper over the [Clerk Backend API](https://clerk.com/docs/reference/backend-api).
+
+## Installation
+
+If you're using Go Modules and have a `go.mod` file in your project's root, you can import `clerk-sdk-go` directly:
 
 ```go
-import "github.com/clerkinc/clerk-sdk-go/clerk"
+import (
+    "github.com/clerk/clerk-sdk-go/v2"
+)
 ```
 
-Go doesn't automatically add the module. You can explicitly add it with:
+Alternatively, you can `go get` the package explicitly:
+
+```sh filename="terminal"
+go get -u github.com/clerk/clerk-sdk-go/v2
+```
+
+## Usage
+
+For details on how to use this module, see the [Go Documentation](https://pkg.go.dev/github.com/clerk/clerk-sdk-go/v2).
+
+The library is organized using a resource-based structure similar to the [Clerk Backend API](https://clerk.com/docs/reference/backend-api).
+Each API supports specific operations, like Create or List. While operations for each resource vary, a similar pattern is applied throughout the library.
+
+To execute API operations, you must configure the library with your Clerk API secret key. Depending on your use case,
+there are two ways to use the library: With or without a client.
+
+For most use cases, the API without a client is a better choice. It requires a minimal setup and provides a more concise API for invoking operations.
+
+However, if you need to operate on multiple Clerk instances from one application, or need more flexibility for tests and mocking,
+you can instantiate multiple API clients with different API keys.
+
+The following examples demonstrate both approaches.
+
+### Usage without a client
+
+If you only use one API key, you can import the packages required for the APIs you need to interact with and call functions for API operations.
 
 ```go
-$ go get github.com/clerkinc/clerk-sdk-go
+import (
+    "github.com/clerk/clerk-sdk-go/v2"
+    "github.com/clerk/clerk-sdk-go/v2/$resource$"
+)
+
+// Each operation requires a context.Context as the first argument.
+ctx := context.Background()
+
+// Set the API key
+clerk.SetKey("sk_live_XXX")
+
+// Create
+resource, err := $resource$.Create(ctx, &$resource$.CreateParams{})
+
+// Get
+resource, err := $resource$.Get(ctx, id)
+
+// Update
+resource, err := $resource$.Update(ctx, id, &$resource$.UpdateParams{})
+
+// Delete
+resource, err := $resource$.Delete(ctx, id)
+
+// List
+list, err := $resource$.List(ctx, &$resource$.ListParams{})
+for _, resource := range list.$Resource$s {
+    // do something with the resource
+}
 ```
 
-## `Clerk` client
+### Usage with a client
 
-Now, you can create a `Clerk` client by calling the `clerk.NewClient()` function. This function requires your Clerk secret key. If you are signed into your Clerk Dashboard, your secret key should become visible by clicking on the eye icon. Otherwise, you can retrieve your Clerk secret key from the Clerk Dashboard on the **[API Keys](https://dashboard.clerk.com/last-active?path=api-keys)** page.
+If you're working with multiple keys, you should use the library with a client. The API packages for each
+resource export a `Client`, which supports all the API's operations.
+This way you can create as many clients as needed, each with their own API key, as shown in the following example:
 
-With your Clerk secret key, create a `Client` object to use the various services Clerk provides.
+```go
+import (
+    "github.com/clerk/clerk-sdk-go/v2"
+    "github.com/clerk/clerk-sdk-go/v2/$resource$"
+)
 
-<InjectKeys>
+// Each operation requires a context.Context as the first argument.
+ctx := context.Background()
 
-```go filename=".env"
-client, err := clerk.NewClient(`{{secret}}`)
-if err != nil {
-    // handle error
-} 
+// Initialize a client with an API key
+config := &clerk.ClientConfig{}
+config.Key = "sk_live_XXX"
+client := $resource$.NewClient(config)
+
+// Create
+resource, err := client.Create(ctx, &$resource$.CreateParams{})
+
+// Get
+resource, err := client.Get(ctx, id)
+
+// Update
+resource, err := client.Update(ctx, id, &$resource$.UpdateParams{})
+
+// Delete
+resource, err := client.Delete(ctx, id)
+
+// List
+list, err := client.List(ctx, &$resource$.ListParams{})
+for _, resource := range list.$Resource$s {
+    // do something with the resource
+}
 ```
 
-</InjectKeys>
-
+For more usage details, check out the [examples](/docs/references/go/other-examples) or the library's [README file](https://github.com/clerk/clerk-sdk-go).

--- a/docs/references/go/verifying-sessions.mdx
+++ b/docs/references/go/verifying-sessions.mdx
@@ -3,100 +3,153 @@ title: Veryifing a session | Clerk Go SDK
 description: Learn how to verify a session with Clerk in your Go application.
 ---
 
-# Verifying a session in Go
+# Verifying a Clerk session in Go
 
-## Protect your backend APIs
-
-Go makes it really easy to create a simple HTTP server, and Clerk makes it simple to authenticate any request. The following examples shows how to verify a session and retrieve the corresponding user.
-
-<InjectKeys>
-
-```go
-package main
-
-import (
-	"net/http"
-	"strings"
-
-	"github.com/clerk/clerk-sdk-go/clerk"
-)
-
-func main() {
-	client, _ := clerk.NewClient(`{{secret}}`)
-
-	http.HandleFunc("/hello", func(w http.ResponseWriter, r *http.Request) {
-		// get session token from Authorization header
-		sessionToken := r.Header.Get("Authorization")
-		sessionToken = strings.TrimPrefix(sessionToken, "Bearer ")
-
-		// verify the session
-		sessClaims, err := client.VerifyToken(sessionToken)
-		if err != nil {
-			w.WriteHeader(http.StatusUnauthorized)
-			w.Write([]byte("Unauthorized"))
-			return
-		}
-
-		// get the user, and say welcome!
-		user, err := client.Users().Read(sessClaims.Claims.Subject)
-		if err != nil {
-			panic(err)
-		}
-
-		w.Write([]byte("Welcome " + *user.FirstName))
-	})
-
-	http.ListenAndServe(":8080", nil)
-}
-```
-
-</InjectKeys>
+Go enables you to create a simple HTTP server, and Clerk enables you to authenticate any request. The following examples show how to verify a session and retrieve the corresponding user.
 
 ## Using middleware
 
-The Clerk SDK also provides a simple middleware that adds the active session to the request's context.
+The library provides two functions for adding authentication to HTTP handlers with Clerk.
+
+Both middleware functions support header based authentication with a bearer token. The token will be parsed, verified, and
+its claims will be extracted as [SessionClaims](https://pkg.go.dev/github.com/clerk/clerk-sdk-go/v2#SessionClaims).
+
+The claims will then be made available in the `http.Request.Context` for the next handler in the chain. The library
+provides the [SessionClaimsFromContext](https://pkg.go.dev/github.com/clerk/clerk-sdk-go/v2#SessionClaimsFromContext) helper for accessing the claims from the context.
+
+There are also two middleware helpers:
+- [WithHeaderAuthorization](https://pkg.go.dev/github.com/clerk/clerk-sdk-go/v2/http#WithHeaderAuthorization)
+- [RequireHeaderAuthorization](https://pkg.go.dev/github.com/clerk/clerk-sdk-go/v2/http#RequireHeaderAuthorization), which calls `WithHeaderAuthorization` under the hood, but responds with HTTP 403 Forbidden if it fails to detect valid session claims.
+
+<Callout type="info">
+Your Clerk secret key is required. If you are signed into your Clerk Dashboard, your secret key should become visible by clicking on the eye icon. Otherwise, you can retrieve your Clerk secret key from the Clerk Dashboard on the **[API Keys](https://dashboard.clerk.com/last-active?path=api-keys)** page.
+</Callout>
 
 <InjectKeys>
-
 ```go
-package main
-
 import (
-	"net/http"
+  "fmt"
+  "net/http"
 
-	"github.com/clerk/clerk-sdk-go/clerk"
+  "github.com/clerk/clerk-sdk-go/v2"
+  clerkhttp "github.com/clerk/clerk-sdk-go/v2/http"
 )
 
 func main() {
-	client, _ := clerk.NewClient(`{{secret}}`)
+  clerk.SetKey(`{{secret}}`)
 
-	mux := http.NewServeMux()
+  mux := http.NewServeMux()
+  mux.HandleFunc("/", publicRoute)
+  protectedHandler := http.HandlerFunc(protectedRoute)
+  mux.Handle(
+    "/protected",
+    clerkhttp.WithHeaderAuthorization()(protectedHandler),
+  )
 
-	injectActiveSession := clerk.WithSessionV2(client)
-	mux.Handle("/hello", injectActiveSession(helloUserHandler(client)))
-
-	http.ListenAndServe(":8080", mux)
+  http.ListenAndServe(":3000", mux)
 }
 
-func helloUserHandler(client clerk.Client) http.HandlerFunc {
-	return func(w http.ResponseWriter, r *http.Request) {
-		ctx := r.Context()
+func publicRoute(w http.ResponseWriter, r *http.Request) {
+  w.Write([]byte(`{"access": "public"}`))
+}
 
-		sessClaims, ok := clerk.SessionFromContext(ctx)
-		if !ok {
-			w.WriteHeader(http.StatusUnauthorized)
-			w.Write([]byte("Unauthorized"))
-			return
-		}
-
-		user, err := client.Users().Read(sessClaims.Claims.Subject)
-		if err != nil {
-			panic(err)
-		}
-
-		w.Write([]byte("Welcome " + *user.FirstName))
-	}
+func protectedRoute(w http.ResponseWriter, r *http.Request) {
+  claims, ok := clerk.SessionClaimsFromContext(r.Context())
+  if !ok {
+    w.WriteHeader(http.StatusUnauthorized)
+    w.Write([]byte(`{"access": "unauthorized"}`))
+    return
+  }
+  fmt.Fprintf(w, `{"user_id": "%s"}`, claims.Subject)
 }
 ```
+</InjectKeys>
 
+## Custom token verification
+
+It is recommended to use the middleware functions for verifying Clerk sessions in an HTTP context.
+
+The middleware guarantees better performance and efficiency by making the minimum necessary requests to the Clerk Backend API.
+
+Verifying a Clerk session requires providing a JSON Web Key. The middleware fetches the key once and caches it.
+
+If you decide to verify the session token on your own, please be mindful of API rate limits. It is recommended to cache your JSON Web Key and invalidate the cache only when a replacement key is generated.
+
+<InjectKeys>
+```go
+import (
+  "fmt"
+  "net/http"
+
+  "github.com/clerk/clerk-sdk-go/v2"
+  "github.com/clerk/clerk-sdk-go/v2/jwks"
+  "github.com/clerk/clerk-sdk-go/v2/jwt"
+)
+
+func main() {
+  clerk.SetKey(`{{secret}}`)
+
+  mux := http.NewServeMux()
+  mux.HandleFunc("/", publicRoute)
+
+  // Fetch the JSON Web Key Set.
+  // Make sure you refetch the JSON Web Key Set whenever your
+  // Clerk secret key changes.
+  jwks, err := jwks.Get(context.Background() &jwks.GetParams{})
+  if err != nil {
+    panic(err)
+  }
+  mux.Handle("/protected", protectedRoute(jwks)),
+
+  http.ListenAndServe(":3000", mux)
+}
+
+func publicRoute(w http.ResponseWriter, r *http.Request) {
+  w.Write([]byte(`{"access": "public"}`))
+}
+
+func protectedRoute(jwks *clerk.JSONWebKeySet) func(http.ResponseWriter, *http.Request) {
+  return func(w http.ResponseWriter, r *http.Request) {
+    // Get the session JWT from the Authorization header
+    sessionToken := strings.TrimPrefix(r.Header.Get("Authorization"), "Bearer ")
+
+    unsafeClaims, err := jwt.Decode(r.Context(), &jwt.DecodeParams{
+      Token: sessionToken,
+    })
+    if err != nil {
+      // handle the error
+      w.WriteHeader(http.StatusUnauthorized)
+      w.Write([]byte(`{"access": "unauthorized"}`))
+      return
+    }
+
+    // Fetch the correct JSON Web Key
+    var jwk *clerk.JSONWebKey
+    for _, k := range jwks.Keys {
+      if k.KeyID == unsafeClaims.KeyID {
+        jwk = k
+        break
+      }
+    }
+    if jwk == nil {
+      w.WriteHeader(http.StatusUnauthorized)
+      w.Write([]byte(`{"access": "unauthorized"}`))
+      return
+    }
+
+    // Verify the session
+    claims, err := jwt.Verify(r.Context(), &jwt.VerifyParams{
+      Token: sessionToken,
+      JWK: jwk,
+    })
+    if err != nil {
+      // handle the error
+      w.WriteHeader(http.StatusUnauthorized)
+      w.Write([]byte(`{"access": "unauthorized"}`))
+      return
+    }
+    fmt.Fprintf(w, `{"user_id": "%s"}`, claims.Subject)
+  }
+}
+```
 </InjectKeys>

--- a/docs/references/go/verifying-sessions.mdx
+++ b/docs/references/go/verifying-sessions.mdx
@@ -75,7 +75,7 @@ func protectedRoute(w http.ResponseWriter, r *http.Request) {
 
 Verifying a Clerk session manually is useful when you want to verify a session in a non-HTTP context, or if you would like total control over the verification process. With the solution above, Clerk middleware makes the minimum necessary requests to the Clerk Backend API. With this solution, you must be mindful of API rate limits.
 
-Verifying a session token requires providing a JSON Web Key. In the solution above, Clerk middleware fetches the key once and caches it for you. However, in this solution, you are required to fetch and cache the key yourself.
+Verifying a session token requires providing a JSON Web Key. When using Clerk middleware to verify a session, it fetches the JSON Web Key once and caches it for you. However, when manually verifying a session, you are required to fetch and cache the JSON Web Key yourself.
 
 Clerk Go SDK provides a set of functions for decoding and verifying JWTs, as well as fetching JSON Web Key Sets. It is recommended to cache your JSON Web Key and invalidate the cache only when a replacement key is generated.
 

--- a/docs/references/go/verifying-sessions.mdx
+++ b/docs/references/go/verifying-sessions.mdx
@@ -6,7 +6,7 @@ description: Learn how to verify a session with Clerk in your Go application.
 # Verify a Clerk session in Go
 
 There are two ways to verify a session with Clerk in your Go application:
-- [Using Clerk middleware](#use-clerk-middleware-to-verify-a-session).
+- [Using Clerk middleware](#use-clerk-middleware-to-verify-a-session)
 If you want to verify a session in an HTTP context, it is recommended to use Clerk middleware. Clerk middleware guarantees better performance and efficiency by making the minimum necessary requests to the Clerk Backend API.
 
 - [Manually verifying the session token](#manually-verify-a-session-token)

--- a/docs/references/go/verifying-sessions.mdx
+++ b/docs/references/go/verifying-sessions.mdx
@@ -1,28 +1,34 @@
 ---
-title: Veryifing a session | Clerk Go SDK
+title: Verify a Clerk session in Go
 description: Learn how to verify a session with Clerk in your Go application.
 ---
 
-# Verifying a Clerk session in Go
+# Verify a Clerk session in Go
 
-Go enables you to create a simple HTTP server, and Clerk enables you to authenticate any request. The following examples show how to verify a session and retrieve the corresponding user.
+There are two ways to verify a session with Clerk in your Go application:
+- [Using Clerk middleware](#use-clerk-middleware-to-verify-a-session)
+If you want to verify a session in an HTTP context, it is recommended to use Clerk middleware. Clerk middleware guarantees better performance and efficiency by making the minimum necessary requests to the Clerk Backend API.
 
-## Using middleware
+- [Manually verifying the session token](#manually-verify-a-session-token)
+If you want to verify a session in a non-HTTP context, or if you would like total control over the verification process, you can verify the session token on your own.
 
-The library provides two functions for adding authentication to HTTP handlers with Clerk.
+## Use Clerk middleware to verify a session
 
-Both middleware functions support header based authentication with a bearer token. The token will be parsed, verified, and
-its claims will be extracted as [SessionClaims](https://pkg.go.dev/github.com/clerk/clerk-sdk-go/v2#SessionClaims).
+Go enables you to create a simple HTTP server, and Clerk enables you to authenticate any request. Together, you can create a secure server that only allows authenticated users to access certain routes.
 
-The claims will then be made available in the `http.Request.Context` for the next handler in the chain. The library
-provides the [SessionClaimsFromContext](https://pkg.go.dev/github.com/clerk/clerk-sdk-go/v2#SessionClaimsFromContext) helper for accessing the claims from the context.
+Clerk Go SDK provides two functions for adding authentication to HTTP handlers:
 
-There are also two middleware helpers:
-- [WithHeaderAuthorization](https://pkg.go.dev/github.com/clerk/clerk-sdk-go/v2/http#WithHeaderAuthorization)
-- [RequireHeaderAuthorization](https://pkg.go.dev/github.com/clerk/clerk-sdk-go/v2/http#RequireHeaderAuthorization), which calls `WithHeaderAuthorization` under the hood, but responds with HTTP 403 Forbidden if it fails to detect valid session claims.
+- [`WithHeaderAuthorization()`](https://pkg.go.dev/github.com/clerk/clerk-sdk-go/v2/http#WithHeaderAuthorization)
+- [`RequireHeaderAuthorization()`](https://pkg.go.dev/github.com/clerk/clerk-sdk-go/v2/http#RequireHeaderAuthorization), which calls `WithHeaderAuthorization()` under the hood, but responds with `HTTP 403 Forbidden` if it fails to detect valid session claims.
+
+Both middleware functions support header based authentication with a bearer token. The token will be parsed, verified, and its claims will be extracted as [`SessionClaims`](https://pkg.go.dev/github.com/clerk/clerk-sdk-go/v2#SessionClaims).
+
+The claims will then be made available in the `http.Request.Context` for the next handler in the chain. Clerk Go SDK provides the [`SessionClaimsFromContext()`](https://pkg.go.dev/github.com/clerk/clerk-sdk-go/v2#SessionClaimsFromContext) helper for accessing the claims from the context.
+
+The following example demonstrates how to use the `WithHeaderAuthorization()` middleware to protect a route. If the user tries accessing the route and their session token is valid, the user's ID will be returned in the response.
 
 <Callout type="info">
-Your Clerk secret key is required. If you are signed into your Clerk Dashboard, your secret key should become visible by clicking on the eye icon. Otherwise, you can retrieve your Clerk secret key from the Clerk Dashboard on the **[API Keys](https://dashboard.clerk.com/last-active?path=api-keys)** page.
+Your Clerk secret key is required. If you are signed in to your Clerk Dashboard, your secret key should become visible by clicking on the eye icon. Otherwise, you can retrieve your Clerk secret key from the Clerk Dashboard on the **[API Keys](https://dashboard.clerk.com/last-active?path=api-keys)** page.
 </Callout>
 
 <InjectKeys>
@@ -65,15 +71,15 @@ func protectedRoute(w http.ResponseWriter, r *http.Request) {
 ```
 </InjectKeys>
 
-## Custom token verification
+## Manually verify a session token
 
-It is recommended to use the middleware functions for verifying Clerk sessions in an HTTP context.
+Verifying a Clerk session manually is useful when you want to verify a session in a non-HTTP context, or if you would like total control over the verification process. With the solution above, Clerk middleware makes the minimum necessary requests to the Clerk Backend API. With this solution, you must be mindful of API rate limits.
 
-The middleware guarantees better performance and efficiency by making the minimum necessary requests to the Clerk Backend API.
+Verifying a session token requires providing a JSON Web Key. In the solution above, Clerk middleware fetches the key once and caches it for you. However, in this solution, you are required to fetch and cache the key yourself.
 
-Verifying a Clerk session requires providing a JSON Web Key. The middleware fetches the key once and caches it.
+Clerk Go SDK provides a set of functions for decoding and verifying JWTs, as well as fetching JSON Web Key Sets. It is recommended to cache your JSON Web Key and invalidate the cache only when a replacement key is generated.
 
-If you decide to verify the session token on your own, please be mindful of API rate limits. It is recommended to cache your JSON Web Key and invalidate the cache only when a replacement key is generated.
+The following example demonstrates how to manually verify a session token. If the user tries accessing the route and their session token is valid, the user's ID will be returned in the response.
 
 <InjectKeys>
 ```go

--- a/docs/references/go/verifying-sessions.mdx
+++ b/docs/references/go/verifying-sessions.mdx
@@ -7,10 +7,10 @@ description: Learn how to verify a session with Clerk in your Go application.
 
 There are two ways to verify a session with Clerk in your Go application:
 - [Using Clerk middleware](#use-clerk-middleware-to-verify-a-session)
-If you want to verify a session in an HTTP context, it is recommended to use Clerk middleware. Clerk middleware guarantees better performance and efficiency by making the minimum necessary requests to the Clerk Backend API.
+<br/>If you want to verify a session in an HTTP context, it is recommended to use Clerk middleware. Clerk middleware guarantees better performance and efficiency by making the minimum necessary requests to the Clerk Backend API.
 
 - [Manually verifying the session token](#manually-verify-a-session-token)
-If you want to verify a session in a non-HTTP context, or if you would like total control over the verification process, you can verify the session token on your own.
+<br/>If you want to verify a session in a non-HTTP context, or if you would like total control over the verification process, you can verify the session token on your own.
 
 ## Use Clerk middleware to verify a session
 

--- a/docs/references/go/verifying-sessions.mdx
+++ b/docs/references/go/verifying-sessions.mdx
@@ -28,7 +28,7 @@ The claims will then be made available in the `http.Request.Context` for the nex
 The following example demonstrates how to use the `WithHeaderAuthorization()` middleware to protect a route. If the user tries accessing the route and their session token is valid, the user's ID will be returned in the response.
 
 <Callout type="info">
-Your Clerk secret key is required. If you are signed in to your Clerk Dashboard, your secret key should become visible by clicking on the eye icon. Otherwise, you can retrieve your Clerk secret key from the Clerk Dashboard on the **[API Keys](https://dashboard.clerk.com/last-active?path=api-keys)** page.
+Your Clerk secret key is required. If you are signed in to your Clerk Dashboard, your secret key should become visible by selecting the eye icon. Otherwise, you can retrieve your Clerk secret key from the Clerk Dashboard on the **[API Keys](https://dashboard.clerk.com/last-active?path=api-keys)** page.
 </Callout>
 
 <InjectKeys>

--- a/docs/references/go/verifying-sessions.mdx
+++ b/docs/references/go/verifying-sessions.mdx
@@ -6,7 +6,7 @@ description: Learn how to verify a session with Clerk in your Go application.
 # Verify a Clerk session in Go
 
 There are two ways to verify a session with Clerk in your Go application:
-- [Using Clerk middleware](#use-clerk-middleware-to-verify-a-session)
+- [Using Clerk middleware](#use-clerk-middleware-to-verify-a-session).
 If you want to verify a session in an HTTP context, it is recommended to use Clerk middleware. Clerk middleware guarantees better performance and efficiency by making the minimum necessary requests to the Clerk Backend API.
 
 - [Manually verifying the session token](#manually-verify-a-session-token)


### PR DESCRIPTION
We got some [feedback](https://github.com/clerk/clerk-docs/pull/712#issuecomment-1960838167) from Giannis regarding the /verifying-sessions document in [this PR](https://github.com/clerk/clerk-docs/pull/712):

> Hey @alexisintech, you are correct. The middleware functions are supposed to work in an HTTP server context.
> 
> We offer these middleware as helpers. They are using the jwt.Verify method internally. The Verify method is the primitive/core function here and the middleware is a convenience method around token verification in an HTTP server.
> 
> Most of the times, there's no need to reach out to Verify directly, but in case you want total control over the verification process, or you want to verify a token in a non-HTTP context, you can use Verify directly.
> 
> Hope that makes it clearer. I'm not sure if we should add this information to the docs, or if it's clear to the reader that
>
> Have HTTP server?
> Yes: Use the middleware
> No: Use the custom flow
> Let me know what you think!

---

I spoke with @gkats , because with this new information, it looked like the /verifying-session doc was going to need some work.

<img width="779" alt="Screenshot 2024-02-23 at 13 10 01" src="https://github.com/clerk/clerk-docs/assets/98043211/0812ecac-3a6e-494b-a5f0-dd46d61b0a5f">

---

This PR is an edit to his original work. The plan is to get a review from @S3Prototype , smooth this doc out, and then get the final approval from Giannis! 
The reason for the separate PR is to isolate changes and review to the single document in a single interface.