### PR TITLE
DOCS-5835 add deprecated to withClerkMiddleware title for search purposes

### DIFF
--- a/docs/references/nextjs/with-clerk-middleware.mdx
+++ b/docs/references/nextjs/with-clerk-middleware.mdx
@@ -6,7 +6,7 @@ description: The withClerkMiddleware wrapper allows Clerk to access session data
 # `withClerkMiddleware()` (deprecated)
 
 <Callout type="danger">
-  `withClerkMiddleware()` was deprecated and will be removed in the next major version (Core 2). Please use [`authMiddleware()`](/docs/references/nextjs/auth-middleware) for now. Note, that `authMiddleware()` will also be removed in the next major version in favor of [`clerkMiddleware()`](https://beta.clerk.com/docs/references/nextjs/clerk-middleware).
+  `withClerkMiddleware()` was deprecated and will be removed in the next major version (Core 2). Please use [`authMiddleware()`](/docs/references/nextjs/auth-middleware) for now. Note that `authMiddleware()` will also be removed in the next major version in favor of [`clerkMiddleware()`](https://beta.clerk.com/docs/references/nextjs/clerk-middleware).
 </Callout>
 
 The `withClerkMiddleware` wrapper allows Clerk to access session data on the server side allowing you to use any of our server side helpers without any additonal network calls.

--- a/docs/references/nextjs/with-clerk-middleware.mdx
+++ b/docs/references/nextjs/with-clerk-middleware.mdx
@@ -1,12 +1,12 @@
 ---
-title: withClerkMiddleware
+title: withClerkMiddleware() (deprecated)
 description: The withClerkMiddleware wrapper allows Clerk to access session data on the server side allowing you to use any of our server side helpers without any additonal network calls.
 ---
 
-# `withClerkMiddleware()`
+# `withClerkMiddleware()` (deprecated)
 
 <Callout type="danger">
-  `withClerkMiddleware()` was deprecated and will be removed in the next major version (V5). Please use [`authMiddleware()`](/docs/references/nextjs/auth-middleware) going forward.
+  `withClerkMiddleware()` was deprecated and will be removed in the next major version (Core 2). Please use [`authMiddleware()`](/docs/references/nextjs/auth-middleware) for now. Note, that `authMiddleware()` will also be removed in the next major version in favor of [`clerkMiddleware()`](https://beta.clerk.com/docs/references/nextjs/clerk-middleware).
 </Callout>
 
 The `withClerkMiddleware` wrapper allows Clerk to access session data on the server side allowing you to use any of our server side helpers without any additonal network calls.


### PR DESCRIPTION
[DOCS-5835](https://linear.app/clerk/issue/DOCS-5835/clerkmiddleware-search-in-docs-shows-results-for-the-now-removed)