### PR TITLE
Remove non-existent property from SignOutButton (redirectUrl)

### DIFF
--- a/docs/components/unstyled/sign-out-button.mdx
+++ b/docs/components/unstyled/sign-out-button.mdx
@@ -22,7 +22,6 @@ The type of the `signOutOptions` prop for the `<SignOutButton>` component is def
 | Name | Type | Description |
 | --- | --- | --- |
 | `sessionId?` | `string` | The ID of a specific session to sign out of. Useful for multi-session applications. |
-| `redirectUrl? ` | `string` | Full URL or path to navigate to after signing out. |
 
 ## How to use the `<SignOutButton>` component
 


### PR DESCRIPTION
Documentation implies that this: `<SignOutButton signOutOptions={{ redirectUrl: "/"}}>` works. It does not.