### PR TITLE
update Go overview; update manifest for consistency in title and sidenav title

### DIFF
--- a/docs/manifest.json
+++ b/docs/manifest.json
@@ -695,7 +695,7 @@
     [
       ["Overview", "references/go/overview"],
       ["Verifying sessions", "references/go/verifying-sessions"],
-      ["Backend examples", "references/go/other-examples"],
+      ["Use Clerk Go for Backend API Operations", "references/go/other-examples"],
       ["Go SDK repository", "https://github.com/clerk/clerk-sdk-go"]
     ]
   ],

--- a/docs/references/go/overview.mdx
+++ b/docs/references/go/overview.mdx
@@ -3,9 +3,9 @@ title: Clerk Go SDK
 description: Learn how to integrate Go into your Clerk application.
 ---
 
-# Go
+# Clerk Go SDK
 
-Clerk's [Go SDK](https://github.com/clerk/clerk-sdk-go) is a wrapper over the [Clerk Backend API](https://clerk.com/docs/reference/backend-api).
+The [Clerk Go SDK](https://github.com/clerk/clerk-sdk-go) is a wrapper over the [Clerk Backend API](https://clerk.com/docs/reference/backend-api).
 
 ## Installation
 
@@ -13,7 +13,7 @@ If you're using Go Modules and have a `go.mod` file in your project's root, you 
 
 ```go
 import (
-    "github.com/clerk/clerk-sdk-go/v2"
+  "github.com/clerk/clerk-sdk-go/v2"
 )
 ```
 
@@ -27,11 +27,17 @@ go get -u github.com/clerk/clerk-sdk-go/v2
 
 For details on how to use this module, see the [Go Documentation](https://pkg.go.dev/github.com/clerk/clerk-sdk-go/v2).
 
-The library is organized using a resource-based structure similar to the [Clerk Backend API](https://clerk.com/docs/reference/backend-api).
-Each API supports specific operations, like Create or List. While operations for each resource vary, a similar pattern is applied throughout the library.
+The Clerk Go SDK is organized using a resource-based structure similar to the [Clerk Backend API](https://clerk.com/docs/reference/backend-api).
+Each API supports specific operations, like Create or List. While operations for each resource vary, a similar pattern is applied throughout Clerk Go.
 
-To execute API operations, you must configure the library with your Clerk API secret key. Depending on your use case,
-there are two ways to use the library: With or without a client.
+To execute API operations, you must configure Clerk Go with your Clerk secret key.
+If you're signed into Clerk, the code examples below will contain your secret key. Otherwise:
+  - Navigate to your [Clerk Dashboard](https://dashboard.clerk.com/last-active?path=api-keys).
+  - Select your application, then select **🔑 API Keys** in the sidebar menu.
+  - In the **Secret Keys** section, you can copy your secret key. It is the same key across all frameworks.
+
+Depending on your use case,
+there are two ways to use the Clerk Go SDK: With or without a client.
 
 For most use cases, the API without a client is a better choice. It requires a minimal setup and provides a more concise API for invoking operations.
 
@@ -44,17 +50,19 @@ The following examples demonstrate both approaches.
 
 If you only use one API key, you can import the packages required for the APIs you need. Then you can execute your desired request methods as functions, such as `$resource$.Get()` or `$resource$.Delete()`. The following example demonstrates this process:
 
+<InjectKeys>
+
 ```go
 import (
-    "github.com/clerk/clerk-sdk-go/v2"
-    "github.com/clerk/clerk-sdk-go/v2/$resource$"
+  "github.com/clerk/clerk-sdk-go/v2"
+  "github.com/clerk/clerk-sdk-go/v2/$resource$"
 )
 
 // Each operation requires a context.Context as the first argument.
 ctx := context.Background()
 
-// Set the API key
-clerk.SetKey("sk_live_XXX")
+// Set the API key with your Clerk secret key
+clerk.SetKey("{{secret_key}}")
 
 // Create
 resource, err := $resource$.Create(ctx, &$resource$.CreateParams{})
@@ -75,16 +83,20 @@ for _, resource := range list.$Resource$s {
 }
 ```
 
+</InjectKeys>
+
 ### Usage with a client
 
-If you're working with multiple keys, you should use the library with a client. The API packages for each
+If you're working with multiple keys, it's recommended to use Clerk Go with a client. The API packages for each
 resource export a `Client`, which supports all the API's operations.
-This way you can create as many clients as needed, each with their own API key, as shown in the following example:
+This way, you can create as many clients as needed, each with their own API key, as shown in the following example:
+
+<InjectKeys>
 
 ```go
 import (
-    "github.com/clerk/clerk-sdk-go/v2"
-    "github.com/clerk/clerk-sdk-go/v2/$resource$"
+  "github.com/clerk/clerk-sdk-go/v2"
+  "github.com/clerk/clerk-sdk-go/v2/$resource$"
 )
 
 // Each operation requires a context.Context as the first argument.
@@ -92,7 +104,7 @@ ctx := context.Background()
 
 // Initialize a client with an API key
 config := &clerk.ClientConfig{}
-config.Key = "sk_live_XXX"
+config.Key = "{{secret_key}}"
 client := $resource$.NewClient(config)
 
 // Create
@@ -113,5 +125,7 @@ for _, resource := range list.$Resource$s {
     // do something with the resource
 }
 ```
+
+</InjectKeys>
 
 For more usage details, check out the [examples](/docs/references/go/other-examples) or the library's [README file](https://github.com/clerk/clerk-sdk-go).

--- a/docs/references/go/overview.mdx
+++ b/docs/references/go/overview.mdx
@@ -30,8 +30,7 @@ For details on how to use this module, see the [Go Documentation](https://pkg.go
 The Clerk Go SDK is organized using a resource-based structure similar to the [Clerk Backend API](https://clerk.com/docs/reference/backend-api).
 Each API supports specific operations, like Create or List. While operations for each resource vary, a similar pattern is applied throughout Clerk Go.
 
-To execute API operations, you must configure Clerk Go with your Clerk secret key.
-If you're signed into Clerk, the code examples below will contain your secret key. Otherwise:
+To execute API operations, you must configure Clerk Go with your Clerk secret key. To find your Clerk secret key:
   - Navigate to your [Clerk Dashboard](https://dashboard.clerk.com/last-active?path=api-keys).
   - Select your application, then select **🔑 API Keys** in the sidebar menu.
   - In the **Secret Keys** section, you can copy your secret key. It is the same key across all frameworks.
@@ -50,8 +49,6 @@ The following examples demonstrate both approaches.
 
 If you only use one API key, you can import the packages required for the APIs you need. Then you can execute your desired request methods as functions, such as `$resource$.Get()` or `$resource$.Delete()`. The following example demonstrates this process:
 
-<InjectKeys>
-
 ```go
 import (
   "github.com/clerk/clerk-sdk-go/v2"
@@ -62,7 +59,7 @@ import (
 ctx := context.Background()
 
 // Set the API key with your Clerk secret key
-clerk.SetKey("{{secret_key}}")
+clerk.SetKey("sk_live_xxx")
 
 // Create
 resource, err := $resource$.Create(ctx, &$resource$.CreateParams{})
@@ -83,15 +80,11 @@ for _, resource := range list.$Resource$s {
 }
 ```
 
-</InjectKeys>
-
 ### Usage with a client
 
 If you're working with multiple keys, it's recommended to use Clerk Go with a client. The API packages for each
 resource export a `Client`, which supports all the API's operations.
 This way, you can create as many clients as needed, each with their own API key, as shown in the following example:
-
-<InjectKeys>
 
 ```go
 import (
@@ -104,7 +97,7 @@ ctx := context.Background()
 
 // Initialize a client with an API key
 config := &clerk.ClientConfig{}
-config.Key = "{{secret_key}}"
+config.Key = "sk_live_xxx"
 client := $resource$.NewClient(config)
 
 // Create
@@ -125,7 +118,5 @@ for _, resource := range list.$Resource$s {
     // do something with the resource
 }
 ```
-
-</InjectKeys>
 
 For more usage details, check out the [examples](/docs/references/go/other-examples) or the library's [README file](https://github.com/clerk/clerk-sdk-go).


### PR DESCRIPTION
The sidenav title for the page was inconsistent with the actual title of the page. The path is "other-examples" and is also inconsistent, but this can addressed in the upcoming IA. No need for adding a redirect right now.

Also, I apologize for these edits slipping through the cracks in the initial PR - but I want this doc as polished as possible since we are currently marketing it!