### PR TITLE
docs-5476 Update /javascript/clerk/sign-in and /javascript/clerk-sign-up

### DIFF
--- a/docs/components/authentication/sign-in.mdx
+++ b/docs/components/authentication/sign-in.mdx
@@ -37,7 +37,7 @@ Below is basic implementation of the `<SignIn />` component. You can use this as
       const SignInPage = () => (
         <SignIn path="/sign-in" routing="path" signUpUrl="/sign-up" />
       );
-      
+
       export default SignInPage;
       ```
     </CodeBlockTabs>
@@ -92,61 +92,43 @@ Below is basic implementation of the `<SignIn />` component. You can use this as
 
     <InjectKeys>
 
-    <CodeBlockTabs type="npm-script" options={['NPM Module', 'window.Clerk']}>
-      ```typescript
+    <CodeBlockTabs type="npm-script" options={['NPM module', '<script>']}>
+      ```js filename="index.js" {14}
       import Clerk from '@clerk/clerk-js';
-      import { dark } from "@clerk/themes";
-
-      // Add a <div> element with id="sign-in" to your HTML
-      document.querySelector<HTMLDivElement>('#app')!.innerHTML = `
-        <div
-          id="sign-in"
-        >
-        </div>
-      `;
-
-      const signInComponent = document.querySelector<HTMLDivElement>('#sign-in')!;
 
       // Initialize Clerk with your Clerk publishable key
-      const clerk = new Clerk(`{{pub_key}}`);
+      const clerk = new Clerk('{{pub_key}}');
       await clerk.load();
 
-      clerk.mountSignIn(signInComponent, {
-        appearance: {
-          baseTheme: dark
-        }
-      });
+      document.getElementById("app").innerHTML = `
+        <div id="sign-in"></div>
+      `;
+
+      const signInDiv =
+        document.getElementById("sign-in");
+
+      clerk.mountSignIn(signInDiv);
       ```
 
-      ```html
-      <!-- Add a <div> element with id="sign-in" to your HTML -->
+      ```html filename="index.html" {10}
+      <!-- Add a <div id="sign-in"> element to your HTML -->
       <div id="sign-in"></div>
 
       <script>
-        const script = document.createElement('script');
-        // Set your Clerk publishable key
-        script.setAttribute('data-clerk-publishable-key', `{{pub_key}}`);
-        script.async = true;
-        script.src = `https://[your-domain].clerk.accounts.dev/npm/@clerk/clerk-js@latest/dist/clerk.browser.js`;
+        window.addEventListener("load", async function () {
+          await Clerk.load();
 
-        script.addEventListener('load', async function () {
-          await window.Clerk.load();
+          const signInDiv =
+            document.getElementById('sign-in');
 
-          const signInComponent = document.querySelector('#sign-in');
-
-          window.Clerk.openSignIn(signInComponent, {
-            appearance: {
-              baseTheme: dark
-            }
-          });
+          Clerk.mountSignIn(signInDiv);
         });
-        document.body.appendChild(script);
       </script>
       ```
     </CodeBlockTabs>
 
     </InjectKeys>
-  </Tab>  
+  </Tab>
 </Tabs>
 
 ## Properties
@@ -170,4 +152,3 @@ To learn about how to customize Clerk components, see the [customization documen
 
 [components-ref]: /docs/components/overview
 [ap-ref]: /docs/account-portal/overview
-

--- a/docs/components/authentication/sign-up.mdx
+++ b/docs/components/authentication/sign-up.mdx
@@ -85,12 +85,48 @@ Below is basic implementation of the `<SignUp />` component. You can use this as
   </Tab>
 
   <Tab>
-    ```js filename="sign-up.js"
-    window.Clerk.mountSignUp(
-      document.getElementById("sign-up")
-    );
-    window.Clerk.openSignUp();
-    ```
+    In the example below, the [`mountSignUp()`](/docs/references/javascript/clerk/sign-up#mount-sign-up) method is used to render the `<SignUp />` component to a `<div>` element with `id="sign-up"`.
+
+    To learn more about the methods available for rendering and controlling the `<SignUp />` component in a JavaScript application, see the [JavaScript reference docs](/docs/references/javascript/clerk/sign-up).
+
+    <InjectKeys>
+
+    <CodeBlockTabs type="npm-script" options={['NPM module', '<script>']}>
+      ```typescript filename="index.ts" {14}
+      import Clerk from '@clerk/clerk-js';
+
+      // Initialize Clerk with your Clerk publishable key
+      const clerk = new Clerk('{{pub_key}}');
+      await clerk.load();
+
+      document.getElementById("app").innerHTML = `
+        <div id="sign-up"></div>
+      `;
+
+      const signUpDiv =
+        document.getElementById("sign-up");
+
+      clerk.mountSignUp(signUpDiv);
+      ```
+
+      ```html filename="index.js" {11}
+      <!-- Add a <div id="sign-up"> element to your HTML -->
+      <div id="sign-up"></div>
+
+      <script>
+        window.addEventListener("load", async function () {
+          await Clerk.load();
+
+          const signUpDiv =
+            document.getElementById('sign-up');
+
+          Clerk.mountSignUp(signUpDiv);
+        });
+      </script>
+      ```
+    </CodeBlockTabs>
+
+    </InjectKeys>
   </Tab>
 </Tabs>
 

--- a/docs/quickstarts/javascript.mdx
+++ b/docs/quickstarts/javascript.mdx
@@ -36,7 +36,7 @@ To add the [ClerkJS SDK](/docs/references/javascript/overview) to your JavaScrip
 
 Select your preferred method below to get started.
 
-<Tabs items={["NPM module", "<script>"]}>
+<Tabs type="npm-script" items={["NPM module", "<script>"]}>
   {/* NPM module tab */}
   <Tab>
     <Steps>

--- a/docs/references/javascript/clerk/sign-in.mdx
+++ b/docs/references/javascript/clerk/sign-in.mdx
@@ -37,52 +37,37 @@ In the example below, the `<SignIn />` component is rendered to a `<div>` elemen
 
 <InjectKeys>
 
-<CodeBlockTabs type="npm-script" options={['NPM Module', 'window.Clerk']}>
-  ```ts filename="index.ts" {17}
+<CodeBlockTabs type="npm-script" options={['NPM module', '<script>']}>
+  ```js filename="index.js" {14}
   import Clerk from '@clerk/clerk-js';
 
-  // Selects for <div id="app"> and adds a <div id="sign-in"> to it
-  document.querySelector<HTMLDivElement>('#app')!.innerHTML = `
-    <div
-      id="sign-in"
-    >
-    </div>
-  `;
-
-  const signInComponent = document.querySelector<HTMLDivElement>('#sign-in')!;
-
   // Initialize Clerk with your Clerk publishable key
-  const clerk = new Clerk(`{{pub_key}}`);
+  const clerk = new Clerk('{{pub_key}}');
   await clerk.load();
 
-  clerk.mountSignIn(signInComponent, {});
+  document.getElementById("app").innerHTML = `
+    <div id="sign-in"></div>
+  `;
+
+  const signInDiv =
+    document.getElementById("sign-in");
+
+  clerk.mountSignIn(signInDiv);
   ```
 
-  ```html filename="index.html" {22}
+  ```html filename="index.html" {10}
   <!-- Add a <div id="sign-in"> element to your HTML -->
   <div id="sign-in"></div>
 
   <script>
-    // Get this URL and Publishable Key from the Clerk Dashboard
-    const clerkPublishableKey = `{{pub_key}}`;
-    const frontendApiUrl = 'https://[your-domain].clerk.accounts.dev';
-    const version = '@latest'; // Set to appropriate version
+    window.addEventListener("load", async function () {
+      await Clerk.load();
 
-    // Creates asynchronous script
-    const script = document.createElement('script');
-    script.setAttribute('data-clerk-frontend-api', frontendApiUrl);
-    script.setAttribute('data-clerk-publishable-key', clerkPublishableKey);
-    script.async = true;
-    script.src = `${frontendApiUrl}/npm/@clerk/clerk-js${version}/dist/clerk.browser.js`;
+      const signInDiv =
+        document.getElementById('sign-in');
 
-    script.addEventListener('load', async function () {
-      await window.Clerk.load();
-
-      const signInComponent = document.querySelector('#sign-in');
-
-      window.Clerk.mountSignIn(signInComponent, {});
+      Clerk.mountSignIn(signInDiv);
     });
-    document.body.appendChild(script);
   </script>
   ```
 </CodeBlockTabs>
@@ -107,56 +92,45 @@ function unmountSignIn(node: HTMLDivElement): void;
 
 <InjectKeys>
 
-<CodeBlockTabs type="npm-script" options={['NPM Module', 'window.Clerk']}>
-  ```js filename="index.ts" {19}
+<CodeBlockTabs type="npm-script" options={['NPM module', '<script>']}>
+  ```js filename="index.js" {18}
   import Clerk from '@clerk/clerk-js';
 
-  document.querySelector<HTMLDivElement>('#app')!.innerHTML = `
-    <div
-      id="sign-in"
-    ></div>
-  `
-
-  const signInComponent = document.querySelector<HTMLDivElement>('#sign-in')!;
-
   // Initialize Clerk with your Clerk publishable key
-  const clerk = new Clerk(`{{pub_key}}`);
+  const clerk = new Clerk('{{pub_key}}');
   await clerk.load();
 
-  clerk.mountSignIn(signInComponent, {});
+  document.getElementById('app').innerHTML = `
+    <div id="sign-in"></div>
+  `
+
+  const signInDiv =
+    document.getElementById('sign-in');
+
+  clerk.mountSignIn(signInDiv);
 
   // ...
 
-  clerk.unmountSignIn(signInComponent, {});
+  clerk.unmountSignIn(signInDiv);
   ```
 
-  ```html filename="index.html" {24}
+  ```html filename="index.html" {15}
+  <!-- Add a <div id="sign-in"> element to your HTML -->
   <div id="sign-in"></div>
+
   <script>
-    // Get this URL and Publishable Key from the Clerk Dashboard
-    const clerkPublishableKey = `{{pub_key}}`;
-    const frontendApiUrl = 'https://[your-domain].clerk.accounts.dev';
-    const version = '@latest'; // Set to appropriate version
+    window.addEventListener("load", async function () {
+      await Clerk.load();
 
-    // Creates asynchronous script
-    const script = document.createElement('script');
-    script.setAttribute('data-clerk-frontend-api', frontendApiUrl);
-    script.setAttribute('data-clerk-publishable-key', clerkPublishableKey);
-    script.async = true;
-    script.src = `${frontendApiUrl}/npm/@clerk/clerk-js${version}/dist/clerk.browser.js`;
+      const signInDiv =
+        document.getElementById('sign-in');
 
-    script.addEventListener('load', async function () {
-      await window.Clerk.load();
-
-      const signInComponent = document.querySelector('#sign-in');
-
-      window.Clerk.mountSignIn(signInComponent, {});
+     Clerk.mountSignIn(signInDiv);
 
       // ...
 
-      window.Clerk.unmountSignIn(signInComponent, {});
+      Clerk.unmountSignIn(signInDiv);
     });
-    document.body.appendChild(script);
   </script>
   ```
 </CodeBlockTabs>
@@ -195,37 +169,24 @@ The type of the `props` parameter in the `openSignIn()` method is defined as fol
 
 <InjectKeys>
 
-<CodeBlockTabs type="npm-script" options={['NPM Module', 'window.Clerk']}>
-  ```js filename="index.ts" {7}
+<CodeBlockTabs type="npm-script" options={['NPM module', '<script>']}>
+  ```js filename="index.js" {7}
   import Clerk from '@clerk/clerk-js';
 
   // Initialize Clerk with your Clerk publishable key
-  const clerk = new Clerk(`{{pub_key}}`);
+  const clerk = new Clerk('{{pub_key}}');
   await clerk.load();
 
   clerk.openSignIn();
   ```
 
-  ```html filename="index.html" {17}
+  ```html filename="index.html" {5}
   <script>
-    // Get this URL and Publishable Key from the Clerk Dashboard
-    const clerkPublishableKey = `{{pub_key}}`;
-    const frontendApiUrl = 'https://[your-domain].clerk.accounts.dev';
-    const version = '@latest'; // Set to appropriate version
+    window.addEventListener("load", async function () {
+      await Clerk.load();
 
-    // Creates asynchronous script
-    const script = document.createElement('script');
-    script.setAttribute('data-clerk-frontend-api', frontendApiUrl);
-    script.setAttribute('data-clerk-publishable-key', clerkPublishableKey);
-    script.async = true;
-    script.src = `${frontendApiUrl}/npm/@clerk/clerk-js${version}/dist/clerk.browser.js`;
-
-    script.addEventListener('load', async function () {
-      await window.Clerk.load();
-
-      window.Clerk.openSignIn();
+      Clerk.openSignIn();
     });
-    document.body.appendChild(script);
   </script>
   ```
 </CodeBlockTabs>
@@ -244,10 +205,9 @@ function closeSignIn(): void;
 
 <InjectKeys>
 
-<CodeBlockTabs type="npm-script" options={['NPM Module', 'window.Clerk']}>
-  ```js filename="index.ts" {12}
+<CodeBlockTabs type="npm-script" options={['NPM module', '<script>']}>
+  ```js filename="index.js" {11}
   import Clerk from '@clerk/clerk-js';
-  import { dark } from "@clerk/themes";
 
   // Initialize Clerk with your Clerk publishable key
   const clerk = new Clerk('{{pub_key}}');
@@ -260,30 +220,17 @@ function closeSignIn(): void;
   clerk.closeSignIn();
   ```
 
-  ```html filename="index.html" {21}
+  ```html filename="index.html" {8}
   <script>
-    // Get your Publishable Key and Frontend API URL from the Clerk Dashboard
-    const clerkPublishableKey = '{{pub_key}}';
-    const frontendApiUrl = 'https://[your-domain].clerk.accounts.dev';
-    const version = '@latest'; // Set to appropriate version
+    window.addEventListener("load", async function () {
+      await Clerk.load();
 
-    // Creates asynchronous script
-    const script = document.createElement('script');
-    script.setAttribute('data-clerk-frontend-api', frontendApiUrl);
-    script.setAttribute('data-clerk-publishable-key', clerkPublishableKey);
-    script.async = true;
-    script.src = `${frontendApiUrl}/npm/@clerk/clerk-js${version}/dist/clerk.browser.js`;
-
-    script.addEventListener('load', async function () {
-      await window.Clerk.load();
-
-      window.Clerk.openSignIn();
+      Clerk.openSignIn();
 
       // ...
 
-      window.Clerk.closeSignIn();
+      Clerk.closeSignIn();
     });
-    document.body.appendChild(script);
   </script>
   ```
 </CodeBlockTabs>

--- a/docs/references/javascript/clerk/sign-up.mdx
+++ b/docs/references/javascript/clerk/sign-up.mdx
@@ -49,51 +49,37 @@ The type of the `props` parameter in the `mountSignUp()` function is defined as 
 
 <InjectKeys>
 
-<CodeBlockTabs type="npm-script" options={['NPM Module', 'window.Clerk']}>
-  ```typescript filename="index.ts" {17}
+<CodeBlockTabs type="npm-script" options={['NPM module', '<script>']}>
+  ```typescript filename="index.ts" {14}
   import Clerk from '@clerk/clerk-js';
-  import { dark } from "@clerk/themes";
-
-  // Selects for <div id="app"> and adds a <div id="sign-up"> to it
-  document.querySelector<HTMLDivElement>('#app')!.innerHTML = `
-    <div
-      id="sign-up"
-    ></div>
-  `;
-
-  const signUpComponent = document.querySelector<HTMLDivElement>('#sign-up')!;
 
   // Initialize Clerk with your Clerk publishable key
-  const clerk = new Clerk(`{{pub_key}}`);
+  const clerk = new Clerk('{{pub_key}}');
   await clerk.load();
 
-  clerk.mountSignUp(signUpComponent, {});
+  document.getElementById("app").innerHTML = `
+    <div id="sign-up"></div>
+  `;
+
+  const signUpDiv =
+    document.getElementById("sign-up");
+
+  clerk.mountSignUp(signUpDiv);
   ```
 
-  ```html filename="index.js" {21}
+  ```html filename="index.js" {11}
   <!-- Add a <div id="sign-up"> element to your HTML -->
   <div id="sign-up"></div>
+
   <script>
-    // Get this URL and Publishable Key from the Clerk Dashboard
-    const clerkPublishableKey = `{{pub_key}}`;
-    const frontendApiUrl = 'https://[your-domain].clerk.accounts.dev';
-    const version = '@latest'; // Set to appropriate version
+    window.addEventListener("load", async function () {
+      await Clerk.load();
 
-    // Creates asynchronous script
-    const script = document.createElement('script');
-    script.setAttribute('data-clerk-frontend-api', frontendApiUrl);
-    script.setAttribute('data-clerk-publishable-key', clerkPublishableKey);
-    script.async = true;
-    script.src = `${frontendApiUrl}/npm/@clerk/clerk-js${version}/dist/clerk.browser.js`;
+      const signUpDiv =
+        document.getElementById('sign-up');
 
-    script.addEventListener('load', async function () {
-      await window.Clerk.load();
-
-      const signUpComponent = document.querySelector('#sign-up');
-
-      window.Clerk.mountSignUp(signUpComponent, {});
+      Clerk.mountSignUp(signUpDiv);
     });
-    document.body.appendChild(script);
   </script>
   ```
 </CodeBlockTabs>
@@ -118,58 +104,45 @@ function unmountSignUp(node: HTMLDivElement): void;
 
 <InjectKeys>
 
-<CodeBlockTabs type="npm-script" options={['NPM Module', 'window.Clerk']}>
-  ```typescript filename="index.ts" {20}
+<CodeBlockTabs type="npm-script" options={['NPM module', '<script>']}>
+  ```typescript filename="index.ts" {18}
   import Clerk from '@clerk/clerk-js';
 
-  // Selects for <div id="app"> and adds a <div id="sign-up"> to it
-  document.querySelector<HTMLDivElement>('#app')!.innerHTML = `
-    <div
-      id="sign-up"
-    ></div>
-  `
-
-  const signUpComponent = document.querySelector<HTMLDivElement>('#sign-up')!;
-
   // Initialize Clerk with your Clerk publishable key
-  const clerk = new Clerk(`{{pub_key}}`);
+  const clerk = new Clerk('{{pub_key}}');
   await clerk.load();
 
-  clerk.mountSignUp(signUpComponent);
+  document.getElementById("app").innerHTML = `
+    <div id="sign-up"></div>
+  `;
+
+  const signUpDiv =
+    document.getElementById("sign-up");
+
+  clerk.mountSignUp(signUpDiv);
 
   // ...
 
-  clerk.unmountSignUp(signUpComponent);
+  clerk.unmountSignUp(signUpDiv);
   ```
 
-  ```html filename="index.js" {25}
+  ```html filename="index.js" {15}
   <!-- Add a <div id="sign-up"> element to your HTML -->
   <div id="sign-up"></div>
+
   <script>
-    // Get this URL and Publishable Key from the Clerk Dashboard
-    const clerkPublishableKey = `{{pub_key}}`;
-    const frontendApiUrl = 'https://[your-domain].clerk.accounts.dev';
-    const version = '@latest'; // Set to appropriate version
+    window.addEventListener("load", async function () {
+      await Clerk.load();
 
-    // Creates asynchronous script
-    const script = document.createElement('script');
-    script.setAttribute('data-clerk-frontend-api', frontendApiUrl);
-    script.setAttribute('data-clerk-publishable-key', clerkPublishableKey);
-    script.async = true;
-    script.src = `${frontendApiUrl}/npm/@clerk/clerk-js${version}/dist/clerk.browser.js`;
+      const signUpDiv =
+        document.getElementById('sign-up');
 
-    script.addEventListener('load', async function () {
-      await window.Clerk.load();
-
-      const signUpComponent = document.querySelector('#sign-up');
-
-      window.Clerk.mountSignUp(signUpComponent);
+      Clerk.mountSignUp(signUpDiv);
 
       // ...
 
-      window.Clerk.unmountSignUp(signUpComponent);
+      Clerk.unmountSignUp(signUpDiv);
     });
-    document.body.appendChild(script);
   </script>
   ```
 </CodeBlockTabs>
@@ -194,37 +167,24 @@ function openSignUp(props?: SignUpProps): void;
 
 <InjectKeys>
 
-<CodeBlockTabs type="npm-script" options={['NPM Module', 'window.Clerk']}>
+<CodeBlockTabs type="npm-script" options={['NPM module', '<script>']}>
   ```js filename="index.ts" {7}
   import Clerk from '@clerk/clerk-js';
 
   // Initialize Clerk with your Clerk publishable key
-  const clerk = new Clerk(`{{pub_key}}`);
+  const clerk = new Clerk('{{pub_key}}');
   await clerk.load();
 
   clerk.openSignUp();
   ```
 
-  ```html filename="index.html" {17}
+  ```html filename="index.html" {4}
   <script>
-    // Get this URL and Publishable Key from the Clerk Dashboard
-    const clerkPublishableKey = `{{pub_key}}`;
-    const frontendApiUrl = 'https://[your-domain].clerk.accounts.dev';
-    const version = '@latest'; // Set to appropriate version
+    window.addEventListener("load", async function () {
+      await Clerk.load();
 
-    // Creates asynchronous script
-    const script = document.createElement('script');
-    script.setAttribute('data-clerk-frontend-api', frontendApiUrl);
-    script.setAttribute('data-clerk-publishable-key', clerkPublishableKey);
-    script.async = true;
-    script.src = `${frontendApiUrl}/npm/@clerk/clerk-js${version}/dist/clerk.browser.js`;
-
-    script.addEventListener('load', async function () {
-      await window.Clerk.load();
-
-      window.Clerk.openSignUp();
+      Clerk.openSignUp();
     });
-    document.body.appendChild(script);
   </script>
   ```
 </CodeBlockTabs>
@@ -243,10 +203,9 @@ function closeSignUp(): void;
 
 <InjectKeys>
 
-<CodeBlockTabs type="npm-script" options={['NPM Module', 'window.Clerk']}>
-  ```typescript filename="index.ts" {12}
+<CodeBlockTabs type="npm-script" options={['NPM module', '<script>']}>
+  ```js filename="index.ts" {11}
   import Clerk from '@clerk/clerk-js';
-  import { dark } from "@clerk/themes";
 
   // Initialize Clerk with your Clerk publishable key
   const clerk = new Clerk('{{pub_key}}');
@@ -259,30 +218,17 @@ function closeSignUp(): void;
   clerk.closeSignUp();
   ```
 
-  ```html filename="index.js" {21}
+  ```html filename="index.html" {8}
   <script>
-    // Get your Publishable Key and Frontend API URL from the Clerk Dashboard
-    const clerkPublishableKey = '{{pub_key}}';
-    const frontendApiUrl = 'https://[your-domain].clerk.accounts.dev';
-    const version = '@latest'; // Set to appropriate version
+    window.addEventListener("load", async function () {
+      await Clerk.load();
 
-    // Creates asynchronous script
-    const script = document.createElement('script');
-    script.setAttribute('data-clerk-frontend-api', frontendApiUrl);
-    script.setAttribute('data-clerk-publishable-key', clerkPublishableKey);
-    script.async = true;
-    script.src = `${frontendApiUrl}/npm/@clerk/clerk-js${version}/dist/clerk.browser.js`;
-
-    script.addEventListener('load', async function () {
-      await window.Clerk.load();
-
-      window.Clerk.openSignUp();
+      Clerk.openSignUp();
 
       // ...
 
-      window.Clerk.closeSignUp();
+      Clerk.closeSignUp();
     });
-    document.body.appendChild(script);
   </script>
   ```
 </CodeBlockTabs>


### PR DESCRIPTION
Part of the JavaScript revamp project: JS Quickstart recently got updated with how users can use JS: npm module vs script tag. Examples need to be updated accordingly. Also, we have a lot of user feedback requesting that JavaScript docs show specific examples on how to use each method on a class, etc.