### PR TITLE
DOCS-5488 overhaul /customization/organization-profile page

### DIFF
--- a/docs/components/customization/organization-profile.mdx
+++ b/docs/components/customization/organization-profile.mdx
@@ -154,7 +154,7 @@ The following example demonstrates two ways that you can render content in the `
 </CodeBlockTabs>
 
 
-## Add a custom link to the `<OrganizationProfile />` component
+## Add a custom link to `<OrganizationProfile />`
 
 You can add external links to the `<OrganizationProfile />` navigation sidebar using the `<OrganizationSwitcher.OrganizationProfileLink />` component or the `<OrganizationProfile.Link />` component, depending on your use case.
 

--- a/docs/components/customization/organization-profile.mdx
+++ b/docs/components/customization/organization-profile.mdx
@@ -1,197 +1,166 @@
 ---
-title: <OrganizationProfile /> customization
+title: Add custom pages and links to the <OrganizationProfile /> component
 description: Learn how to add custom pages and include external links within the navigation sidebar of the <OrganizationProfile /> component.
 ---
 
 # `<OrganizationProfile />` customization
 
-The [`<OrganizationProfile />`][orgprofile-ref] component supports the addition of custom pages and use of external links in the navigation sidebar. 
+The [`<OrganizationProfile />`](/docs/components/organization/organization-profile) component supports the addition of custom pages and use of external links in the navigation sidebar.
 
-## `<OrganizationProfile.Page />`
+There are two ways to render the `<OrganizationProfile />` component:
+- As a modal
+- As a dedicated page
 
-Custom pages can be rendered inside the [`<OrganizationProfile />`][orgprofile-ref] component and provide a way to incorporate app-specific settings or additional functionality.
+Both can be accessed when the user selects the [`<OrganizationSwitcher />`](/docs/components/organization/organization-switcher), and then selects the **Manage Organization** option.
 
-To add a custom page to the [`<OrganizationProfile />`][orgprofile-ref] component, use the `<OrganizationProfile.Page />` component.
+This guide includes examples for both use cases. You can select one of the following two tabs on the code examples to see the implementation for your preferred use case:
 
-### Usage
+- `<OrganizationSwitcher />` tab: By default, the `<OrganizationSwitcher />` sets `organizationProfileMode='modal'`. If you are using the default settings, then you should select this tab.
+- `Dedicated page` tab: If you do not want the `<OrganizationProfile />` to open as a modal, then you should select this tab. For these examples, you need to set `organizationProfileMode='navigation'` and `organizationProfileUrl='/organization-profile'` on the `<OrganizationSwitcher />` component.
 
-<Tabs type="framework" items={["Next.js", "React", "Remix"]}>
-  <Tab>
-    `<OrganizationProfile.Page />` can be rendered **only on the client**. For Next.js applications using App Router, the `"use client";` directive must be added.
+For the sake of this guide, examples are written for Next.js App Router, but they are supported by any React meta framework, such as Remix or Gatsby.
 
-    <CodeBlockTabs type="router" options={["App Router", "Pages Router"]}>
-      ```jsx filename="/app/organization-profile/[[...organization-profile]]/page.tsx"
-      "use client";
+## Add a custom page to the `<OrganizationProfile />` component
 
-      import { OrganizationProfile } from "@clerk/nextjs";
-      import { CustomProfilePage, CustomTerms } from "../components";
-      import { CustomIcon } from "../icons";
+Custom pages can be rendered inside the `<OrganizationProfile />` component and provide a way to incorporate app-specific settings or additional functionality.
 
-      const OrganizationProfilePage = () => (
-        <OrganizationProfile path="/organization-profile" routing="path">
-          <OrganizationProfile.Page label="Custom Page" labelIcon={<CustomIcon />} url="custom-page">
-              <CustomProfilePage />
-          </OrganizationProfile.Page>
-          <OrganizationProfile.Page label="Terms" labelIcon={<CustomIcon />} url="terms">
-              <CustomTerms />
-          </OrganizationProfile.Page>
-        </OrganizationProfile>
-      );
-
-      export default OrganizationProfilePage;
-      ```
-
-      ```jsx filename="/pages/organization-profile/[[...index]].tsx"
-      import { OrganizationProfile } from "@clerk/nextjs";
-      import { CustomProfilePage, CustomTerms } from "../components";
-      import { CustomIcon } from "../icons";
-
-      const OrganizationProfilePage = () => (
-        <OrganizationProfile path="/organization-profile" routing="path">
-          <OrganizationProfile.Page label="Custom Page" labelIcon={<CustomIcon />} url="custom-page">
-              <CustomProfilePage />
-          </OrganizationProfile.Page>
-          <OrganizationProfile.Page label="Terms" labelIcon={<CustomIcon />} url="terms">
-              <CustomTerms />
-          </OrganizationProfile.Page>
-        </OrganizationProfile>
-      );
-
-      export default OrganizationProfilePage;
-      ```
-    </CodeBlockTabs>
-  </Tab>
-
-  <Tab>
-    ```jsx filename="/organization-profile.tsx"
-    import { OrganizationProfile } from "@clerk/clerk-react";
-    import { CustomProfilePage, CustomTerms } from "../components";
-    import { CustomIcon } from "../icons";
-
-    const OrganizationProfilePage = () => (
-      <OrganizationProfile path="/organization-profile" routing="path">
-        <OrganizationProfile.Page label="Custom Page" labelIcon={<CustomIcon />} url="custom-page">
-            <CustomProfilePage />
-        </OrganizationProfile.Page>
-        <OrganizationProfile.Page label="Terms" labelIcon={<CustomIcon />} url="terms">
-            <CustomTerms />
-        </OrganizationProfile.Page>
-      </OrganizationProfile>
-    );
-
-    export default OrganizationProfilePage;
-    ```
-  </Tab>
-
-  <Tab>
-    ```tsx filename="routes/organization/$.tsx"
-    import { OrganizationProfile } from "@clerk/remix";
-    import { CustomProfilePage, CustomTerms } from "../components";
-    import { CustomIcon } from "../icons";
-
-    export default function OrganizationProfilePage() {
-    return (
-      <OrganizationProfile path="/organization-profile" routing="path">
-        <OrganizationProfile.Page label="Custom Page" labelIcon={<CustomIcon />} url="custom-page">
-            <CustomProfilePage />
-        </OrganizationProfile.Page>
-        <OrganizationProfile.Page label="Terms" labelIcon={<CustomIcon />} url="terms">
-            <CustomTerms />
-        </OrganizationProfile.Page>
-      </OrganizationProfile>
-    );
-    }
-    ```
-  </Tab>
-</Tabs>
+To add a custom page to the `<OrganizationProfile />` component, use the `<OrganizationSwitcher.OrganizationProfilePage />` component or the `<OrganizationProfile.Page />` component, depending on your use case.
 
 ### Props
 
-All props below are required.
+`<OrganizationSwitcher.OrganizationProfilePage />` and `<OrganizationProfile.Page />` accept the following props, all of which are *required*:
 
 | Name | Type | Description |
 | --- | --- | --- |
 | `label` | `string` | The name that will be displayed in the navigation sidebar for the custom page. |
 | `labelIcon` | `React.ReactElement` | An icon displayed next to the label in the navigation sidebar. |
-| `url` | `string` | The path segment that will be used to navigate to the custom page. (e.g. if the `OrganizationProfile` component is rendered at `/organization`, then the custom page will be accessed at `/organization/{url}` when using path routing). |
+| `url` | `string` | The path segment that will be used to navigate to the custom page. (e.g. if the `<OrganizationProfile />` component is rendered at `/organization`, then the custom page will be accessed at `/organization/{url}` when using path routing). |
 | `children` | `React.ReactElement` | The components to be rendered as content inside the custom page. |
 
-## `<OrganizationProfile.Link />`
+### Example
 
-You can add external links to the [`<OrganizationProfile />`][orgprofile-ref] navigation sidebar using the `<OrganizationProfile.Link />` component.
+The following example demonstrates two ways that you can render content in the `<OrganizationSwitcher.OrganizationProfilePage />` or `<OrganizationProfile.Page />` component: as a component or as a direct child.
 
-### Usage
+<CodeBlockTabs type="usage" options={["<OrganizationSwitcher />", "Dedicated page"]}>
+  ```tsx filename="/app/components/Header.tsx"
+  "use client";
 
-<Tabs type="framework" items={["Next.js", "React", "Remix"]}>
-  <Tab>
-    `<OrganizationProfile.Link />` can be rendered **only on the client**. For Next.js applications using App Router, the `"use client";` directive must be added.
+  import { OrganizationSwitcher } from "@clerk/nextjs";
 
-    <CodeBlockTabs type="router" options={["App Router", "Pages Router"]}>
-      ```jsx filename="/app/organization-profile/[[...organization-profile]]/page.tsx"
-      "use client";
-
-      import { OrganizationProfile } from "@clerk/nextjs";
-      import { CustomIcon } from "../icons";
-
-      const OrganizationProfilePage = () => (
-        <OrganizationProfile path="/organization-profile" routing="path">
-          <OrganizationProfile.Link label="Homepage" labelIcon={<CustomIcon />} url="/home" />
-        </OrganizationProfile>
-      );
-
-      export default OrganizationProfilePage;
-      ```
-
-      ```jsx filename="/pages/organization-profile/[[...index]].tsx"
-      import { OrganizationProfile } from "@clerk/nextjs";
-      import { CustomIcon } from "../icons";
-
-      const OrganizationProfilePage = () => (
-        <OrganizationProfile path="/organization-profile" routing="path">
-          <OrganizationProfile.Link label="Homepage" labelIcon={<CustomIcon />} url="/home" />
-        </OrganizationProfile>
-      );
-
-      export default OrganizationProfilePage;
-      ```
-    </CodeBlockTabs>
-  </Tab>
-
-  <Tab>
-    ```jsx filename="/organization-profile.tsx"
-    import { OrganizationProfile } from "@clerk/clerk-react";
-    import { CustomIcon } from "../icons";
-
-    const OrganizationProfilePage = () => (
-      <OrganizationProfile path="/organization-profile" routing="path">
-        <OrganizationProfile.Link label="Homepage" labelIcon={<CustomIcon />} url="/home" />
-      </OrganizationProfile>
-    );
-
-    export default OrganizationProfilePage;
-    ```
-  </Tab>
-
-  <Tab>
-    ```tsx filename="routes/organization/$.tsx"
-    import { OrganizationProfile } from "@clerk/remix";
-    import { CustomIcon } from "../icons";
-
-    export default function OrganizationProfilePage() {
+  const DotIcon = () => {
     return (
-      <OrganizationProfile path="/organization-profile" routing="path">
-        <OrganizationProfile.Link label="Homepage" labelIcon={<CustomIcon />} url="/home" />
-      </OrganizationProfile>
-    );
-    }
-    ```
-  </Tab>
-</Tabs>
+      <svg
+        xmlns="http://www.w3.org/2000/svg"
+        viewBox="0 0 512 512"
+        fill="currentColor"
+      >
+        <path d="M256 512A256 256 0 1 0 256 0a256 256 0 1 0 0 512z" />
+      </svg>
+    )
+  }
 
+  const CustomPage = () => {
+    return (
+      <div>
+        <h1>Custom Organization Profile Page</h1>
+        <p>This is the custom organization profile page</p>
+      </div>
+    );
+  };
+
+  const Header = () => (
+    <header>
+      <OrganizationSwitcher>
+        {/* You can pass the content as a component */}
+        <OrganizationSwitcher.OrganizationProfilePage
+          label="Custom Page"
+          url="custom"
+          labelIcon={<DotIcon />}
+        >
+          <CustomPage />
+        </OrganizationSwitcher.OrganizationProfilePage>
+
+        {/* You can also pass the content as direct children */}
+        <OrganizationSwitcher.OrganizationProfilePage
+          label="Terms"
+          labelIcon={<DotIcon />}
+          url="terms"
+        >
+          <div>
+            <h1>Custom Terms Page</h1>
+            <p>This is the custom terms page</p>
+          </div>
+        </OrganizationSwitcher.OrganizationProfilePage>
+      </OrganizationSwitcher>
+    </header>
+  );
+
+  export default Header;
+  ```
+
+  ```tsx filename="/app/organization-profile/[[...organization-profile]]/page.tsx"
+  "use client";
+
+  import { OrganizationProfile } from '@clerk/nextjs';
+
+  const DotIcon = () => {
+    return (
+      <svg
+        xmlns="http://www.w3.org/2000/svg"
+        viewBox="0 0 512 512"
+        fill="currentColor"
+      >
+        <path d="M256 512A256 256 0 1 0 256 0a256 256 0 1 0 0 512z" />
+      </svg>
+    )
+  }
+
+  const CustomPage = () => {
+    return (
+      <div>
+        <h1>Custom Organization Profile Page</h1>
+        <p>This is the custom organization profile page</p>
+      </div>
+    );
+  };
+
+  const OrganizationProfilePage = () => (
+    <OrganizationProfile path="/organization-profile" routing="path">
+      {/* You can pass the content as a component */}
+      <OrganizationProfile.Page
+        label="Custom Page"
+        labelIcon={<DotIcon />}
+        url="custom-page"
+      >
+        <CustomPage />
+      </OrganizationProfile.Page>
+
+      {/* You can also pass the content as direct children */}
+      <OrganizationProfile.Page
+        label="Terms"
+        labelIcon={<DotIcon />}
+        url="terms"
+      >
+        <div>
+          <h1>Custom Terms Page</h1>
+          <p>This is the custom terms page</p>
+        </div>
+      </OrganizationProfile.Page>
+    </OrganizationProfile>
+  );
+
+  export default OrganizationProfilePage;
+  ```
+</CodeBlockTabs>
+
+
+## Add a custom link to the `<OrganizationProfile />` component
+
+You can add external links to the `<OrganizationProfile />` navigation sidebar using the `<OrganizationSwitcher.OrganizationProfileLink />` component or the `<OrganizationProfile.Link />` component, depending on your use case.
 
 ### Props
 
-All props below are required.
+`<OrganizationSwitcher.OrganizationProfileLink />` and `<OrganizationProfile.Link />` accept the following props, all of which are *required*:
 
 | Name | Type | Description |
 | --- | --- | --- |
@@ -199,74 +168,180 @@ All props below are required.
 | `labelIcon` | `React.ReactElement` | An icon displayed next to the label in the navigation sidebar. |
 | `url` | `string` | The absolute or relative url to navigate to. |
 
+### Example
+
+The following example adds a link to the homepage in the navigation sidebar of the `<OrganizationProfile />` component.
+
+<CodeBlockTabs type="usage" options={["<OrganizationSwitcher />", "Dedicated page"]}>
+  ```tsx filename="/app/components/Header.tsx"
+  "use client";
+
+  import { OrganizationSwitcher } from "@clerk/nextjs";
+
+  const DotIcon = () => {
+    return (
+      <svg
+        xmlns="http://www.w3.org/2000/svg"
+        viewBox="0 0 512 512"
+        fill="currentColor"
+      >
+        <path d="M256 512A256 256 0 1 0 256 0a256 256 0 1 0 0 512z" />
+      </svg>
+    )
+  }
+
+  const Header = () => (
+    <header>
+      <OrganizationSwitcher>
+        <OrganizationSwitcher.OrganizationProfileLink
+          label="Homepage"
+          url="/"
+          labelIcon={<DotIcon />}
+        />
+      </OrganizationSwitcher>
+    </header>
+  );
+
+  export default Header;
+  ```
+
+  ```tsx filename="/app/organization-profile/[[...organization-profile]]/page.tsx"
+  "use client";
+
+  import { OrganizationProfile } from "@clerk/nextjs";
+
+  const DotIcon = () => {
+    return (
+      <svg
+        xmlns="http://www.w3.org/2000/svg"
+        viewBox="0 0 512 512"
+        fill="currentColor"
+      >
+        <path d="M256 512A256 256 0 1 0 256 0a256 256 0 1 0 0 512z" />
+      </svg>
+    )
+  }
+
+  const OrganizationProfilePage = () => (
+    <OrganizationProfile path="/organization-profile" routing="path">
+      <OrganizationProfile.Link
+        label="Homepage"
+        labelIcon={<DotIcon />}
+        url="/"
+      />
+    </OrganizationProfile>
+  );
+
+  export default OrganizationProfilePage;
+  ```
+</CodeBlockTabs>
 
 ## Advanced use cases
 
 ### Reordering default routes
 
-If you want to reorder the default routes (`Members` and `Settings`) in the `OrganizationProfile` navigation sidebar, you can use the `<OrganizationProfile.Page />` component with the `label` prop set to `'members'` or `'settings'`. This will target the existing default page and allow you to rearrange it.
+If you want to reorder the default routes, `Members` and `Settings`, set the `label` prop to `'members'` or `'settings'`. This will target the existing default page and allow you to rearrange it.
 
-### Usage
+Note that when reordering default routes, the first item in the navigation sidebar cannot be a `<OrganizationSwitcher.OrganizationProfileLink />` or `<OrganizationProfile.Link />` component.
 
-<Tabs type="framework" items={["Next.js", "React", "Remix"]}>
+<Tabs type="usage" items={["<OrganizationSwitcher />", "Dedicated Page"]}>
   <Tab>
-    `<OrganizationProfile.Page />` and `<OrganizationProfile.Link />` can be rendered **only on the client**.  For Next.js applications that use App Router, the `"use client";` directive needs to be used.
+    ```tsx filename="/app/components/Header.tsx"
+    "use client";
 
-    <CodeBlockTabs type="router" options={["App Router", "Pages Router"]}>
-      ```jsx filename="/app/organization-profile/[[...organization-profile]]/page.tsx"
-      "use client";
+    import { OrganizationSwitcher } from "@clerk/nextjs";
 
-      import { OrganizationProfile } from "@clerk/nextjs";
-      import { MyCustomPageContent } from "../components";
-      import { CustomIcon, Icon } from "../icons";
+    const DotIcon = () => {
+      return (
+        <svg
+          xmlns="http://www.w3.org/2000/svg"
+          viewBox="0 0 512 512"
+          fill="currentColor"
+        >
+          <path d="M256 512A256 256 0 1 0 256 0a256 256 0 1 0 0 512z" />
+        </svg>
+      )
+    }
 
-      const OrganizationProfilePage = () => (
-        <OrganizationProfile path="/organization-profile" routing="path">
-          <OrganizationProfile.Page label="Custom Page" url="custom" labelIcon={<CustomIcon />}>
-              <MyCustomPageContent />
-          </OrganizationProfile.Page>
-          <OrganizationProfile.Link label="Homepage" url="/home" labelIcon={<Icon />} />
-          <OrganizationProfile.Page label="members" />
-          <OrganizationProfile.Page label="settings" />
-        </OrganizationProfile>
+    const CustomPage = () => {
+      return (
+        <div>
+          <h1>Custom Organization Profile Page</h1>
+          <p>This is the custom organization profile page</p>
+        </div>
       );
+    };
 
-      export default OrganizationProfilePage;
-      ```
+    const Header = () => (
+      <header>
+        <OrganizationSwitcher>
+          <OrganizationSwitcher.OrganizationProfilePage
+            label="Custom Page"
+            url="custom"
+            labelIcon={<DotIcon />}
+          >
+            <CustomPage />
+          </OrganizationSwitcher.OrganizationProfilePage>
+          <OrganizationSwitcher.OrganizationProfileLink
+            label="Homepage"
+            url="/"
+            labelIcon={<DotIcon />}
+          />
+          <OrganizationSwitcher.OrganizationProfilePage label="members" />
+          <OrganizationSwitcher.OrganizationProfilePage label="settings" />
+        </OrganizationSwitcher>
+      </header>
+    );
 
-      ```jsx filename="/pages/organization-profile/[[...index]].tsx"
-      import { OrganizationProfile } from "@clerk/nextjs";
-      import { MyCustomPageContent } from "../components";
-      import { CustomIcon, Icon } from "../icons";
-
-      const OrganizationProfilePage = () => (
-        <OrganizationProfile path="/organization-profile" routing="path">
-          <OrganizationProfile.Page label="Custom Page" url="custom" labelIcon={<CustomIcon />}>
-              <MyCustomPageContent />
-          </OrganizationProfile.Page>
-          <OrganizationProfile.Link label="Homepage" url="/home" labelIcon={<Icon />} />
-          <OrganizationProfile.Page label="members" />
-          <OrganizationProfile.Page label="settings" />
-        </OrganizationProfile>
-      );
-
-      export default OrganizationProfilePage;
-      ```
-    </CodeBlockTabs>
+    export default Header;
+    ```
   </Tab>
 
   <Tab>
-    ```jsx filename="/organization-profile.tsx"
-    import { OrganizationProfile } from "@clerk/clerk-react";
-    import { MyCustomPageContent } from "../components";
-    import { CustomIcon, Icon } from "../icons";
+    The first page in the list will always be rendered under the root path defined with the `path` prop. Its `url` prop will be ignored.
+
+    In the following example, `path` is set to `/organization-profile`, so the `<CustomPage />` is rendered under the `/organization-profile` path.
+
+    ```tsx filename="/app/organization-profile/[[...organization-profile]]/page.tsx"
+    "use client";
+
+    import { OrganizationProfile } from "@clerk/nextjs";
+
+    const DotIcon = () => {
+      return (
+        <svg
+          xmlns="http://www.w3.org/2000/svg"
+          viewBox="0 0 512 512"
+          fill="currentColor"
+        >
+          <path d="M256 512A256 256 0 1 0 256 0a256 256 0 1 0 0 512z" />
+        </svg>
+      )
+    }
+
+    const CustomPage = () => {
+      return (
+        <div>
+          <h1>Custom Organization Profile Page</h1>
+          <p>This is the custom organization profile page</p>
+        </div>
+      );
+    };
 
     const OrganizationProfilePage = () => (
       <OrganizationProfile path="/organization-profile" routing="path">
-        <OrganizationProfile.Page label="Custom Page" url="custom" labelIcon={<CustomIcon />}>
-            <MyCustomPageContent />
+        <OrganizationProfile.Page
+          label="Custom Page"
+          url="custom"
+          labelIcon={<DotIcon />}
+        >
+          <CustomPage />
         </OrganizationProfile.Page>
-        <OrganizationProfile.Link label="Homepage" url="/home" labelIcon={<Icon />} />
+        <OrganizationProfile.Link
+          label="Homepage"
+          url="/"
+          labelIcon={<DotIcon />}
+        />
         <OrganizationProfile.Page label="members" />
         <OrganizationProfile.Page label="settings" />
       </OrganizationProfile>
@@ -275,142 +350,11 @@ If you want to reorder the default routes (`Members` and `Settings`) in the `Org
     export default OrganizationProfilePage;
     ```
   </Tab>
-
-  <Tab>
-    ```tsx filename="routes/organization/$.tsx"
-    import { OrganizationProfile } from "@clerk/remix";
-    import { MyCustomPageContent } from "../components";
-    import { CustomIcon, Icon } from "../icons";
-
-    export default function OrganizationProfilePage() {
-    return (
-      <OrganizationProfile path="/organization-profile" routing="path">
-        <OrganizationProfile.Page label="Custom Page" url="custom" labelIcon={<CustomIcon />}>
-            <MyCustomPageContent />
-        </OrganizationProfile.Page>
-        <OrganizationProfile.Link label="Homepage" url="/home" labelIcon={<Icon />} />
-        <OrganizationProfile.Page label="members" />
-        <OrganizationProfile.Page label="settings" />
-      </OrganizationProfile>
-    );
-    }
-    ```
-  </Tab>
 </Tabs>
 
-The above example will result in the following order:
+With the above example, the `<OrganizationProfile />` navigation sidebar will be in the following order:
 
 1. Custom Page
 2. Homepage
 3. Members
 4. Settings
-
-It's important to note that the first page in the list will be rendered under the root path `/` (its `url` will be ignored) and the Clerk pages will be rendered under the path `/organitzation-members` and `/organization-settings`. Also, the first item in the list cannot be a `<OrganizationProfile.Link />` component.
-
-### Using custom pages with the `<OrganizationSwitcher />` component
-
-If you are using the `<OrganizationSwitcher />` component with the default props (where the `OrganizationProfile` opens as a modal), then you should also be providing these custom pages as children to the component (using the `<OrganizationSwitcher.OrganizationProfilePage />` and `<OrganizationSwitcher.OrganizationProfileLink />` components respectively).
-
-### Usage
-
-<Tabs type="framework" items={["Next.js", "React", "Remix"]}>
-  <Tab>
-    `<OrganizationSwitcher.OrganizationProfilePage />` and `<OrganizationSwitcher.OrganizationProfileLink />` can be rendered **only on the client**.  For Next.js applications using App Router, the `"use client";` directive must be added.
-
-    <CodeBlockTabs type="router" options={["App Router", "Pages Router"]}>
-      ```jsx filename="/app/components/Header.tsx"
-      "use client";
-
-      import { OrganizationSwitcher } from "@clerk/nextjs";
-      import { MyCustomPageContent } from "../components";
-      import { CustomIcon, Icon } from "../icons";
-
-      const Header = () => (
-        <header>
-          <OrganizationSwitcher afterSignOutUrl='/'>
-            <OrganizationSwitcher.OrganizationProfilePage label="Custom Page" url="custom" labelIcon={<CustomIcon />}>
-                <MyCustomPageContent />
-            </OrganizationSwitcher.OrganizationProfilePage>
-            <OrganizationSwitcher.OrganizationProfileLink label="Homepage" url="/home" labelIcon={<Icon />} />
-            <OrganizationSwitcher.OrganizationProfilePage label="members" />
-            <OrganizationSwitcher.OrganizationProfilePage label="settings" />
-          </OrganizationSwitcher>
-        </header>
-      );
-
-      export default Header;
-      ```
-
-      ```jsx filename="/pages/components/Header.tsx"
-      import { OrganizationSwitcher } from "@clerk/nextjs";
-      import { MyCustomPageContent } from "../components";
-      import { CustomIcon, Icon } from "../icons";
-
-      const Header = () => (
-        <header>
-          <OrganizationSwitcher afterSignOutUrl='/'>
-            <OrganizationSwitcher.OrganizationProfilePage label="Custom Page" url="custom" labelIcon={<CustomIcon />}>
-                <MyCustomPageContent />
-            </OrganizationSwitcher.OrganizationProfilePage>
-            <OrganizationSwitcher.OrganizationProfileLink label="Homepage" url="/home" labelIcon={<Icon />} />
-            <OrganizationSwitcher.OrganizationProfilePage label="members" />
-            <OrganizationSwitcher.OrganizationProfilePage label="settings" />
-          </OrganizationSwitcher>
-        </header>
-      );
-
-      export default Header;
-      ```
-    </CodeBlockTabs>
-  </Tab>
-
-  <Tab>
-      ```jsx filename="/components/Header.tsx"
-      import { OrganizationSwitcher } from "@clerk/clerk-react";
-      import { MyCustomPageContent } from "../components";
-      import { CustomIcon, Icon } from "../icons";
-
-      const Header = () => (
-        <header>
-          <OrganizationSwitcher afterSignOutUrl='/'>
-            <OrganizationSwitcher.OrganizationProfilePage label="Custom Page" url="custom" labelIcon={<CustomIcon />}>
-                <MyCustomPageContent />
-            </OrganizationSwitcher.OrganizationProfilePage>
-            <OrganizationSwitcher.OrganizationProfileLink label="Homepage" url="/home" labelIcon={<Icon />} />
-            <OrganizationSwitcher.OrganizationProfilePage label="members" />
-            <OrganizationSwitcher.OrganizationProfilePage label="settings" />
-          </OrganizationSwitcher>
-        </header>
-      );
-
-      export default Header;
-      ```
-  </Tab>
-
-  <Tab>
-      ```tsx filename="components/Header.tsx"
-      import { OrganizationSwitcher } from "@clerk/remix";
-      import { MyCustomPageContent } from "../components";
-      import { CustomIcon, Icon } from "../icons";
-
-      export default function Header() {
-      return (
-        <header>
-          <OrganizationSwitcher afterSignOutUrl='/'>
-            <OrganizationSwitcher.OrganizationProfilePage label="Custom Page" url="custom" labelIcon={<CustomIcon />}>
-                <MyCustomPageContent />
-            </OrganizationSwitcher.OrganizationProfilePage>
-            <OrganizationSwitcher.OrganizationProfileLink label="Homepage" url="/home" labelIcon={<Icon />} />
-            <OrganizationSwitcher.OrganizationProfilePage label="members" />
-            <OrganizationSwitcher.OrganizationProfilePage label="settings" />
-          </OrganizationSwitcher>
-        </header>
-          );
-      }
-      ```
-  </Tab>
-</Tabs>
-
-This repetition of the same property can be avoided when the user is using the `organizationProfileMode='navigation'` and `organizationProfileUrl='<some url>'` props on the `<OrganizationSwitcher />` component and has implemented a dedicated page for the [`<OrganizationProfile />`][orgprofile-ref] component.
-
-[orgprofile-ref]: /docs/components/organization/organization-profile

--- a/docs/components/customization/organization-profile.mdx
+++ b/docs/components/customization/organization-profile.mdx
@@ -237,7 +237,7 @@ The following example adds a link to the homepage in the navigation sidebar of t
 </CodeBlockTabs>
 
 
-### Reordering default routes
+## Reordering default routes
 
 If you want to reorder the default routes, `Members` and `Settings`, set the `label` prop to `'members'` or `'settings'`. This will target the existing default page and allow you to rearrange it.
 

--- a/docs/components/customization/organization-profile.mdx
+++ b/docs/components/customization/organization-profile.mdx
@@ -236,7 +236,6 @@ The following example adds a link to the homepage in the navigation sidebar of t
   ```
 </CodeBlockTabs>
 
-## Advanced use cases
 
 ### Reordering default routes
 

--- a/docs/components/customization/organization-profile.mdx
+++ b/docs/components/customization/organization-profile.mdx
@@ -20,7 +20,7 @@ This guide includes examples for both use cases. You can select one of the follo
 
 For the sake of this guide, examples are written for Next.js App Router, but they are supported by any React meta framework, such as Remix or Gatsby.
 
-## Add a custom page to the `<OrganizationProfile />` component
+## Add a custom page to `<OrganizationProfile />`
 
 Custom pages can be rendered inside the `<OrganizationProfile />` component and provide a way to incorporate app-specific settings or additional functionality.
 


### PR DESCRIPTION
Recently, the /customization/user-profile docs page got a complete overhaul. Details are in this PR: https://github.com/clerk/clerk-docs/pull/751

We need to also update the /customization/organization-profile docs page for consistency!