### PR TITLE
D0CS-5373 Update session-options and multi-session custom flow guides

### DIFF
--- a/docs/authentication/configuration/session-options.mdx
+++ b/docs/authentication/configuration/session-options.mdx
@@ -45,8 +45,6 @@ By default, this setting is enabled with a default value of 7 days for all newly
 
 ## Multi-session applications
 
-One of the most powerful features that Clerk provides out of the box is multi-session applications.
-
 A multi-session application is an application that allows multiple accounts to be signed in from the same browser at the same time. The user can switch from one account to another seamlessly. Each account is independent from the rest and has access to different resources.
 
 To enable multi-session in your application, you need to configure it in the Clerk Dashboard.

--- a/docs/authentication/configuration/session-options.mdx
+++ b/docs/authentication/configuration/session-options.mdx
@@ -27,20 +27,20 @@ A user is considered inactive when the application is closed, or when the app st
 
 By default, this setting is disabled for all newly created instances. To enable it and set your desired value:
 
-1. Navigate to the Clerk Dashboard.
-2. Select your application, then select **[Sessions](https://dashboard.clerk.com/last-active?path=sessions)** from the navigation sidebar.
-3. Toggle the **Inactivity timeout** switch to enable it.
+1. Navigate to the [Clerk Dashboard](https://dashboard.clerk.com/last-active?path=sessions) and select your application.
+2. In the navigation sidebar, select **Sessions**.
+3. Toggle on **Inactivity timeout**.
 4. Set your desired duration.
 
 ### Maximum lifetime
 
-Denotes the duration after which a session will expire and the user will have to sign in again, regardless of their activity on your site.
+The duration after which a session will expire and the user will have to sign in again, regardless of their activity on your site.
 
 By default, this setting is enabled with a default value of 7 days for all newly created instances. To find this setting and change the value:
 
-1. Navigate to the the Clerk Dashboard.
-2. Select your application, then select **[Sessions](https://dashboard.clerk.com/last-active?path=sessions)** from the navigation sidebar.
-3. Toggle the **Maximum lifetime** switch to enable it.
+1. Navigate to the the [Clerk Dashboard](https://dashboard.clerk.com/last-active?path=sessions) and select your application.
+2. In the navigation sidebar, select **Sessions**.
+3. Toggle on **Maximum lifetime**.
 4. Set your desired duration.
 
 ## Multi-session applications
@@ -51,8 +51,8 @@ A multi-session application is an application that allows multiple accounts to b
 
 To enable multi-session in your application, you need to configure it in the Clerk Dashboard.
 
-1. Navigate to the [Clerk Dashboard](https://dashboard.clerk.com/last-active?path=sessions)
-2. Select your application, then select **Sessions** in the navigation sidebar.
+1. Navigate to the [Clerk Dashboard](https://dashboard.clerk.com/last-active?path=sessions) and select your application.
+2. In the navigation sidebar, select **Sessions**.
 3. Toggle on **Multi-session handling**.
 4. Select **Save changes**.
 

--- a/docs/authentication/configuration/session-options.mdx
+++ b/docs/authentication/configuration/session-options.mdx
@@ -21,52 +21,45 @@ Fortunately, with Clerk you have to ability to fully control the lifetime of you
 
 ### Inactivity timeout
 
-Denotes the duration after which a session will expire and the user will have to sign in again, if they haven't been active on your site. By default, this setting is disabled for all newly created instances. To enable it and set your desired value, in the Clerk Dashboard, go to **[Sessions](https://dashboard.clerk.com/last-active?path=sessions)**.
+Denotes the duration after which a session will expire and the user will have to sign in again, if they haven't been active on your site. A user is considered inactive when the application is closed, or when the app stops refreshing the token.
 
-<Images
-width={3024}
-height={1652}
-src="/docs/images/authentication/session-options/inactivity-timeout.jpg"
-alt="The 'Sessions' configuration section in the Clerk Dashboard with a red outline around the 'Inactivity timeout' section. This option is toggled on, revealing an input for customizing the time duration until inactivity timeout. A red arrow is pointing to the 'Apply Changes' button."
-/>
+By default, this setting is disabled for all newly created instances. To enable it and set your desired value:
+
+1. Navigate to the Clerk Dashboard.
+2. Select your application, then select **[Sessions](https://dashboard.clerk.com/last-active?path=sessions)** from the navigation sidebar.
+3. Toggle the **Inactivity timeout** switch to enable it.
+4. Set your desired duration.
 
 ### Maximum lifetime
 
-Denotes the duration after which a session will expire and the user will have to sign in again, regardless of their activity on your site. By default, this setting is enabled with a default value of 7 days for all newly created instances. To find this setting and change the value, in the Clerk Dashboard, go to **[Sessions](https://dashboard.clerk.com/last-active?path=sessions)**.
+Denotes the duration after which a session will expire and the user will have to sign in again, regardless of their activity on your site.
 
-<Images
-width={3024}
-height={1652}
-src="/docs/images/authentication/session-options/maximum-lifetime.jpg"
-alt="The 'Sessions' settings in the Clerk Dashboard with a red outline around the 'Maximum lifetime' section. This option is toggled on, revealing an input for customizing duration of a session lifetime."
-/>
+By default, this setting is enabled with a default value of 7 days for all newly created instances. To find this setting and change the value:
+
+1. Navigate to the the Clerk Dashboard.
+2. Select your application, then select **[Sessions](https://dashboard.clerk.com/last-active?path=sessions)** from the navigation sidebar.
+3. Toggle the **Maximum lifetime** switch to enable it.
+4. Set your desired duration.
 
 ## Multi-session applications
 
-Multi-session applications allow users to be signed into more than one account at a time from the same browser. Users may switch the active account by opening the [`<UserButton />`](/docs/components/user/user-button) and selecting the desired account.
+One of the most powerful features that Clerk provides out of the box is multi-session applications.
 
-To enable this feature in your application, in the Clerk Dashboard, go to **[Sessions](https://dashboard.clerk.com/last-active?path=sessions)**. Turn on the **Mutli-session handling** toggle.
+A multi-session application is an application that allows multiple accounts to be signed in from the same browser at the same time. The user can switch from one account to another seamlessly. Each account is independent from the rest and has access to different resources.
 
-<Images
-width={3024}
-height={1652}
-src="/docs/images/authentication/session-options/multisession-handling.jpg"
-alt="The 'Multi-session handling' section under the 'Sessions' settings in the Clerk Dashboard. A red arrow is pointing to the 'Multi-session handling' toggle, which is toggled on, and there is also a red arrow pointing to the 'Apply Changes' button."
-/>
+To enable multi-session in your application, you need to configure it in the Clerk Dashboard.
 
-Learn more about working with multi-session applications with Clerk components and custom flows in our [detailed guide](/docs/custom-flows/multi-session-applications).
+1. Navigate to the [Clerk Dashboard](https://dashboard.clerk.com/last-active?path=sessions)
+2. Select your application, then select **Sessions** in the navigation sidebar.
+3. Toggle on **Multi-session handling**.
+4. Select **Save changes**.
+
+There are two main ways to add the multi-session feature to your application:
+- Use the [`<UserButton />`](/docs/components/user/user-button) component if you want to use Clerk's pre-built UI.
+- [Build a custom flow](/docs/custom-flows/multi-session-applications) if you want to rebuild the existing Clerk flow using the Clerk API.
 
 ## Customize session token
 
-Session tokens are JWTs that contain a set of standard claims required by Clerk, but there are times when you want to augment these tokens by providing additional claims of your own.
+Session tokens are JWTs that contain a set of [default claims](/docs/backend-requests/resources/session-tokens) required by Clerk. You can customize these tokens by providing additional claims of your own.
 
-To add custom claims to the session token, in the Clerk Dashboard, go to **[Sessions](https://dashboard.clerk.com/last-active?path=sessions)**. In the **Customize session token** section, click on the **Edit** button. This will open a modal window where you can add claims and even use our handy shortcodes.
-
-<Images
-width={3024}
-height={1652}
-src="/docs/images/authentication/session-options/customize-session-token.jpg"
-alt="The 'Customize session token' section under the 'Sessions' settings in the Clerk Dashboard. A red arrow is pointing to the 'Edit' button."
-/>
-
-To read more about the Clerk standard claims and customizing these tokens with JWT Templates, check out our [session token customization guide](/docs/backend-requests/making/custom-session-token).
+To learn how to customize session tokens, check out our [Customize your session token](/docs/backend-requests/making/custom-session-token) guide.

--- a/docs/authentication/configuration/session-options.mdx
+++ b/docs/authentication/configuration/session-options.mdx
@@ -21,7 +21,9 @@ Fortunately, with Clerk you have to ability to fully control the lifetime of you
 
 ### Inactivity timeout
 
-Denotes the duration after which a session will expire and the user will have to sign in again, if they haven't been active on your site. A user is considered inactive when the application is closed, or when the app stops refreshing the token.
+The duration after which a session will expire and the user will have to sign in again, if they haven't been active on your site.
+
+A user is considered inactive when the application is closed, or when the app stops refreshing the token.
 
 By default, this setting is disabled for all newly created instances. To enable it and set your desired value:
 

--- a/docs/custom-flows/multi-session-applications.mdx
+++ b/docs/custom-flows/multi-session-applications.mdx
@@ -1,74 +1,54 @@
 ---
 title: Multi-session applications
-description: Learn how to configure and work with multi-session applications
+description: Learn how to use the Clerk API to add multi-session handling to your application.
 ---
 
 # Multi-session applications
 
-One of the most powerful features that Clerk provides out of the box is multi-session applications.
+<Callout type="danger">
+  This guide is for users who want to build a *custom* user interface using the Clerk API. To implement multi-session handling with a *prebuilt* UI, you should use Clerk's [`<UserButton />`](/docs/components/user/user-button) component.
+</Callout>
 
 A multi-session application is an application that allows multiple accounts to be signed in from the same browser at the same time. The user can switch from one account to another seamlessly. Each account is independent from the rest and has access to different resources.
+
+This guide provides you with the necessary information to build a custom multi-session flow using Clerk's API.
+
+To implement the multi-session feature to your application, you need to handle the following scenarios:
+
+- [Switching between different accounts](#switch-between-sessions)
+- [Adding new accounts](#add-a-new-session)
+- [Signing out from one account, while remaining signed in to the rest](#sign-out-active-session)
+- [Signing out from all accounts](#sign-out-all-sessions)
 
 ## Enable multi-session in your application
 
 To enable multi-session in your application, you need to configure it in the Clerk Dashboard.
 
-- Navigate to the [Clerk Dashboard](https://dashboard.clerk.com/last-active?path=sessions)
-- Select your application, then select **Sessions** in the navigation sidebar.
-- Toggle on **Multi-session handling**.
-- Select **Save changes**.
+1. Navigate to the [Clerk Dashboard](https://dashboard.clerk.com/last-active?path=sessions)
+2. Select your application, then select **Sessions** in the navigation sidebar.
+3. Toggle on **Multi-session handling**.
+4. Select **Save changes**.
 
-## Add multi-session support to your application
-
-There are two main ways to add the multi-session feature to your application:
-- [Use Clerk components](#use-clerk-components) if you want to use Clerk's pre-built UI
-- [Build a *custom flow*](#build-a-custom-flow) if you want to rebuild the existing Clerk flow using the Clerk API.
-
-### Use Clerk components
-
-The easiest way to add the multi-session feature to your application is by using Clerk's [`<UserButton />`](/docs/components/user/user-button) component.
-
-The following image demonstrates the `<UserButton />` component with two accounts signed in. The user can switch between the two accounts, add a new account, or sign out from one or all accounts.
-
-<Images
-  width={440}
-  height={479}
-  src="/docs/images/custom-flows/user-button-multisession.jpg"
-  alt="The User Button component with multiple accounts signed in."
-/>
-
-To learn how to use the `<UserButton />` component in your application, check out the [reference documentation](/docs/components/user/user-button).
-
-### Build a custom flow
-
-If the `UserButton />` component doesn't cover your needs, you can build a custom multi-session flow using Clerk's API.
-
-To enable a multi-session instance, you need to handle the following scenarios:
-
-- Switching between different accounts
-- Adding new accounts
-- Signing out from one account, while remaining signed in to the rest
-
-### Get the active session and user
+## Get the active session and user
 
 <CodeBlockTabs type="framework" options={["React", "JavaScript"]}>
 ```jsx
 import { useClerk } from "@clerk/clerk-react";
 
-// Getting the active session and user
-const { session: activeSession, user: activeUser } = useClerk();
+// Retrieve the active session and user
+const { session, user } = useClerk();
 ```
 
 ```js
-// Getting the active session
+// Retrieve the active session
 const activeSession = window.Clerk.session;
 
-// Getting the active user
+// Retrieve the active user
 const activeUser = window.Clerk.user;
 ```
 </CodeBlockTabs>
 
-### Switch between sessions
+## Switch between sessions
 
 <CodeBlockTabs type="framework" options={["React", "JavaScript"]}>
 ```jsx
@@ -92,7 +72,7 @@ window.Clerk.setActive({ session: availableSessions[0].id });
 ```
 </CodeBlockTabs>
 
-### Add a new session
+## Add a new session
 
 To add a new session, simply link to your existing sign-in flow. New sign-ins will automatically add to the list of available sessions on the client. To create a sign-in flow, please check one of the following popular guides:
 
@@ -102,35 +82,15 @@ To add a new session, simply link to your existing sign-in flow. New sign-ins wi
 
 For more information on how Clerk's sign-in flow works, check out the [detailed sign-in guide](/docs/custom-flows/overview#sign-in-flow).
 
-### Sign out active session
+## Sign out all sessions
 
-This version of sign out will deactivate the active session. The rest of the available sessions will remain intact.
-
-<CodeBlockTabs type="framework" options={["React", "JavaScript"]}>
-```jsx
-import { useClerk } from "@clerk/clerk-react";
-
-const { signOutOne } = useClerk();
-
-// Use signOutOne to sign-out only from the active session.
-await signOutOne();
-```
-
-```js
-// Use signOutOne to sign-out only from the active session.
-await window.Clerk.signOutOne();
-```
-</CodeBlockTabs>
-
-### Sign out all sessions
-
-This request will deactivate all sessions on the current client.
+Use the [`signOut()`](/docs/references/javascript/clerk/clerk#sign-out) method to deactivate all sessions on the current client.
 
 <CodeBlockTabs type="framework" options={["React", "JavaScript"]}>
 ```jsx
 import { useClerk } from "@clerk/clerk-react";
 
-const { signOut } = useClerk();
+const { signOut, session } = useClerk();
 
 // Use signOut to sign-out all active sessions.
 await signOut();
@@ -139,5 +99,29 @@ await signOut();
 ```js
 // Use signOut to sign-out all active sessions.
 await window.Clerk.signOut();
+```
+</CodeBlockTabs>
+
+## Sign out active session
+
+Use the [`signOut()`](/docs/references/javascript/clerk/clerk#sign-out) method to deactivate a specific session by passing the session ID.
+
+<CodeBlockTabs type="framework" options={["React", "JavaScript"]}>
+```jsx
+import { useClerk } from "@clerk/clerk-react";
+
+// Retrieve the signOut method and the active session
+const { signOut, session } = useClerk();
+
+// Use signOut to sign-out the active session
+await signOut(session.id);
+```
+
+```js
+// Retrieve the active session
+const activeSession = window.Clerk.session;
+
+// Use signOut to sign-out the active session
+await window.Clerk.signOut(activeSession.id);
 ```
 </CodeBlockTabs>

--- a/docs/custom-flows/multi-session-applications.mdx
+++ b/docs/custom-flows/multi-session-applications.mdx
@@ -35,15 +35,15 @@ To enable multi-session in your application, you need to configure it in the Cle
 ```jsx
 import { useClerk } from "@clerk/clerk-react";
 
-// Retrieve the active session and user
+// Get the active session and user
 const { session, user } = useClerk();
 ```
 
 ```js
-// Retrieve the active session
+// Get the active session
 const activeSession = window.Clerk.session;
 
-// Retrieve the active user
+// Get the active user
 const activeUser = window.Clerk.user;
 ```
 </CodeBlockTabs>
@@ -56,7 +56,7 @@ import { useClerk } from "@clerk/clerk-react";
 
 const { client, setActive } = useClerk();
 
-// You can retrieve all the available sessions through the client
+// You can get all the available sessions through the client
 const availableSessions = client.sessions;
 
 // Use setActive to set the active session.
@@ -64,7 +64,7 @@ setActive({ session: availableSessions[0].id });
 ```
 
 ```js
-// You can retrieve all the available sessions through the client
+// You can get all the available sessions through the client
 const availableSessions = window.Clerk.client.sessions;
 
 // Use setActive to set the active session.
@@ -84,7 +84,7 @@ For more information on how Clerk's sign-in flow works, check out the [detailed 
 
 ## Sign out all sessions
 
-Use the [`signOut()`](/docs/references/javascript/clerk/clerk#sign-out) method to deactivate all sessions on the current client.
+Use [`signOut()`](/docs/references/javascript/clerk/clerk#sign-out) to deactivate all sessions on the current client.
 
 <CodeBlockTabs type="framework" options={["React", "JavaScript"]}>
 ```jsx
@@ -104,13 +104,13 @@ await window.Clerk.signOut();
 
 ## Sign out active session
 
-Use the [`signOut()`](/docs/references/javascript/clerk/clerk#sign-out) method to deactivate a specific session by passing the session ID.
+Use [`signOut()`](/docs/references/javascript/clerk/clerk#sign-out) to deactivate a specific session by passing the session ID.
 
 <CodeBlockTabs type="framework" options={["React", "JavaScript"]}>
 ```jsx
 import { useClerk } from "@clerk/clerk-react";
 
-// Retrieve the signOut method and the active session
+// Get the signOut method and the active session
 const { signOut, session } = useClerk();
 
 // Use signOut to sign-out the active session
@@ -118,7 +118,7 @@ await signOut(session.id);
 ```
 
 ```js
-// Retrieve the active session
+// Get the active session
 const activeSession = window.Clerk.session;
 
 // Use signOut to sign-out the active session

--- a/docs/custom-flows/multi-session-applications.mdx
+++ b/docs/custom-flows/multi-session-applications.mdx
@@ -1,11 +1,11 @@
 ---
-title: Multi-session applications
+title: Build a custom multi-session flow
 description: Learn how to use the Clerk API to add multi-session handling to your application.
 ---
 
-# Multi-session applications
+# Build a custom multi-session flow
 
-<Callout type="danger">
+<Callout type="warning">
   This guide is for users who want to build a *custom* user interface using the Clerk API. To implement multi-session handling with a *prebuilt* UI, you should use Clerk's [`<UserButton />`](/docs/components/user/user-button) component.
 </Callout>
 

--- a/docs/manifest.json
+++ b/docs/manifest.json
@@ -149,7 +149,7 @@
       ["Same-Origin Requests", "/backend-requests/making/same-origin"],
       ["Cross-Origin Requests", "/backend-requests/making/cross-origin"],
       [
-        "Session token customization",
+        "Customize your session token",
         "/backend-requests/making/custom-session-token"
       ],
       ["JWT Templates", "/backend-requests/making/jwt-templates"],


### PR DESCRIPTION
[DOCS-5373](https://linear.app/clerk/issue/DOCS-5373/update-copy-that-explains-inactivity-timeout) calls to "Update copy that explains Inactivity Timeout"

While updating the copy, I went ahead and updated the entire page as it needed.
- Removed unnecessary screenshots
- Removed redundant information like the "customize session token" section - we have a whole guide for this
- Removed redundancy from the multi-session application section and the multi-session custom flow guide, resulting in an update of the custom flow guide as there was some outdated information
- Updates the "Customize your session token" guide's name in the nav to match the page's title (they weren't consistent)