### PR TITLE
add docs for transferring app ownership

### DIFF
--- a/docs/manifest.json
+++ b/docs/manifest.json
@@ -397,6 +397,7 @@
       ["Overview", "/troubleshooting/overview"],
       ["Email Deliverability", "/troubleshooting/email-deliverability"],
       ["Script Loading", "/troubleshooting/script-loading"],
+      ["Transferring your App", "/troubleshooting/transferring-your-app"],
       "# Help & Support",
       ["Create a minimal reproduction", "/troubleshooting/create-a-minimal-reproduction"],
       ["Community Discord", "https://clerk.com/discord"],

--- a/docs/troubleshooting/transferring-your-app.mdx
+++ b/docs/troubleshooting/transferring-your-app.mdx
@@ -1,0 +1,24 @@
+---
+title: Issues with transferring the ownership of your application
+description: A guide covering some of the edge cases when transferring your application
+---
+
+# Transferring ownership of your application
+To transfer your application, head to the [Settings view](https://dashboard.clerk.com/last-active?path=settings) within the Clerk Dashboard and select `Transfer Ownership`. From here you can transfer an application to your "Personal Account" or any Organization where you are an admin. 
+
+
+## Transferring to an Org that does not have any billing methods
+
+To ensure continuity in your subscription, an application with an existing paid subscription can only be transferred to an Organization with active payment methods. Some customers attempt to transfer ownership to a brand new Organization and expect the payment details to transfer but unfortunately this type of transfer is not allowed by our payment provider. 
+
+To overcome this limitation, we ask that you establish a payment method on the receiving Organization first, and then re-attempt your transfer. 
+
+To establish a payment method, without being charged:
+- Use the Organization Switcher in the Dashboard and select the "cog" icon to manage the organization.
+- Use the sidebar to navigate to the "Billing" section of the modal.
+- Click the banner that says "Upgrade to unlimited members". **This won't actually charge you anything immediately**. It's just a way to ensure billing information is added to the organization and you won't actually be charged anything.
+- Once that billing information is added, you will be able to transfer the app over without issue.
+
+<Callout type="info">
+    We're actively working on making this process easier within the Clerk Dashboard. This guide is meant to be a helpful workaround until that work is deployed.
+</Callout>


### PR DESCRIPTION
some customers struggle with understanding this workaround. we've added better error handling within the Dashboard and we link to a docs page for more detailed information. This page is specifically for that link. 

Note that soon enough we'll make this more intuitive for customers but for now this is a workaround