### PR TITLE
Hyperlink url-based-session-syncing

### DIFF
--- a/docs/upgrade-guides/url-based-session-syncing.mdx
+++ b/docs/upgrade-guides/url-based-session-syncing.mdx
@@ -5,7 +5,7 @@ description: Development instances communicating with the Frontend API without t
 
 # URL-based session syncing
 
-Development instances created before December 6, 2022 communicate with C[lerk's Frontend API](https://clerk.com/docs/reference/frontend-api) using third-party cookies. More concretely, the authentication state of the current session is transported via a long-lived third-party cookie, between your frontend (e.g. `localhost:3000`) and the Frontend API (e.g. `clerk.happy.hippo-1.lcl.dev`).
+Development instances created before December 6, 2022 communicate with [Clerk's Frontend API](https://clerk.com/docs/reference/frontend-api) using third-party cookies. More concretely, the authentication state of the current session is transported via a long-lived third-party cookie, between your frontend (e.g. `localhost:3000`) and the Frontend API (e.g. `clerk.happy.hippo-1.lcl.dev`).
 
 URL-based session syncing (previously known as Cookieless Development mode) is a new, experimental mode of operation for development instances, in which communication with the Clerk Frontend API is done via URL decoration instead.
 


### PR DESCRIPTION
The hyperlink didnt include C from Clerk, minor fix made.