### PR TITLE
DOCS-5427 fix broken authMiddleware example

### DIFF
--- a/docs/references/nextjs/auth-middleware.mdx
+++ b/docs/references/nextjs/auth-middleware.mdx
@@ -200,7 +200,7 @@ You can also use regex to match routes. The following is an example of a negativ
 import { authMiddleware } from "@clerk/nextjs";
 
 export default authMiddleware({
-  publicRoutes: ["((?!^/admin/).*)"],
+  publicRoutes: ["((?!^/admin).*)"],
 });
 
 export const config = {


### PR DESCRIPTION
[DOCS-5427 ](https://linear.app/clerk/issue/DOCS-5427/feedback-for-referencesnextjsauth-middleware) is a user feedback ticket that says:
>"You can also use regex to match routes. The following is an example of a negative assertion that makes only the /admin route protected."
>
>The example regex given does not match "/admin" exactly, only "/admin/...", meaning [site.com/admin](http://site.com/admin) is still a public route

This PR fixes the broken example ! Tested with @jescalan 