### PR TITLE
(core 1) update JS references for sign-in and sign-up

### DIFF
--- a/docs/references/javascript/clerk/sign-in.mdx
+++ b/docs/references/javascript/clerk/sign-in.mdx
@@ -20,11 +20,11 @@ The following methods available on an instance of the [`Clerk`](/docs/references
 
 Render the `<SignIn />` component to an HTML `<div>` element.
 
-### `mountSignIn()` properties
-
 ```typescript
 function mountSignIn(node: HTMLDivElement, props?: SignInProps): void;
 ```
+
+### `mountSignIn()` params
 
 | Name | Type | Description |
 | --- | --- | --- |
@@ -38,9 +38,8 @@ In the example below, the `<SignIn />` component is rendered to a `<div>` elemen
 <InjectKeys>
 
 <CodeBlockTabs type="npm-script" options={['NPM Module', 'window.Clerk']}>
-  ```typescript
+  ```ts filename="index.ts" {17}
   import Clerk from '@clerk/clerk-js';
-  import { dark } from "@clerk/themes";
 
   // Selects for <div id="app"> and adds a <div id="sign-in"> to it
   document.querySelector<HTMLDivElement>('#app')!.innerHTML = `
@@ -59,16 +58,22 @@ In the example below, the `<SignIn />` component is rendered to a `<div>` elemen
   clerk.mountSignIn(signInComponent, {});
   ```
 
-  ```html
-  <!-- Add a <div> element with id="sign-in" to your HTML -->
+  ```html filename="index.html" {22}
+  <!-- Add a <div id="sign-in"> element to your HTML -->
   <div id="sign-in"></div>
 
   <script>
+    // Get this URL and Publishable Key from the Clerk Dashboard
+    const clerkPublishableKey = `{{pub_key}}`;
+    const frontendApiUrl = 'https://[your-domain].clerk.accounts.dev';
+    const version = '@latest'; // Set to appropriate version
+
+    // Creates asynchronous script
     const script = document.createElement('script');
-    // Set your Clerk publishable key
-    script.setAttribute('data-clerk-publishable-key', `{{pub_key}}`);
+    script.setAttribute('data-clerk-frontend-api', frontendApiUrl);
+    script.setAttribute('data-clerk-publishable-key', clerkPublishableKey);
     script.async = true;
-    script.src = `https://[your-domain].clerk.accounts.dev/npm/@clerk/clerk-js@latest/dist/clerk.browser.js`;
+    script.src = `${frontendApiUrl}/npm/@clerk/clerk-js${version}/dist/clerk.browser.js`;
 
     script.addEventListener('load', async function () {
       await window.Clerk.load();
@@ -88,11 +93,11 @@ In the example below, the `<SignIn />` component is rendered to a `<div>` elemen
 
 Unmount and run cleanup on an existing `<SignIn />` component instance.
 
-### `unmountSignIn()` properties
-
 ```typescript
 function unmountSignIn(node: HTMLDivElement): void;
 ```
+
+### `unmountSignIn()` params
 
 | Name | Type | Description |
 | --- | --- | --- |
@@ -100,8 +105,10 @@ function unmountSignIn(node: HTMLDivElement): void;
 
 ### `unmountSignIn()` usage
 
+<InjectKeys>
+
 <CodeBlockTabs type="npm-script" options={['NPM Module', 'window.Clerk']}>
-  ```typescript {19}
+  ```js filename="index.ts" {19}
   import Clerk from '@clerk/clerk-js';
 
   document.querySelector<HTMLDivElement>('#app')!.innerHTML = `
@@ -112,98 +119,122 @@ function unmountSignIn(node: HTMLDivElement): void;
 
   const signInComponent = document.querySelector<HTMLDivElement>('#sign-in')!;
 
-  const clerk = new Clerk('pk_[publishable_key]');
-
+  // Initialize Clerk with your Clerk publishable key
+  const clerk = new Clerk(`{{pub_key}}`);
   await clerk.load();
 
-  clerk.mountSignIn(signInComponent);
+  clerk.mountSignIn(signInComponent, {});
 
   // ...
 
-  clerk.unmountSignIn(signInComponent);
+  clerk.unmountSignIn(signInComponent, {});
   ```
 
-  ```html {17}
+  ```html filename="index.html" {24}
   <div id="sign-in"></div>
   <script>
+    // Get this URL and Publishable Key from the Clerk Dashboard
+    const clerkPublishableKey = `{{pub_key}}`;
+    const frontendApiUrl = 'https://[your-domain].clerk.accounts.dev';
+    const version = '@latest'; // Set to appropriate version
+
+    // Creates asynchronous script
     const script = document.createElement('script');
-    script.setAttribute('data-clerk-publishable-key', 'pk_[publishable_key]');
+    script.setAttribute('data-clerk-frontend-api', frontendApiUrl);
+    script.setAttribute('data-clerk-publishable-key', clerkPublishableKey);
     script.async = true;
-    script.src = `https://[your-domain].clerk.accounts.dev/npm/@clerk/clerk-js@latest/dist/clerk.browser.js`;
+    script.src = `${frontendApiUrl}/npm/@clerk/clerk-js${version}/dist/clerk.browser.js`;
 
     script.addEventListener('load', async function () {
       await window.Clerk.load();
 
       const signInComponent = document.querySelector('#sign-in');
 
-      window.Clerk.mountSignIn(signInComponent);
+      window.Clerk.mountSignIn(signInComponent, {});
 
       // ...
 
-      window.Clerk.unmountSignIn(signInComponent);
+      window.Clerk.unmountSignIn(signInComponent, {});
     });
     document.body.appendChild(script);
   </script>
   ```
 </CodeBlockTabs>
+
+</InjectKeys>
 
 ## `openSignIn()`
 
 Opens the `<SignIn />` component as an overlay at the root of your HTML `body` element.
 
-### `openSignIn()` properties
-
 ```typescript
 function openSignIn(props?: SignInProps): void;
 ```
+
+### `openSignIn()` params
 
 | Name | Type | Desciption |
 | --- | --- | --- |
 | `props?` | [`SignInProps`](#sign-in-props) | The properties to pass to the `<SignIn />` component |
 
+#### `SignInProps`
+
+The type of the `props` parameter in the `openSignIn()` method is defined as follows:
+
+| Name | Type | Description |
+| --- | --- | --- |
+| `routing` | `'hash' \| 'path' \| 'virtual'` | The routing strategy for your pages. Defaults to `'path'`. |
+| `path` | `string` | The path where the component is mounted on when path-based routing is used.<br />For example, `/sign-in`<br />This prop is ignored in hash- and virtual-based routing. |
+| `redirectUrl` | `string` | Full URL or path to navigate after successful sign in or sign up.<br />The same as setting `afterSignInUrl` and `afterSignUpUrl` to the same value. |
+| `afterSignInUrl` | `string` | The full URL or path to navigate after a successful sign in. Defaults to `/`. |
+| `signUpUrl` | `string` | Full URL or path to the sign up page. Use this property to provide the target of the 'Sign Up' link that's rendered. |
+| `afterSignUpUrl` | `string` | The full URL or path to navigate after a successful sign up. Defaults to `/`. |
+| `initialValues` | [`SignInInitialValues`](/docs/references/javascript/types/sign-in-initial-values) | The values used to prefill the sign-in fields with. |
+
 ### `openSignIn()` usage
 
-<CodeBlockTabs type="npm-script" options={['NPM Module', 'window.Clerk']}>
-  ```typescript {7-11}
-  import Clerk from '@clerk/clerk-js';
-  import { dark } from "@clerk/themes";
+<InjectKeys>
 
-  const clerk = new Clerk('pk_[publishable_key]');
+<CodeBlockTabs type="npm-script" options={['NPM Module', 'window.Clerk']}>
+  ```js filename="index.ts" {7}
+  import Clerk from '@clerk/clerk-js';
+
+  // Initialize Clerk with your Clerk publishable key
+  const clerk = new Clerk(`{{pub_key}}`);
   await clerk.load();
 
-  clerk.openSignIn({
-    appearance: {
-      baseTheme: dark
-    }
-  });
+  clerk.openSignIn();
   ```
 
-  ```html {10-14}
+  ```html filename="index.html" {17}
   <script>
+    // Get this URL and Publishable Key from the Clerk Dashboard
+    const clerkPublishableKey = `{{pub_key}}`;
+    const frontendApiUrl = 'https://[your-domain].clerk.accounts.dev';
+    const version = '@latest'; // Set to appropriate version
+
+    // Creates asynchronous script
     const script = document.createElement('script');
-    script.setAttribute('data-clerk-publishable-key', 'pk_[publishable_key]');
+    script.setAttribute('data-clerk-frontend-api', frontendApiUrl);
+    script.setAttribute('data-clerk-publishable-key', clerkPublishableKey);
     script.async = true;
-    script.src = `https://[your-domain].clerk.accounts.dev/npm/@clerk/clerk-js@latest/dist/clerk.browser.js`;
+    script.src = `${frontendApiUrl}/npm/@clerk/clerk-js${version}/dist/clerk.browser.js`;
 
     script.addEventListener('load', async function () {
       await window.Clerk.load();
 
-      window.Clerk.openSignIn({
-        appearance: {
-          baseTheme: dark
-        }
-      });
+      window.Clerk.openSignIn();
     });
     document.body.appendChild(script);
   </script>
   ```
 </CodeBlockTabs>
 
+</InjectKeys>
+
 ## `closeSignIn()`
 
 Closes the sign in overlay.
-
-### `closeSignIn()` properties
 
 ```typescript
 function closeSignIn(): void;
@@ -211,12 +242,15 @@ function closeSignIn(): void;
 
 ### `closeSignIn()` usage
 
+<InjectKeys>
+
 <CodeBlockTabs type="npm-script" options={['NPM Module', 'window.Clerk']}>
-  ```typescript {11}
+  ```js filename="index.ts" {12}
   import Clerk from '@clerk/clerk-js';
   import { dark } from "@clerk/themes";
 
-  const clerk = new Clerk('pk_[publishable_key]');
+  // Initialize Clerk with your Clerk publishable key
+  const clerk = new Clerk(`{{pub_key}}`);
   await clerk.load();
 
   clerk.openSignIn();
@@ -226,12 +260,19 @@ function closeSignIn(): void;
   clerk.closeSignIn();
   ```
 
-  ```html {14}
+  ```html filename="index.html" {21}
   <script>
+    // Get this URL and Publishable Key from the Clerk Dashboard
+    const clerkPublishableKey = `{{pub_key}}`;
+    const frontendApiUrl = 'https://[your-domain].clerk.accounts.dev';
+    const version = '@latest'; // Set to appropriate version
+
+    // Creates asynchronous script
     const script = document.createElement('script');
-    script.setAttribute('data-clerk-publishable-key', 'pk_[publishable_key]');
+    script.setAttribute('data-clerk-frontend-api', frontendApiUrl);
+    script.setAttribute('data-clerk-publishable-key', clerkPublishableKey);
     script.async = true;
-    script.src = `https://[your-domain].clerk.accounts.dev/npm/@clerk/clerk-js@latest/dist/clerk.browser.js`;
+    script.src = `${frontendApiUrl}/npm/@clerk/clerk-js${version}/dist/clerk.browser.js`;
 
     script.addEventListener('load', async function () {
       await window.Clerk.load();
@@ -247,16 +288,4 @@ function closeSignIn(): void;
   ```
 </CodeBlockTabs>
 
-## `SignInProps`
-
-All props below are optional.
-
-| Name | Type | Description |
-| --- | --- | --- |
-| `routing` | `'hash' \| 'path' \| 'virtual'` | The routing strategy for your pages.<br />Note: If you are using environment variables for Next.js or Remix to specify your routes, this will be set to `path`. |
-| `path` | `string` | The path where the component is mounted on when path-based routing is used e.g. /sign-in. |
-| `redirectUrl` | `string` | Full URL or path to navigate after successful sign in or sign up.<br /> The same as setting `afterSignInUrl` and `afterSignUpUrl` to the same value. |
-| `afterSignInUrl` | `string` | The full URL or path to navigate after a successful sign in. |
-| `signUpUrl` | `string` | Full URL or path to the sign up page. Use this property to provide the target of the 'Sign Up' link that's rendered. |
-| `afterSignUpUrl` | `string` | The full URL or path to navigate after a successful sign up. |
-| `initialValues` | [`SignInInitialValues`](/docs/references/javascript/types/sign-in-initial-values) | The values used to prefill the sign-in fields with. |
+</InjectKeys>

--- a/docs/references/javascript/clerk/sign-in.mdx
+++ b/docs/references/javascript/clerk/sign-in.mdx
@@ -250,7 +250,7 @@ function closeSignIn(): void;
   import { dark } from "@clerk/themes";
 
   // Initialize Clerk with your Clerk publishable key
-  const clerk = new Clerk(`{{pub_key}}`);
+  const clerk = new Clerk('{{pub_key}}');
   await clerk.load();
 
   clerk.openSignIn();
@@ -262,8 +262,8 @@ function closeSignIn(): void;
 
   ```html filename="index.html" {21}
   <script>
-    // Get this URL and Publishable Key from the Clerk Dashboard
-    const clerkPublishableKey = `{{pub_key}}`;
+    // Get your Publishable Key and Frontend API URL from the Clerk Dashboard
+    const clerkPublishableKey = '{{pub_key}}';
     const frontendApiUrl = 'https://[your-domain].clerk.accounts.dev';
     const version = '@latest'; // Set to appropriate version
 

--- a/docs/references/javascript/clerk/sign-up.mdx
+++ b/docs/references/javascript/clerk/sign-up.mdx
@@ -249,7 +249,7 @@ function closeSignUp(): void;
   import { dark } from "@clerk/themes";
 
   // Initialize Clerk with your Clerk publishable key
-  const clerk = new Clerk(`{{pub_key}}`);
+  const clerk = new Clerk('{{pub_key}}');
   await clerk.load();
 
   clerk.openSignUp();
@@ -261,8 +261,8 @@ function closeSignUp(): void;
 
   ```html filename="index.js" {21}
   <script>
-    // Get this URL and Publishable Key from the Clerk Dashboard
-    const clerkPublishableKey = `{{pub_key}}`;
+    // Get your Publishable Key and Frontend API URL from the Clerk Dashboard
+    const clerkPublishableKey = '{{pub_key}}';
     const frontendApiUrl = 'https://[your-domain].clerk.accounts.dev';
     const version = '@latest'; // Set to appropriate version
 

--- a/docs/references/javascript/clerk/sign-up.mdx
+++ b/docs/references/javascript/clerk/sign-up.mdx
@@ -7,18 +7,50 @@ description: The <SignUp /> component renders a UI for signing up users. The fun
 
 <Images width={496} height={780} src="/docs/images/ui-components/component-sign_up.svg" alt="Sign up component example" />
 
-The [`<SignUp />`][signup-ref] component renders a UI for signing up users. The functionality of the [`<SignUp />`][signup-ref] component are controlled by the instance settings you specify in your [Clerk Dashboard](https://dashboard.clerk.com). You can further customize your [`<SignUp />`][signup-ref] component by passing additional properties at the time of rendering.
+The [`<SignUp />`][signup-ref] component renders a UI for signing up users. The functionality of the [`<SignUp />`][signup-ref] component are controlled by the instance settings you specify in your [Clerk Dashboard](https://dashboard.clerk.com), such as [sign-up options](/docs/authentication/configuration/sign-up-options) and [social connections](/docs/authentication/social-connections/overview). You can further customize your [`<SignUp />`][signup-ref] component by passing additional properties at the time of rendering.
 
-> All of these are methods on [an instance of the `Clerk` class](/docs/references/javascript/clerk/clerk).
+The following methods available on an instance of the [`Clerk`](/docs/references/javascript/clerk/clerk) class are used to render and control the `<SignUp />` component:
+
+- [`mountSignUp()`](#mount-sign-up)
+- [`unmountSignUp()`](#unmount-sign-up)
+- [`openSignUp()`](#open-sign-up)
+- [`closeSignUp()`](#close-sign-up)
 
 ## `mountSignUp()`
 
 Render the [`<SignUp />`][signup-ref] component to an HTML `<div>` element.
 
-### Usage
+```typescript
+function mountSignUp(node: HTMLDivElement, props?: SignUpProps): void;
+```
+
+### `mountSignUp()` params
+
+| Name | Type | Description |
+| --- | --- | --- |
+| `node ` | [`HTMLDivElement`](https://developer.mozilla.org/en-US/docs/Web/API/HTMLDivElement) | The `<div>` element used to render in the `<SignUp />` component |
+| `props?` | [`SignUpProps`](#sign-up-props) | The properties to pass to the `<SignUp />` component. |
+
+#### `SignUpProps`
+
+The type of the `props` parameter in the `mountSignUp()` function is defined as follows:
+
+| Name | Type | Description |
+| --- | --- | --- |
+| `routing` | `'hash' \| 'path' \| 'virtual'` | The routing strategy for your pages.<br />Note: If you are using environment variables for Next.js or Remix to specify your routes, this will be set to `path`. |
+| `path` | `string` | The path where the component is mounted on when path-based routing is used.<br />`/sign-in`<br />This prop is ignored in hash- and virtual-based routing. |
+| `redirectUrl` | `string` | Full URL or path to navigate after successful sign in or sign up.<br /> The same as setting `afterSignInUrl` and `afterSignUpUrl` to the same value. |
+| `afterSignInUrl` | `string` | The full URL or path to navigate after a successful sign in. Defaults to `/`. |
+| `signInUrl` | `string` | Full URL or path to the sign in page. Use this property to provide the target of the 'Sign In' link that's rendered. |
+| `afterSignUpUrl` | `string` | The full URL or path to navigate after a successful sign up. Defaults to `/`. |
+| `initialValues` | [`SignUpInitialValues`](/docs/references/javascript/types/sign-up-initial-values) | The values used to prefill the sign-up fields with. |
+
+### `mountSignUp()` usage
+
+<InjectKeys>
 
 <CodeBlockTabs type="npm-script" options={['NPM Module', 'window.Clerk']}>
-  ```typescript {15-19}
+  ```typescript filename="index.ts" {17}
   import Clerk from '@clerk/clerk-js';
   import { dark } from "@clerk/themes";
 
@@ -31,19 +63,28 @@ Render the [`<SignUp />`][signup-ref] component to an HTML `<div>` element.
 
   const signUpComponent = document.querySelector<HTMLDivElement>('#sign-up')!;
 
-  const clerk = new Clerk('pk_[publishable_key]');
+  // Initialize Clerk with your Clerk publishable key
+  const clerk = new Clerk(`{{pub_key}}`);
   await clerk.load();
 
   clerk.mountSignUp(signUpComponent, {});
   ```
 
-  ```html {13-17}
+  ```html filename="index.js" {21}
+  <!-- Add a <div id="sign-up"> element to your HTML -->
   <div id="sign-up"></div>
   <script>
+    // Get this URL and Publishable Key from the Clerk Dashboard
+    const clerkPublishableKey = `{{pub_key}}`;
+    const frontendApiUrl = 'https://[your-domain].clerk.accounts.dev';
+    const version = '@latest'; // Set to appropriate version
+
+    // Creates asynchronous script
     const script = document.createElement('script');
-    script.setAttribute('data-clerk-publishable-key', 'pk_[publishable_key]');
+    script.setAttribute('data-clerk-frontend-api', frontendApiUrl);
+    script.setAttribute('data-clerk-publishable-key', clerkPublishableKey);
     script.async = true;
-    script.src = `https://[your-domain].clerk.accounts.dev/npm/@clerk/clerk-js@latest/dist/clerk.browser.js`;
+    script.src = `${frontendApiUrl}/npm/@clerk/clerk-js${version}/dist/clerk.browser.js`;
 
     script.addEventListener('load', async function () {
       await window.Clerk.load();
@@ -57,27 +98,31 @@ Render the [`<SignUp />`][signup-ref] component to an HTML `<div>` element.
   ```
 </CodeBlockTabs>
 
-### Properties
-
-```typescript
-function mountSignUp(node: HTMLDivElement, props?: SignUpProps): void;
-```
-
-| Name | Type | Description |
-| --- | --- | --- |
-| `node ` | [`HTMLDivElement`](https://developer.mozilla.org/en-US/docs/Web/API/HTMLDivElement) | The `<div>` element used to render in the [`<SignUp />`][signup-ref] component |
-| `props?` | [`SignUpProps`](#sign-up-props) | The properties to pass to the [`<SignUp />`][signup-ref] component |
+</InjectKeys>
 
 ## `unmountSignUp()`
 
 Unmount and run cleanup on an existing [`<SignUp />`][signup-ref] component instance.
 
-### Usage
+```typescript
+function unmountSignUp(node: HTMLDivElement): void;
+```
+
+### `unmountSignUp()` params
+
+| Name | Type | Description |
+| --- | --- | --- |
+| `node ` | [`HTMLDivElement`](https://developer.mozilla.org/en-US/docs/Web/API/HTMLDivElement) | The container `<div>` element with a rendered [`<SignUp />`][signup-ref] component instance |
+
+### `unmountSignUp()` usage
+
+<InjectKeys>
 
 <CodeBlockTabs type="npm-script" options={['NPM Module', 'window.Clerk']}>
-  ```typescript {19}
+  ```typescript filename="index.ts" {20}
   import Clerk from '@clerk/clerk-js';
 
+  // Selects for <div id="app"> and adds a <div id="sign-up"> to it
   document.querySelector<HTMLDivElement>('#app')!.innerHTML = `
     <div
       id="sign-up"
@@ -86,8 +131,8 @@ Unmount and run cleanup on an existing [`<SignUp />`][signup-ref] component inst
 
   const signUpComponent = document.querySelector<HTMLDivElement>('#sign-up')!;
 
-  const clerk = new Clerk('pk_[publishable_key]');
-
+  // Initialize Clerk with your Clerk publishable key
+  const clerk = new Clerk(`{{pub_key}}`);
   await clerk.load();
 
   clerk.mountSignUp(signUpComponent);
@@ -97,13 +142,21 @@ Unmount and run cleanup on an existing [`<SignUp />`][signup-ref] component inst
   clerk.unmountSignUp(signUpComponent);
   ```
 
-  ```html {17}
+  ```html filename="index.js" {25}
+  <!-- Add a <div id="sign-up"> element to your HTML -->
   <div id="sign-up"></div>
   <script>
+    // Get this URL and Publishable Key from the Clerk Dashboard
+    const clerkPublishableKey = `{{pub_key}}`;
+    const frontendApiUrl = 'https://[your-domain].clerk.accounts.dev';
+    const version = '@latest'; // Set to appropriate version
+
+    // Creates asynchronous script
     const script = document.createElement('script');
-    script.setAttribute('data-clerk-publishable-key', 'pk_[publishable_key]');
+    script.setAttribute('data-clerk-frontend-api', frontendApiUrl);
+    script.setAttribute('data-clerk-publishable-key', clerkPublishableKey);
     script.async = true;
-    script.src = `https://[your-domain].clerk.accounts.dev/npm/@clerk/clerk-js@latest/dist/clerk.browser.js`;
+    script.src = `${frontendApiUrl}/npm/@clerk/clerk-js${version}/dist/clerk.browser.js`;
 
     script.addEventListener('load', async function () {
       await window.Clerk.load();
@@ -121,80 +174,82 @@ Unmount and run cleanup on an existing [`<SignUp />`][signup-ref] component inst
   ```
 </CodeBlockTabs>
 
-### Properties
-
-```typescript
-function unmountSignUp(node: HTMLDivElement): void;
-```
-
-| Name | Type | Description |
-| --- | --- | --- |
-| `node ` | [`HTMLDivElement`](https://developer.mozilla.org/en-US/docs/Web/API/HTMLDivElement) | The container `<div>` element with a rendered [`<SignUp />`][signup-ref] component instance |
+</InjectKeys>
 
 ## `openSignUp()`
 
 Opens the [`<SignUp />`][signup-ref] component as an overlay at the root of your HTML `body` element.
 
-### Usage
+```typescript
+function openSignUp(props?: SignUpProps): void;
+```
+
+### `openSignUp()` params
+
+| Name | Type | Description |
+| --- | --- | --- |
+| `props?` | [`SignUpProps`](#sign-up-props) | The properties to pass to the [`<SignUp />`][signup-ref] component |
+
+### `openSignUp()` usage
+
+<InjectKeys>
 
 <CodeBlockTabs type="npm-script" options={['NPM Module', 'window.Clerk']}>
-  ```typescript {7-11}
+  ```js filename="index.ts" {7}
   import Clerk from '@clerk/clerk-js';
-  import { dark } from "@clerk/themes";
 
-  const clerk = new Clerk('pk_[publishable_key]');
+  // Initialize Clerk with your Clerk publishable key
+  const clerk = new Clerk(`{{pub_key}}`);
   await clerk.load();
 
-  clerk.openSignUp({
-    appearance: {
-      baseTheme: dark
-    }
-  });
+  clerk.openSignUp();
   ```
 
-  ```html {10-14}
+  ```html filename="index.html" {17}
   <script>
+    // Get this URL and Publishable Key from the Clerk Dashboard
+    const clerkPublishableKey = `{{pub_key}}`;
+    const frontendApiUrl = 'https://[your-domain].clerk.accounts.dev';
+    const version = '@latest'; // Set to appropriate version
+
+    // Creates asynchronous script
     const script = document.createElement('script');
-    script.setAttribute('data-clerk-publishable-key', 'pk_[publishable_key]');
+    script.setAttribute('data-clerk-frontend-api', frontendApiUrl);
+    script.setAttribute('data-clerk-publishable-key', clerkPublishableKey);
     script.async = true;
-    script.src = `https://[your-domain].clerk.accounts.dev/npm/@clerk/clerk-js@latest/dist/clerk.browser.js`;
+    script.src = `${frontendApiUrl}/npm/@clerk/clerk-js${version}/dist/clerk.browser.js`;
 
     script.addEventListener('load', async function () {
       await window.Clerk.load();
 
-      window.Clerk.openSignUp({
-        appearance: {
-          baseTheme: dark
-        }
-      });
+      window.Clerk.openSignUp();
     });
     document.body.appendChild(script);
   </script>
   ```
 </CodeBlockTabs>
 
-### Properties
-
-```typescript
-function openSignUp(props?: SignUpProps): void;
-```
-
-| Name | Type | Description |
-| --- | --- | --- |
-| `props?` | [`SignUpProps`](#sign-up-props) | The properties to pass to the [`<SignUp />`][signup-ref] component |
+</InjectKeys>
 
 ## `closeSignUp()`
 
 Closes the sign up overlay.
 
-### Usage
+```typescript
+function closeSignUp(): void;
+```
+
+### `closeSignUp()` usage
+
+<InjectKeys>
 
 <CodeBlockTabs type="npm-script" options={['NPM Module', 'window.Clerk']}>
-  ```typescript {11}
+  ```typescript filename="index.ts" {12}
   import Clerk from '@clerk/clerk-js';
   import { dark } from "@clerk/themes";
 
-  const clerk = new Clerk('pk_[publishable_key]');
+  // Initialize Clerk with your Clerk publishable key
+  const clerk = new Clerk(`{{pub_key}}`);
   await clerk.load();
 
   clerk.openSignUp();
@@ -204,12 +259,19 @@ Closes the sign up overlay.
   clerk.closeSignUp();
   ```
 
-  ```html {14}
+  ```html filename="index.js" {21}
   <script>
+    // Get this URL and Publishable Key from the Clerk Dashboard
+    const clerkPublishableKey = `{{pub_key}}`;
+    const frontendApiUrl = 'https://[your-domain].clerk.accounts.dev';
+    const version = '@latest'; // Set to appropriate version
+
+    // Creates asynchronous script
     const script = document.createElement('script');
-    script.setAttribute('data-clerk-publishable-key', 'pk_[publishable_key]');
+    script.setAttribute('data-clerk-frontend-api', frontendApiUrl);
+    script.setAttribute('data-clerk-publishable-key', clerkPublishableKey);
     script.async = true;
-    script.src = `https://[your-domain].clerk.accounts.dev/npm/@clerk/clerk-js@latest/dist/clerk.browser.js`;
+    script.src = `${frontendApiUrl}/npm/@clerk/clerk-js${version}/dist/clerk.browser.js`;
 
     script.addEventListener('load', async function () {
       await window.Clerk.load();
@@ -225,24 +287,6 @@ Closes the sign up overlay.
   ```
 </CodeBlockTabs>
 
-### Properties
-
-```typescript
-function closeSignUp(): void;
-```
-
-## `SignUpProps`
-
-All props below are optional.
-
-| Name | Type | Description |
-| --- | --- | --- |
-| `routing` | `'hash' \| 'path' \| 'virtual'` | The routing strategy for your pages.<br />Note: If you are using environment variables for Next.js or Remix to specify your routes, this will be set to `path`. |
-| `path` | `string` | The path where the component is mounted on when path-based routing is used e.g. `/sign-in`. |
-| `redirectUrl` | `string` | Full URL or path to navigate after successful sign in or sign up.<br /> The same as setting `afterSignInUrl` and `afterSignUpUrl` to the same value. |
-| `afterSignInUrl` | `string` | The full URL or path to navigate after a successful sign in. |
-| `signInUrl` | `string` | Full URL or path to the sign in page. Use this property to provide the target of the 'Sign In' link that's rendered. |
-| `afterSignUpUrl` | `string` | The full URL or path to navigate after a successful sign up. |
-| `initialValues` | [`SignUpInitialValues`](/docs/references/javascript/types/sign-up-initial-values) | The values used to prefill the sign-up fields with. |
+</InjectKeys>
 
 [signup-ref]: /docs/components/authentication/sign-up


### PR DESCRIPTION
copied updates from core 2 JS updates, because as core 1 stands, the code examples were highlighted incorrectly and this page was kinda JANK.