### PR TITLE
Add an Image Optimization guide

### DIFF
--- a/docs/guides/image-optimization/imageurl-image-optimization.mdx
+++ b/docs/guides/image-optimization/imageurl-image-optimization.mdx
@@ -1,11 +1,15 @@
 ---
-title: Use Image Optimization with imageUrl
-description: Learn how to migrate an application using Auth.js to use Clerk for authentication.
+title: Use image optimization to improve app performance
+description: Learn how to use image optimization when fetching user images from Clerk.
 ---
 
-# Use Image Optimization with `imageUrl`
+# Use image optimization to improve app performance
 
-Some types in Clerk's JavaScript SDK, such as [`User`](/docs/references/javascript/user/user), [`PublicUserData`](/docs/references/javascript/types/public-user-data#properties), and [`Organization`](/docs/references/javascript/organization/organization#properties), have an `imageUrl`. The URL returned from this property can be scaled down with the following Image Optimization options:
+When displaying your users' profile images, you should use query parameters to specify a maximum size and minimum quality. Doing so can allow you to improve your app's overall page load times by reducing the file sizes of the images you're fetching.
+
+## Add query parameters to `imageUrl`
+
+Some types in Clerk's JavaScript SDK, such as [`User`](/docs/references/javascript/user/user), [`PublicUserData`](/docs/references/javascript/types/public-user-data#properties), and [`Organization`](/docs/references/javascript/organization/organization#properties), have an `imageUrl`. The URL returned from this property can be scaled down with the following image optimization options:
 
 - `"width"`: Sets the max width of the image in pixels.
 - `"height"`: Sets the max height of the image in pixels.
@@ -16,9 +20,9 @@ Some types in Clerk's JavaScript SDK, such as [`User`](/docs/references/javascri
 
 ## Example
 
-The following example demonstrates how you can get the `imageUrl` from currently active user in a session, and display their profile picture using Clerk's image optimization options:
+The following example demonstrates how you can get the `imageUrl` from the currently active user in a session, and display their profile picture using Clerk's image optimization options:
 
-<CodeBlockTabs type="framework" options={["Next.js App", "Next.js Pages", "React"]}>
+<CodeBlockTabs type="framework" options={["Next.js", "React"]}>
 
 ```tsx filename="app/image-optimization/page.tsx"
 import { currentUser } from "@clerk/nextjs";
@@ -47,36 +51,10 @@ export default async function ImageOptimization() {
   );
 }
 ```
-```tsx filename="pages/image-optimization/index.tsx"
-import { currentUser } from "@clerk/nextjs";
-
-export default async function ImageOptimization() {
-  const user = await currentUser();
-  if (!user) return <p>No Image URL found</p>;
-
-  const { imageUrl } = user;
-  const params = new URLSearchParams();
-
-  params.set("height", "200");
-  params.set("width", "200");
-  params.set("quality", "100");
-  params.set("fit", "crop");
-
-  const imageSrc = `${imageUrl}?${params.toString()}`;
-
-  return (
-    <div>
-      <h1>Image source:</h1>
-      <p>{imageSrc}</p>
-      <h2>Image:</h2>
-      <img src={imageSrc} alt="User image" />
-    </div>
-  );
-}
-```
 ```tsx filename="components/image-optimization.tsx"
 import { useClerk } from "@clerk/clerk-react";
- 
+import React from "react";
+
 export default function ImageOptimization() {
   const clerk = useClerk();
   const { user } = clerk;

--- a/docs/guides/image-optimization/imageurl-image-optimization.mdx
+++ b/docs/guides/image-optimization/imageurl-image-optimization.mdx
@@ -1,0 +1,109 @@
+---
+title: Use Image Optimization with imageUrl
+description: Learn how to migrate an application using Auth.js to use Clerk for authentication.
+---
+
+# Use Image Optimization with `imageUrl`
+
+Some types in Clerk's JavaScript SDK, such as [`User`](/docs/references/javascript/user/user), [`PublicUserData`](/docs/references/javascript/types/public-user-data#properties), and [`Organization`](/docs/references/javascript/organization/organization#properties), have an `imageUrl`. The URL returned from this property can be scaled down with the following Image Optimization options:
+
+- `"width"`: Sets the max width of the image in pixels.
+- `"height"`: Sets the max height of the image in pixels.
+- `"fit"`: Describes how the image should fit its container. It can take the following values:
+    - `"scale-down"`: The image will scale down to fit the sizes specified in `"width"` and `"height"` if it's bigger, but will not scale up if it's smaller.
+    - `"crop"`: The image will scale down and be cropped to fit within the area specified in `"width"` and `"height"`.
+- `"quality"`: Specifies the image quality for JPEG, WebP, PNG, and AVIF files. Accepts values from `1` to `100`. Defaults to `85`.
+
+## Example
+
+The following example demonstrates how you can get the `imageUrl` from currently active user in a session, and display their profile picture using Clerk's image optimization options:
+
+<CodeBlockTabs type="framework" options={["Next.js App", "Next.js Pages", "React"]}>
+
+```tsx filename="app/image-optimization/page.tsx"
+import { currentUser } from "@clerk/nextjs";
+
+export default async function ImageOptimization() {
+  const user = await currentUser();
+  if (!user) return <p>No Image URL found</p>;
+
+  const { imageUrl } = user;
+  const params = new URLSearchParams();
+
+  params.set("height", "200");
+  params.set("width", "200");
+  params.set("quality", "100");
+  params.set("fit", "crop");
+
+  const imageSrc = `${imageUrl}?${params.toString()}`;
+
+  return (
+    <div>
+      <h1>Image source:</h1>
+      <p>{imageSrc}</p>
+      <h2>Image:</h2>
+      <img src={imageSrc} alt="User image" />
+    </div>
+  );
+}
+```
+```tsx filename="pages/image-optimization/index.tsx"
+import { currentUser } from "@clerk/nextjs";
+
+export default async function ImageOptimization() {
+  const user = await currentUser();
+  if (!user) return <p>No Image URL found</p>;
+
+  const { imageUrl } = user;
+  const params = new URLSearchParams();
+
+  params.set("height", "200");
+  params.set("width", "200");
+  params.set("quality", "100");
+  params.set("fit", "crop");
+
+  const imageSrc = `${imageUrl}?${params.toString()}`;
+
+  return (
+    <div>
+      <h1>Image source:</h1>
+      <p>{imageSrc}</p>
+      <h2>Image:</h2>
+      <img src={imageSrc} alt="User image" />
+    </div>
+  );
+}
+```
+```tsx filename="components/image-optimization.tsx"
+import { useClerk } from "@clerk/clerk-react";
+ 
+export default function ImageOptimization() {
+  const clerk = useClerk();
+  const { user } = clerk;
+  if (!user) return <p>No Image URL found</p>;
+  
+  const { imageUrl } = user;
+  const params = new URLSearchParams();
+
+  params.set("height", "200");
+  params.set("width", "200");
+  params.set("quality", "100");
+  params.set("fit", "crop");
+
+  const imageSrc = `${imageUrl}?${params.toString()}`;
+
+  return (
+    <div>
+      <h1>Image source:</h1>
+      <p>{imageSrc}</p>
+      <h2>Image:</h2>
+      <img src={imageSrc} alt="User image" />
+    </div>
+  );
+}
+```
+
+</CodeBlockTabs>
+
+
+

--- a/docs/manifest.json
+++ b/docs/manifest.json
@@ -31,6 +31,7 @@
     },
     [
       ["Overview", "/guides/overview"],
+      ["Use Image Optimization with imageUrl", "/guides/image-optimization/imageurl-image-optimization"],
       ["Implement basic Role Based Access Control with metadata", "/guides/basic-rbac"],
       ["Hide Personal Accounts and force organizations", "/guides/force-organizations"],
       ["Migrating to Clerk from Auth.js", "/guides/authjs-migration"]

--- a/docs/manifest.json
+++ b/docs/manifest.json
@@ -31,7 +31,7 @@
     },
     [
       ["Overview", "/guides/overview"],
-      ["Use Image Optimization with imageUrl", "/guides/image-optimization/imageurl-image-optimization"],
+      ["Use image optimization to improve app performance", "/guides/image-optimization/imageurl-image-optimization"],
       ["Implement basic Role Based Access Control with metadata", "/guides/basic-rbac"],
       ["Hide Personal Accounts and force organizations", "/guides/force-organizations"],
       ["Migrating to Clerk from Auth.js", "/guides/authjs-migration"]

--- a/docs/references/javascript/organization/organization.mdx
+++ b/docs/references/javascript/organization/organization.mdx
@@ -15,7 +15,7 @@ This is a class that represents an organization. It's returned from the [`create
 | `name` | `string` | The name of the related organization. |
 | `slug` | `string \| null` | The organization slug. If supplied, it must be unique for the instance. |
 | `logoUrl` (deprecated) | `string \| null` | Deprecated in favor of `imageUrl`. |
-| `imageUrl` | `string` | Holds the organization logo or default logo. |
+| `imageUrl` | `string` | Holds the organization logo or default logo. Compatible with Clerk's [Image Optimization](/docs/guides/image-optimization/imageurl-image-optimization). |
 | `hasImage` | `boolean` | A getter boolean to check if the organization has an uploaded image. Returns `false` if Clerk is displaying an avatar for the organization. |
 | `membersCount` | `number` | The number of members the associated organization contains. |
 | `pendingInvitationsCount` | `number` | The number of pending invitations to users to join the organization. |

--- a/docs/references/javascript/types/public-user-data.mdx
+++ b/docs/references/javascript/types/public-user-data.mdx
@@ -13,7 +13,7 @@ Information about the user that's publicly available.
 | --- | --- | --- |
 | `firstName` | `string \| null` | The user's first name. |
 | `lastName` | `string \| null` | The user's last name. |
-| `imageUrl` | `string` | Holds the default avatar or users uploaded profile image. |
+| `imageUrl` | `string` | Holds the default avatar or user's uploaded profile image. Compatible with Clerk's [Image Optimization](/docs/guides/image-optimization/imageurl-image-optimization). |
 | `hasImage` | `boolean` | A getter boolean to check if the user has uploaded an image or one was copied from OAuth. Returns `false` if Clerk is displaying an avatar for the user. |
 | `identifier` | `string` | The user's identifier. |
 | `userId?` | `string \| null` | The user's ID. |

--- a/docs/references/javascript/user/user.mdx
+++ b/docs/references/javascript/user/user.mdx
@@ -24,7 +24,7 @@ The ClerkJS SDK provides some helper [methods](#methods) on the `User` object to
 | `username` | `string \| null` | The user's username. |
 | `hasImage` | `boolean` | A getter boolean to check if the user has uploaded an image or one was copied from OAuth. Returns `false` if Clerk is displaying an avatar for the user. |
 | `profileImageUrl` (deprecated) | `string \| null` | Deprecated in favor of `image_url`. |
-| `imageUrl` | `string` | The URL of the user's profile image. |
+| `imageUrl` | `string` | Holds the default avatar or user's uploaded profile image. Compatible with Clerk's [Image Optimization](/docs/guides/image-optimization/imageurl-image-optimization). |
 | `primaryEmailAddress` | [`EmailAddress`][email-ref] \| `null` | Information about the user's primary email address. |
 | `primaryEmailAddressId` | `string \| null` | The unique identifier for the `EmailAddress` that the user has set as primary. |
 | `emailAddresses` | [`EmailAddress[]`][email-ref] | An array of all the `EmailAddress` objects associated with the user. Includes the primary. |


### PR DESCRIPTION
This PR:

- Adds a guide that documents our Image Optimization options
  - [Preview](https://docs-preview-748.clerkpreview.com/docs/guides/image-optimization/imageurl-image-optimization)
- Adds a link to this guide everywhere it's relevant in the docs. Check where it says `imageUrl` on these pages:
  - [PublicUserData](https://docs-preview-748.clerkpreview.com/docs/references/javascript/types/public-user-data#properties)
  - [User](https://docs-preview-748.clerkpreview.com/docs/references/javascript/user/user)
  - [Organization](https://docs-preview-748.clerkpreview.com/docs/references/javascript/organization/organization#properties)
