### PR TITLE
Move SAML to its own dedicated authentication section

### DIFF
--- a/docs/authentication/saml/overview.mdx
+++ b/docs/authentication/saml/overview.mdx
@@ -1,9 +1,9 @@
 ---
-title: SAML at Clerk (Beta)
+title: SAML (Beta)
 description: Clerk supports Enterprise SSO via the SAML protocol so that you can create authentication strategies for Identity Providers, such as Okta.
 ---
 
-# SAML at Clerk (Beta)
+# SAML (Beta)
 
 Clerk supports Enterprise SSO via the SAML protocol so that you can create authentication strategies for Identity Providers, such as Okta.
 

--- a/docs/custom-flows/saml-connections.mdx
+++ b/docs/custom-flows/saml-connections.mdx
@@ -5,7 +5,7 @@ description: Learn how to leverage the Clerk SDK to build a completely custom SA
 
 # SAML connections
 
-In case our default [SAML flow](/docs/authentication/saml-at-clerk) doesn’t cover your needs, you can leverage the Clerk SDK to build a completely custom SAML flow.
+If [the default SAML flow](/docs/authentication/saml/overview) doesn’t cover your needs, you can build a custom SAML flow with the Clerk SDK.
 
 <Callout type="info">
   You still need to configure your instance through the Clerk Dashboard. You can create a SAML connection by visiting the **[Enterprise Connections](https://dashboard.clerk.com/last-active?path=user-authentication/enterprise-connections)** page.

--- a/docs/manifest.json
+++ b/docs/manifest.json
@@ -50,7 +50,6 @@
       ["Session options", "/authentication/configuration/session-options"],
       ["Email & SMS options", "/authentication/configuration/email-options"],
       ["Restrictions", "/authentication/configuration/restrictions"],
-      ["SAML at Clerk", "/authentication/saml-at-clerk"],
       "# Prebuilt Components",
       ["<SignIn />", "https://clerk.com/docs/components/authentication/sign-in"],
       ["<SignUp />", "https://clerk.com/docs/components/authentication/sign-up"],
@@ -90,7 +89,9 @@
           ["X/Twitter v2", "/authentication/social-connections/x-twitter"],
           ["Xero", "/authentication/social-connections/xero/"]
         ]
-      ]
+      ],
+      "# SAML",
+      ["Overview", "/authentication/saml/overview"]
     ]
   ],
   [


### PR DESCRIPTION
Move SAML to its own dedicated authentication section as we are planning to add dedicated guides per provider and also more pages for various flows

Note: I will make sure to update any old link with the new ones across our stack