### PR TITLE
Add H1s to all docs where they're missing

### DIFF
--- a/docs/authentication/social-connections/linkedin-oidc.mdx
+++ b/docs/authentication/social-connections/linkedin-oidc.mdx
@@ -3,6 +3,8 @@ title: Set up a social connection with LinkedIn OpenID Connect
 description: Learn how to set up a social connection with LinkedIn in your Clerk application.
 ---
 
+# LinkedIn OpenID Connect
+
 <TutorialHero 
   beforeYouStart={[
     {

--- a/docs/authentication/social-connections/x-twitter.mdx
+++ b/docs/authentication/social-connections/x-twitter.mdx
@@ -3,6 +3,8 @@ title: Set up a social connection with X/Twitter v2
 description: Learn how to set up a social connection with X/Twitter v2 in your Clerk application.
 ---
 
+# X (Twitter V2)
+
 <TutorialHero 
   beforeYouStart={[
     {

--- a/docs/deployments/exporting-users.mdx
+++ b/docs/deployments/exporting-users.mdx
@@ -3,9 +3,9 @@ title: Exporting Users
 description: Learn how to export user's data from your Clerk application.
 ---
 
-## Exporting your user's data from Clerk
+# Exporting your user's data from Clerk
 
-### Programmatic access to user data
+## Programmatic access to user data
 By using the [GetUserList](https://clerk.com/docs/reference/backend-api/tag/Users#operation/GetUserList) endpoint of Clerk's Backend API, you can programmatically export your user's data safely. 
 
 Additionally, the [`getUserList()`](/docs/references/backend/user/get-user-list) method in the [Clerk Backend SDK](/docs/references/backend/overview) can also be used to retrieve a list of users.

--- a/docs/deployments/exporting-users.mdx
+++ b/docs/deployments/exporting-users.mdx
@@ -3,9 +3,9 @@ title: Exporting Users
 description: Learn how to export user's data from your Clerk application.
 ---
 
-# Exporting your user's data from Clerk
+# Export your user's data from Clerk
 
-## Programmatic access to user data
+## Access user data in the backend
 By using the [GetUserList](https://clerk.com/docs/reference/backend-api/tag/Users#operation/GetUserList) endpoint of Clerk's Backend API, you can programmatically export your user's data safely. 
 
 Additionally, the [`getUserList()`](/docs/references/backend/user/get-user-list) method in the [Clerk Backend SDK](/docs/references/backend/overview) can also be used to retrieve a list of users.

--- a/docs/guides/authjs-migration.mdx
+++ b/docs/guides/authjs-migration.mdx
@@ -3,6 +3,8 @@ title: Migrate from Auth.js to Clerk
 description: Learn how to migrate an application using Auth.js to use Clerk for authentication.
 ---
 
+# Migrate from Auth.js to Clerk
+
 <TutorialHero
   framework="authjs"
   exampleRepoTitle="Migration Script Repository"

--- a/docs/guides/force-organizations.mdx
+++ b/docs/guides/force-organizations.mdx
@@ -3,6 +3,8 @@ title: Hide Personal Accounts and force organizations
 description: Learn how to hide Personal Accounts and force organizations in your Clerk application.
 ---
 
+# Hide Personal Accounts and force organizations
+
 <TutorialHero
   beforeYouStart={[
     {

--- a/docs/integrations/databases/convex.mdx
+++ b/docs/integrations/databases/convex.mdx
@@ -3,6 +3,8 @@ title: Integrate Convex with Clerk
 description: Learn how to integrate Clerk into your Convex application.
 ---
 
+# Integrate Convex with Clerk
+
 <TutorialHero
   beforeYouStart={[
     {

--- a/docs/integrations/databases/supabase.mdx
+++ b/docs/integrations/databases/supabase.mdx
@@ -3,6 +3,7 @@ title: Integrate Supabase with Clerk
 description: Learn how to integrate Clerk into your Supabase application.
 ---
 
+# Integrate Supabase with Clerk
 
 <TutorialHero
   beforeYouStart={[

--- a/docs/quickstarts/javascript.mdx
+++ b/docs/quickstarts/javascript.mdx
@@ -3,6 +3,8 @@ title: JavaScript Quickstart
 description: Add authentication and user management to your JavaScript app with Clerk.
 ---
 
+# JavaScript Quickstart
+
 <TutorialHero
   framework="javascript"
   exampleRepo={[

--- a/docs/quickstarts/nextjs.mdx
+++ b/docs/quickstarts/nextjs.mdx
@@ -3,6 +3,8 @@ title: Next.js Quickstart
 description: Add authentication and user management to your Next.js app with Clerk.
 ---
 
+# Next.js Quickstart
+
 <TutorialHero
   framework="nextjs"
   beforeYouStart={[

--- a/docs/quickstarts/react.mdx
+++ b/docs/quickstarts/react.mdx
@@ -3,6 +3,8 @@ title: React Quickstart
 description: Add authentication and user management to your React app with Clerk.
 ---
 
+# React Quickstart
+
 <TutorialHero
   framework="react"
   exampleRepo={[

--- a/docs/references/backend/invitations/get-invitation-list.mdx
+++ b/docs/references/backend/invitations/get-invitation-list.mdx
@@ -3,7 +3,7 @@ title: getInvitationList()
 description: Retrieves a list of all non-revoked invitations for your application, sorted by descending creation date.
 ---
 
-## `getInvitationList()`
+# `getInvitationList()`
 
 Retrieves a list of all non-revoked invitations for your application, sorted by descending creation date.
 

--- a/docs/references/backend/invitations/revoke-invitation.mdx
+++ b/docs/references/backend/invitations/revoke-invitation.mdx
@@ -3,7 +3,7 @@ title: revokeInvitation()
 description: Revokes the invitation with the provided `invitationId`. Throws an error if `invitationId` is invalid.
 ---
 
-## `revokeInvitation()`
+# `revokeInvitation()`
 
 Revokes the invitation with the provided `invitationId`. Throws an error if `invitationId` is invalid.
 


### PR DESCRIPTION
This is a companion to the clerk-marketing PR that adds all H1 conent to the SEO title of the page.

This needs to be approved first before merging that one. There is no risk of showing duplicate titles on these pages, as Clerk marketing already shows **either** the frontmatter title or the H1.

[Clerk Marketing PR here](https://github.com/clerk/clerk-marketing/pull/901)

## How to test

If you want to ensure this is the full list of pages with missing H1s, follow these instructions in the `clerk-marketing` repo:

**In `lib/docs/scripts/index-content.mts`**
1. Add `data` to the options on line 142, so it looks like this:
```
.use(remarkPluginExtractSearchRecords, { records, data })
```
**In `lib/docs/plugins/remark-plugin-extract-search-records.mts`**
1. Add `data` to the `RemarkPluginExtractSearchRecordsOptions` type:
```
type RemarkPluginExtractSearchRecordsOptions = {
  records: ExtractedRecord[];
  data?: {
    [key: string]: string;
  };
};
```
2. Add `data` to the options on line 43, so it looks like this:
```
> = ({ records, data }: RemarkPluginExtractSearchRecordsOptions) => {
```
3. Add the following code after line 91, outside of the `visit` method 
```
   if (data && !headings.some(h => h.level === 1)) {
      const { title } = data;
      console.log(title);
    }
``` 
In the console, run `yarn docs:index-content`. It will print a list of the pages that are missing an H1. Ignore the overview pages like "Component Reference" and "Welcome to Clerk Docs"
