### PR TITLE
Revert "use the right import for clerkClient"

### DIFF
--- a/docs/references/backend/overview.mdx
+++ b/docs/references/backend/overview.mdx
@@ -14,7 +14,7 @@ Clerk SDKs expose an instance of the Clerk Backend SDK for use in server environ
   The Backend SDK is accessible via the `clerkClient` object if you are using Next.js.
 
   ```jsx
-  import { clerkClient } from '@clerk/nextjs/server';
+  import { clerkClient } from '@clerk/nextjs';
   ```
   </Tab>
 


### PR DESCRIPTION
Reverts clerk/clerk-docs#772
This change was made to core-2 docs as it's a core-2 update. It should not be made to the core-1 docs.