### PR TITLE
fix: Fix typo in Sign-up and sign-in options URL

### DIFF
--- a/docs/manifest.json
+++ b/docs/manifest.json
@@ -46,7 +46,7 @@
     [
       ["Overview", "/authentication/overview"],
       "# Configuration",
-      ["Sign-up and sign-in options", "/authentication/configuration/sign-u[-sign-in-options"],
+      ["Sign-up and sign-in options", "/authentication/configuration/sign-up-sign-in-options"],
       ["Session options", "/authentication/configuration/session-options"],
       ["Email & SMS options", "/authentication/configuration/email-options"],
       ["Restrictions", "/authentication/configuration/restrictions"],


### PR DESCRIPTION
This PR fixes a simple typo in the URL for sign in and sign up options which currently 404s: https://clerk.com/docs/authentication/configuration/sign-u[-sign-in-options