### PR TITLE
OVERHAUL /docs/components/customization/user-profile

### DIFF
--- a/docs/components/customization/user-profile.mdx
+++ b/docs/components/customization/user-profile.mdx
@@ -242,7 +242,7 @@ Note that the first item in the navigation sidebar cannot be a `<UserProfile.Lin
 
 <Tabs type="usage" items={["Dedicated Page", "<UserButton />"]}>
   <Tab>
-    It's important to note that the first page in the list will always be rendered under the root path that you set with the `path` prop. It's `url` prop will be ignored, so you can pass any value you want. In the following example, the root path is set to `/user-profile`, so the `<CustomPage />` is rendered under `/user-profile`.
+    It's important to note that the first page in the list will always be rendered under the root path that you set with the `path` prop. It's `url` prop will be ignored, so you can pass any value you want. In the following example, `path` is set to `/user-profile`, so the `<CustomPage />` is rendered under the `/user-profile` path.
 
     ```tsx filename="/app/user-profile/[[...user-profile]]/page.tsx"
     "use client";

--- a/docs/components/customization/user-profile.mdx
+++ b/docs/components/customization/user-profile.mdx
@@ -8,8 +8,10 @@ description: Learn how to add custom pages and include external links within the
 The [`<UserProfile />`](/docs/components/user/user-profile) component supports the addition of custom pages and use of external links in the navigation sidebar.
 
 There are two ways to render the `<UserProfile />` component:
-- As a modal that opens when the [`<UserButton />`](/docs/components/user/user-button) is clicked
+- As a modal
 - As a dedicated page
+
+Both can be accessed when the user selects the [`<UserButton />`](/docs/components/user/user-button), and then selects the **Manage account** option.
 
 This guide includes examples for both use cases. You can select one of the following two tabs on the code examples to see the implementation for your preferred use case:
 

--- a/docs/components/customization/user-profile.mdx
+++ b/docs/components/customization/user-profile.mdx
@@ -11,9 +11,10 @@ There are two ways to render the `<UserProfile />` component:
 - As a modal that opens when the [`<UserButton />`](/docs/components/user/user-button) is clicked
 - As a dedicated page
 
-This guide includes examples for both use cases. You can select the tabs on the code examples to see the implementation for your preferred use case.
+This guide includes examples for both use cases. You can select one of the following two tabs on the code examples to see the implementation for your preferred use case:
 
-By default, the `<UserButton />` sets `userProfileMode='modal'`. If you are using the default settings, then you should use the `<UserButton />` examples. However, if you are using the  `userProfileMode='navigation'` and `userProfileUrl='/user-profile'` props on the `<UserButton />` component, then you should use the `Dedicated page` examples.
+- `<UserButton />` tab: By default, the `<UserButton />` sets `userProfileMode='modal'`. If you are using the default settings, then you should select this tab.
+- `Dedicated page` tab: If you do not want the `<UserProfile />` to open as a modal, then you should select this tab. For these examples, you need to set `userProfileMode='navigation'` and `userProfileUrl='/user-profile'` on the `<UserButton />` component.
 
 For the sake of this guide, examples are written for Next.js App Router, but they are supported by any React meta framework, such as Remix or Gatsby.
 

--- a/docs/components/customization/user-profile.mdx
+++ b/docs/components/customization/user-profile.mdx
@@ -1,113 +1,31 @@
 ---
-title: <UserProfile /> customization
+title: Add custom pages and links to the <UserProfile /> component
 description: Learn how to add custom pages and include external links within the navigation sidebar of the <UserProfile /> component.
 ---
 
-# `<UserProfile />` customization
+# Add custom pages and links to the `<UserProfile />` component
 
-The [`<UserProfile />`][userprofile-ref] component supports the addition of custom pages and use of external links in the navigation sidebar. 
+The [`<UserProfile />`](/docs/components/user/user-profile) component supports the addition of custom pages and use of external links in the navigation sidebar.
 
-## `<UserProfile.Page />`
+There are two ways to render the `<UserProfile />` component:
+- As a modal that opens when the [`<UserButton />`](/docs/components/user/user-button) is clicked
+- As a dedicated page
 
-Custom pages can be rendered inside the [`<UserProfile />`][userprofile-ref] component and provide a way to incorporate app-specific settings or additional functionality.
+This guide includes examples for both use cases. You can select the tabs on the code examples to see the implementation for your preferred use case.
 
-To add a custom page to the [`<UserProfile />`][userprofile-ref] component, use the `<UserProfile.Page />` component.
+By default, the `<UserButton />` sets `userProfileMode='modal'`. If you are using the default settings, then you should use the `<UserButton />` examples. However, if you are using the  `userProfileMode='navigation'` and `userProfileUrl='/user-profile'` props on the `<UserButton />` component, then you should use the `Dedicated page` examples.
 
-### Usage
+For the sake of this guide, examples are written for Next.js App Router but they are supported by any React meta framework, such as Remix or Gatsby.
 
-<Tabs type="framework" items={["Next.js", "React", "Remix"]}>
-  <Tab>
-    `<UserProfile.Page />` can be rendered **only on the client**. For Next.js applications using App Router, the `"use client";` directive must be added.
+## Add a custom page to the `<UserProfile />` component
 
-    <CodeBlockTabs type="router" options={["App Router", "Pages Router"]}>
-      ```jsx filename="/app/user-profile/[[...user-profile]]/page.tsx"
-      "use client";
+Custom pages can be rendered inside the `<UserProfile />` component and provide a way to incorporate app-specific settings or additional functionality.
 
-      import { UserProfile } from "@clerk/nextjs";
-      import { CustomProfilePage, CustomTerms } from "../components";
-      import { CustomIcon } from "../icons";
-
-      const UserProfilePage = () => (
-        <UserProfile path="/user-profile" routing="path">
-          <UserProfile.Page label="Custom Page" labelIcon={<CustomIcon />} url="custom-page">
-              <CustomProfilePage />
-          </UserProfile.Page>
-          <UserProfile.Page label="Terms" labelIcon={<CustomIcon />} url="terms">
-              <CustomTerms />
-          </UserProfile.Page>
-        </UserProfile>
-      );
-
-      export default UserProfilePage;
-      ```
-
-      ```jsx filename="/pages/user-profile/[[...index]].tsx"
-      import { UserProfile } from "@clerk/nextjs";
-      import { CustomProfilePage, CustomTerms } from "../components";
-      import { CustomIcon } from "../icons";
-
-      const UserProfilePage = () => (
-        <UserProfile path="/user-profile" routing="path">
-          <UserProfile.Page label="Custom Page" labelIcon={<CustomIcon />} url="custom-page">
-              <CustomProfilePage />
-          </UserProfile.Page>
-          <UserProfile.Page label="Terms" labelIcon={<CustomIcon />} url="terms">
-              <CustomTerms />
-          </UserProfile.Page>
-        </UserProfile>
-      );
-
-      export default UserProfilePage;
-      ```
-    </CodeBlockTabs>
-  </Tab>
-
-  <Tab>
-      ```jsx filename="/user-profile.tsx"
-      import { UserProfile } from "@clerk/clerk-react";
-      import { CustomProfilePage, CustomTerms } from "../components";
-      import { CustomIcon } from "../icons";
-
-      const UserProfilePage = () => (
-        <UserProfile path="/user-profile" routing="path">
-          <UserProfile.Page label="Custom Page" labelIcon={<CustomIcon />} url="custom-page">
-              <CustomProfilePage />
-          </UserProfile.Page>
-          <UserProfile.Page label="Terms" labelIcon={<CustomIcon />} url="terms">
-              <CustomTerms />
-          </UserProfile.Page>
-        </UserProfile>
-      );
-
-      export default UserProfilePage;
-      ```
-  </Tab>
-
-  <Tab>
-    ```tsx filename="routes/user/$.tsx"
-    import { UserProfile } from "@clerk/remix";
-    import { CustomProfilePage, CustomTerms } from "../components";
-    import { CustomIcon } from "../icons";
-
-    export default function UserProfilePage() {
-      return (
-        <UserProfile path="/user-profile" routing="path">
-          <UserProfile.Page label="Custom Page" labelIcon={<CustomIcon />} url="custom-page">
-              <CustomProfilePage />
-          </UserProfile.Page>
-          <UserProfile.Page label="Terms" labelIcon={<CustomIcon />} url="terms">
-              <CustomTerms />
-          </UserProfile.Page>
-        </UserProfile>
-      );
-    }
-    ```
-  </Tab>
-</Tabs>
+To add a custom page to the `<UserProfile />` component, use the `<UserProfile.Page />` component or the `<UserButton.UserProfilePage />` component, depending on your use case.
 
 ### Props
 
-All props below are required.
+`<UserProfile.Page />` and `<UserButton.UserProfilePage />` accept the following props, all of which are *required*:
 
 | Name | Type | Description |
 | --- | --- | --- |
@@ -116,55 +34,258 @@ All props below are required.
 | `url` | `string` | The path segment that will be used to navigate to the custom page. (e.g. if the `UserProfile` component is rendered at `/user`, then the custom page will be accessed at `/user/{url}` when using path routing) |
 | `children` | `React.ReactElement` | The components to be rendered as content inside the custom page. |
 
-## `<UserProfile.Link />`
+### Example
 
-You can add external links to the [`<UserProfile />`][userprofile-ref] navigation sidebar using the `<UserProfile.Link />` component.
+The following example demonstrates two ways that you can render content in the `<UserProfile.Page />` or `UserButton.UserProfilePage` component: as a component or as a direct child.
 
-### Usage
+<CodeBlockTabs type="usage" options={["Dedicated page", "<UserButton />"]}>
+  ```tsx filename="/app/user-profile/[[...user-profile]]/page.tsx"
+  "use client";
 
-<Tabs type="framework" items={["Next.js", "React", "Remix"]}>
+  import { UserProfile } from '@clerk/nextjs';
+
+  const DotIcon = () => {
+    return (
+      <svg
+        xmlns="http://www.w3.org/2000/svg"
+        viewBox="0 0 512 512"
+        fill="currentColor"
+      >
+        <path d="M256 512A256 256 0 1 0 256 0a256 256 0 1 0 0 512z" />
+      </svg>
+    )
+  }
+
+  const CustomPage = () => {
+    return (
+      <div>
+        <h1>Custom Profile Page</h1>
+        <p>This is the custom profile page</p>
+      </div>
+    );
+  };
+
+  const UserProfilePage = () => (
+    <UserProfile path="/user-profile" routing="path">
+      {/* You can pass the content as a component */}
+      <UserProfile.Page
+        label="Custom Page"
+        labelIcon={<DotIcon />}
+        url="custom-page"
+      >
+        <CustomPage />
+      </UserProfile.Page>
+
+      {/* You can also pass the content as direct children */}
+      <UserProfile.Page
+        label="Terms"
+        labelIcon={<DotIcon />}
+        url="terms"
+      >
+        <div>
+          <h1>Custom Terms Page</h1>
+          <p>This is the custom terms page</p>
+        </div>
+      </UserProfile.Page>
+    </UserProfile>
+  );
+
+  export default UserProfilePage;
+  ```
+
+  ```tsx filename="/app/components/Header.tsx"
+  "use client";
+
+  import { UserButton } from "@clerk/nextjs";
+
+  const DotIcon = () => {
+    return (
+      <svg
+        xmlns="http://www.w3.org/2000/svg"
+        viewBox="0 0 512 512"
+        fill="currentColor"
+      >
+        <path d="M256 512A256 256 0 1 0 256 0a256 256 0 1 0 0 512z" />
+      </svg>
+    )
+  }
+
+  const CustomPage = () => {
+    return (
+      <div>
+        <h1>Custom Profile Page</h1>
+        <p>This is the custom profile page</p>
+      </div>
+    );
+  };
+
+  const Header = () => (
+    <header>
+      <UserButton afterSignOutUrl='/'>
+        {/* You can pass the content as a component */}
+        <UserButton.UserProfilePage
+          label="Custom Page"
+          url="custom"
+          labelIcon={<DotIcon />}
+        >
+          <CustomPage />
+        </UserButton.UserProfilePage>
+
+        {/* You can also pass the content as direct children */}
+        <UserButton.UserProfilePage
+          label="Terms"
+          labelIcon={<DotIcon />}
+          url="terms"
+        >
+          <div>
+            <h1>Custom Terms Page</h1>
+            <p>This is the custom terms page</p>
+          </div>
+        </UserButton.UserProfilePage>
+      </UserButton>
+    </header>
+  );
+
+  export default Header;
+  ```
+</CodeBlockTabs>
+
+## Add a custom link to the `<UserProfile />` component
+
+You can add external links to the `<UserProfile />` navigation sidebar using the `<UserProfile.Link />` component or the `<UserButton.UserProfileLink />` component, depending on your use case.
+
+### Props
+
+`<UserProfile.Link />` and `<UserButton.UserProfileLink />` accept the following props, all of which are *required*:
+
+| Name | Type | Description |
+| --- | --- | --- |
+| `label` | `string` | The name that will be displayed in the navigation sidebar for the link.  |
+| `labelIcon` | `React.ReactElement` | An icon displayed next to the label in the navigation sidebar. |
+| `url` | `string` | The absolute or relative url to navigate to |
+
+### Example
+
+The following example adds a link to the homepage in the navigation sidebar of the `<UserProfile />` component.
+
+<CodeBlockTabs type="usage" options={["Dedicated page", "<UserButton />"]}>
+  ```tsx filename="/app/user-profile/[[...user-profile]]/page.tsx"
+  "use client";
+
+  import { UserProfile } from "@clerk/nextjs";
+
+  const DotIcon = () => {
+    return (
+      <svg
+        xmlns="http://www.w3.org/2000/svg"
+        viewBox="0 0 512 512"
+        fill="currentColor"
+      >
+        <path d="M256 512A256 256 0 1 0 256 0a256 256 0 1 0 0 512z" />
+      </svg>
+    )
+  }
+
+  const UserProfilePage = () => (
+    <UserProfile path="/user-profile" routing="path">
+      <UserProfile.Link
+        label="Homepage"
+        labelIcon={<DotIcon />}
+        url="/"
+      />
+    </UserProfile>
+  );
+
+  export default UserProfilePage;
+  ```
+
+  ```tsx filename="/app/components/Header.tsx"
+  "use client";
+
+  import { UserButton } from "@clerk/nextjs";
+
+  const DotIcon = () => {
+    return (
+      <svg
+        xmlns="http://www.w3.org/2000/svg"
+        viewBox="0 0 512 512"
+        fill="currentColor"
+      >
+        <path d="M256 512A256 256 0 1 0 256 0a256 256 0 1 0 0 512z" />
+      </svg>
+    )
+  }
+
+  const Header = () => (
+    <header>
+      <UserButton afterSignOutUrl='/'>
+        <UserButton.UserProfileLink
+          label="Homepage"
+          url="/"
+          labelIcon={<DotIcon />}
+        />
+      </UserButton>
+    </header>
+  );
+
+  export default Header;
+  ```
+</CodeBlockTabs>
+
+## Advanced use cases
+
+### Reorder default routes
+
+If you want to reorder the default routes (`Account` and `Security`) in the `<UserProfile />` navigation sidebar, you can use the `<UserProfile.Page />` component with the `label` prop set to `'account'` or `'security'`. This will target the existing default page and allow you to rearrange it.
+
+Note that the first item in the navigation sidebar cannot be a `<UserProfile.Link />` or `<UserButton.UserProfileLink />` component.
+
+<Tabs type="usage" items={["Dedicated Page", "<UserButton />"]}>
   <Tab>
-    `<UserProfile.Link />` can be rendered **only on the client**. For Next.js applications using App Router, the `"use client";` directive must be added.
+    It's important to note that the first page in the list will always be rendered under the root path that you set with the `path` prop. It's `url` prop will be ignored, so you can pass any value you want. In the following example, the root path is set to `/user-profile`, so the `<CustomPage />` is rendered under `/user-profile`.
 
-    <CodeBlockTabs type="router" options={["App Router", "Pages Router"]}>
-      ```jsx filename="/app/user-profile/[[...user-profile]]/page.tsx"
-      "use client";
+    ```tsx filename="/app/user-profile/[[...user-profile]]/page.tsx"
+    "use client";
 
-      import { UserProfile } from "@clerk/nextjs";
-      import { CustomIcon } from "../icons";
+    import { UserProfile } from "@clerk/nextjs";
 
-      const UserProfilePage = () => (
-        <UserProfile path="/user-profile" routing="path">
-          <UserProfile.Link label="Homepage" labelIcon={<CustomIcon />} url="/home" />
-        </UserProfile>
+    const DotIcon = () => {
+      return (
+        <svg
+          xmlns="http://www.w3.org/2000/svg"
+          viewBox="0 0 512 512"
+          fill="currentColor"
+        >
+          <path d="M256 512A256 256 0 1 0 256 0a256 256 0 1 0 0 512z" />
+        </svg>
+      )
+    }
+
+    const CustomPage = () => {
+      return (
+        <div>
+          <h1>Custom Profile Page</h1>
+          <p>This is the custom profile page</p>
+        </div>
       );
-
-      export default UserProfilePage;
-      ```
-
-      ```jsx filename="/pages/user-profile/[[...index]].tsx"
-      import { UserProfile } from "@clerk/nextjs";
-      import { CustomIcon } from "../icons";
-
-      const UserProfilePage = () => (
-        <UserProfile path="/user-profile" routing="path">
-          <UserProfile.Link label="Homepage" labelIcon={<CustomIcon />} url="/home" />
-        </UserProfile>
-      );
-
-      export default UserProfilePage;
-      ```
-    </CodeBlockTabs>
-  </Tab>
-
-  <Tab>
-    ```jsx filename="/user-profile.tsx"
-    import { UserProfile } from "@clerk/clerk-react";
-    import { CustomIcon } from "../icons";
+    };
 
     const UserProfilePage = () => (
       <UserProfile path="/user-profile" routing="path">
-        <UserProfile.Link label="Homepage" labelIcon={<CustomIcon />} url="/home" />
+        <UserProfile.Page
+          label="Custom Page"
+          url="custom"
+          labelIcon={<DotIcon />}
+        >
+          <CustomPage />
+        </UserProfile.Page>
+        <UserProfile.Link
+          label="Homepage"
+          url="/"
+          labelIcon={<DotIcon />}
+        />
+        <UserProfile.Page label="account" />
+        <UserProfile.Page label="security" />
       </UserProfile>
     );
 
@@ -173,244 +294,61 @@ You can add external links to the [`<UserProfile />`][userprofile-ref] navigatio
   </Tab>
 
   <Tab>
-    ```tsx filename="routes/user/$.tsx"
-    import { UserProfile } from "@clerk/remix";
-    import { CustomIcon } from "../icons";
+    ```tsx filename="/app/components/Header.tsx"
+    "use client";
 
-    export default function UserProfilePage() {
+    import { UserButton } from "@clerk/nextjs";
+
+    const DotIcon = () => {
       return (
-        <UserProfile path="/user-profile" routing="path">
-          <UserProfile.Link label="Homepage" labelIcon={<CustomIcon />} url="/home" />
-        </UserProfile>
-      );
+        <svg
+          xmlns="http://www.w3.org/2000/svg"
+          viewBox="0 0 512 512"
+          fill="currentColor"
+        >
+          <path d="M256 512A256 256 0 1 0 256 0a256 256 0 1 0 0 512z" />
+        </svg>
+      )
     }
-    ```
-  </Tab>
-</Tabs>
 
-
-### Props
-
-All props below are required.
-
-| Name | Type | Description |
-| --- | --- | --- |
-| `label` | `string` | The name that will be displayed in the navigation sidebar for the link.  |
-| `labelIcon` | `React.ReactElement` | An icon displayed next to the label in the navigation sidebar. |
-| `url` | `string` | The absolute or relative url to navigate to |
-
-
-## Advanced use cases
-
-### Reordering default routes
-
-If you want to reorder the default routes (`Account` and `Security`) in the `UserProfile` navigation sidebar, you can use the `<UserProfile.Page />` component with the `label` prop set to `'account'` or `'security'`. This will target the existing default page and allow you to rearrange it.
-
-### Usage
-
-<Tabs type="framework" items={["Next.js", "React", "Remix"]}>
-  <Tab>
-    `<UserProfile.Page />` and `<UserProfile.Link />` can be rendered **only on the client**. For Next.js applications using App Router, the `"use client";` directive must be added.
-
-    <CodeBlockTabs type="router" options={["App Router", "Pages Router"]}>
-      ```jsx filename="/app/user-profile/[[...user-profile]]/page.tsx"
-      "use client";
-
-      import { UserProfile } from "@clerk/nextjs";
-      import { MyCustomPageContent } from "../components";
-      import { CustomIcon, Icon } from "../icons";
-
-      const UserProfilePage = () => (
-        <UserProfile path="/user-profile" routing="path">
-          <UserProfile.Page label="Custom Page" url="custom" labelIcon={<CustomIcon />}>
-              <MyCustomPageContent />
-          </UserProfile.Page>
-          <UserProfile.Link label="Homepage" url="/home" labelIcon={<Icon />} />
-          <UserProfile.Page label="account" />
-          <UserProfile.Page label="security" />
-        </UserProfile>
-      );
-
-      export default UserProfilePage;
-      ```
-
-      ```jsx filename="/pages/user-profile/[[...index]].tsx"
-      import { UserProfile } from "@clerk/nextjs";
-      import { MyCustomPageContent } from "../components";
-      import { CustomIcon, Icon } from "../icons";
-
-      const UserProfilePage = () => (
-        <UserProfile path="/user-profile" routing="path">
-          <UserProfile.Page label="Custom Page" url="custom" labelIcon={<CustomIcon />}>
-              <MyCustomPageContent />
-          </UserProfile.Page>
-          <UserProfile.Link label="Homepage" url="/home" labelIcon={<Icon />} />
-          <UserProfile.Page label="account" />
-          <UserProfile.Page label="security" />
-        </UserProfile>
-      );
-
-      export default UserProfilePage;
-      ```
-    </CodeBlockTabs>
-  </Tab>
-
-  <Tab>
-      ```jsx filename="/user-profile.tsx"
-      import { UserProfile } from "@clerk/clerk-react";
-      import { MyCustomPageContent } from "../components";
-      import { CustomIcon, Icon } from "../icons";
-
-      const UserProfilePage = () => (
-        <UserProfile path="/user-profile" routing="path">
-          <UserProfile.Page label="Custom Page" url="custom" labelIcon={<CustomIcon />}>
-              <MyCustomPageContent />
-          </UserProfile.Page>
-          <UserProfile.Link label="Homepage" url="/home" labelIcon={<Icon />} />
-          <UserProfile.Page label="account" />
-          <UserProfile.Page label="security" />
-        </UserProfile>
-      );
-
-      export default UserProfilePage;
-      ```
-  </Tab>
-
-  <Tab>
-    ```tsx filename="routes/user/$.tsx"
-    import { UserProfile } from "@clerk/remix";
-    import { MyCustomPageContent } from "../components";
-    import { CustomIcon, Icon } from "../icons";
-
-    export default function UserProfilePage() {
+    const CustomPage = () => {
       return (
-        <UserProfile path="/user-profile" routing="path">
-          <UserProfile.Page label="Custom Page" url="custom" labelIcon={<CustomIcon />}>
-              <MyCustomPageContent />
-          </UserProfile.Page>
-          <UserProfile.Link label="Homepage" url="/home" labelIcon={<Icon />} />
-          <UserProfile.Page label="account" />
-          <UserProfile.Page label="security" />
-        </UserProfile>
+        <div>
+          <h1>Custom Profile Page</h1>
+          <p>This is the custom profile page</p>
+        </div>
       );
-    }
-    ```
-  </Tab>
-</Tabs>
-
-The above example will result in the following order:
-
-1. Custom Page
-2. Homepage
-3. Account
-4. Security
-
-It's important to note that the first page in the list will be rendered under the root path `/` (its `url` will be ignored) and the Clerk pages will be rendered under the path `/account`. Also, the first item in the list cannot be a `<UserProfile.Link />` component.
-
-### Using custom pages with the `<UserButton />` component
-
-If you are using the `<UserButton />` component with the default props (where the `UserProfile` opens as a modal), then you should also be providing these custom pages as children to the component (using the `<UserButton.UserProfilePage />` and `<UserButton.UserProfileLink />` components respectively).
-
-### Usage
-
-<Tabs type="framework" items={["Next.js", "React", "Remix"]}>
-  <Tab>
-    `<UserButton.UserProfilePage />` and `<UserButton.UserProfileLink />` can be rendered **only on the client**. For Next.js applications using App Router, the `"use client";` directive must be added.
-
-    <CodeBlockTabs type="router" options={["App Router", "Pages Router"]}>
-      ```jsx filename="/app/components/Header.tsx"
-      "use client";
-
-      import { UserButton } from "@clerk/nextjs";
-      import { MyCustomPageContent } from "../components";
-      import { CustomIcon, Icon } from "../icons";
-
-      const Header = () => (
-        <header>
-          <UserButton afterSignOutUrl='/'>
-            <UserButton.UserProfilePage label="Custom Page" url="custom" labelIcon={<CustomIcon />}>
-                <MyCustomPageContent />
-            </UserButton.UserProfilePage>
-            <UserButton.UserProfileLink label="Homepage" url="/home" labelIcon={<Icon />} />
-            <UserButton.UserProfilePage label="account" />
-            <UserButton.UserProfilePage label="security" />
-          </UserButton>
-        </header>
-      );
-
-      export default Header;
-      ```
-
-      ```jsx filename="/pages/components/Header.tsx"
-      import { UserButton } from "@clerk/nextjs";
-      import { MyCustomPageContent } from "../components";
-      import { CustomIcon, Icon } from "../icons";
-
-      const Header = () => (
-        <header>
-          <UserButton afterSignOutUrl='/'>
-            <UserButton.UserProfilePage label="Custom Page" url="custom" labelIcon={<CustomIcon />}>
-                <MyCustomPageContent />
-            </UserButton.UserProfilePage>
-            <UserButton.UserProfileLink label="Homepage" url="/home" labelIcon={<Icon />} />
-            <UserButton.UserProfilePage label="account" />
-            <UserButton.UserProfilePage label="security" />
-          </UserButton>
-        </header>
-      );
-
-      export default Header;
-      ```
-    </CodeBlockTabs>
-</Tab>
-
-<Tab>
-    ```jsx filename="/components/Header.tsx"
-    import { UserButton } from "@clerk/clerk-react";
-    import { MyCustomPageContent } from "../components";
-    import { CustomIcon, Icon } from "../icons";
+    };
 
     const Header = () => (
-        <header>
-          <UserButton afterSignOutUrl='/'>
-            <UserButton.UserProfilePage label="Custom Page" url="custom" labelIcon={<CustomIcon />}>
-                <MyCustomPageContent />
-            </UserButton.UserProfilePage>
-            <UserButton.UserProfileLink label="Homepage" url="/home" labelIcon={<Icon />} />
-            <UserButton.UserProfilePage label="account" />
-            <UserButton.UserProfilePage label="security" />
-          </UserButton>
-        </header>
-    );
-
-    export default Header;
-    ```
-</Tab>
-
-<Tab>
-    ```tsx filename="components/Header.tsx"
-    import { UserButton } from "@clerk/remix";
-    import { MyCustomPageContent } from "../components";
-    import { CustomIcon, Icon } from "../icons";
-
-    export default function Header() {
-    return (
       <header>
         <UserButton afterSignOutUrl='/'>
-          <UserButton.UserProfilePage label="Custom Page" url="custom" labelIcon={<CustomIcon />}>
-              <MyCustomPageContent />
+          <UserButton.UserProfilePage
+            label="Custom Page"
+            url="custom"
+            labelIcon={<DotIcon />}
+          >
+            <CustomPage />
           </UserButton.UserProfilePage>
-          <UserButton.UserProfileLink label="Homepage" url="/home" labelIcon={<Icon />} />
+          <UserButton.UserProfileLink
+            label="Homepage"
+            url="/"
+            labelIcon={<DotIcon />}
+          />
           <UserButton.UserProfilePage label="account" />
           <UserButton.UserProfilePage label="security" />
         </UserButton>
       </header>
     );
-    }
+
+    export default Header;
     ```
   </Tab>
 </Tabs>
 
-This repetition of the same property can be avoided when the user is using the `userProfileMode='navigation'` and `userProfileUrl='<some url>'` props on the `<UserButton />` component and has implemented a dedicated page for the [`<UserProfile />`][userprofile-ref] component.
+With the above example, the `<UserProfile />` navigation sidebar will be in the following order:
 
-[userprofile-ref]: /docs/components/user/user-profile
+1. Custom Page
+2. Homepage
+3. Account
+4. Security

--- a/docs/components/customization/user-profile.mdx
+++ b/docs/components/customization/user-profile.mdx
@@ -32,7 +32,7 @@ To add a custom page to the `<UserProfile />` component, use the `<UserProfile.P
 | --- | --- | --- |
 | `label` | `string` | The name that will be displayed in the navigation sidebar for the custom page. |
 | `labelIcon` | `React.ReactElement` | An icon displayed next to the label in the navigation sidebar. |
-| `url` | `string` | The path segment that will be used to navigate to the custom page. (e.g. if the `UserProfile` component is rendered at `/user`, then the custom page will be accessed at `/user/{url}` when using path routing) |
+| `url` | `string` | The path segment that will be used to navigate to the custom page. (e.g. if the `<UserProfile />` component is rendered at `/user`, then the custom page will be accessed at `/user/{url}` when using path routing) |
 | `children` | `React.ReactElement` | The components to be rendered as content inside the custom page. |
 
 ### Example
@@ -243,7 +243,9 @@ Note that the first item in the navigation sidebar cannot be a `<UserProfile.Lin
 
 <Tabs type="usage" items={["Dedicated Page", "<UserButton />"]}>
   <Tab>
-    It's important to note that the first page in the list will always be rendered under the root path that you set with the `path` prop. It's `url` prop will be ignored, so you can pass any value you want. In the following example, `path` is set to `/user-profile`, so the `<CustomPage />` is rendered under the `/user-profile` path.
+    The first page in the list will always be rendered under the root path defined with the `path` prop. Its `url` prop will be ignored.
+
+    In the following example, `path` is set to `/user-profile`, so the `<CustomPage />` is rendered under the `/user-profile` path.
 
     ```tsx filename="/app/user-profile/[[...user-profile]]/page.tsx"
     "use client";

--- a/docs/components/customization/user-profile.mdx
+++ b/docs/components/customization/user-profile.mdx
@@ -22,11 +22,11 @@ For the sake of this guide, examples are written for Next.js App Router, but the
 
 Custom pages can be rendered inside the `<UserProfile />` component and provide a way to incorporate app-specific settings or additional functionality.
 
-To add a custom page to the `<UserProfile />` component, use the `<UserProfile.Page />` component or the `<UserButton.UserProfilePage />` component, depending on your use case.
+To add a custom page to the `<UserProfile />` component, use the `<UserButton.UserProfilePage />` component or the `<UserProfile.Page />` component, depending on your use case.
 
 ### Props
 
-`<UserProfile.Page />` and `<UserButton.UserProfilePage />` accept the following props, all of which are *required*:
+`<UserButton.UserProfilePage />` and `<UserProfile.Page />` accept the following props, all of which are *required*:
 
 | Name | Type | Description |
 | --- | --- | --- |
@@ -37,63 +37,9 @@ To add a custom page to the `<UserProfile />` component, use the `<UserProfile.P
 
 ### Example
 
-The following example demonstrates two ways that you can render content in the `<UserProfile.Page />` or `UserButton.UserProfilePage` component: as a component or as a direct child.
+The following example demonstrates two ways that you can render content in the `<UserButton.UserProfilePage />` or `<UserProfile.Page />` component: as a component or as a direct child.
 
-<CodeBlockTabs type="usage" options={["Dedicated page", "<UserButton />"]}>
-  ```tsx filename="/app/user-profile/[[...user-profile]]/page.tsx"
-  "use client";
-
-  import { UserProfile } from '@clerk/nextjs';
-
-  const DotIcon = () => {
-    return (
-      <svg
-        xmlns="http://www.w3.org/2000/svg"
-        viewBox="0 0 512 512"
-        fill="currentColor"
-      >
-        <path d="M256 512A256 256 0 1 0 256 0a256 256 0 1 0 0 512z" />
-      </svg>
-    )
-  }
-
-  const CustomPage = () => {
-    return (
-      <div>
-        <h1>Custom Profile Page</h1>
-        <p>This is the custom profile page</p>
-      </div>
-    );
-  };
-
-  const UserProfilePage = () => (
-    <UserProfile path="/user-profile" routing="path">
-      {/* You can pass the content as a component */}
-      <UserProfile.Page
-        label="Custom Page"
-        labelIcon={<DotIcon />}
-        url="custom-page"
-      >
-        <CustomPage />
-      </UserProfile.Page>
-
-      {/* You can also pass the content as direct children */}
-      <UserProfile.Page
-        label="Terms"
-        labelIcon={<DotIcon />}
-        url="terms"
-      >
-        <div>
-          <h1>Custom Terms Page</h1>
-          <p>This is the custom terms page</p>
-        </div>
-      </UserProfile.Page>
-    </UserProfile>
-  );
-
-  export default UserProfilePage;
-  ```
-
+<CodeBlockTabs type="usage" options={["<UserButton />", "Dedicated page"]}>
   ```tsx filename="/app/components/Header.tsx"
   "use client";
 
@@ -149,31 +95,11 @@ The following example demonstrates two ways that you can render content in the `
 
   export default Header;
   ```
-</CodeBlockTabs>
 
-## Add a custom link to the `<UserProfile />` component
-
-You can add external links to the `<UserProfile />` navigation sidebar using the `<UserProfile.Link />` component or the `<UserButton.UserProfileLink />` component, depending on your use case.
-
-### Props
-
-`<UserProfile.Link />` and `<UserButton.UserProfileLink />` accept the following props, all of which are *required*:
-
-| Name | Type | Description |
-| --- | --- | --- |
-| `label` | `string` | The name that will be displayed in the navigation sidebar for the link.  |
-| `labelIcon` | `React.ReactElement` | An icon displayed next to the label in the navigation sidebar. |
-| `url` | `string` | The absolute or relative url to navigate to |
-
-### Example
-
-The following example adds a link to the homepage in the navigation sidebar of the `<UserProfile />` component.
-
-<CodeBlockTabs type="usage" options={["Dedicated page", "<UserButton />"]}>
   ```tsx filename="/app/user-profile/[[...user-profile]]/page.tsx"
   "use client";
 
-  import { UserProfile } from "@clerk/nextjs";
+  import { UserProfile } from '@clerk/nextjs';
 
   const DotIcon = () => {
     return (
@@ -187,19 +113,63 @@ The following example adds a link to the homepage in the navigation sidebar of t
     )
   }
 
+  const CustomPage = () => {
+    return (
+      <div>
+        <h1>Custom Profile Page</h1>
+        <p>This is the custom profile page</p>
+      </div>
+    );
+  };
+
   const UserProfilePage = () => (
     <UserProfile path="/user-profile" routing="path">
-      <UserProfile.Link
-        label="Homepage"
+      {/* You can pass the content as a component */}
+      <UserProfile.Page
+        label="Custom Page"
         labelIcon={<DotIcon />}
-        url="/"
-      />
+        url="custom-page"
+      >
+        <CustomPage />
+      </UserProfile.Page>
+
+      {/* You can also pass the content as direct children */}
+      <UserProfile.Page
+        label="Terms"
+        labelIcon={<DotIcon />}
+        url="terms"
+      >
+        <div>
+          <h1>Custom Terms Page</h1>
+          <p>This is the custom terms page</p>
+        </div>
+      </UserProfile.Page>
     </UserProfile>
   );
 
   export default UserProfilePage;
   ```
+</CodeBlockTabs>
 
+## Add a custom link to the `<UserProfile />` component
+
+You can add external links to the `<UserProfile />` navigation sidebar using the `<UserButton.UserProfileLink />` component or the `<UserProfile.Link />` component, depending on your use case.
+
+### Props
+
+`<UserButton.UserProfileLink />` and `<UserProfile.Link />` accept the following props, all of which are *required*:
+
+| Name | Type | Description |
+| --- | --- | --- |
+| `label` | `string` | The name that will be displayed in the navigation sidebar for the link.  |
+| `labelIcon` | `React.ReactElement` | An icon displayed next to the label in the navigation sidebar. |
+| `url` | `string` | The absolute or relative url to navigate to |
+
+### Example
+
+The following example adds a link to the homepage in the navigation sidebar of the `<UserProfile />` component.
+
+<CodeBlockTabs type="usage" options={["<UserButton />", "Dedicated page"]}>
   ```tsx filename="/app/components/Header.tsx"
   "use client";
 
@@ -231,6 +201,36 @@ The following example adds a link to the homepage in the navigation sidebar of t
 
   export default Header;
   ```
+
+  ```tsx filename="/app/user-profile/[[...user-profile]]/page.tsx"
+  "use client";
+
+  import { UserProfile } from "@clerk/nextjs";
+
+  const DotIcon = () => {
+    return (
+      <svg
+        xmlns="http://www.w3.org/2000/svg"
+        viewBox="0 0 512 512"
+        fill="currentColor"
+      >
+        <path d="M256 512A256 256 0 1 0 256 0a256 256 0 1 0 0 512z" />
+      </svg>
+    )
+  }
+
+  const UserProfilePage = () => (
+    <UserProfile path="/user-profile" routing="path">
+      <UserProfile.Link
+        label="Homepage"
+        labelIcon={<DotIcon />}
+        url="/"
+      />
+    </UserProfile>
+  );
+
+  export default UserProfilePage;
+  ```
 </CodeBlockTabs>
 
 ## Advanced use cases
@@ -239,9 +239,61 @@ The following example adds a link to the homepage in the navigation sidebar of t
 
 If you want to reorder the default routes, `Account` and `Security`, set the `label` prop to `'account'` or `'security'`. This will target the existing default page and allow you to rearrange it.
 
-Note that when reordering default routes, the first item in the navigation sidebar cannot be a `<UserProfile.Link />` or `<UserButton.UserProfileLink />` component.
+Note that when reordering default routes, the first item in the navigation sidebar cannot be a `<UserButton.UserProfileLink />` or `<UserProfile.Link />` component.
 
-<Tabs type="usage" items={["Dedicated Page", "<UserButton />"]}>
+<Tabs type="usage" items={["<UserButton />", "Dedicated Page"]}>
+  <Tab>
+    ```tsx filename="/app/components/Header.tsx"
+    "use client";
+
+    import { UserButton } from "@clerk/nextjs";
+
+    const DotIcon = () => {
+      return (
+        <svg
+          xmlns="http://www.w3.org/2000/svg"
+          viewBox="0 0 512 512"
+          fill="currentColor"
+        >
+          <path d="M256 512A256 256 0 1 0 256 0a256 256 0 1 0 0 512z" />
+        </svg>
+      )
+    }
+
+    const CustomPage = () => {
+      return (
+        <div>
+          <h1>Custom Profile Page</h1>
+          <p>This is the custom profile page</p>
+        </div>
+      );
+    };
+
+    const Header = () => (
+      <header>
+        <UserButton afterSignOutUrl='/'>
+          <UserButton.UserProfilePage
+            label="Custom Page"
+            url="custom"
+            labelIcon={<DotIcon />}
+          >
+            <CustomPage />
+          </UserButton.UserProfilePage>
+          <UserButton.UserProfileLink
+            label="Homepage"
+            url="/"
+            labelIcon={<DotIcon />}
+          />
+          <UserButton.UserProfilePage label="account" />
+          <UserButton.UserProfilePage label="security" />
+        </UserButton>
+      </header>
+    );
+
+    export default Header;
+    ```
+  </Tab>
+
   <Tab>
     The first page in the list will always be rendered under the root path defined with the `path` prop. Its `url` prop will be ignored.
 
@@ -293,58 +345,6 @@ Note that when reordering default routes, the first item in the navigation sideb
     );
 
     export default UserProfilePage;
-    ```
-  </Tab>
-
-  <Tab>
-    ```tsx filename="/app/components/Header.tsx"
-    "use client";
-
-    import { UserButton } from "@clerk/nextjs";
-
-    const DotIcon = () => {
-      return (
-        <svg
-          xmlns="http://www.w3.org/2000/svg"
-          viewBox="0 0 512 512"
-          fill="currentColor"
-        >
-          <path d="M256 512A256 256 0 1 0 256 0a256 256 0 1 0 0 512z" />
-        </svg>
-      )
-    }
-
-    const CustomPage = () => {
-      return (
-        <div>
-          <h1>Custom Profile Page</h1>
-          <p>This is the custom profile page</p>
-        </div>
-      );
-    };
-
-    const Header = () => (
-      <header>
-        <UserButton afterSignOutUrl='/'>
-          <UserButton.UserProfilePage
-            label="Custom Page"
-            url="custom"
-            labelIcon={<DotIcon />}
-          >
-            <CustomPage />
-          </UserButton.UserProfilePage>
-          <UserButton.UserProfileLink
-            label="Homepage"
-            url="/"
-            labelIcon={<DotIcon />}
-          />
-          <UserButton.UserProfilePage label="account" />
-          <UserButton.UserProfilePage label="security" />
-        </UserButton>
-      </header>
-    );
-
-    export default Header;
     ```
   </Tab>
 </Tabs>

--- a/docs/components/customization/user-profile.mdx
+++ b/docs/components/customization/user-profile.mdx
@@ -15,7 +15,7 @@ This guide includes examples for both use cases. You can select the tabs on the 
 
 By default, the `<UserButton />` sets `userProfileMode='modal'`. If you are using the default settings, then you should use the `<UserButton />` examples. However, if you are using the  `userProfileMode='navigation'` and `userProfileUrl='/user-profile'` props on the `<UserButton />` component, then you should use the `Dedicated page` examples.
 
-For the sake of this guide, examples are written for Next.js App Router but they are supported by any React meta framework, such as Remix or Gatsby.
+For the sake of this guide, examples are written for Next.js App Router, but they are supported by any React meta framework, such as Remix or Gatsby.
 
 ## Add a custom page to the `<UserProfile />` component
 

--- a/docs/components/customization/user-profile.mdx
+++ b/docs/components/customization/user-profile.mdx
@@ -237,9 +237,9 @@ The following example adds a link to the homepage in the navigation sidebar of t
 
 ### Reorder default routes
 
-If you want to reorder the default routes (`Account` and `Security`) in the `<UserProfile />` navigation sidebar, you can use the `<UserProfile.Page />` component with the `label` prop set to `'account'` or `'security'`. This will target the existing default page and allow you to rearrange it.
+If you want to reorder the default routes, `Account` and `Security`, set the `label` prop to `'account'` or `'security'`. This will target the existing default page and allow you to rearrange it.
 
-Note that the first item in the navigation sidebar cannot be a `<UserProfile.Link />` or `<UserButton.UserProfileLink />` component.
+Note that when reordering default routes, the first item in the navigation sidebar cannot be a `<UserProfile.Link />` or `<UserButton.UserProfileLink />` component.
 
 <Tabs type="usage" items={["Dedicated Page", "<UserButton />"]}>
   <Tab>


### PR DESCRIPTION
[DOCS-5412](https://linear.app/clerk/issue/DOCS-5412/%F0%9F%98%A2-feedback-for-componentscustomizationuser-profile) is a user feedback ticket that complains: "Unsure on how the custom page works, the code provided doesn't work".

The purpose of this PR is to not only fix the code examples to be standalone, copyable, working examples, but to update the entire guide to better explain how to use this feature.

🔎 [Preview](https://docs-preview-751.clerkpreview.com/docs/components/customization/user-profile)

- removed next.js pages, react and remix examples, as they were the exact same as next.js app router example. added this copy to the top of the guide: "For the sake of this guide, examples are written for Next.js App Router but they are supported by any React meta framework, such as Remix or Gatsby." This is how we are moving forward in the docs - less code to maintain.
- reorganized the document to follow the user's story: either using a dedicated page to host their UserProfile component, or using a UserButton that opens the UserProfile component as a modal.