### PR TITLE
Fix: Added missing import Statement in doc

### DIFF
--- a/docs/references/nextjs/auth-middleware.mdx
+++ b/docs/references/nextjs/auth-middleware.mdx
@@ -70,6 +70,7 @@ NEXT_PUBLIC_CLERK_AFTER_SIGN_UP_URL=/
 Some developers will need to handle specific cases such as handling redirects differently or detecting if a user is inside an organization. These cases can be handled with `afterAuth()`.
 
 ```ts filename="middleware.ts"
+import { NextResponse } from "next/server";
 import { authMiddleware, redirectToSignIn } from "@clerk/nextjs";
 
 export default authMiddleware({


### PR DESCRIPTION
This PR addresses a minor oversight in our documentation where an essential import statement was missing from one of the provided code blocks. 