### PR TITLE
fix(sdk-go): Added instructions for caching JSON Web Keys

### DIFF
--- a/docs/references/go/other-examples.mdx
+++ b/docs/references/go/other-examples.mdx
@@ -30,7 +30,7 @@ func main() {
   ctx := context.Background()
 
   // Set the API key
-  clerk.SetKey(`{{secret}}`)
+  clerk.SetKey("{{secret}}")
 
   // Create an organization
   org, err := organization.Create(ctx, &organization.CreateParams{

--- a/docs/references/go/overview.mdx
+++ b/docs/references/go/overview.mdx
@@ -5,7 +5,7 @@ description: Learn how to integrate Go into your Clerk application.
 
 # Go
 
-Clerk's [Go SDK](https://github.com/clerk/clerk-sdk-go) is a wrapper over the [Clerk Backend API](https://clerk.com/docs/reference/backend-api).
+Clerk's [Go SDK](https://github.com/clerk/clerk-sdk-go/tree/v2) is a wrapper over the [Clerk Backend API](/docs/reference/backend-api).
 
 ## Installation
 
@@ -27,7 +27,7 @@ go get -u github.com/clerk/clerk-sdk-go/v2
 
 For details on how to use this module, see the [Go Documentation](https://pkg.go.dev/github.com/clerk/clerk-sdk-go/v2).
 
-The library is organized using a resource-based structure similar to the [Clerk Backend API](https://clerk.com/docs/reference/backend-api).
+The library is organized using a resource-based structure similar to the [Clerk Backend API](/docs/reference/backend-api).
 Each API supports specific operations, like Create or List. While operations for each resource vary, a similar pattern is applied throughout the library.
 
 To execute API operations, you must configure the library with your Clerk API secret key. Depending on your use case,
@@ -114,4 +114,4 @@ for _, resource := range list.$Resource$s {
 }
 ```
 
-For more usage details, check out the [examples](/docs/references/go/other-examples) or the library's [README file](https://github.com/clerk/clerk-sdk-go).
+For more usage details, check out the [examples](/docs/references/go/other-examples) or the library's [README file](https://github.com/clerk/clerk-sdk-go/tree/v2).

--- a/docs/references/go/verifying-sessions.mdx
+++ b/docs/references/go/verifying-sessions.mdx
@@ -42,7 +42,7 @@ import (
 )
 
 func main() {
-  clerk.SetKey(`{{secret}}`)
+  clerk.SetKey("{{secret}}")
 
   mux := http.NewServeMux()
   mux.HandleFunc("/", publicRoute)
@@ -75,9 +75,9 @@ func protectedRoute(w http.ResponseWriter, r *http.Request) {
 
 Verifying a Clerk session manually is useful when you want to verify a session in a non-HTTP context, or if you would like total control over the verification process. With the solution above, Clerk middleware makes the minimum necessary requests to the Clerk Backend API. With this solution, you must be mindful of API rate limits.
 
-Verifying a session token requires providing a JSON Web Key. When using Clerk middleware to verify a session, it fetches the JSON Web Key once and caches it for you. However, when manually verifying a session, you are required to fetch and cache the JSON Web Key yourself.
+Verifying a session token requires providing a JSON Web Key. When using Clerk middleware to verify a session, it fetches the JSON Web Key once and caches it for you. However, when manually verifying a session, there's no caching layer for the JSON Web Key.
 
-Clerk Go SDK provides a set of functions for decoding and verifying JWTs, as well as fetching JSON Web Key Sets. It is recommended to cache your JSON Web Key and invalidate the cache only when a replacement key is generated.
+Clerk Go SDK provides a set of functions for decoding and verifying JWTs, as well as fetching JSON Web Keys. It is recommended to cache your JSON Web Key and invalidate the cache only when a replacement key is generated.
 
 The following example demonstrates how to manually verify a session token. If the user tries accessing the route and their session token is valid, the user's ID will be returned in the response.
 
@@ -93,19 +93,11 @@ import (
 )
 
 func main() {
-  clerk.SetKey(`{{secret}}`)
+  clerk.SetKey("{{secret}}")
 
   mux := http.NewServeMux()
   mux.HandleFunc("/", publicRoute)
-
-  // Fetch the JSON Web Key Set.
-  // Make sure you refetch the JSON Web Key Set whenever your
-  // Clerk secret key changes.
-  jwks, err := jwks.Get(context.Background() &jwks.GetParams{})
-  if err != nil {
-    panic(err)
-  }
-  mux.Handle("/protected", protectedRoute(jwks)),
+  mux.Handle("/protected", protectedRoute),
 
   http.ListenAndServe(":3000", mux)
 }
@@ -114,12 +106,13 @@ func publicRoute(w http.ResponseWriter, r *http.Request) {
   w.Write([]byte(`{"access": "public"}`))
 }
 
-func protectedRoute(jwks *clerk.JSONWebKeySet) func(http.ResponseWriter, *http.Request) {
+func protectedRoute() func(http.ResponseWriter, *http.Request) {
   return func(w http.ResponseWriter, r *http.Request) {
     // Get the session JWT from the Authorization header
     sessionToken := strings.TrimPrefix(r.Header.Get("Authorization"), "Bearer ")
 
-    unsafeClaims, err := jwt.Decode(r.Context(), &jwt.DecodeParams{
+    // Verify the session
+    claims, err := jwt.Verify(r.Context(), &jwt.VerifyParams{
       Token: sessionToken,
     })
     if err != nil {
@@ -128,20 +121,85 @@ func protectedRoute(jwks *clerk.JSONWebKeySet) func(http.ResponseWriter, *http.R
       w.Write([]byte(`{"access": "unauthorized"}`))
       return
     }
+    fmt.Fprintf(w, `{"user_id": "%s"}`, claims.Subject)
+  }
+}
+```
+</InjectKeys>
 
-    // Fetch the correct JSON Web Key
-    var jwk *clerk.JSONWebKey
-    for _, k := range jwks.Keys {
-      if k.KeyID == unsafeClaims.KeyID {
-        jwk = k
-        break
+If you need to verify session tokens frequently, it might be a good idea to cache the JSON Web Key for your instance, to avoid making too many requests to the Clerk Backend API.
+
+The following snippet repeats the same example as above. However, it demonstrates a possible way to store your JSON Web Key. The example is meant as a rough guide, implementation may vary depending on your needs.
+
+<InjectKeys>
+```go
+import (
+  "fmt"
+  "net/http"
+
+  "github.com/clerk/clerk-sdk-go/v2"
+  "github.com/clerk/clerk-sdk-go/v2/jwks"
+  "github.com/clerk/clerk-sdk-go/v2/jwt"
+)
+
+func main() {
+  mux := http.NewServeMux()
+  mux.HandleFunc("/", publicRoute)
+
+  // Initialize storage for JSON Web Keys. You can cache/store
+  // the key for as long as it's valid, and pass it to jwt.Verify.
+  // This way jwt.Verify won't make requests to the Clerk
+  // Backend API to refetch the JSON Web Key.
+  // Make sure you refetch the JSON Web Key whenever your
+  // Clerk secret key changes.
+  jwkStore := NewJWKStore()
+
+  config := &clerk.ClientConfig{}
+  config.Key = "{{secret}}"
+  jwksClient := jwks.NewClient(config)
+  mux.Handle("/protected", protectedRoute(jwksClient, jwkStore)),
+
+  http.ListenAndServe(":3000", mux)
+}
+
+func publicRoute(w http.ResponseWriter, r *http.Request) {
+  w.Write([]byte(`{"access": "public"}`))
+}
+
+func protectedRoute(jwksClient *jwks.Client, store JWKStore) func(http.ResponseWriter, *http.Request) {
+  return func(w http.ResponseWriter, r *http.Request) {
+    // Get the session JWT from the Authorization header
+    sessionToken := strings.TrimPrefix(r.Header.Get("Authorization"), "Bearer ")
+
+    // Attempt to get the JSON Web Key from your store.
+    jwk := store.GetJWK()
+    if jwk == nil {
+      // Decode the session JWT so that we can find the key ID.
+      unsafeClaims, err := jwt.Decode(r.Context(), &jwt.DecodeParams{
+        Token: sessionToken,
+      })
+      if err != nil {
+        // handle the error
+        w.WriteHeader(http.StatusUnauthorized)
+        w.Write([]byte(`{"access": "unauthorized"}`))
+        return
+      }
+
+      // Fetch the JSON Web Key
+      jwk, err := jwt.GetJSONWebKey(r.Context(), &jwt.GetJSONWebKeyParams{
+        KeyID: unsafeClaims.KeyID,
+        JWKSClient: jwksClient,
+      })
+      if err != nil {
+        // handle the error
+        w.WriteHeader(http.StatusUnauthorized)
+        w.Write([]byte(`{"access": "unauthorized"}`))
+        return
       }
     }
-    if jwk == nil {
-      w.WriteHeader(http.StatusUnauthorized)
-      w.Write([]byte(`{"access": "unauthorized"}`))
-      return
-    }
+    // Write the JSON Web Key to your store, so that next time
+    // you can use the cached value.
+    store.SetJWK(jwk)
 
     // Verify the session
     claims, err := jwt.Verify(r.Context(), &jwt.VerifyParams{
@@ -156,6 +214,18 @@ func protectedRoute(jwks *clerk.JSONWebKeySet) func(http.ResponseWriter, *http.R
     }
     fmt.Fprintf(w, `{"user_id": "%s"}`, claims.Subject)
   }
+}
+
+// Sample interface for JSON Web Key storage.
+// Implementation may vary.
+type JWKStore interface {
+  GetJWK() *clerk.JSONWebKey
+  SetJWK(*clerk.JSONWebKey)
+}
+
+func NewJWKStore() JWKStore() {
+  // Implementation may vary. This can be an
+  // in-memory store, database, caching layer,...
 }
 ```
 </InjectKeys>


### PR DESCRIPTION
When verifying session tokens manually, you can fetch the JSON Web Key for your instance once and cache it until it's rolled. Updated the verifying-sessions page with a rough outline of the SDK methods you would need to fetch the JWK and a brief outline of how you could cache it.

This commit also fixes some links to use a relative path to other docs pages and the references to the secret API key, so that they are valid Go strings.