### PR TITLE
fix: Typo in User metadata

### DIFF
--- a/docs/users/metadata.mdx
+++ b/docs/users/metadata.mdx
@@ -447,8 +447,7 @@ The "unsafe" custom attributes can be set upon sign-up when creating or updating
 
     export default function UnSafePage() {
       const { user } = useUser();
-      const [birthday, setBirthday] = ""
-
+      const [birthday, setBirthday] = useState("");
 
       return(
         <div>
@@ -471,8 +470,7 @@ The "unsafe" custom attributes can be set upon sign-up when creating or updating
 
     export default function UnSafePage() {
       const { user } = useUser();
-      const [birthday, setBirthday] = ""
-
+      const [birthday, setBirthday] = useState("")
 
       return(
         <div>
@@ -498,7 +496,7 @@ The "unsafe" custom attributes can be set upon sign-up when creating or updating
 
   export default function UnSafePage() {
     const { user } = useUser();
-    const [birthday, setBirthday] = ""
+    const [birthday, setBirthday] = useState("")
 
     return(
       <div>
@@ -523,7 +521,8 @@ The "unsafe" custom attributes can be set upon sign-up when creating or updating
 
   export default function UnSafePage() {
     const { user } = useUser();
-    const [birthday, setBirthday] = ""
+    const [birthday, setBirthday] = useState("")
+
     return(
       <div>
         <input type="text" value={birthday} onChange={(e) => setBirthday(e.target.value)} />
@@ -548,8 +547,7 @@ The "unsafe" custom attributes can be set upon sign-up when creating or updating
 
   export default function UnSafePage() {
     const { user } = useUser();
-    const [birthday, setBirthday] = ""
-
+    const [birthday, setBirthday] = useState("")
 
     return(
       <div>
@@ -571,21 +569,17 @@ The "unsafe" custom attributes can be set upon sign-up when creating or updating
   ```html filename="unsafe.html"
   <!DOCTYPE html>
   <html lang="en">
-
   <head>
       <meta charset="UTF-8" />
       <meta http-equiv="X-UA-Compatible" content="IE=edge" />
       <meta name="viewport" content="width=device-width, initial-scale=1.0" />
       <title>Clerk Unsafe Update</title>
   </head>
-
   <body>
       <h1>Clerk JavaScript Email + Password</h1>
-
       <div id="birthday-update">
           <input placeholder="your birthday" id="birthday" type="string"></input>
           <button onclick="updateBirthday()">Update Birthday</button>
-
       </div>
       <script>
           const updateBirthday = async () => {
@@ -601,7 +595,6 @@ The "unsafe" custom attributes can be set upon sign-up when creating or updating
       // Script to load Clerk up
       <script src="src/script.js" async crossorigin="anonymous"></script>
   </body>
-
   </html>
   ```
   </Tab>


### PR DESCRIPTION
A user reported a typo in https://twitter.com/ImLunaHey/status/1764190938421977551 - this PR fixes the missing `useState("")` calls.

I also removed some whitespace to make things more concise and the same everywhere.