### PR TITLE
DOCS-5438 Provide more context to the custom session token guide

### DIFF
--- a/docs/backend-requests/making/custom-session-token.mdx
+++ b/docs/backend-requests/making/custom-session-token.mdx
@@ -37,7 +37,7 @@ alt="Clerk Dashboard showing the custom claim modal"
 
 ### Use the custom claims in your application
 
-The `Auth` object in the `@clerk/nextjs` package includes a `sessionClaims` property that contains the custom claims you added to your session token.
+The [`Auth`](/docs/references/nextjs/auth-object) object in the `@clerk/nextjs` package includes a `sessionClaims` property that contains the custom claims you added to your session token.
 
 Access the custom claims in your application by calling `auth()` in App Router applications or `getAuth(req)` in Pages Router applications.
 
@@ -77,7 +77,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
 
 ### Add global TypeScript type for custom session claims
 
-To get auto-complete and prevent TypeScript errors when working with custom session claims, you can add a global TypeScript type for custom session claims.
+To get auto-complete and prevent TypeScript errors when working with custom session claims, you can define a global type.
 
 1. In your application's root folder, add a `types` directory.
 2. Inside of the `types` directory, add a `globals.d.ts` file.

--- a/docs/backend-requests/making/custom-session-token.mdx
+++ b/docs/backend-requests/making/custom-session-token.mdx
@@ -15,35 +15,18 @@ This guide will show you how to customize a session token to include additional 
   The entire session token has a max size of 4kb. Exceeding this size can have adverse effects, including a possible infinite redirect loop for users who exceed this size on Next applications.
 </Callout>
 
-## How to customize your session token
+{/* TODO: Update the H3 to an H2 when the Steps component can accept headings other than H3. */}
 
 <Steps>
 
-### Go to **Sessions** in the Clerk Dashboard
+### Add custom claims to your session token
 
-In the Clerk Dashboard, navigate to the **[Sessions](https://dashboard.clerk.com/last-active?path=sessions)** page.
+1. Navigate to your [Clerk Dashboard](https://dashboard.clerk.com/last-active?path=sessions).
+2. Select your application, then select **Sessions** in the sidebar menu.
+3. In the **Customize your session token** section, click the **Edit** button.
+4. In the modal that opens, you can add any claim to your session token that you need.
 
-<Images
-src="/docs/images/advance/session-tokens/clerk-session.png"
-width={3024}
-height={1748}
-alt="Clerk Dashboard with a session token"
-/>
-
-### Click the **Edit** button
-
-In the section titled **Customize your session token**, click on the **Edit** button.
-
-<Images
-src="/docs/images/advance/session-tokens/clerk-session-edit.png"
-width={3024}
-height={1748}
-alt="Clerk Dashboard with an arrow pointing to the edit"
-/>
-
-### Add a new claim to the session token
-
-In the modal that opens, you can add any claim to your session token that you need. This examples adds a new claim called `fullName` and `primaryEmail` to the session token.
+The following example adds the `fullName` and `primaryEmail` claims to the session token.
 
 <Images
 src="/docs/images/advance/session-tokens/custom-session-example.png"
@@ -52,11 +35,13 @@ height={1748}
 alt="Clerk Dashboard showing the custom claim modal"
 />
 
-### Using the custom claims in your application
+### Use the custom claims in your application
 
-Now that you have added the custom claims to your session token, you can use them in your application. Below is an example of how you can use the [`getAuth`](/docs/references/nextjs/get-auth) helper to access the custom claims in your Next.js application.
+The `Auth` object in the `@clerk/nextjs` package includes a `sessionClaims` property that contains the custom claims you added to your session token.
 
-#### Using `getAuth` in your Next.js application
+Access the custom claims in your application by calling `auth()` in App Router applications or `getAuth(req)` in Pages Router applications.
+
+The following example demonstrates how to access the `fullName` and `primaryEmail` claims that were added to the session token in the last step.
 
 <CodeBlockTabs type="router" options={["App Router", "Pages Router"]}>
 ```tsx filename="app/page.tsx"
@@ -90,9 +75,16 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
 ```
 </CodeBlockTabs>
 
-## Add global TypeScript type for additional session claims
+### Add global TypeScript type for custom session claims
 
-A global type for additional session claims defined in a declaration file avoids type errors and provides auto-completion.
+To get auto-complete and prevent TypeScript errors when working with custom session claims, you can add a global TypeScript type for custom session claims.
+
+1. In your application's root folder, add a `types` directory.
+2. Inside of the `types` directory, add a `globals.d.ts` file.
+3. Create the `CustomJwtSessionClaims` interface and declare it globally.
+4. Add the custom claims to the `CustomJwtSessionClaims` interface.
+
+The following example demonstrates how to add the `firstName` and `primaryEmail` claims to the `CustomJwtSessionClaims` interface.
 
 ```tsx filename="types/globals.d.ts"
 export { };


### PR DESCRIPTION
[DOCS-5438](https://linear.app/clerk/issue/DOCS-5438/feedback-for-backend-requestsmakingcustom-session-token) is a user feedback ticket that reads: "I don't see how to use CustomJwtSessionClaims successfully; is this references somewhere else in Clerk?"

This PR serves to adds more context about creating and using `CustomJwtSessionClaims`. It also updates the rest of the tutorial.