### PR TITLE
Update JS examples to follow new JS quickstart installation instructions

### DIFF
--- a/docs/advanced-usage/using-proxies.mdx
+++ b/docs/advanced-usage/using-proxies.mdx
@@ -227,7 +227,7 @@ To configure your proxy setup using environment variables, your `.env.local` fil
     To configure your proxy setup using properties in your JavaScript application, pass the `proxyUrl` option to the [`load()`](https://clerk.com/docs/references/javascript/clerk/clerk#load) method.
 
     <InjectKeys>
-      <CodeBlockTabs options={["NPM module", "<script>"]}>
+      <CodeBlockTabs type="npm-script" options={["NPM module", "<script>"]}>
         ```js filename="main.js"
           import Clerk from '@clerk/clerk-js';
 

--- a/docs/advanced-usage/using-proxies.mdx
+++ b/docs/advanced-usage/using-proxies.mdx
@@ -140,94 +140,126 @@ In order to enable proxying, you need to set a proxy URL for your Clerk instance
 
 ### Configure your proxy setup
 
-You can configure your proxy setup via environment variables or via properties.
+You can configure your proxy setup by either:
+- Setting environment variables
+- Using properties in your application
 
-**Pro tip!** If you are signed into your Clerk Dashboard, your secret key should become visible by clicking on the eye icon. Otherwise, you can find your keys in the Clerk Dashboard on the [API Keys](https://dashboard.clerk.com/last-active?path=api-keys) page.
+#### Environment variables
 
-<Tabs items={["Environment Variables", "Properties"]}>
+To configure your proxy setup using environment variables, your `.env.local` file should look like this:
+
+<InjectKeys>
+  <CodeBlockTabs type="framework" options={["Next.js", "Remix", 'Gatsby']}>
+    ```env filename=".env.local"
+    NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY={{pub_key}}
+    CLERK_SECRET_KEY={{secret}}
+
+    NEXT_PUBLIC_CLERK_PROXY_URL=https://app.dev/__clerk
+    ```
+    ```env filename=".env.local"
+    CLERK_PUBLISHABLE_KEY={{pub_key}}
+    CLERK_SECRET_KEY={{secret}}
+
+    CLERK_PROXY_URL=https://app.dev/__clerk
+    ```
+
+    ```env filename=".env.development"
+    CLERK_PUBLISHABLE_KEY={{pub_key}}
+    CLERK_SECRET_KEY={{secret}}
+
+    CLERK_PROXY_URL=https://app.dev/__clerk
+    ```
+  </CodeBlockTabs>
+</InjectKeys>
+
+#### Properties in your application
+
+<Tabs type="framework" options={["Next.js", "Remix", "JavaScript"]}>
   <Tab>
-    <InjectKeys>
-      <CodeBlockTabs type="framework" options={["Next.js", "Remix", 'Gatsby']}>
-        ```env filename=".env.local"
-        NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY={{pub_key}}
-        CLERK_SECRET_KEY={{secret}}
+    To configure your proxy setup using properties in your Next.js application, set the `proxyUrl` property on the [`<ClerkProvider>`](https://clerk.com/docs/components/clerk-provider) component.
 
-        NEXT_PUBLIC_CLERK_PROXY_URL=https://app.dev/__clerk
-        ```
-        ```env filename=".env"
-        CLERK_PUBLISHABLE_KEY={{pub_key}}
-        CLERK_SECRET_KEY={{secret}}
+    ```tsx filename="_app.tsx"
+      import { ClerkProvider } from "@clerk/nextjs";
+      import Head from "next/head";
 
-        CLERK_PROXY_URL=https://app.dev/__clerk
-        ```
-
-        ```env filename=".env.development"
-        CLERK_PUBLISHABLE_KEY={{pub_key}}
-        CLERK_SECRET_KEY={{secret}}
-
-        CLERK_PROXY_URL=https://app.dev/__clerk
-        ```
-      </CodeBlockTabs>
-    </InjectKeys>
+      export default function App({ Component, pageProps }) {
+        return (
+          <ClerkProvider proxyUrl='https://app.dev/__clerk' {...pageProps}>
+            <Head>
+              <title>Proxy Next.js app</title>
+              <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+            </Head>
+            <Component {...pageProps} />
+          </ClerkProvider>
+        );
+      }
+    ```
   </Tab>
+
   <Tab>
-    You can skip this step if you configured your proxy setup with environment variables.
+    To configure your proxy setup using properties in your Remix application, set the `proxyUrl` property on the [`ClerkApp`](https://clerk.com/docs/references/remix/clerk-app) wrapper.
 
-    This is an alternative configuration to the environment variable based setup that we described in the previous step.
+    ```tsx filename="root.tsx"
+      export const loader = (args) => {
+        return rootAuthLoader(
+          args,
+          ({ request }) => {
+            const { userId, sessionId, getToken } = request.auth;
+            return json({
+                message: `Hello from the root loader :)`,
+                ENV: getBrowserEnvironment(),
+            });
+          },
+          {
+            loadUser: true,
+            proxyUrl: 'https://app.dev/__clerk'
+          } as const
+        );
+      };
 
-    <CodeBlockTabs type="framework" options={["Next.js", "Remix", "JavaScript"]}>
-      ```tsx filename="_app.tsx"
-        import { ClerkProvider } from "@clerk/nextjs";
-        import Head from "next/head";
+      export default ClerkApp(App, {
+        proxyUrl: 'https://app.dev/__clerk'
+      });
+    ```
+  </Tab>
 
-        export default function App({ Component, pageProps }) {
-          return (
-            <ClerkProvider proxyUrl='https://app.dev/__clerk' {...pageProps}>
-              <Head>
-                <title>Proxy Next.js app</title>
-                <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-              </Head>
-              <Component {...pageProps} />
-            </ClerkProvider>
-          );
-        }
-      ```
+  <Tab>
+    To configure your proxy setup using properties in your JavaScript application, pass the `proxyUrl` option to the [`load()`](https://clerk.com/docs/references/javascript/clerk/clerk#load) method.
 
-      ```tsx filename="root.tsx"
-        export const loader = (args) => {
-          return rootAuthLoader(
-            args,
-            ({ request }) => {
-              const { userId, sessionId, getToken } = request.auth;
-              return json({
-                  message: `Hello from the root loader :)`,
-                  ENV: getBrowserEnvironment(),
-              });
-            },
-            {
-              loadUser: true,
-              proxyUrl: 'https://app.dev/__clerk'
-            } as const
-          );
-        };
-
-        export default ClerkApp(App, {
-          proxyUrl: 'https://app.dev/__clerk'
-        });
-      ```
-
-      <InjectKeys>
-        ```tsx filename="app.tsx"
+    <InjectKeys>
+      <CodeBlockTabs options={["NPM module", "<script>"]}>
+        ```js filename="main.js"
           import Clerk from '@clerk/clerk-js';
 
-          const clerkPublishableKey = `{{pub_key}}`;
-          const clerk = new Clerk(clerkPublishableKey);
+          // Initialize Clerk with your Clerk publishable key
+          const clerk = new Clerk('{{pub_key}}');
+
           await clerk.load({
             proxyUrl: 'https://app.dev/__clerk',
           });
         ```
-      </InjectKeys>
-    </CodeBlockTabs>
+
+        ```html filename="index.html"
+          <!-- Initialize Clerk with your
+          Clerk publishable key and Frontend API URL -->
+          <script
+            async
+            crossorigin="anonymous"
+            data-clerk-publishable-key="{{pub_key}}"
+            src="https://[your-domain].clerk.accounts.dev/npm/@clerk/clerk-js@latest/dist/clerk.browser.js"
+            type="text/javascript"
+          ></script>
+
+          <script>
+            window.addEventListener("load", async function () {
+              await Clerk.load({
+                proxyUrl: 'https://app.dev/__clerk',
+              });
+            });
+          </script>
+        ```
+      </CodeBlockTabs>
+    </InjectKeys>
   </Tab>
 </Tabs>
 

--- a/docs/advanced-usage/using-proxies.mdx
+++ b/docs/advanced-usage/using-proxies.mdx
@@ -174,7 +174,7 @@ To configure your proxy setup using environment variables, your `.env.local` fil
 
 #### Properties in your application
 
-<Tabs type="framework" options={["Next.js", "Remix", "JavaScript"]}>
+<Tabs type="framework" items={["Next.js", "Remix", "JavaScript"]}>
   <Tab>
     To configure your proxy setup using properties in your Next.js application, set the `proxyUrl` property on the [`<ClerkProvider>`](https://clerk.com/docs/components/clerk-provider) component.
 

--- a/docs/advanced-usage/using-proxies.mdx
+++ b/docs/advanced-usage/using-proxies.mdx
@@ -241,12 +241,12 @@ To configure your proxy setup using environment variables, your `.env.local` fil
 
         ```html filename="index.html"
           <!-- Initialize Clerk with your
-          Clerk publishable key and Frontend API URL -->
+          Clerk Publishable key and Frontend API URL -->
           <script
             async
             crossorigin="anonymous"
             data-clerk-publishable-key="{{pub_key}}"
-            src="https://[your-domain].clerk.accounts.dev/npm/@clerk/clerk-js@latest/dist/clerk.browser.js"
+            src="https://{{fapi_key}}/npm/@clerk/clerk-js@latest/dist/clerk.browser.js"
             type="text/javascript"
           ></script>
 

--- a/docs/advanced-usage/using-proxies.mdx
+++ b/docs/advanced-usage/using-proxies.mdx
@@ -149,27 +149,36 @@ You can configure your proxy setup by either:
 To configure your proxy setup using environment variables, your `.env.local` file should look like this:
 
 <InjectKeys>
-  <CodeBlockTabs type="framework" options={["Next.js", "Remix", 'Gatsby']}>
+  <Tabs type="framework" items={["Next.js", "Remix", "JavaScript"]}>
+    <Tab>
     ```env filename=".env.local"
     NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY={{pub_key}}
     CLERK_SECRET_KEY={{secret}}
 
     NEXT_PUBLIC_CLERK_PROXY_URL=https://app.dev/__clerk
     ```
+    </Tab>
+
+    <Tab>
     ```env filename=".env.local"
     CLERK_PUBLISHABLE_KEY={{pub_key}}
     CLERK_SECRET_KEY={{secret}}
 
     CLERK_PROXY_URL=https://app.dev/__clerk
     ```
+    </Tab>
 
-    ```env filename=".env.development"
+    <Tab>
+    You will only need to set environment variables in your JavaScript application if you are using a bundler (the `NPM module` method for ClerkJS installation). If you are using the `<script>` method, configure your proxy setup using [properties in your application](#properties-in-your-application) instead.
+
+    ```env filename=".env.local"
     CLERK_PUBLISHABLE_KEY={{pub_key}}
     CLERK_SECRET_KEY={{secret}}
 
     CLERK_PROXY_URL=https://app.dev/__clerk
     ```
-  </CodeBlockTabs>
+    </Tab>
+  </Tabs>
 </InjectKeys>
 
 #### Properties in your application
@@ -178,26 +187,43 @@ To configure your proxy setup using environment variables, your `.env.local` fil
   <Tab>
     To configure your proxy setup using properties in your Next.js application, set the `proxyUrl` property on the [`<ClerkProvider>`](https://clerk.com/docs/components/clerk-provider) component.
 
-    ```tsx filename="_app.tsx"
-      import { ClerkProvider } from "@clerk/nextjs";
-      import Head from "next/head";
+    <CodeBlockTabs type="router" options={["App Router", "Pages Router"]}>
+    ```tsx filename="app/layout.tsx" {9}
+    import { ClerkProvider } from '@clerk/nextjs';
 
-      export default function App({ Component, pageProps }) {
-        return (
-          <ClerkProvider proxyUrl='https://app.dev/__clerk' {...pageProps}>
-            <Head>
-              <title>Proxy Next.js app</title>
-              <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-            </Head>
-            <Component {...pageProps} />
-          </ClerkProvider>
-        );
-      }
+    export default function RootLayout({
+      children,
+    }: {
+      children: React.ReactNode
+    }) {
+      return (
+        <ClerkProvider proxyUrl='https://app.dev/__clerk'>
+          <html lang="en">
+            <body>{children}</body>
+          </html>
+        </ClerkProvider>
+      )
+    }
     ```
+
+    ```tsx filename="_app.tsx" {6}
+    import { ClerkProvider } from "@clerk/nextjs";
+    import type { AppProps } from "next/app";
+
+    function MyApp({ Component, pageProps }: AppProps) {
+      return (
+        <ClerkProvider proxyUrl='https://app.dev/__clerk' {...pageProps}>
+          <Component {...pageProps} />
+        </ClerkProvider>
+      );
+    }
+    export default MyApp;
+    ```
+    </CodeBlockTabs>
   </Tab>
 
   <Tab>
-    To configure your proxy setup using properties in your Remix application, set the `proxyUrl` property on the [`ClerkApp`](https://clerk.com/docs/references/remix/clerk-app) wrapper.
+    To configure your proxy setup using properties in your Remix application, set the `proxyUrl` property on the [`ClerkApp`](/docs/references/remix/clerk-app) wrapper.
 
     ```tsx filename="root.tsx"
       export const loader = (args) => {
@@ -224,7 +250,7 @@ To configure your proxy setup using environment variables, your `.env.local` fil
   </Tab>
 
   <Tab>
-    To configure your proxy setup using properties in your JavaScript application, pass the `proxyUrl` option to the [`load()`](https://clerk.com/docs/references/javascript/clerk/clerk#load) method.
+    To configure your proxy setup using properties in your JavaScript application, pass the `proxyUrl` option to the [`load()`](/docs/references/javascript/clerk/clerk#load) method.
 
     <InjectKeys>
       <CodeBlockTabs type="npm-script" options={["NPM module", "<script>"]}>

--- a/docs/advanced-usage/using-proxies.mdx
+++ b/docs/advanced-usage/using-proxies.mdx
@@ -246,7 +246,7 @@ To configure your proxy setup using environment variables, your `.env.local` fil
             async
             crossorigin="anonymous"
             data-clerk-publishable-key="{{pub_key}}"
-            src="https://{{fapi_key}}/npm/@clerk/clerk-js@latest/dist/clerk.browser.js"
+            src="https://{{fapi_url}}/npm/@clerk/clerk-js@latest/dist/clerk.browser.js"
             type="text/javascript"
           ></script>
 

--- a/docs/components/authentication/sign-in.mdx
+++ b/docs/components/authentication/sign-in.mdx
@@ -159,7 +159,7 @@ function mountSignIn(node: HTMLDivElement, props?: SignInProps): void;
     async
     crossorigin="anonymous"
     data-clerk-publishable-key="{{pub_key}}"
-    src="https://{{fapi_key}}/npm/@clerk/clerk-js@latest/dist/clerk.browser.js"
+    src="https://{{fapi_url}}/npm/@clerk/clerk-js@latest/dist/clerk.browser.js"
     type="text/javascript"
   ></script>
 
@@ -228,7 +228,7 @@ function unmountSignIn(node: HTMLDivElement): void;
     async
     crossorigin="anonymous"
     data-clerk-publishable-key="{{pub_key}}"
-    src="https://{{fapi_key}}/npm/@clerk/clerk-js@latest/dist/clerk.browser.js"
+    src="https://{{fapi_url}}/npm/@clerk/clerk-js@latest/dist/clerk.browser.js"
     type="text/javascript"
   ></script>
 
@@ -287,7 +287,7 @@ function openSignIn(props?: SignInProps): void;
     async
     crossorigin="anonymous"
     data-clerk-publishable-key="{{pub_key}}"
-    src="https://{{fapi_key}}/npm/@clerk/clerk-js@latest/dist/clerk.browser.js"
+    src="https://{{fapi_url}}/npm/@clerk/clerk-js@latest/dist/clerk.browser.js"
     type="text/javascript"
   ></script>
 
@@ -337,7 +337,7 @@ function closeSignIn(): void;
     async
     crossorigin="anonymous"
     data-clerk-publishable-key="{{pub_key}}"
-    src="https://{{fapi_key}}/npm/@clerk/clerk-js@latest/dist/clerk.browser.js"
+    src="https://{{fapi_url}}/npm/@clerk/clerk-js@latest/dist/clerk.browser.js"
     type="text/javascript"
   ></script>
 

--- a/docs/components/authentication/sign-in.mdx
+++ b/docs/components/authentication/sign-in.mdx
@@ -153,6 +153,16 @@ function mountSignIn(node: HTMLDivElement, props?: SignInProps): void;
   <!-- Add a <div id="sign-in"> element to your HTML -->
   <div id="sign-in"></div>
 
+  <!-- Initialize Clerk with your
+  Clerk publishable key and Frontend API URL -->
+  <script
+    async
+    crossorigin="anonymous"
+    data-clerk-publishable-key='{{pub_key}}'
+    src="https://[your-domain].clerk.accounts.dev/npm/@clerk/clerk-js@latest/dist/clerk.browser.js"
+    type="text/javascript"
+  ></script>
+
   <script>
     window.addEventListener("load", async function () {
       await Clerk.load();
@@ -212,6 +222,16 @@ function unmountSignIn(node: HTMLDivElement): void;
   <!-- Add a <div id="sign-in"> element to your HTML -->
   <div id="sign-in"></div>
 
+  <!-- Initialize Clerk with your
+  Clerk publishable key and Frontend API URL -->
+  <script
+    async
+    crossorigin="anonymous"
+    data-clerk-publishable-key='{{pub_key}}'
+    src="https://[your-domain].clerk.accounts.dev/npm/@clerk/clerk-js@latest/dist/clerk.browser.js"
+    type="text/javascript"
+  ></script>
+
   <script>
     window.addEventListener("load", async function () {
       await Clerk.load();
@@ -261,6 +281,16 @@ function openSignIn(props?: SignInProps): void;
   ```
 
   ```html filename="index.html" {5}
+  <!-- Initialize Clerk with your
+  Clerk publishable key and Frontend API URL -->
+  <script
+    async
+    crossorigin="anonymous"
+    data-clerk-publishable-key='{{pub_key}}'
+    src="https://[your-domain].clerk.accounts.dev/npm/@clerk/clerk-js@latest/dist/clerk.browser.js"
+    type="text/javascript"
+  ></script>
+
   <script>
     window.addEventListener("load", async function () {
       await Clerk.load();
@@ -301,6 +331,16 @@ function closeSignIn(): void;
   ```
 
   ```html filename="index.html" {9}
+  <!-- Initialize Clerk with your
+  Clerk publishable key and Frontend API URL -->
+  <script
+    async
+    crossorigin="anonymous"
+    data-clerk-publishable-key='{{pub_key}}'
+    src="https://[your-domain].clerk.accounts.dev/npm/@clerk/clerk-js@latest/dist/clerk.browser.js"
+    type="text/javascript"
+  ></script>
+
   <script>
     window.addEventListener("load", async function () {
       await Clerk.load();

--- a/docs/components/authentication/sign-in.mdx
+++ b/docs/components/authentication/sign-in.mdx
@@ -149,7 +149,7 @@ function mountSignIn(node: HTMLDivElement, props?: SignInProps): void;
   clerk.mountSignIn(signInDiv);
   ```
 
-  ```html filename="index.html" {11}
+  ```html filename="index.html" {21}
   <!-- Add a <div id="sign-in"> element to your HTML -->
   <div id="sign-in"></div>
 
@@ -218,7 +218,7 @@ function unmountSignIn(node: HTMLDivElement): void;
   clerk.unmountSignIn(signInDiv);
   ```
 
-  ```html filename="index.html" {15}
+  ```html filename="index.html" {25}
   <!-- Add a <div id="sign-in"> element to your HTML -->
   <div id="sign-in"></div>
 
@@ -280,7 +280,7 @@ function openSignIn(props?: SignInProps): void;
   clerk.openSignIn();
   ```
 
-  ```html filename="index.html" {5}
+  ```html filename="index.html" {15}
   <!-- Initialize Clerk with your
   Clerk Publishable key and Frontend API URL -->
   <script
@@ -330,7 +330,7 @@ function closeSignIn(): void;
   clerk.closeSignIn();
   ```
 
-  ```html filename="index.html" {9}
+  ```html filename="index.html" {19}
   <!-- Initialize Clerk with your
   Clerk Publishable key and Frontend API URL -->
   <script

--- a/docs/components/authentication/sign-in.mdx
+++ b/docs/components/authentication/sign-in.mdx
@@ -154,12 +154,12 @@ function mountSignIn(node: HTMLDivElement, props?: SignInProps): void;
   <div id="sign-in"></div>
 
   <!-- Initialize Clerk with your
-  Clerk publishable key and Frontend API URL -->
+  Clerk Publishable key and Frontend API URL -->
   <script
     async
     crossorigin="anonymous"
-    data-clerk-publishable-key='{{pub_key}}'
-    src="https://[your-domain].clerk.accounts.dev/npm/@clerk/clerk-js@latest/dist/clerk.browser.js"
+    data-clerk-publishable-key="{{pub_key}}"
+    src="https://{{fapi_key}}/npm/@clerk/clerk-js@latest/dist/clerk.browser.js"
     type="text/javascript"
   ></script>
 
@@ -223,12 +223,12 @@ function unmountSignIn(node: HTMLDivElement): void;
   <div id="sign-in"></div>
 
   <!-- Initialize Clerk with your
-  Clerk publishable key and Frontend API URL -->
+  Clerk Publishable key and Frontend API URL -->
   <script
     async
     crossorigin="anonymous"
-    data-clerk-publishable-key='{{pub_key}}'
-    src="https://[your-domain].clerk.accounts.dev/npm/@clerk/clerk-js@latest/dist/clerk.browser.js"
+    data-clerk-publishable-key="{{pub_key}}"
+    src="https://{{fapi_key}}/npm/@clerk/clerk-js@latest/dist/clerk.browser.js"
     type="text/javascript"
   ></script>
 
@@ -282,12 +282,12 @@ function openSignIn(props?: SignInProps): void;
 
   ```html filename="index.html" {5}
   <!-- Initialize Clerk with your
-  Clerk publishable key and Frontend API URL -->
+  Clerk Publishable key and Frontend API URL -->
   <script
     async
     crossorigin="anonymous"
-    data-clerk-publishable-key='{{pub_key}}'
-    src="https://[your-domain].clerk.accounts.dev/npm/@clerk/clerk-js@latest/dist/clerk.browser.js"
+    data-clerk-publishable-key="{{pub_key}}"
+    src="https://{{fapi_key}}/npm/@clerk/clerk-js@latest/dist/clerk.browser.js"
     type="text/javascript"
   ></script>
 
@@ -332,12 +332,12 @@ function closeSignIn(): void;
 
   ```html filename="index.html" {9}
   <!-- Initialize Clerk with your
-  Clerk publishable key and Frontend API URL -->
+  Clerk Publishable key and Frontend API URL -->
   <script
     async
     crossorigin="anonymous"
-    data-clerk-publishable-key='{{pub_key}}'
-    src="https://[your-domain].clerk.accounts.dev/npm/@clerk/clerk-js@latest/dist/clerk.browser.js"
+    data-clerk-publishable-key="{{pub_key}}"
+    src="https://{{fapi_key}}/npm/@clerk/clerk-js@latest/dist/clerk.browser.js"
     type="text/javascript"
   ></script>
 

--- a/docs/components/authentication/sign-up.mdx
+++ b/docs/components/authentication/sign-up.mdx
@@ -151,6 +151,16 @@ function mountSignUp(node: HTMLDivElement, props?: SignUpProps): void;
   <!-- Add a <div id="sign-up"> element to your HTML -->
   <div id="sign-up"></div>
 
+  <!-- Initialize Clerk with your
+  Clerk publishable key and Frontend API URL -->
+  <script
+    async
+    crossorigin="anonymous"
+    data-clerk-publishable-key='{{pub_key}}'
+    src="https://[your-domain].clerk.accounts.dev/npm/@clerk/clerk-js@latest/dist/clerk.browser.js"
+    type="text/javascript"
+  ></script>
+
   <script>
     window.addEventListener("load", async function () {
       await Clerk.load();
@@ -210,6 +220,16 @@ function unmountSignUp(node: HTMLDivElement): void;
   <!-- Add a <div id="sign-up"> element to your HTML -->
   <div id="sign-up"></div>
 
+  <!-- Initialize Clerk with your
+  Clerk publishable key and Frontend API URL -->
+  <script
+    async
+    crossorigin="anonymous"
+    data-clerk-publishable-key='{{pub_key}}'
+    src="https://[your-domain].clerk.accounts.dev/npm/@clerk/clerk-js@latest/dist/clerk.browser.js"
+    type="text/javascript"
+  ></script>
+
   <script>
     window.addEventListener("load", async function () {
       await Clerk.load();
@@ -259,6 +279,16 @@ function openSignUp(props?: SignUpProps): void;
   ```
 
   ```html filename="index.html" {5}
+  <!-- Initialize Clerk with your
+  Clerk publishable key and Frontend API URL -->
+  <script
+    async
+    crossorigin="anonymous"
+    data-clerk-publishable-key='{{pub_key}}'
+    src="https://[your-domain].clerk.accounts.dev/npm/@clerk/clerk-js@latest/dist/clerk.browser.js"
+    type="text/javascript"
+  ></script>
+
   <script>
     window.addEventListener("load", async function () {
       await Clerk.load();
@@ -299,6 +329,16 @@ function closeSignUp(): void;
   ```
 
   ```html filename="index.html" {9}
+  <!-- Initialize Clerk with your
+  Clerk publishable key and Frontend API URL -->
+  <script
+    async
+    crossorigin="anonymous"
+    data-clerk-publishable-key='{{pub_key}}'
+    src="https://[your-domain].clerk.accounts.dev/npm/@clerk/clerk-js@latest/dist/clerk.browser.js"
+    type="text/javascript"
+  ></script>
+
   <script>
     window.addEventListener("load", async function () {
       await Clerk.load();

--- a/docs/components/authentication/sign-up.mdx
+++ b/docs/components/authentication/sign-up.mdx
@@ -152,12 +152,12 @@ function mountSignUp(node: HTMLDivElement, props?: SignUpProps): void;
   <div id="sign-up"></div>
 
   <!-- Initialize Clerk with your
-  Clerk publishable key and Frontend API URL -->
+  Clerk Publishable key and Frontend API URL -->
   <script
     async
     crossorigin="anonymous"
-    data-clerk-publishable-key='{{pub_key}}'
-    src="https://[your-domain].clerk.accounts.dev/npm/@clerk/clerk-js@latest/dist/clerk.browser.js"
+    data-clerk-publishable-key="{{pub_key}}"
+    src="https://{{fapi_key}}/npm/@clerk/clerk-js@latest/dist/clerk.browser.js"
     type="text/javascript"
   ></script>
 
@@ -221,12 +221,12 @@ function unmountSignUp(node: HTMLDivElement): void;
   <div id="sign-up"></div>
 
   <!-- Initialize Clerk with your
-  Clerk publishable key and Frontend API URL -->
+  Clerk Publishable key and Frontend API URL -->
   <script
     async
     crossorigin="anonymous"
-    data-clerk-publishable-key='{{pub_key}}'
-    src="https://[your-domain].clerk.accounts.dev/npm/@clerk/clerk-js@latest/dist/clerk.browser.js"
+    data-clerk-publishable-key="{{pub_key}}"
+    src="https://{{fapi_key}}/npm/@clerk/clerk-js@latest/dist/clerk.browser.js"
     type="text/javascript"
   ></script>
 
@@ -280,12 +280,12 @@ function openSignUp(props?: SignUpProps): void;
 
   ```html filename="index.html" {5}
   <!-- Initialize Clerk with your
-  Clerk publishable key and Frontend API URL -->
+  Clerk Publishable key and Frontend API URL -->
   <script
     async
     crossorigin="anonymous"
-    data-clerk-publishable-key='{{pub_key}}'
-    src="https://[your-domain].clerk.accounts.dev/npm/@clerk/clerk-js@latest/dist/clerk.browser.js"
+    data-clerk-publishable-key="{{pub_key}}"
+    src="https://{{fapi_key}}/npm/@clerk/clerk-js@latest/dist/clerk.browser.js"
     type="text/javascript"
   ></script>
 
@@ -330,12 +330,12 @@ function closeSignUp(): void;
 
   ```html filename="index.html" {9}
   <!-- Initialize Clerk with your
-  Clerk publishable key and Frontend API URL -->
+  Clerk Publishable key and Frontend API URL -->
   <script
     async
     crossorigin="anonymous"
-    data-clerk-publishable-key='{{pub_key}}'
-    src="https://[your-domain].clerk.accounts.dev/npm/@clerk/clerk-js@latest/dist/clerk.browser.js"
+    data-clerk-publishable-key="{{pub_key}}"
+    src="https://{{fapi_key}}/npm/@clerk/clerk-js@latest/dist/clerk.browser.js"
     type="text/javascript"
   ></script>
 

--- a/docs/components/authentication/sign-up.mdx
+++ b/docs/components/authentication/sign-up.mdx
@@ -157,7 +157,7 @@ function mountSignUp(node: HTMLDivElement, props?: SignUpProps): void;
     async
     crossorigin="anonymous"
     data-clerk-publishable-key="{{pub_key}}"
-    src="https://{{fapi_key}}/npm/@clerk/clerk-js@latest/dist/clerk.browser.js"
+    src="https://{{fapi_url}}/npm/@clerk/clerk-js@latest/dist/clerk.browser.js"
     type="text/javascript"
   ></script>
 
@@ -226,7 +226,7 @@ function unmountSignUp(node: HTMLDivElement): void;
     async
     crossorigin="anonymous"
     data-clerk-publishable-key="{{pub_key}}"
-    src="https://{{fapi_key}}/npm/@clerk/clerk-js@latest/dist/clerk.browser.js"
+    src="https://{{fapi_url}}/npm/@clerk/clerk-js@latest/dist/clerk.browser.js"
     type="text/javascript"
   ></script>
 
@@ -285,7 +285,7 @@ function openSignUp(props?: SignUpProps): void;
     async
     crossorigin="anonymous"
     data-clerk-publishable-key="{{pub_key}}"
-    src="https://{{fapi_key}}/npm/@clerk/clerk-js@latest/dist/clerk.browser.js"
+    src="https://{{fapi_url}}/npm/@clerk/clerk-js@latest/dist/clerk.browser.js"
     type="text/javascript"
   ></script>
 
@@ -335,7 +335,7 @@ function closeSignUp(): void;
     async
     crossorigin="anonymous"
     data-clerk-publishable-key="{{pub_key}}"
-    src="https://{{fapi_key}}/npm/@clerk/clerk-js@latest/dist/clerk.browser.js"
+    src="https://{{fapi_url}}/npm/@clerk/clerk-js@latest/dist/clerk.browser.js"
     type="text/javascript"
   ></script>
 

--- a/docs/components/authentication/sign-up.mdx
+++ b/docs/components/authentication/sign-up.mdx
@@ -147,7 +147,7 @@ function mountSignUp(node: HTMLDivElement, props?: SignUpProps): void;
   clerk.mountSignUp(signUpDiv);
   ```
 
-  ```html filename="index.js" {11}
+  ```html filename="index.js" {21}
   <!-- Add a <div id="sign-up"> element to your HTML -->
   <div id="sign-up"></div>
 
@@ -216,7 +216,7 @@ function unmountSignUp(node: HTMLDivElement): void;
   clerk.unmountSignUp(signUpDiv);
   ```
 
-  ```html filename="index.js" {15}
+  ```html filename="index.js" {25}
   <!-- Add a <div id="sign-up"> element to your HTML -->
   <div id="sign-up"></div>
 
@@ -278,7 +278,7 @@ function openSignUp(props?: SignUpProps): void;
   clerk.openSignUp();
   ```
 
-  ```html filename="index.html" {5}
+  ```html filename="index.html" {15}
   <!-- Initialize Clerk with your
   Clerk Publishable key and Frontend API URL -->
   <script
@@ -328,7 +328,7 @@ function closeSignUp(): void;
   clerk.closeSignUp();
   ```
 
-  ```html filename="index.html" {9}
+  ```html filename="index.html" {19}
   <!-- Initialize Clerk with your
   Clerk Publishable key and Frontend API URL -->
   <script

--- a/docs/components/organization/create-organization.mdx
+++ b/docs/components/organization/create-organization.mdx
@@ -131,7 +131,7 @@ function mountCreateOrganization(node: HTMLDivElement, props?: CreateOrganizatio
     async
     crossorigin="anonymous"
     data-clerk-publishable-key="{{pub_key}}"
-    src="https://{{fapi_key}}/npm/@clerk/clerk-js@latest/dist/clerk.browser.js"
+    src="https://{{fapi_url}}/npm/@clerk/clerk-js@latest/dist/clerk.browser.js"
     type="text/javascript"
   ></script>
 
@@ -200,7 +200,7 @@ function unmountCreateOrganization(node: HTMLDivElement): void;
     async
     crossorigin="anonymous"
     data-clerk-publishable-key="{{pub_key}}"
-    src="https://{{fapi_key}}/npm/@clerk/clerk-js@latest/dist/clerk.browser.js"
+    src="https://{{fapi_url}}/npm/@clerk/clerk-js@latest/dist/clerk.browser.js"
     type="text/javascript"
   ></script>
 
@@ -269,7 +269,7 @@ function openCreateOrganization(props?: CreateOrganizationProps): void;
     async
     crossorigin="anonymous"
     data-clerk-publishable-key="{{pub_key}}"
-    src="https://{{fapi_key}}/npm/@clerk/clerk-js@latest/dist/clerk.browser.js"
+    src="https://{{fapi_url}}/npm/@clerk/clerk-js@latest/dist/clerk.browser.js"
     type="text/javascript"
   ></script>
 
@@ -332,7 +332,7 @@ function closeCreateOrganization(): void;
     async
     crossorigin="anonymous"
     data-clerk-publishable-key="{{pub_key}}"
-    src="https://{{fapi_key}}/npm/@clerk/clerk-js@latest/dist/clerk.browser.js"
+    src="https://{{fapi_url}}/npm/@clerk/clerk-js@latest/dist/clerk.browser.js"
     type="text/javascript"
   ></script>
 

--- a/docs/components/organization/create-organization.mdx
+++ b/docs/components/organization/create-organization.mdx
@@ -125,6 +125,16 @@ function mountCreateOrganization(node: HTMLDivElement, props?: CreateOrganizatio
   <!-- Add a <div id="create-organization"> element to your HTML -->
   <div id="create-organization"></div>
 
+  <!-- Initialize Clerk with your
+  Clerk publishable key and Frontend API URL -->
+  <script
+    async
+    crossorigin="anonymous"
+    data-clerk-publishable-key='{{pub_key}}'
+    src="https://[your-domain].clerk.accounts.dev/npm/@clerk/clerk-js@latest/dist/clerk.browser.js"
+    type="text/javascript"
+  ></script>
+
   <script>
     window.addEventListener("load", async function () {
       await Clerk.load();
@@ -183,6 +193,16 @@ function unmountCreateOrganization(node: HTMLDivElement): void;
   ```html filename="index.html" {15}
   <!-- Add a <div id="create-organization"> element to your HTML -->
   <div id="create-organization"></div>
+
+  <!-- Initialize Clerk with your
+  Clerk publishable key and Frontend API URL -->
+  <script
+    async
+    crossorigin="anonymous"
+    data-clerk-publishable-key='{{pub_key}}'
+    src="https://[your-domain].clerk.accounts.dev/npm/@clerk/clerk-js@latest/dist/clerk.browser.js"
+    type="text/javascript"
+  ></script>
 
   <script>
     window.addEventListener("load", async function () {
@@ -243,6 +263,16 @@ function openCreateOrganization(props?: CreateOrganizationProps): void;
   <!-- Add a <div id="create-organization"> element to your HTML -->
   <div id="create-organization"></div>
 
+  <!-- Initialize Clerk with your
+  Clerk publishable key and Frontend API URL -->
+  <script
+    async
+    crossorigin="anonymous"
+    data-clerk-publishable-key='{{pub_key}}'
+    src="https://[your-domain].clerk.accounts.dev/npm/@clerk/clerk-js@latest/dist/clerk.browser.js"
+    type="text/javascript"
+  ></script>
+
   <script>
     window.addEventListener("load", async function () {
       await Clerk.load();
@@ -295,6 +325,16 @@ function closeCreateOrganization(): void;
   ```html filename="index.html" {15}
   <!-- Add a <div id="create-organization"> element to your HTML -->
   <div id="create-organization"></div>
+
+  <!-- Initialize Clerk with your
+  Clerk publishable key and Frontend API URL -->
+  <script
+    async
+    crossorigin="anonymous"
+    data-clerk-publishable-key='{{pub_key}}'
+    src="https://[your-domain].clerk.accounts.dev/npm/@clerk/clerk-js@latest/dist/clerk.browser.js"
+    type="text/javascript"
+  ></script>
 
   <script>
     window.addEventListener("load", async function () {

--- a/docs/components/organization/create-organization.mdx
+++ b/docs/components/organization/create-organization.mdx
@@ -121,7 +121,7 @@ function mountCreateOrganization(node: HTMLDivElement, props?: CreateOrganizatio
   clerk.mountCreateOrganization(createOrgDiv);
   ```
 
-  ```html filename="index.html" {11}
+  ```html filename="index.html" {21}
   <!-- Add a <div id="create-organization"> element to your HTML -->
   <div id="create-organization"></div>
 
@@ -190,7 +190,7 @@ function unmountCreateOrganization(node: HTMLDivElement): void;
   clerk.unmountCreateOrganization(createOrgDiv);
   ```
 
-  ```html filename="index.html" {15}
+  ```html filename="index.html" {25}
   <!-- Add a <div id="create-organization"> element to your HTML -->
   <div id="create-organization"></div>
 
@@ -259,7 +259,7 @@ function openCreateOrganization(props?: CreateOrganizationProps): void;
   clerk.openCreateOrganization(createOrgDiv);
   ```
 
-  ```html filename="index.html" {15}
+  ```html filename="index.html" {21}
   <!-- Add a <div id="create-organization"> element to your HTML -->
   <div id="create-organization"></div>
 
@@ -322,7 +322,7 @@ function closeCreateOrganization(): void;
   clerk.closeCreateOrganization(createOrgDiv);
   ```
 
-  ```html filename="index.html" {15}
+  ```html filename="index.html" {25}
   <!-- Add a <div id="create-organization"> element to your HTML -->
   <div id="create-organization"></div>
 

--- a/docs/components/organization/create-organization.mdx
+++ b/docs/components/organization/create-organization.mdx
@@ -126,12 +126,12 @@ function mountCreateOrganization(node: HTMLDivElement, props?: CreateOrganizatio
   <div id="create-organization"></div>
 
   <!-- Initialize Clerk with your
-  Clerk publishable key and Frontend API URL -->
+  Clerk Publishable key and Frontend API URL -->
   <script
     async
     crossorigin="anonymous"
-    data-clerk-publishable-key='{{pub_key}}'
-    src="https://[your-domain].clerk.accounts.dev/npm/@clerk/clerk-js@latest/dist/clerk.browser.js"
+    data-clerk-publishable-key="{{pub_key}}"
+    src="https://{{fapi_key}}/npm/@clerk/clerk-js@latest/dist/clerk.browser.js"
     type="text/javascript"
   ></script>
 
@@ -195,12 +195,12 @@ function unmountCreateOrganization(node: HTMLDivElement): void;
   <div id="create-organization"></div>
 
   <!-- Initialize Clerk with your
-  Clerk publishable key and Frontend API URL -->
+  Clerk Publishable key and Frontend API URL -->
   <script
     async
     crossorigin="anonymous"
-    data-clerk-publishable-key='{{pub_key}}'
-    src="https://[your-domain].clerk.accounts.dev/npm/@clerk/clerk-js@latest/dist/clerk.browser.js"
+    data-clerk-publishable-key="{{pub_key}}"
+    src="https://{{fapi_key}}/npm/@clerk/clerk-js@latest/dist/clerk.browser.js"
     type="text/javascript"
   ></script>
 
@@ -264,12 +264,12 @@ function openCreateOrganization(props?: CreateOrganizationProps): void;
   <div id="create-organization"></div>
 
   <!-- Initialize Clerk with your
-  Clerk publishable key and Frontend API URL -->
+  Clerk Publishable key and Frontend API URL -->
   <script
     async
     crossorigin="anonymous"
-    data-clerk-publishable-key='{{pub_key}}'
-    src="https://[your-domain].clerk.accounts.dev/npm/@clerk/clerk-js@latest/dist/clerk.browser.js"
+    data-clerk-publishable-key="{{pub_key}}"
+    src="https://{{fapi_key}}/npm/@clerk/clerk-js@latest/dist/clerk.browser.js"
     type="text/javascript"
   ></script>
 
@@ -327,12 +327,12 @@ function closeCreateOrganization(): void;
   <div id="create-organization"></div>
 
   <!-- Initialize Clerk with your
-  Clerk publishable key and Frontend API URL -->
+  Clerk Publishable key and Frontend API URL -->
   <script
     async
     crossorigin="anonymous"
-    data-clerk-publishable-key='{{pub_key}}'
-    src="https://[your-domain].clerk.accounts.dev/npm/@clerk/clerk-js@latest/dist/clerk.browser.js"
+    data-clerk-publishable-key="{{pub_key}}"
+    src="https://{{fapi_key}}/npm/@clerk/clerk-js@latest/dist/clerk.browser.js"
     type="text/javascript"
   ></script>
 

--- a/docs/components/organization/organization-list.mdx
+++ b/docs/components/organization/organization-list.mdx
@@ -151,7 +151,7 @@ function mountOrganizationList(node: HTMLDivElement, props?: OrganizationListPro
     async
     crossorigin="anonymous"
     data-clerk-publishable-key="{{pub_key}}"
-    src="https://{{fapi_key}}/npm/@clerk/clerk-js@latest/dist/clerk.browser.js"
+    src="https://{{fapi_url}}/npm/@clerk/clerk-js@latest/dist/clerk.browser.js"
     type="text/javascript"
   ></script>
 
@@ -220,7 +220,7 @@ function unmountOrganizationList(node: HTMLDivElement): void;
     async
     crossorigin="anonymous"
     data-clerk-publishable-key="{{pub_key}}"
-    src="https://{{fapi_key}}/npm/@clerk/clerk-js@latest/dist/clerk.browser.js"
+    src="https://{{fapi_url}}/npm/@clerk/clerk-js@latest/dist/clerk.browser.js"
     type="text/javascript"
   ></script>
 

--- a/docs/components/organization/organization-list.mdx
+++ b/docs/components/organization/organization-list.mdx
@@ -141,7 +141,7 @@ function mountOrganizationList(node: HTMLDivElement, props?: OrganizationListPro
   clerk.mountOrganizationList(orgListDiv);
   ```
 
-  ```html filename="index.html" {11}
+  ```html filename="index.html" {21}
   <!-- Add a <div id="organization-list"> element to your HTML -->
   <div id="organization-list"></div>
 
@@ -210,7 +210,7 @@ function unmountOrganizationList(node: HTMLDivElement): void;
   clerk.unmountOrganizationList(orgListDiv);
   ```
 
-  ```html filename="index.html" {15}
+  ```html filename="index.html" {25}
   <!-- Add a <div id="organization-list"> element to your HTML -->
   <div id="organization-list"></div>
 

--- a/docs/components/organization/organization-list.mdx
+++ b/docs/components/organization/organization-list.mdx
@@ -145,6 +145,16 @@ function mountOrganizationList(node: HTMLDivElement, props?: OrganizationListPro
   <!-- Add a <div id="organization-list"> element to your HTML -->
   <div id="organization-list"></div>
 
+  <!-- Initialize Clerk with your
+  Clerk publishable key and Frontend API URL -->
+  <script
+    async
+    crossorigin="anonymous"
+    data-clerk-publishable-key='{{pub_key}}'
+    src="https://[your-domain].clerk.accounts.dev/npm/@clerk/clerk-js@latest/dist/clerk.browser.js"
+    type="text/javascript"
+  ></script>
+
   <script>
     window.addEventListener("load", async function () {
       await Clerk.load();
@@ -203,6 +213,16 @@ function unmountOrganizationList(node: HTMLDivElement): void;
   ```html filename="index.html" {15}
   <!-- Add a <div id="organization-list"> element to your HTML -->
   <div id="organization-list"></div>
+
+  <!-- Initialize Clerk with your
+  Clerk publishable key and Frontend API URL -->
+  <script
+    async
+    crossorigin="anonymous"
+    data-clerk-publishable-key='{{pub_key}}'
+    src="https://[your-domain].clerk.accounts.dev/npm/@clerk/clerk-js@latest/dist/clerk.browser.js"
+    type="text/javascript"
+  ></script>
 
   <script>
     window.addEventListener("load", async function () {

--- a/docs/components/organization/organization-list.mdx
+++ b/docs/components/organization/organization-list.mdx
@@ -146,12 +146,12 @@ function mountOrganizationList(node: HTMLDivElement, props?: OrganizationListPro
   <div id="organization-list"></div>
 
   <!-- Initialize Clerk with your
-  Clerk publishable key and Frontend API URL -->
+  Clerk Publishable key and Frontend API URL -->
   <script
     async
     crossorigin="anonymous"
-    data-clerk-publishable-key='{{pub_key}}'
-    src="https://[your-domain].clerk.accounts.dev/npm/@clerk/clerk-js@latest/dist/clerk.browser.js"
+    data-clerk-publishable-key="{{pub_key}}"
+    src="https://{{fapi_key}}/npm/@clerk/clerk-js@latest/dist/clerk.browser.js"
     type="text/javascript"
   ></script>
 
@@ -215,12 +215,12 @@ function unmountOrganizationList(node: HTMLDivElement): void;
   <div id="organization-list"></div>
 
   <!-- Initialize Clerk with your
-  Clerk publishable key and Frontend API URL -->
+  Clerk Publishable key and Frontend API URL -->
   <script
     async
     crossorigin="anonymous"
-    data-clerk-publishable-key='{{pub_key}}'
-    src="https://[your-domain].clerk.accounts.dev/npm/@clerk/clerk-js@latest/dist/clerk.browser.js"
+    data-clerk-publishable-key="{{pub_key}}"
+    src="https://{{fapi_key}}/npm/@clerk/clerk-js@latest/dist/clerk.browser.js"
     type="text/javascript"
   ></script>
 

--- a/docs/components/organization/organization-profile.mdx
+++ b/docs/components/organization/organization-profile.mdx
@@ -133,7 +133,7 @@ function mountOrganizationProfile(node: HTMLDivElement, props?: OrganizationProf
     async
     crossorigin="anonymous"
     data-clerk-publishable-key="{{pub_key}}"
-    src="https://{{fapi_key}}/npm/@clerk/clerk-js@latest/dist/clerk.browser.js"
+    src="https://{{fapi_url}}/npm/@clerk/clerk-js@latest/dist/clerk.browser.js"
     type="text/javascript"
   ></script>
 
@@ -202,7 +202,7 @@ function unmountOrganizationProfile(node: HTMLDivElement): void;
     async
     crossorigin="anonymous"
     data-clerk-publishable-key="{{pub_key}}"
-    src="https://{{fapi_key}}/npm/@clerk/clerk-js@latest/dist/clerk.browser.js"
+    src="https://{{fapi_url}}/npm/@clerk/clerk-js@latest/dist/clerk.browser.js"
     type="text/javascript"
   ></script>
 
@@ -271,7 +271,7 @@ function openOrganizationProfile(props?: OrganizationProfileProps): void;
     async
     crossorigin="anonymous"
     data-clerk-publishable-key="{{pub_key}}"
-    src="https://{{fapi_key}}/npm/@clerk/clerk-js@latest/dist/clerk.browser.js"
+    src="https://{{fapi_url}}/npm/@clerk/clerk-js@latest/dist/clerk.browser.js"
     type="text/javascript"
   ></script>
 
@@ -330,7 +330,7 @@ function closeOrganizationProfile(): void;
     async
     crossorigin="anonymous"
     data-clerk-publishable-key="{{pub_key}}"
-    src="https://{{fapi_key}}/npm/@clerk/clerk-js@latest/dist/clerk.browser.js"
+    src="https://{{fapi_url}}/npm/@clerk/clerk-js@latest/dist/clerk.browser.js"
     type="text/javascript"
   ></script>
 

--- a/docs/components/organization/organization-profile.mdx
+++ b/docs/components/organization/organization-profile.mdx
@@ -123,7 +123,7 @@ function mountOrganizationProfile(node: HTMLDivElement, props?: OrganizationProf
   clerk.mountOrganizationProfile(orgProfileDiv);
   ```
 
-  ```html filename="index.html" {11}
+  ```html filename="index.html" {21}
   <!-- Add a <div id="organization-profile"> element to your HTML -->
   <div id="organization-profile"></div>
 
@@ -192,7 +192,7 @@ function unmountOrganizationProfile(node: HTMLDivElement): void;
   clerk.unmountOrganizationProfile(orgProfileDiv);
   ```
 
-  ```html filename="index.html" {15}
+  ```html filename="index.html" {25}
   <!-- Add a <div id="organization-profile"> element to your HTML -->
   <div id="organization-profile"></div>
 
@@ -261,7 +261,7 @@ function openOrganizationProfile(props?: OrganizationProfileProps): void;
   clerk.openOrganizationProfile(orgProfileDiv);
   ```
 
-  ```html filename="index.html" {11}
+  ```html filename="index.html" {21}
   <!-- Add a <div id="organization-profile"> element to your HTML -->
   <div id="organization-profile"></div>
 
@@ -320,7 +320,7 @@ function closeOrganizationProfile(): void;
   clerk.closeOrganizationProfile(orgProfileDiv);
   ```
 
-  ```html filename="index.html" {11}
+  ```html filename="index.html" {21}
   <!-- Add a <div id="organization-profile"> element to your HTML -->
   <div id="organization-profile"></div>
 

--- a/docs/components/organization/organization-profile.mdx
+++ b/docs/components/organization/organization-profile.mdx
@@ -127,6 +127,16 @@ function mountOrganizationProfile(node: HTMLDivElement, props?: OrganizationProf
   <!-- Add a <div id="organization-profile"> element to your HTML -->
   <div id="organization-profile"></div>
 
+  <!-- Initialize Clerk with your
+  Clerk publishable key and Frontend API URL -->
+  <script
+    async
+    crossorigin="anonymous"
+    data-clerk-publishable-key='{{pub_key}}'
+    src="https://[your-domain].clerk.accounts.dev/npm/@clerk/clerk-js@latest/dist/clerk.browser.js"
+    type="text/javascript"
+  ></script>
+
   <script>
     window.addEventListener("load", async function () {
       await Clerk.load();
@@ -185,6 +195,16 @@ function unmountOrganizationProfile(node: HTMLDivElement): void;
   ```html filename="index.html" {15}
   <!-- Add a <div id="organization-profile"> element to your HTML -->
   <div id="organization-profile"></div>
+
+  <!-- Initialize Clerk with your
+  Clerk publishable key and Frontend API URL -->
+  <script
+    async
+    crossorigin="anonymous"
+    data-clerk-publishable-key='{{pub_key}}'
+    src="https://[your-domain].clerk.accounts.dev/npm/@clerk/clerk-js@latest/dist/clerk.browser.js"
+    type="text/javascript"
+  ></script>
 
   <script>
     window.addEventListener("load", async function () {
@@ -245,6 +265,16 @@ function openOrganizationProfile(props?: OrganizationProfileProps): void;
   <!-- Add a <div id="organization-profile"> element to your HTML -->
   <div id="organization-profile"></div>
 
+  <!-- Initialize Clerk with your
+  Clerk publishable key and Frontend API URL -->
+  <script
+    async
+    crossorigin="anonymous"
+    data-clerk-publishable-key='{{pub_key}}'
+    src="https://[your-domain].clerk.accounts.dev/npm/@clerk/clerk-js@latest/dist/clerk.browser.js"
+    type="text/javascript"
+  ></script>
+
   <script>
     window.addEventListener("load", async function () {
       await Clerk.load();
@@ -293,6 +323,16 @@ function closeOrganizationProfile(): void;
   ```html filename="index.html" {11}
   <!-- Add a <div id="organization-profile"> element to your HTML -->
   <div id="organization-profile"></div>
+
+  <!-- Initialize Clerk with your
+  Clerk publishable key and Frontend API URL -->
+  <script
+    async
+    crossorigin="anonymous"
+    data-clerk-publishable-key='{{pub_key}}'
+    src="https://[your-domain].clerk.accounts.dev/npm/@clerk/clerk-js@latest/dist/clerk.browser.js"
+    type="text/javascript"
+  ></script>
 
   <script>
     window.addEventListener("load", async function () {

--- a/docs/components/organization/organization-profile.mdx
+++ b/docs/components/organization/organization-profile.mdx
@@ -128,12 +128,12 @@ function mountOrganizationProfile(node: HTMLDivElement, props?: OrganizationProf
   <div id="organization-profile"></div>
 
   <!-- Initialize Clerk with your
-  Clerk publishable key and Frontend API URL -->
+  Clerk Publishable key and Frontend API URL -->
   <script
     async
     crossorigin="anonymous"
-    data-clerk-publishable-key='{{pub_key}}'
-    src="https://[your-domain].clerk.accounts.dev/npm/@clerk/clerk-js@latest/dist/clerk.browser.js"
+    data-clerk-publishable-key="{{pub_key}}"
+    src="https://{{fapi_key}}/npm/@clerk/clerk-js@latest/dist/clerk.browser.js"
     type="text/javascript"
   ></script>
 
@@ -197,12 +197,12 @@ function unmountOrganizationProfile(node: HTMLDivElement): void;
   <div id="organization-profile"></div>
 
   <!-- Initialize Clerk with your
-  Clerk publishable key and Frontend API URL -->
+  Clerk Publishable key and Frontend API URL -->
   <script
     async
     crossorigin="anonymous"
-    data-clerk-publishable-key='{{pub_key}}'
-    src="https://[your-domain].clerk.accounts.dev/npm/@clerk/clerk-js@latest/dist/clerk.browser.js"
+    data-clerk-publishable-key="{{pub_key}}"
+    src="https://{{fapi_key}}/npm/@clerk/clerk-js@latest/dist/clerk.browser.js"
     type="text/javascript"
   ></script>
 
@@ -266,12 +266,12 @@ function openOrganizationProfile(props?: OrganizationProfileProps): void;
   <div id="organization-profile"></div>
 
   <!-- Initialize Clerk with your
-  Clerk publishable key and Frontend API URL -->
+  Clerk Publishable key and Frontend API URL -->
   <script
     async
     crossorigin="anonymous"
-    data-clerk-publishable-key='{{pub_key}}'
-    src="https://[your-domain].clerk.accounts.dev/npm/@clerk/clerk-js@latest/dist/clerk.browser.js"
+    data-clerk-publishable-key="{{pub_key}}"
+    src="https://{{fapi_key}}/npm/@clerk/clerk-js@latest/dist/clerk.browser.js"
     type="text/javascript"
   ></script>
 
@@ -325,12 +325,12 @@ function closeOrganizationProfile(): void;
   <div id="organization-profile"></div>
 
   <!-- Initialize Clerk with your
-  Clerk publishable key and Frontend API URL -->
+  Clerk Publishable key and Frontend API URL -->
   <script
     async
     crossorigin="anonymous"
-    data-clerk-publishable-key='{{pub_key}}'
-    src="https://[your-domain].clerk.accounts.dev/npm/@clerk/clerk-js@latest/dist/clerk.browser.js"
+    data-clerk-publishable-key="{{pub_key}}"
+    src="https://{{fapi_key}}/npm/@clerk/clerk-js@latest/dist/clerk.browser.js"
     type="text/javascript"
   ></script>
 

--- a/docs/components/organization/organization-switcher.mdx
+++ b/docs/components/organization/organization-switcher.mdx
@@ -138,7 +138,7 @@ function mountOrganizationSwitcher(node: HTMLDivElement, props?: OrganizationSwi
   clerk.mountOrganizationSwitcher(orgSwitcherDiv);
   ```
 
-  ```html filename="index.html" {11}
+  ```html filename="index.html" {21}
   <!-- Add a <div id="organization-switcher"> element to your HTML -->
   <div id="organization-switcher"></div>
 
@@ -207,7 +207,7 @@ function unmountOrganizationSwitcher(node: HTMLDivElement): void;
   clerk.unmountOrganizationSwitcher(orgSwitcherDiv);
   ```
 
-  ```html filename="index.html" {15}
+  ```html filename="index.html" {25}
   <!-- Add a <div id="organization-switcher"> element to your HTML -->
   <div id="organization-switcher"></div>
 

--- a/docs/components/organization/organization-switcher.mdx
+++ b/docs/components/organization/organization-switcher.mdx
@@ -142,6 +142,16 @@ function mountOrganizationSwitcher(node: HTMLDivElement, props?: OrganizationSwi
   <!-- Add a <div id="organization-switcher"> element to your HTML -->
   <div id="organization-switcher"></div>
 
+  <!-- Initialize Clerk with your
+  Clerk publishable key and Frontend API URL -->
+  <script
+    async
+    crossorigin="anonymous"
+    data-clerk-publishable-key='{{pub_key}}'
+    src="https://[your-domain].clerk.accounts.dev/npm/@clerk/clerk-js@latest/dist/clerk.browser.js"
+    type="text/javascript"
+  ></script>
+
   <script>
     window.addEventListener("load", async function () {
       await Clerk.load();
@@ -200,6 +210,16 @@ function unmountOrganizationSwitcher(node: HTMLDivElement): void;
   ```html filename="index.html" {15}
   <!-- Add a <div id="organization-switcher"> element to your HTML -->
   <div id="organization-switcher"></div>
+
+  <!-- Initialize Clerk with your
+  Clerk publishable key and Frontend API URL -->
+  <script
+    async
+    crossorigin="anonymous"
+    data-clerk-publishable-key='{{pub_key}}'
+    src="https://[your-domain].clerk.accounts.dev/npm/@clerk/clerk-js@latest/dist/clerk.browser.js"
+    type="text/javascript"
+  ></script>
 
   <script>
     window.addEventListener("load", async function () {

--- a/docs/components/organization/organization-switcher.mdx
+++ b/docs/components/organization/organization-switcher.mdx
@@ -148,7 +148,7 @@ function mountOrganizationSwitcher(node: HTMLDivElement, props?: OrganizationSwi
     async
     crossorigin="anonymous"
     data-clerk-publishable-key="{{pub_key}}"
-    src="https://{{fapi_key}}/npm/@clerk/clerk-js@latest/dist/clerk.browser.js"
+    src="https://{{fapi_url}}/npm/@clerk/clerk-js@latest/dist/clerk.browser.js"
     type="text/javascript"
   ></script>
 
@@ -217,7 +217,7 @@ function unmountOrganizationSwitcher(node: HTMLDivElement): void;
     async
     crossorigin="anonymous"
     data-clerk-publishable-key="{{pub_key}}"
-    src="https://{{fapi_key}}/npm/@clerk/clerk-js@latest/dist/clerk.browser.js"
+    src="https://{{fapi_url}}/npm/@clerk/clerk-js@latest/dist/clerk.browser.js"
     type="text/javascript"
   ></script>
 

--- a/docs/components/organization/organization-switcher.mdx
+++ b/docs/components/organization/organization-switcher.mdx
@@ -143,12 +143,12 @@ function mountOrganizationSwitcher(node: HTMLDivElement, props?: OrganizationSwi
   <div id="organization-switcher"></div>
 
   <!-- Initialize Clerk with your
-  Clerk publishable key and Frontend API URL -->
+  Clerk Publishable key and Frontend API URL -->
   <script
     async
     crossorigin="anonymous"
-    data-clerk-publishable-key='{{pub_key}}'
-    src="https://[your-domain].clerk.accounts.dev/npm/@clerk/clerk-js@latest/dist/clerk.browser.js"
+    data-clerk-publishable-key="{{pub_key}}"
+    src="https://{{fapi_key}}/npm/@clerk/clerk-js@latest/dist/clerk.browser.js"
     type="text/javascript"
   ></script>
 
@@ -212,12 +212,12 @@ function unmountOrganizationSwitcher(node: HTMLDivElement): void;
   <div id="organization-switcher"></div>
 
   <!-- Initialize Clerk with your
-  Clerk publishable key and Frontend API URL -->
+  Clerk Publishable key and Frontend API URL -->
   <script
     async
     crossorigin="anonymous"
-    data-clerk-publishable-key='{{pub_key}}'
-    src="https://[your-domain].clerk.accounts.dev/npm/@clerk/clerk-js@latest/dist/clerk.browser.js"
+    data-clerk-publishable-key="{{pub_key}}"
+    src="https://{{fapi_key}}/npm/@clerk/clerk-js@latest/dist/clerk.browser.js"
     type="text/javascript"
   ></script>
 

--- a/docs/components/user/user-button.mdx
+++ b/docs/components/user/user-button.mdx
@@ -266,7 +266,7 @@ function mountUserButton(node: HTMLDivElement, props?: UserButtonProps): void;
     async
     crossorigin="anonymous"
     data-clerk-publishable-key="{{pub_key}}"
-    src="https://{{fapi_key}}/npm/@clerk/clerk-js@latest/dist/clerk.browser.js"
+    src="https://{{fapi_url}}/npm/@clerk/clerk-js@latest/dist/clerk.browser.js"
     type="text/javascript"
   ></script>
 
@@ -335,7 +335,7 @@ function unmountUserButton(node: HTMLDivElement): void;
     async
     crossorigin="anonymous"
     data-clerk-publishable-key="{{pub_key}}"
-    src="https://{{fapi_key}}/npm/@clerk/clerk-js@latest/dist/clerk.browser.js"
+    src="https://{{fapi_url}}/npm/@clerk/clerk-js@latest/dist/clerk.browser.js"
     type="text/javascript"
   ></script>
 

--- a/docs/components/user/user-button.mdx
+++ b/docs/components/user/user-button.mdx
@@ -256,7 +256,7 @@ function mountUserButton(node: HTMLDivElement, props?: UserButtonProps): void;
   clerk.mountUserButton(userbuttonDiv);
   ```
 
-  ```html filename="index.html" {11}
+  ```html filename="index.html" {21}
   <!-- Add a <div id="user-button"> element to your HTML -->
   <div id="user-button"></div>
 
@@ -325,7 +325,7 @@ function unmountUserButton(node: HTMLDivElement): void;
   clerk.unmountUserButton(userButtonDiv);
   ```
 
-  ```html filename="index.html" {15}
+  ```html filename="index.html" {25}
   <!-- Add a <div id="user-button"> element to your HTML -->
   <div id="user-button"></div>
 

--- a/docs/components/user/user-button.mdx
+++ b/docs/components/user/user-button.mdx
@@ -261,12 +261,12 @@ function mountUserButton(node: HTMLDivElement, props?: UserButtonProps): void;
   <div id="user-button"></div>
 
   <!-- Initialize Clerk with your
-  Clerk publishable key and Frontend API URL -->
+  Clerk Publishable key and Frontend API URL -->
   <script
     async
     crossorigin="anonymous"
-    data-clerk-publishable-key='{{pub_key}}'
-    src="https://[your-domain].clerk.accounts.dev/npm/@clerk/clerk-js@latest/dist/clerk.browser.js"
+    data-clerk-publishable-key="{{pub_key}}"
+    src="https://{{fapi_key}}/npm/@clerk/clerk-js@latest/dist/clerk.browser.js"
     type="text/javascript"
   ></script>
 
@@ -330,12 +330,12 @@ function unmountUserButton(node: HTMLDivElement): void;
   <div id="user-button"></div>
 
   <!-- Initialize Clerk with your
-  Clerk publishable key and Frontend API URL -->
+  Clerk Publishable key and Frontend API URL -->
   <script
     async
     crossorigin="anonymous"
-    data-clerk-publishable-key='{{pub_key}}'
-    src="https://[your-domain].clerk.accounts.dev/npm/@clerk/clerk-js@latest/dist/clerk.browser.js"
+    data-clerk-publishable-key="{{pub_key}}"
+    src="https://{{fapi_key}}/npm/@clerk/clerk-js@latest/dist/clerk.browser.js"
     type="text/javascript"
   ></script>
 

--- a/docs/components/user/user-button.mdx
+++ b/docs/components/user/user-button.mdx
@@ -260,6 +260,16 @@ function mountUserButton(node: HTMLDivElement, props?: UserButtonProps): void;
   <!-- Add a <div id="user-button"> element to your HTML -->
   <div id="user-button"></div>
 
+  <!-- Initialize Clerk with your
+  Clerk publishable key and Frontend API URL -->
+  <script
+    async
+    crossorigin="anonymous"
+    data-clerk-publishable-key='{{pub_key}}'
+    src="https://[your-domain].clerk.accounts.dev/npm/@clerk/clerk-js@latest/dist/clerk.browser.js"
+    type="text/javascript"
+  ></script>
+
   <script>
     window.addEventListener("load", async function () {
       await Clerk.load();
@@ -318,6 +328,16 @@ function unmountUserButton(node: HTMLDivElement): void;
   ```html filename="index.html" {15}
   <!-- Add a <div id="user-button"> element to your HTML -->
   <div id="user-button"></div>
+
+  <!-- Initialize Clerk with your
+  Clerk publishable key and Frontend API URL -->
+  <script
+    async
+    crossorigin="anonymous"
+    data-clerk-publishable-key='{{pub_key}}'
+    src="https://[your-domain].clerk.accounts.dev/npm/@clerk/clerk-js@latest/dist/clerk.browser.js"
+    type="text/javascript"
+  ></script>
 
   <script>
     window.addEventListener("load", async function () {

--- a/docs/components/user/user-profile.mdx
+++ b/docs/components/user/user-profile.mdx
@@ -130,12 +130,12 @@ function mountUserProfile(node: HTMLDivElement, props?: UserProfileProps): void;
   <div id="user-profile"></div>
 
   <!-- Initialize Clerk with your
-  Clerk publishable key and Frontend API URL -->
+  Clerk Publishable key and Frontend API URL -->
   <script
     async
     crossorigin="anonymous"
-    data-clerk-publishable-key='{{pub_key}}'
-    src="https://[your-domain].clerk.accounts.dev/npm/@clerk/clerk-js@latest/dist/clerk.browser.js"
+    data-clerk-publishable-key="{{pub_key}}"
+    src="https://{{fapi_key}}/npm/@clerk/clerk-js@latest/dist/clerk.browser.js"
     type="text/javascript"
   ></script>
 
@@ -199,12 +199,12 @@ function unmountUserProfile(node: HTMLDivElement): void;
   <div id="user-profile"></div>
 
   <!-- Initialize Clerk with your
-  Clerk publishable key and Frontend API URL -->
+  Clerk Publishable key and Frontend API URL -->
   <script
     async
     crossorigin="anonymous"
-    data-clerk-publishable-key='{{pub_key}}'
-    src="https://[your-domain].clerk.accounts.dev/npm/@clerk/clerk-js@latest/dist/clerk.browser.js"
+    data-clerk-publishable-key="{{pub_key}}"
+    src="https://{{fapi_key}}/npm/@clerk/clerk-js@latest/dist/clerk.browser.js"
     type="text/javascript"
   ></script>
 
@@ -268,12 +268,12 @@ function openUserProfile(props?: UserProfileProps): void;
   <div id="user-profile"></div>
 
   <!-- Initialize Clerk with your
-  Clerk publishable key and Frontend API URL -->
+  Clerk Publishable key and Frontend API URL -->
   <script
     async
     crossorigin="anonymous"
-    data-clerk-publishable-key='{{pub_key}}'
-    src="https://[your-domain].clerk.accounts.dev/npm/@clerk/clerk-js@latest/dist/clerk.browser.js"
+    data-clerk-publishable-key="{{pub_key}}"
+    src="https://{{fapi_key}}/npm/@clerk/clerk-js@latest/dist/clerk.browser.js"
     type="text/javascript"
   ></script>
 
@@ -327,12 +327,12 @@ function closeUserProfile(): void;
   <div id="user-profile"></div>
 
   <!-- Initialize Clerk with your
-  Clerk publishable key and Frontend API URL -->
+  Clerk Publishable key and Frontend API URL -->
   <script
     async
     crossorigin="anonymous"
-    data-clerk-publishable-key='{{pub_key}}'
-    src="https://[your-domain].clerk.accounts.dev/npm/@clerk/clerk-js@latest/dist/clerk.browser.js"
+    data-clerk-publishable-key="{{pub_key}}"
+    src="https://{{fapi_key}}/npm/@clerk/clerk-js@latest/dist/clerk.browser.js"
     type="text/javascript"
   ></script>
 

--- a/docs/components/user/user-profile.mdx
+++ b/docs/components/user/user-profile.mdx
@@ -135,7 +135,7 @@ function mountUserProfile(node: HTMLDivElement, props?: UserProfileProps): void;
     async
     crossorigin="anonymous"
     data-clerk-publishable-key="{{pub_key}}"
-    src="https://{{fapi_key}}/npm/@clerk/clerk-js@latest/dist/clerk.browser.js"
+    src="https://{{fapi_url}}/npm/@clerk/clerk-js@latest/dist/clerk.browser.js"
     type="text/javascript"
   ></script>
 
@@ -204,7 +204,7 @@ function unmountUserProfile(node: HTMLDivElement): void;
     async
     crossorigin="anonymous"
     data-clerk-publishable-key="{{pub_key}}"
-    src="https://{{fapi_key}}/npm/@clerk/clerk-js@latest/dist/clerk.browser.js"
+    src="https://{{fapi_url}}/npm/@clerk/clerk-js@latest/dist/clerk.browser.js"
     type="text/javascript"
   ></script>
 
@@ -273,7 +273,7 @@ function openUserProfile(props?: UserProfileProps): void;
     async
     crossorigin="anonymous"
     data-clerk-publishable-key="{{pub_key}}"
-    src="https://{{fapi_key}}/npm/@clerk/clerk-js@latest/dist/clerk.browser.js"
+    src="https://{{fapi_url}}/npm/@clerk/clerk-js@latest/dist/clerk.browser.js"
     type="text/javascript"
   ></script>
 
@@ -332,7 +332,7 @@ function closeUserProfile(): void;
     async
     crossorigin="anonymous"
     data-clerk-publishable-key="{{pub_key}}"
-    src="https://{{fapi_key}}/npm/@clerk/clerk-js@latest/dist/clerk.browser.js"
+    src="https://{{fapi_url}}/npm/@clerk/clerk-js@latest/dist/clerk.browser.js"
     type="text/javascript"
   ></script>
 

--- a/docs/components/user/user-profile.mdx
+++ b/docs/components/user/user-profile.mdx
@@ -129,6 +129,16 @@ function mountUserProfile(node: HTMLDivElement, props?: UserProfileProps): void;
   <!-- Add a <div id="user-profile"> element to your HTML -->
   <div id="user-profile"></div>
 
+  <!-- Initialize Clerk with your
+  Clerk publishable key and Frontend API URL -->
+  <script
+    async
+    crossorigin="anonymous"
+    data-clerk-publishable-key='{{pub_key}}'
+    src="https://[your-domain].clerk.accounts.dev/npm/@clerk/clerk-js@latest/dist/clerk.browser.js"
+    type="text/javascript"
+  ></script>
+
   <script>
     window.addEventListener("load", async function () {
       await Clerk.load();
@@ -187,6 +197,16 @@ function unmountUserProfile(node: HTMLDivElement): void;
   ```html filename="index.html" {15}
   <!-- Add a <div id="user-profile"> element to your HTML -->
   <div id="user-profile"></div>
+
+  <!-- Initialize Clerk with your
+  Clerk publishable key and Frontend API URL -->
+  <script
+    async
+    crossorigin="anonymous"
+    data-clerk-publishable-key='{{pub_key}}'
+    src="https://[your-domain].clerk.accounts.dev/npm/@clerk/clerk-js@latest/dist/clerk.browser.js"
+    type="text/javascript"
+  ></script>
 
   <script>
     window.addEventListener("load", async function () {
@@ -247,6 +267,16 @@ function openUserProfile(props?: UserProfileProps): void;
   <!-- Add a <div id="user-profile"> element to your HTML -->
   <div id="user-profile"></div>
 
+  <!-- Initialize Clerk with your
+  Clerk publishable key and Frontend API URL -->
+  <script
+    async
+    crossorigin="anonymous"
+    data-clerk-publishable-key='{{pub_key}}'
+    src="https://[your-domain].clerk.accounts.dev/npm/@clerk/clerk-js@latest/dist/clerk.browser.js"
+    type="text/javascript"
+  ></script>
+
   <script>
     window.addEventListener("load", async function () {
       await Clerk.load();
@@ -295,6 +325,16 @@ function closeUserProfile(): void;
   ```html filename="index.html" {11}
   <!-- Add a <div id="user-profile"> element to your HTML -->
   <div id="user-profile"></div>
+
+  <!-- Initialize Clerk with your
+  Clerk publishable key and Frontend API URL -->
+  <script
+    async
+    crossorigin="anonymous"
+    data-clerk-publishable-key='{{pub_key}}'
+    src="https://[your-domain].clerk.accounts.dev/npm/@clerk/clerk-js@latest/dist/clerk.browser.js"
+    type="text/javascript"
+  ></script>
 
   <script>
     window.addEventListener("load", async function () {

--- a/docs/components/user/user-profile.mdx
+++ b/docs/components/user/user-profile.mdx
@@ -125,7 +125,7 @@ function mountUserProfile(node: HTMLDivElement, props?: UserProfileProps): void;
   clerk.mountUserProfile(userProfileDiv);
   ```
 
-  ```html filename="index.html" {11}
+  ```html filename="index.html" {21}
   <!-- Add a <div id="user-profile"> element to your HTML -->
   <div id="user-profile"></div>
 
@@ -194,7 +194,7 @@ function unmountUserProfile(node: HTMLDivElement): void;
   clerk.unmountUserProfile(userProfileDiv);
   ```
 
-  ```html filename="index.html" {15}
+  ```html filename="index.html" {25}
   <!-- Add a <div id="user-profile"> element to your HTML -->
   <div id="user-profile"></div>
 
@@ -263,7 +263,7 @@ function openUserProfile(props?: UserProfileProps): void;
   clerk.openUserProfile(userProfileDiv);
   ```
 
-  ```html filename="index.html" {11}
+  ```html filename="index.html" {21}
   <!-- Add a <div id="user-profile"> element to your HTML -->
   <div id="user-profile"></div>
 
@@ -322,7 +322,7 @@ function closeUserProfile(): void;
   clerk.closeUserProfile(userProfileDiv);
   ```
 
-  ```html filename="index.html" {11}
+  ```html filename="index.html" {21}
   <!-- Add a <div id="user-profile"> element to your HTML -->
   <div id="user-profile"></div>
 

--- a/docs/custom-flows/user-impersonation.mdx
+++ b/docs/custom-flows/user-impersonation.mdx
@@ -100,7 +100,9 @@ The above JSON snippet shows what a Clerk session token looks like when a user i
 
 ### Detect impersonated sessions in the frontend
 
-When working with frontend (client-side) code, you can easily detect impersonated sessions and gain access to the actor ID or other information from the `act` claim.
+When working with client-side code, you can detect impersonated sessions and gain access to the actor ID or other information from the `act` claim.
+
+{/* TODO (DOCS-259): Add App Router example */}
 
 <Tabs type="framework" items={["Next.js", "React", "JavaScript"]}>
   <Tab>

--- a/docs/custom-flows/user-impersonation.mdx
+++ b/docs/custom-flows/user-impersonation.mdx
@@ -102,79 +102,121 @@ The above JSON snippet shows what a Clerk session token looks like when a user i
 
 When working with frontend (client-side) code, you can easily detect impersonated sessions and gain access to the actor ID or other information from the `act` claim.
 
-<CodeBlockTabs type="framework" options={["Next.js", "React", "JavaScript"]}>
-```jsx
-import { useAuth } from "@clerk/nextjs";
-import { withServerSideAuth } from "@clerk/nextjs";
+<Tabs type="framework" items={["Next.js", "React", "JavaScript"]}>
+  <Tab>
+  ```jsx
+  import { useAuth } from "@clerk/nextjs";
+  import { withServerSideAuth } from "@clerk/nextjs";
 
-// SSR authentication context
-export const getServerSideProps = withServerSideAuth(
-  async ({ req }) => {
-    // The request is augmented with an auth object.
-    // The actor object is available in there.
-    const { userId, actor } = req.auth;
+  // SSR authentication context
+  export const getServerSideProps = withServerSideAuth(
+    async ({ req }) => {
+      // The request is augmented with an auth object.
+      // The actor object is available in there.
+      const { userId, actor } = req.auth;
 
-    return {
-      props: { userId, actor },
-    };
+      return {
+        props: { userId, actor },
+      };
+    }
+  );
+
+  function Home({ userId, actor }) {
+    return (
+      <div>
+        Server side info:
+        <p>
+          {actor && <span>User {actor.sub} has </span>}
+          signed in as user {userId}
+        </p>
+
+        <ClientSideInfo />
+      </div>
+    )
   }
-);
 
-function Home({ userId, actor }) {
-  return (
-    <div>
-      Server side info:
-      <p>
-        {actor && <span>User {actor.sub} has </span>}
+  function ClientSideInfo() {
+    // Client-side authentication context.
+    const { userId, actor } = useAuth();
+
+    return (
+      <div>
+        Client side info:
+        <p>
+          {actor && <span>User {actor.sub} has </span>}
+          signed in as user {userId}
+        </p>
+      </div>
+    );
+  }
+  ```
+  </Tab>
+
+  <Tab>
+  ```jsx
+  import { useAuth } from "@clerk/react";
+
+  function Home() {
+    const { userId, actor } = useAuth();
+
+    return (
+      <div>
+        {actor && <span>user {actor.sub} has </span>}
         signed in as user {userId}
-      </p>
+      </div>
+    );
+  }
+  ```
+  </Tab>
 
-      <ClientSideInfo />
-    </div>
-  )
-}
+  <Tab>
+    <InjectKeys>
 
-function ClientSideInfo() {
-  // Client-side authentication context.
-  const { userId, actor } = useAuth();
+    <CodeBlockTabs type="npm-script" options={["NPM module", "<script>"]}>
+    ```js filename="main.js"
+    import Clerk from '@clerk/clerk-js';
 
-  return (
-    <div>
-      Client side info:
-      <p>
-        {actor && <span>User {actor.sub} has </span>}
-        signed in as user {userId}
-      </p>
-    </div>
-  );
-}
-```
+    // Initialize Clerk with your Clerk publishable key
+    const clerk = new Clerk("{{pub_key}}");
+    await clerk.load();
 
-```jsx
-import { useAuth } from "@clerk/react";
+    const { session } = clerk;
 
-function Home() {
-  const { userId, actor } = useAuth();
+    if (session.actor) {
+      const { actor, user } = session;
 
-  return (
-    <div>
-      {actor && <span>user {actor.sub} has </span>}
-      signed in as user {userId}
-    </div>
-  );
-}
-```
+      console.log(`User ${actor.sub} is signed in as user ${user.id}.`)
+    }
+    ```
 
-```js
-const { session } = window.Clerk;
+    ```html filename="index.html"
+    <script
+      async
+      crossorigin="anonymous"
+      data-clerk-publishable-key="{{pub_key}}"
+      src="https://[your-domain].clerk.accounts.dev/npm/@clerk/clerk-js@latest/dist/clerk.browser.js"
+      type="text/javascript"
+    ></script>
 
-if (session.actor) {
-  const { actor, user } = session;
+    <script>
+    window.addEventListener("load", async function () {
+      await Clerk.load();
 
-  console.log(`User ${actor.sub} is signed in as user ${user.id}.`)
-}
-```
-</CodeBlockTabs>
+      const { session } = Clerk;
+
+      if (session.actor) {
+        const { actor, user } = session;
+
+        console.log(`User ${actor.sub} is signed in as user ${user.id}.`)
+      }
+    });
+    </script>
+    ```
+    </CodeBlockTabs>
+
+    </InjectKeys>
+  </Tab>
+</Tabs>
 
 ### Detect impersonated sessions in the backend
 

--- a/docs/quickstarts/javascript.mdx
+++ b/docs/quickstarts/javascript.mdx
@@ -207,7 +207,7 @@ Select your preferred method below to get started.
         async
         crossorigin="anonymous"
         data-clerk-publishable-key="{{pub_key}}"
-        src="https://{{fapi_key}}/npm/@clerk/clerk-js@latest/dist/clerk.browser.js"
+        src="https://{{fapi_url}}/npm/@clerk/clerk-js@latest/dist/clerk.browser.js"
         type="text/javascript"
       ></script>
       ```
@@ -252,7 +252,7 @@ Select your preferred method below to get started.
         async
         crossorigin="anonymous"
         data-clerk-publishable-key="{{pub_key}}"
-        src="https://{{fapi_key}}/npm/@clerk/clerk-js@latest/dist/clerk.browser.js"
+        src="https://{{fapi_url}}/npm/@clerk/clerk-js@latest/dist/clerk.browser.js"
         type="text/javascript"
       ></script>
 

--- a/docs/quickstarts/javascript.mdx
+++ b/docs/quickstarts/javascript.mdx
@@ -203,13 +203,13 @@ Select your preferred method below to get started.
       <InjectKeys>
 
       ```html filename="index.html"
-        <script
-          async
-          crossorigin="anonymous"
-          data-clerk-publishable-key={{pub_key}}
-          src="https://[your-domain].clerk.accounts.dev/npm/@clerk/clerk-js@latest/dist/clerk.browser.js"
-          type="text/javascript"
-        ></script>
+      <script
+        async
+        crossorigin="anonymous"
+        data-clerk-publishable-key="{{pub_key}}"
+        src="https://{{fapi_key}}/npm/@clerk/clerk-js@latest/dist/clerk.browser.js"
+        type="text/javascript"
+      ></script>
       ```
 
       </InjectKeys>
@@ -246,11 +246,13 @@ Select your preferred method below to get started.
       ```html filename="index.html"
       <div id="app"></div>
 
+      <!-- Initialize Clerk with your
+      Clerk Publishable key and Frontend API URL -->
       <script
         async
         crossorigin="anonymous"
-        data-clerk-publishable-key={{pub_key}}
-        src="https://[your-domain].clerk.accounts.dev/npm/@clerk/clerk-js@latest/dist/clerk.browser.js"
+        data-clerk-publishable-key="{{pub_key}}"
+        src="https://{{fapi_key}}/npm/@clerk/clerk-js@latest/dist/clerk.browser.js"
         type="text/javascript"
       ></script>
 

--- a/docs/references/javascript/clerk/organization-methods.mdx
+++ b/docs/references/javascript/clerk/organization-methods.mdx
@@ -81,12 +81,12 @@ function getOrganization(organizationId: string): Promise<Organization | undefin
   <div id="sign-in"></div>
 
   <!-- Initialize Clerk with your
-  Clerk publishable key and Frontend API URL -->
+  Clerk Publishable key and Frontend API URL -->
   <script
     async
     crossorigin="anonymous"
-    data-clerk-publishable-key='{{pub_key}}'
-    src="https://[your-domain].clerk.accounts.dev/npm/@clerk/clerk-js@latest/dist/clerk.browser.js"
+    data-clerk-publishable-key="{{pub_key}}"
+    src="https://{{fapi_key}}/npm/@clerk/clerk-js@latest/dist/clerk.browser.js"
     type="text/javascript"
   ></script>
 
@@ -198,12 +198,12 @@ function createOrganization({name, slug}: CreateOrganizationParams): Promise<Org
   <div id="create-org-button"></div>
 
   <!-- Initialize Clerk with your
-  Clerk publishable key and Frontend API URL -->
+  Clerk Publishable key and Frontend API URL -->
   <script
     async
     crossorigin="anonymous"
-    data-clerk-publishable-key='{{pub_key}}'
-    src="https://[your-domain].clerk.accounts.dev/npm/@clerk/clerk-js@latest/dist/clerk.browser.js"
+    data-clerk-publishable-key="{{pub_key}}"
+    src="https://{{fapi_key}}/npm/@clerk/clerk-js@latest/dist/clerk.browser.js"
     type="text/javascript"
   ></script>
 

--- a/docs/references/javascript/clerk/organization-methods.mdx
+++ b/docs/references/javascript/clerk/organization-methods.mdx
@@ -77,7 +77,7 @@ function getOrganization(organizationId: string): Promise<Organization | undefin
   </Tab>
 
   <Tab>
-  ```html filename="index.html" {9}
+  ```html filename="index.html" {19}
   <div id="sign-in"></div>
 
   <!-- Initialize Clerk with your
@@ -193,7 +193,7 @@ function createOrganization({name, slug}: CreateOrganizationParams): Promise<Org
   </Tab>
 
   <Tab>
-  ```html filename="index.html" {12-14}
+  ```html filename="index.html" {22-24}
   <div id="sign-in"></div>
   <div id="create-org-button"></div>
 

--- a/docs/references/javascript/clerk/organization-methods.mdx
+++ b/docs/references/javascript/clerk/organization-methods.mdx
@@ -80,6 +80,16 @@ function getOrganization(organizationId: string): Promise<Organization | undefin
   ```html filename="index.html" {9}
   <div id="sign-in"></div>
 
+  <!-- Initialize Clerk with your
+  Clerk publishable key and Frontend API URL -->
+  <script
+    async
+    crossorigin="anonymous"
+    data-clerk-publishable-key='{{pub_key}}'
+    src="https://[your-domain].clerk.accounts.dev/npm/@clerk/clerk-js@latest/dist/clerk.browser.js"
+    type="text/javascript"
+  ></script>
+
   <script>
     window.addEventListener("load", async function () {
       await Clerk.load();
@@ -186,6 +196,16 @@ function createOrganization({name, slug}: CreateOrganizationParams): Promise<Org
   ```html filename="index.html" {12-14}
   <div id="sign-in"></div>
   <div id="create-org-button"></div>
+
+  <!-- Initialize Clerk with your
+  Clerk publishable key and Frontend API URL -->
+  <script
+    async
+    crossorigin="anonymous"
+    data-clerk-publishable-key='{{pub_key}}'
+    src="https://[your-domain].clerk.accounts.dev/npm/@clerk/clerk-js@latest/dist/clerk.browser.js"
+    type="text/javascript"
+  ></script>
 
   <script>
     window.addEventListener("load", async function () {

--- a/docs/references/javascript/clerk/organization-methods.mdx
+++ b/docs/references/javascript/clerk/organization-methods.mdx
@@ -86,7 +86,7 @@ function getOrganization(organizationId: string): Promise<Organization | undefin
     async
     crossorigin="anonymous"
     data-clerk-publishable-key="{{pub_key}}"
-    src="https://{{fapi_key}}/npm/@clerk/clerk-js@latest/dist/clerk.browser.js"
+    src="https://{{fapi_url}}/npm/@clerk/clerk-js@latest/dist/clerk.browser.js"
     type="text/javascript"
   ></script>
 
@@ -203,7 +203,7 @@ function createOrganization({name, slug}: CreateOrganizationParams): Promise<Org
     async
     crossorigin="anonymous"
     data-clerk-publishable-key="{{pub_key}}"
-    src="https://{{fapi_key}}/npm/@clerk/clerk-js@latest/dist/clerk.browser.js"
+    src="https://{{fapi_url}}/npm/@clerk/clerk-js@latest/dist/clerk.browser.js"
     type="text/javascript"
   ></script>
 

--- a/docs/references/javascript/organization-invitation.mdx
+++ b/docs/references/javascript/organization-invitation.mdx
@@ -104,12 +104,12 @@ if (clerk.user) {
   <div id="app"></div>
 
   <!-- Initialize Clerk with your
-  Clerk publishable key and Frontend API URL -->
+  Clerk Publishable key and Frontend API URL -->
   <script
     async
     crossorigin="anonymous"
-    data-clerk-publishable-key='{{pub_key}}'
-    src="https://[your-domain].clerk.accounts.dev/npm/@clerk/clerk-js@latest/dist/clerk.browser.js"
+    data-clerk-publishable-key="{{pub_key}}"
+    src="https://{{fapi_key}}/npm/@clerk/clerk-js@latest/dist/clerk.browser.js"
     type="text/javascript"
   ></script>
 

--- a/docs/references/javascript/organization-invitation.mdx
+++ b/docs/references/javascript/organization-invitation.mdx
@@ -52,7 +52,7 @@ It assumes:
 <InjectKeys>
 
 <CodeBlockTabs type="npm-script" options={['NPM module', '<script>']}>
-```js filename="main.js" {23}
+```js filename="main.js" {21}
 import Clerk from '@clerk/clerk-js';
 
 // Initialize Clerk with your Clerk publishable key
@@ -100,7 +100,7 @@ if (clerk.user) {
 }
 ```
 
-```html filename="index.html" {33}
+```html filename="index.html" {31}
   <div id="app"></div>
 
   <!-- Initialize Clerk with your

--- a/docs/references/javascript/organization-invitation.mdx
+++ b/docs/references/javascript/organization-invitation.mdx
@@ -109,7 +109,7 @@ if (clerk.user) {
     async
     crossorigin="anonymous"
     data-clerk-publishable-key="{{pub_key}}"
-    src="https://{{fapi_key}}/npm/@clerk/clerk-js@latest/dist/clerk.browser.js"
+    src="https://{{fapi_url}}/npm/@clerk/clerk-js@latest/dist/clerk.browser.js"
     type="text/javascript"
   ></script>
 

--- a/docs/references/javascript/organization/domains.mdx
+++ b/docs/references/javascript/organization/domains.mdx
@@ -84,7 +84,7 @@ if (clerk.user) {
     async
     crossorigin="anonymous"
     data-clerk-publishable-key="{{pub_key}}"
-    src="https://{{fapi_key}}/npm/@clerk/clerk-js@latest/dist/clerk.browser.js"
+    src="https://{{fapi_url}}/npm/@clerk/clerk-js@latest/dist/clerk.browser.js"
     type="text/javascript"
   ></script>
 
@@ -198,7 +198,7 @@ if (clerk.user) {
     async
     crossorigin="anonymous"
     data-clerk-publishable-key="{{pub_key}}"
-    src="https://{{fapi_key}}/npm/@clerk/clerk-js@latest/dist/clerk.browser.js"
+    src="https://{{fapi_url}}/npm/@clerk/clerk-js@latest/dist/clerk.browser.js"
     type="text/javascript"
   ></script>
 
@@ -312,7 +312,7 @@ if (clerk.user) {
     async
     crossorigin="anonymous"
     data-clerk-publishable-key="{{pub_key}}"
-    src="https://{{fapi_key}}/npm/@clerk/clerk-js@latest/dist/clerk.browser.js"
+    src="https://{{fapi_url}}/npm/@clerk/clerk-js@latest/dist/clerk.browser.js"
     type="text/javascript"
   ></script>
 

--- a/docs/references/javascript/organization/domains.mdx
+++ b/docs/references/javascript/organization/domains.mdx
@@ -79,12 +79,12 @@ if (clerk.user) {
   <div id="app"></div>
 
   <!-- Initialize Clerk with your
-  Clerk publishable key and Frontend API URL -->
+  Clerk Publishable key and Frontend API URL -->
   <script
     async
     crossorigin="anonymous"
-    data-clerk-publishable-key='{{pub_key}}'
-    src="https://[your-domain].clerk.accounts.dev/npm/@clerk/clerk-js@latest/dist/clerk.browser.js"
+    data-clerk-publishable-key="{{pub_key}}"
+    src="https://{{fapi_key}}/npm/@clerk/clerk-js@latest/dist/clerk.browser.js"
     type="text/javascript"
   ></script>
 
@@ -193,12 +193,12 @@ if (clerk.user) {
   <div id="app"></div>
 
   <!-- Initialize Clerk with your
-  Clerk publishable key and Frontend API URL -->
+  Clerk Publishable key and Frontend API URL -->
   <script
     async
     crossorigin="anonymous"
-    data-clerk-publishable-key='{{pub_key}}'
-    src="https://[your-domain].clerk.accounts.dev/npm/@clerk/clerk-js@latest/dist/clerk.browser.js"
+    data-clerk-publishable-key="{{pub_key}}"
+    src="https://{{fapi_key}}/npm/@clerk/clerk-js@latest/dist/clerk.browser.js"
     type="text/javascript"
   ></script>
 
@@ -307,12 +307,12 @@ if (clerk.user) {
   <div id="app"></div>
 
   <!-- Initialize Clerk with your
-  Clerk publishable key and Frontend API URL -->
+  Clerk Publishable key and Frontend API URL -->
   <script
     async
     crossorigin="anonymous"
-    data-clerk-publishable-key='{{pub_key}}'
-    src="https://[your-domain].clerk.accounts.dev/npm/@clerk/clerk-js@latest/dist/clerk.browser.js"
+    data-clerk-publishable-key="{{pub_key}}"
+    src="https://{{fapi_key}}/npm/@clerk/clerk-js@latest/dist/clerk.browser.js"
     type="text/javascript"
   ></script>
 

--- a/docs/references/javascript/organization/invitations.mdx
+++ b/docs/references/javascript/organization/invitations.mdx
@@ -80,12 +80,12 @@ if (clerk.user) {
   <div id="app"></div>
 
   <!-- Initialize Clerk with your
-  Clerk publishable key and Frontend API URL -->
+  Clerk Publishable key and Frontend API URL -->
   <script
     async
     crossorigin="anonymous"
-    data-clerk-publishable-key='{{pub_key}}'
-    src="https://[your-domain].clerk.accounts.dev/npm/@clerk/clerk-js@latest/dist/clerk.browser.js"
+    data-clerk-publishable-key="{{pub_key}}"
+    src="https://{{fapi_key}}/npm/@clerk/clerk-js@latest/dist/clerk.browser.js"
     type="text/javascript"
   ></script>
 
@@ -223,12 +223,12 @@ if (clerk.user) {
   <div id="app"></div>
 
   <!-- Initialize Clerk with your
-  Clerk publishable key and Frontend API URL -->
+  Clerk Publishable key and Frontend API URL -->
   <script
     async
     crossorigin="anonymous"
-    data-clerk-publishable-key='{{pub_key}}'
-    src="https://[your-domain].clerk.accounts.dev/npm/@clerk/clerk-js@latest/dist/clerk.browser.js"
+    data-clerk-publishable-key="{{pub_key}}"
+    src="https://{{fapi_key}}/npm/@clerk/clerk-js@latest/dist/clerk.browser.js"
     type="text/javascript"
   ></script>
 
@@ -344,12 +344,12 @@ if (clerk.user) {
   <div id="app"></div>
 
   <!-- Initialize Clerk with your
-  Clerk publishable key and Frontend API URL -->
+  Clerk Publishable key and Frontend API URL -->
   <script
     async
     crossorigin="anonymous"
-    data-clerk-publishable-key='{{pub_key}}'
-    src="https://[your-domain].clerk.accounts.dev/npm/@clerk/clerk-js@latest/dist/clerk.browser.js"
+    data-clerk-publishable-key="{{pub_key}}"
+    src="https://{{fapi_key}}/npm/@clerk/clerk-js@latest/dist/clerk.browser.js"
     type="text/javascript"
   ></script>
 

--- a/docs/references/javascript/organization/invitations.mdx
+++ b/docs/references/javascript/organization/invitations.mdx
@@ -85,7 +85,7 @@ if (clerk.user) {
     async
     crossorigin="anonymous"
     data-clerk-publishable-key="{{pub_key}}"
-    src="https://{{fapi_key}}/npm/@clerk/clerk-js@latest/dist/clerk.browser.js"
+    src="https://{{fapi_url}}/npm/@clerk/clerk-js@latest/dist/clerk.browser.js"
     type="text/javascript"
   ></script>
 
@@ -228,7 +228,7 @@ if (clerk.user) {
     async
     crossorigin="anonymous"
     data-clerk-publishable-key="{{pub_key}}"
-    src="https://{{fapi_key}}/npm/@clerk/clerk-js@latest/dist/clerk.browser.js"
+    src="https://{{fapi_url}}/npm/@clerk/clerk-js@latest/dist/clerk.browser.js"
     type="text/javascript"
   ></script>
 
@@ -349,7 +349,7 @@ if (clerk.user) {
     async
     crossorigin="anonymous"
     data-clerk-publishable-key="{{pub_key}}"
-    src="https://{{fapi_key}}/npm/@clerk/clerk-js@latest/dist/clerk.browser.js"
+    src="https://{{fapi_url}}/npm/@clerk/clerk-js@latest/dist/clerk.browser.js"
     type="text/javascript"
   ></script>
 

--- a/docs/references/javascript/organization/members.mdx
+++ b/docs/references/javascript/organization/members.mdx
@@ -383,12 +383,12 @@ The following example demonstrates how to use the organization membership method
       <pre id="response"></pre>
 
       <!-- Initialize Clerk with your
-      Clerk publishable key and Frontend API URL -->
+      Clerk Publishable key and Frontend API URL -->
       <script
         async
         crossorigin="anonymous"
-        data-clerk-publishable-key='{{pub_key}}'
-        src="https://[your-domain].clerk.accounts.dev/npm/@clerk/clerk-js@latest/dist/clerk.browser.js"
+        data-clerk-publishable-key="{{pub_key}}"
+        src="https://{{fapi_key}}/npm/@clerk/clerk-js@latest/dist/clerk.browser.js"
         type="text/javascript"
       ></script>
 

--- a/docs/references/javascript/organization/members.mdx
+++ b/docs/references/javascript/organization/members.mdx
@@ -388,7 +388,7 @@ The following example demonstrates how to use the organization membership method
         async
         crossorigin="anonymous"
         data-clerk-publishable-key="{{pub_key}}"
-        src="https://{{fapi_key}}/npm/@clerk/clerk-js@latest/dist/clerk.browser.js"
+        src="https://{{fapi_url}}/npm/@clerk/clerk-js@latest/dist/clerk.browser.js"
         type="text/javascript"
       ></script>
 

--- a/docs/references/javascript/organization/membership-request.mdx
+++ b/docs/references/javascript/organization/membership-request.mdx
@@ -264,12 +264,12 @@ The following example demonstrates how to use the `getMembershipRequests()` meth
       <pre id="response"></pre>
 
       <!-- Initialize Clerk with your
-      Clerk publishable key and Frontend API URL -->
+      Clerk Publishable key and Frontend API URL -->
       <script
         async
         crossorigin="anonymous"
-        data-clerk-publishable-key='{{pub_key}}'
-        src="https://[your-domain].clerk.accounts.dev/npm/@clerk/clerk-js@latest/dist/clerk.browser.js"
+        data-clerk-publishable-key="{{pub_key}}"
+        src="https://{{fapi_key}}/npm/@clerk/clerk-js@latest/dist/clerk.browser.js"
         type="text/javascript"
       ></script>
 

--- a/docs/references/javascript/organization/membership-request.mdx
+++ b/docs/references/javascript/organization/membership-request.mdx
@@ -269,7 +269,7 @@ The following example demonstrates how to use the `getMembershipRequests()` meth
         async
         crossorigin="anonymous"
         data-clerk-publishable-key="{{pub_key}}"
-        src="https://{{fapi_key}}/npm/@clerk/clerk-js@latest/dist/clerk.browser.js"
+        src="https://{{fapi_url}}/npm/@clerk/clerk-js@latest/dist/clerk.browser.js"
         type="text/javascript"
       ></script>
 

--- a/docs/references/javascript/organization/organization.mdx
+++ b/docs/references/javascript/organization/organization.mdx
@@ -99,12 +99,12 @@ if (clerk.user) {
   <div id="app"></div>
 
   <!-- Initialize Clerk with your
-  Clerk publishable key and Frontend API URL -->
+  Clerk Publishable key and Frontend API URL -->
   <script
     async
     crossorigin="anonymous"
-    data-clerk-publishable-key='{{pub_key}}'
-    src="https://[your-domain].clerk.accounts.dev/npm/@clerk/clerk-js@latest/dist/clerk.browser.js"
+    data-clerk-publishable-key="{{pub_key}}"
+    src="https://{{fapi_key}}/npm/@clerk/clerk-js@latest/dist/clerk.browser.js"
     type="text/javascript"
   ></script>
 
@@ -208,12 +208,12 @@ if (clerk.user) {
   <div id="app"></div>
 
   <!-- Initialize Clerk with your
-  Clerk publishable key and Frontend API URL -->
+  Clerk Publishable key and Frontend API URL -->
   <script
     async
     crossorigin="anonymous"
-    data-clerk-publishable-key='{{pub_key}}'
-    src="https://[your-domain].clerk.accounts.dev/npm/@clerk/clerk-js@latest/dist/clerk.browser.js"
+    data-clerk-publishable-key="{{pub_key}}"
+    src="https://{{fapi_key}}/npm/@clerk/clerk-js@latest/dist/clerk.browser.js"
     type="text/javascript"
   ></script>
 
@@ -356,14 +356,14 @@ function setLogo(params: SetOrganizationLogoParams): Promise<Organization>;
     <button id="upload-logo">Upload Logo</button>
 
     <!-- Initialize Clerk with your
-    Clerk publishable key and Frontend API URL -->
-    <script
-      async
-      crossorigin="anonymous"
-      data-clerk-publishable-key='{{pub_key}}'
-      src="https://[your-domain].clerk.accounts.dev/npm/@clerk/clerk-js@latest/dist/clerk.browser.js"
-      type="text/javascript"
-    ></script>
+  Clerk Publishable key and Frontend API URL -->
+  <script
+    async
+    crossorigin="anonymous"
+    data-clerk-publishable-key="{{pub_key}}"
+    src="https://{{fapi_key}}/npm/@clerk/clerk-js@latest/dist/clerk.browser.js"
+    type="text/javascript"
+  ></script>
 
     <script>
       window.addEventListener("load", async function () {
@@ -504,12 +504,12 @@ if (clerk.user) {
   <div id="app"></div>
 
   <!-- Initialize Clerk with your
-  Clerk publishable key and Frontend API URL -->
+  Clerk Publishable key and Frontend API URL -->
   <script
     async
     crossorigin="anonymous"
-    data-clerk-publishable-key='{{pub_key}}'
-    src="https://[your-domain].clerk.accounts.dev/npm/@clerk/clerk-js@latest/dist/clerk.browser.js"
+    data-clerk-publishable-key="{{pub_key}}"
+    src="https://{{fapi_key}}/npm/@clerk/clerk-js@latest/dist/clerk.browser.js"
     type="text/javascript"
   ></script>
 

--- a/docs/references/javascript/organization/organization.mdx
+++ b/docs/references/javascript/organization/organization.mdx
@@ -104,7 +104,7 @@ if (clerk.user) {
     async
     crossorigin="anonymous"
     data-clerk-publishable-key="{{pub_key}}"
-    src="https://{{fapi_key}}/npm/@clerk/clerk-js@latest/dist/clerk.browser.js"
+    src="https://{{fapi_url}}/npm/@clerk/clerk-js@latest/dist/clerk.browser.js"
     type="text/javascript"
   ></script>
 
@@ -213,7 +213,7 @@ if (clerk.user) {
     async
     crossorigin="anonymous"
     data-clerk-publishable-key="{{pub_key}}"
-    src="https://{{fapi_key}}/npm/@clerk/clerk-js@latest/dist/clerk.browser.js"
+    src="https://{{fapi_url}}/npm/@clerk/clerk-js@latest/dist/clerk.browser.js"
     type="text/javascript"
   ></script>
 
@@ -361,7 +361,7 @@ function setLogo(params: SetOrganizationLogoParams): Promise<Organization>;
     async
     crossorigin="anonymous"
     data-clerk-publishable-key="{{pub_key}}"
-    src="https://{{fapi_key}}/npm/@clerk/clerk-js@latest/dist/clerk.browser.js"
+    src="https://{{fapi_url}}/npm/@clerk/clerk-js@latest/dist/clerk.browser.js"
     type="text/javascript"
   ></script>
 
@@ -509,7 +509,7 @@ if (clerk.user) {
     async
     crossorigin="anonymous"
     data-clerk-publishable-key="{{pub_key}}"
-    src="https://{{fapi_key}}/npm/@clerk/clerk-js@latest/dist/clerk.browser.js"
+    src="https://{{fapi_url}}/npm/@clerk/clerk-js@latest/dist/clerk.browser.js"
     type="text/javascript"
   ></script>
 

--- a/docs/references/javascript/overview.mdx
+++ b/docs/references/javascript/overview.mdx
@@ -11,88 +11,13 @@ While we typically recommend using one of our framework SDK's, such as [Clerk Re
 
 ## Installation
 
-There are two ways you can include ClerkJS in your project. You can either [import the ClerkJS npm module](#install-clerk-js-as-es-module) or [load ClerkJS with a script tag](#install-clerk-js-as-script).
-
-> You need to create a Clerk Application in your [Clerk Dashboard](https://dashboard.clerk.com/) before you can set up ClerkJS. For more information, check out our [Set up your application](/docs/quickstarts/setup-clerk) guide.
-
-### Install ClerkJS as ES module
-
-<CodeBlockTabs type="installer" options={["npm", "yarn", "pnpm"]}>
-  ```bash filename="terminal"
-  npm install @clerk/clerk-js
-  ```
-
-```bash filename="terminal"
-yarn add @clerk/clerk-js
-```
-
-```bash filename="terminal"
-pnpm add @clerk/clerk-js
-```
-
-</CodeBlockTabs>
-
-Once you have installed the package, you will need to import the ClerkJS object constructor into your code and pass it your Clerk Publishable Key as a parameter. You can find your Clerk Publishable Key in the Clerk Dashboard on the [**API Keys**](https://dashboard.clerk.com/last-active?path=api-keys) page. Then, you can call the `load()` method to initialize ClerkJS. For more information on the `load()` method and what options you can pass to it, check out the [reference documentation](/docs/references/javascript/clerk/clerk#load).
-
-<InjectKeys>
-
-```js
-import Clerk from '@clerk/clerk-js';
-
-const clerkPublishableKey = `{{pub_key}}`;
-const clerk = new Clerk(clerkPublishableKey);
-await clerk.load({
-  // Set load options here...
-});
-```
-
-</InjectKeys>
-
-### Install ClerkJS as script
-
-ClerkJS can be loaded from a `<script />` tag with the source from your **Frontend API URL**. You can find your **Frontend API URL** in the Clerk Dashboard on the **[API Keys](https://dashboard.clerk.com/last-active?path=api-keys)** page. Click on the **Advanced** dropdown to reveal the **Frontend API URL**.
-
-Add the following script to your site's `<body>` element:
-
-<Callout type="info">
-  Calling the `load()` method initializes ClerkJS. For more information on the
-  `load()` method and what options you can pass to it, check out the [reference
-  documentation](/docs/references/javascript/clerk/clerk#load).
-</Callout>
-
-<InjectKeys>
-
-```html
-<script>
-  // Get this URL and Publishable Key from the Clerk Dashboard
-  const clerkPublishableKey = `{{pub_key}}`;
-  const frontendApi = '[your-domain].clerk.accounts.dev';
-  const version = '@latest'; // Set to appropriate version
-
-  // Creates asynchronous script
-  const script = document.createElement('script');
-  script.setAttribute('data-clerk-frontend-api', frontendApi);
-  script.setAttribute('data-clerk-publishable-key', clerkPublishableKey);
-  script.async = true;
-  script.src = `https://${frontendApi}/npm/@clerk/clerk-js${version}/dist/clerk.browser.js`;
-
-  // Adds listener to initialize ClerkJS after it's loaded
-  script.addEventListener('load', async function () {
-    await window.Clerk.load({
-      // Set load options here...
-    });
-  });
-  document.body.appendChild(script);
-</script>
-```
-
-</InjectKeys>
+Please follow the instructions in the [ClerkJS quickstart](/docs/quickstarts/javascript) to add ClerkJS to your project.
 
 ## Usage
 
-Once you have access to the [`Clerk` class](/docs/references/javascript/clerk/clerk), you're able to access and call a myriad of attributes and methods to control your program.
+Once you have ClerkJS integrated into your project and have access to the [`Clerk` class](/docs/references/javascript/clerk/clerk), you're able to access and call a myriad of attributes and methods to control your user management and authentication.
 
-To utilize these methods and attributes, Clerk has a wide array of classes you'll access such as:
+To utilize these methods and attributes, Clerk has a wide array of classes you will access, such as:
 
 - [`Clerk`](/docs/references/javascript/clerk/clerk)
 - [`User`](/docs/references/javascript/user/user)

--- a/docs/references/javascript/user/create-metadata.mdx
+++ b/docs/references/javascript/user/create-metadata.mdx
@@ -73,7 +73,7 @@ if (clerk.user) {
     async
     crossorigin="anonymous"
     data-clerk-publishable-key="{{pub_key}}"
-    src="https://{{fapi_key}}/npm/@clerk/clerk-js@latest/dist/clerk.browser.js"
+    src="https://{{fapi_url}}/npm/@clerk/clerk-js@latest/dist/clerk.browser.js"
     type="text/javascript"
   ></script>
 
@@ -167,7 +167,7 @@ if (clerk.user) {
     async
     crossorigin="anonymous"
     data-clerk-publishable-key="{{pub_key}}"
-    src="https://{{fapi_key}}/npm/@clerk/clerk-js@latest/dist/clerk.browser.js"
+    src="https://{{fapi_url}}/npm/@clerk/clerk-js@latest/dist/clerk.browser.js"
     type="text/javascript"
   ></script>
 
@@ -261,7 +261,7 @@ if (clerk.user) {
     async
     crossorigin="anonymous"
     data-clerk-publishable-key="{{pub_key}}"
-    src="https://{{fapi_key}}/npm/@clerk/clerk-js@latest/dist/clerk.browser.js"
+    src="https://{{fapi_url}}/npm/@clerk/clerk-js@latest/dist/clerk.browser.js"
     type="text/javascript"
   ></script>
 
@@ -414,7 +414,7 @@ The following example demonstrates how to add a Notion account as an external ac
       async
       crossorigin="anonymous"
       data-clerk-publishable-key="{{pub_key}}"
-      src="https://{{fapi_key}}/npm/@clerk/clerk-js@latest/dist/clerk.browser.js"
+      src="https://{{fapi_url}}/npm/@clerk/clerk-js@latest/dist/clerk.browser.js"
       type="text/javascript"
     ></script>
 

--- a/docs/references/javascript/user/create-metadata.mdx
+++ b/docs/references/javascript/user/create-metadata.mdx
@@ -68,12 +68,12 @@ if (clerk.user) {
   <div id="app"></div>
 
   <!-- Initialize Clerk with your
-  Clerk publishable key and Frontend API URL -->
+  Clerk Publishable key and Frontend API URL -->
   <script
     async
     crossorigin="anonymous"
-    data-clerk-publishable-key='{{pub_key}}'
-    src="https://[your-domain].clerk.accounts.dev/npm/@clerk/clerk-js@latest/dist/clerk.browser.js"
+    data-clerk-publishable-key="{{pub_key}}"
+    src="https://{{fapi_key}}/npm/@clerk/clerk-js@latest/dist/clerk.browser.js"
     type="text/javascript"
   ></script>
 
@@ -162,12 +162,12 @@ if (clerk.user) {
   <div id="app"></div>
 
   <!-- Initialize Clerk with your
-  Clerk publishable key and Frontend API URL -->
+  Clerk Publishable key and Frontend API URL -->
   <script
     async
     crossorigin="anonymous"
-    data-clerk-publishable-key='{{pub_key}}'
-    src="https://[your-domain].clerk.accounts.dev/npm/@clerk/clerk-js@latest/dist/clerk.browser.js"
+    data-clerk-publishable-key="{{pub_key}}"
+    src="https://{{fapi_key}}/npm/@clerk/clerk-js@latest/dist/clerk.browser.js"
     type="text/javascript"
   ></script>
 
@@ -256,12 +256,12 @@ if (clerk.user) {
   <div id="app"></div>
 
   <!-- Initialize Clerk with your
-  Clerk publishable key and Frontend API URL -->
+  Clerk Publishable key and Frontend API URL -->
   <script
     async
     crossorigin="anonymous"
-    data-clerk-publishable-key='{{pub_key}}'
-    src="https://[your-domain].clerk.accounts.dev/npm/@clerk/clerk-js@latest/dist/clerk.browser.js"
+    data-clerk-publishable-key="{{pub_key}}"
+    src="https://{{fapi_key}}/npm/@clerk/clerk-js@latest/dist/clerk.browser.js"
     type="text/javascript"
   ></script>
 
@@ -409,12 +409,12 @@ The following example demonstrates how to add a Notion account as an external ac
     <button id="add-notion">Add Notion as a social connection</button>
 
     <!-- Initialize Clerk with your
-    Clerk publishable key and Frontend API URL -->
+    Clerk Publishable key and Frontend API URL -->
     <script
       async
       crossorigin="anonymous"
-      data-clerk-publishable-key='{{pub_key}}'
-      src="https://[your-domain].clerk.accounts.dev/npm/@clerk/clerk-js@latest/dist/clerk.browser.js"
+      data-clerk-publishable-key="{{pub_key}}"
+      src="https://{{fapi_key}}/npm/@clerk/clerk-js@latest/dist/clerk.browser.js"
       type="text/javascript"
     ></script>
 

--- a/docs/references/javascript/user/password-management.mdx
+++ b/docs/references/javascript/user/password-management.mdx
@@ -129,7 +129,7 @@ function updatePassword: (params: UpdateUserPasswordParams) => Promise<User>;
       async
       crossorigin="anonymous"
       data-clerk-publishable-key="{{pub_key}}"
-      src="https://{{fapi_key}}/npm/@clerk/clerk-js@latest/dist/clerk.browser.js"
+      src="https://{{fapi_url}}/npm/@clerk/clerk-js@latest/dist/clerk.browser.js"
       type="text/javascript"
     ></script>
 
@@ -277,7 +277,7 @@ function removePassword: (params: RemoveUserPasswordParams) => Promise<User>;
       async
       crossorigin="anonymous"
       data-clerk-publishable-key="{{pub_key}}"
-      src="https://{{fapi_key}}/npm/@clerk/clerk-js@latest/dist/clerk.browser.js"
+      src="https://{{fapi_url}}/npm/@clerk/clerk-js@latest/dist/clerk.browser.js"
       type="text/javascript"
     ></script>
 

--- a/docs/references/javascript/user/password-management.mdx
+++ b/docs/references/javascript/user/password-management.mdx
@@ -123,11 +123,13 @@ function updatePassword: (params: UpdateUserPasswordParams) => Promise<User>;
     <p id="error"></p>
     <button id="update-password-button">Update password</button>
 
+    <!-- Initialize Clerk with your
+    Clerk Publishable key and Frontend API URL -->
     <script
       async
       crossorigin="anonymous"
-      data-clerk-publishable-key='{{pub_key}}'
-      src="https://[your-domain].clerk.accounts.dev/npm/@clerk/clerk-js@latest/dist/clerk.browser.js"
+      data-clerk-publishable-key="{{pub_key}}"
+      src="https://{{fapi_key}}/npm/@clerk/clerk-js@latest/dist/clerk.browser.js"
       type="text/javascript"
     ></script>
 
@@ -269,11 +271,13 @@ function removePassword: (params: RemoveUserPasswordParams) => Promise<User>;
     <p id="error"></p>
     <button id="remove-password-button">Remove Password</button>
 
+    <!-- Initialize Clerk with your
+    Clerk Publishable key and Frontend API URL -->
     <script
       async
       crossorigin="anonymous"
-      data-clerk-publishable-key='{{pub_key}}'
-      src="https://[your-domain].clerk.accounts.dev/npm/@clerk/clerk-js@latest/dist/clerk.browser.js"
+      data-clerk-publishable-key="{{pub_key}}"
+      src="https://{{fapi_key}}/npm/@clerk/clerk-js@latest/dist/clerk.browser.js"
       type="text/javascript"
     ></script>
 

--- a/docs/references/javascript/user/totp.mdx
+++ b/docs/references/javascript/user/totp.mdx
@@ -284,7 +284,7 @@ The following example assumes:
       async
       crossorigin="anonymous"
       data-clerk-publishable-key="{{pub_key}}"
-      src="https://{{fapi_key}}/npm/@clerk/clerk-js@latest/dist/clerk.browser.js"
+      src="https://{{fapi_url}}/npm/@clerk/clerk-js@latest/dist/clerk.browser.js"
       type="text/javascript"
     ></script>
 

--- a/docs/references/javascript/user/totp.mdx
+++ b/docs/references/javascript/user/totp.mdx
@@ -279,12 +279,12 @@ The following example assumes:
     <pre id="response"></pre>
 
     <!-- Initialize Clerk with your
-    Clerk publishable key and Frontend API URL -->
+    Clerk Publishable key and Frontend API URL -->
     <script
       async
       crossorigin="anonymous"
-      data-clerk-publishable-key='{{pub_key}}'
-      src="https://[your-domain].clerk.accounts.dev/npm/@clerk/clerk-js@latest/dist/clerk.browser.js"
+      data-clerk-publishable-key="{{pub_key}}"
+      src="https://{{fapi_key}}/npm/@clerk/clerk-js@latest/dist/clerk.browser.js"
       type="text/javascript"
     ></script>
 

--- a/docs/references/javascript/user/user.mdx
+++ b/docs/references/javascript/user/user.mdx
@@ -120,12 +120,12 @@ In the following example, the user's first name is updated to "Test".
   <div id="app"></div>
 
   <!-- Initialize Clerk with your
-  Clerk publishable key and Frontend API URL -->
+  Clerk Publishable key and Frontend API URL -->
   <script
     async
     crossorigin="anonymous"
-    data-clerk-publishable-key='{{pub_key}}'
-    src="https://[your-domain].clerk.accounts.dev/npm/@clerk/clerk-js@latest/dist/clerk.browser.js"
+    data-clerk-publishable-key="{{pub_key}}"
+    src="https://{{fapi_key}}/npm/@clerk/clerk-js@latest/dist/clerk.browser.js"
     type="text/javascript"
   ></script>
 
@@ -192,12 +192,12 @@ function delete: () => Promise<void>;
   <div id="app"></div>
 
   <!-- Initialize Clerk with your
-  Clerk publishable key and Frontend API URL -->
+  Clerk Publishable key and Frontend API URL -->
   <script
     async
     crossorigin="anonymous"
-    data-clerk-publishable-key='{{pub_key}}'
-    src="https://[your-domain].clerk.accounts.dev/npm/@clerk/clerk-js@latest/dist/clerk.browser.js"
+    data-clerk-publishable-key="{{pub_key}}"
+    src="https://{{fapi_key}}/npm/@clerk/clerk-js@latest/dist/clerk.browser.js"
     type="text/javascript"
   ></script>
 
@@ -323,12 +323,12 @@ function setProfileImage: (params: SetProfileImageParams) => Promise<ImageResour
     <button id="upload-image">Upload profile image</button>
 
     <!-- Initialize Clerk with your
-    Clerk publishable key and Frontend API URL -->
+    Clerk Publishable key and Frontend API URL -->
     <script
       async
       crossorigin="anonymous"
-      data-clerk-publishable-key='{{pub_key}}'
-      src="https://[your-domain].clerk.accounts.dev/npm/@clerk/clerk-js@latest/dist/clerk.browser.js"
+      data-clerk-publishable-key="{{pub_key}}"
+      src="https://{{fapi_key}}/npm/@clerk/clerk-js@latest/dist/clerk.browser.js"
       type="text/javascript"
     ></script>
 
@@ -393,12 +393,12 @@ function reload: (p?: ClerkResourceReloadParams) => Promise<this>;
 
   ```html filename="index.html" {15}
   <!-- Initialize Clerk with your
-  Clerk publishable key and Frontend API URL -->
+  Clerk Publishable key and Frontend API URL -->
   <script
     async
     crossorigin="anonymous"
-    data-clerk-publishable-key='{{pub_key}}'
-    src="https://[your-domain].clerk.accounts.dev/npm/@clerk/clerk-js@latest/dist/clerk.browser.js"
+    data-clerk-publishable-key="{{pub_key}}"
+    src="https://{{fapi_key}}/npm/@clerk/clerk-js@latest/dist/clerk.browser.js"
     type="text/javascript"
   ></script>
 
@@ -459,12 +459,12 @@ function getSessions: () => Promise<SessionWithActivities[]>;
   <div id="app"></div>
 
   <!-- Initialize Clerk with your
-  Clerk publishable key and Frontend API URL -->
+  Clerk Publishable key and Frontend API URL -->
   <script
     async
     crossorigin="anonymous"
-    data-clerk-publishable-key='{{pub_key}}'
-    src="https://[your-domain].clerk.accounts.dev/npm/@clerk/clerk-js@latest/dist/clerk.browser.js"
+    data-clerk-publishable-key="{{pub_key}}"
+    src="https://{{fapi_key}}/npm/@clerk/clerk-js@latest/dist/clerk.browser.js"
     type="text/javascript"
   ></script>
 
@@ -559,12 +559,12 @@ function getOrganizationInvitations: (params?: GetUserOrganizationInvitationsPar
   <div id="app"></div>
 
   <!-- Initialize Clerk with your
-  Clerk publishable key and Frontend API URL -->
+  Clerk Publishable key and Frontend API URL -->
   <script
     async
     crossorigin="anonymous"
-    data-clerk-publishable-key='{{pub_key}}'
-    src="https://[your-domain].clerk.accounts.dev/npm/@clerk/clerk-js@latest/dist/clerk.browser.js"
+    data-clerk-publishable-key="{{pub_key}}"
+    src="https://{{fapi_key}}/npm/@clerk/clerk-js@latest/dist/clerk.browser.js"
     type="text/javascript"
   ></script>
 
@@ -645,12 +645,12 @@ function getOrganizationSuggestions: (params?: GetUserOrganizationSuggestionsPar
   <div id="app"></div>
 
   <!-- Initialize Clerk with your
-  Clerk publishable key and Frontend API URL -->
+  Clerk Publishable key and Frontend API URL -->
   <script
     async
     crossorigin="anonymous"
-    data-clerk-publishable-key='{{pub_key}}'
-    src="https://[your-domain].clerk.accounts.dev/npm/@clerk/clerk-js@latest/dist/clerk.browser.js"
+    data-clerk-publishable-key="{{pub_key}}"
+    src="https://{{fapi_key}}/npm/@clerk/clerk-js@latest/dist/clerk.browser.js"
     type="text/javascript"
   ></script>
 
@@ -730,12 +730,12 @@ function getOrganizationMemberships: (params?: GetUserOrganizationMembershipPara
   <div id="app"></div>
 
   <!-- Initialize Clerk with your
-  Clerk publishable key and Frontend API URL -->
+  Clerk Publishable key and Frontend API URL -->
   <script
     async
     crossorigin="anonymous"
-    data-clerk-publishable-key='{{pub_key}}'
-    src="https://[your-domain].clerk.accounts.dev/npm/@clerk/clerk-js@latest/dist/clerk.browser.js"
+    data-clerk-publishable-key="{{pub_key}}"
+    src="https://{{fapi_key}}/npm/@clerk/clerk-js@latest/dist/clerk.browser.js"
     type="text/javascript"
   ></script>
 

--- a/docs/references/javascript/user/user.mdx
+++ b/docs/references/javascript/user/user.mdx
@@ -125,7 +125,7 @@ In the following example, the user's first name is updated to "Test".
     async
     crossorigin="anonymous"
     data-clerk-publishable-key="{{pub_key}}"
-    src="https://{{fapi_key}}/npm/@clerk/clerk-js@latest/dist/clerk.browser.js"
+    src="https://{{fapi_url}}/npm/@clerk/clerk-js@latest/dist/clerk.browser.js"
     type="text/javascript"
   ></script>
 
@@ -197,7 +197,7 @@ function delete: () => Promise<void>;
     async
     crossorigin="anonymous"
     data-clerk-publishable-key="{{pub_key}}"
-    src="https://{{fapi_key}}/npm/@clerk/clerk-js@latest/dist/clerk.browser.js"
+    src="https://{{fapi_url}}/npm/@clerk/clerk-js@latest/dist/clerk.browser.js"
     type="text/javascript"
   ></script>
 
@@ -328,7 +328,7 @@ function setProfileImage: (params: SetProfileImageParams) => Promise<ImageResour
       async
       crossorigin="anonymous"
       data-clerk-publishable-key="{{pub_key}}"
-      src="https://{{fapi_key}}/npm/@clerk/clerk-js@latest/dist/clerk.browser.js"
+      src="https://{{fapi_url}}/npm/@clerk/clerk-js@latest/dist/clerk.browser.js"
       type="text/javascript"
     ></script>
 
@@ -398,7 +398,7 @@ function reload: (p?: ClerkResourceReloadParams) => Promise<this>;
     async
     crossorigin="anonymous"
     data-clerk-publishable-key="{{pub_key}}"
-    src="https://{{fapi_key}}/npm/@clerk/clerk-js@latest/dist/clerk.browser.js"
+    src="https://{{fapi_url}}/npm/@clerk/clerk-js@latest/dist/clerk.browser.js"
     type="text/javascript"
   ></script>
 
@@ -464,7 +464,7 @@ function getSessions: () => Promise<SessionWithActivities[]>;
     async
     crossorigin="anonymous"
     data-clerk-publishable-key="{{pub_key}}"
-    src="https://{{fapi_key}}/npm/@clerk/clerk-js@latest/dist/clerk.browser.js"
+    src="https://{{fapi_url}}/npm/@clerk/clerk-js@latest/dist/clerk.browser.js"
     type="text/javascript"
   ></script>
 
@@ -564,7 +564,7 @@ function getOrganizationInvitations: (params?: GetUserOrganizationInvitationsPar
     async
     crossorigin="anonymous"
     data-clerk-publishable-key="{{pub_key}}"
-    src="https://{{fapi_key}}/npm/@clerk/clerk-js@latest/dist/clerk.browser.js"
+    src="https://{{fapi_url}}/npm/@clerk/clerk-js@latest/dist/clerk.browser.js"
     type="text/javascript"
   ></script>
 
@@ -650,7 +650,7 @@ function getOrganizationSuggestions: (params?: GetUserOrganizationSuggestionsPar
     async
     crossorigin="anonymous"
     data-clerk-publishable-key="{{pub_key}}"
-    src="https://{{fapi_key}}/npm/@clerk/clerk-js@latest/dist/clerk.browser.js"
+    src="https://{{fapi_url}}/npm/@clerk/clerk-js@latest/dist/clerk.browser.js"
     type="text/javascript"
   ></script>
 
@@ -735,7 +735,7 @@ function getOrganizationMemberships: (params?: GetUserOrganizationMembershipPara
     async
     crossorigin="anonymous"
     data-clerk-publishable-key="{{pub_key}}"
-    src="https://{{fapi_key}}/npm/@clerk/clerk-js@latest/dist/clerk.browser.js"
+    src="https://{{fapi_url}}/npm/@clerk/clerk-js@latest/dist/clerk.browser.js"
     type="text/javascript"
   ></script>
 

--- a/docs/users/metadata.mdx
+++ b/docs/users/metadata.mdx
@@ -331,6 +331,8 @@ The "unsafe" custom attributes can be set upon sign-up when creating or updating
 
 ### Setting unsafe metadata
 
+Updating this value overrides the previous value; it does not merge. To perform a merge, you can pass something like `{ …user.unsafeMetadata, …newData }` to this parameter.
+
 #### Using the Backend API
 
 <Tabs type="framework" items={["Next.js", "Node", "Go", "Ruby",  "cURL"]}>
@@ -566,37 +568,84 @@ The "unsafe" custom attributes can be set upon sign-up when creating or updating
   </Tab>
 
   <Tab>
-  ```html filename="unsafe.html"
-  <!DOCTYPE html>
-  <html lang="en">
-  <head>
-      <meta charset="UTF-8" />
-      <meta http-equiv="X-UA-Compatible" content="IE=edge" />
-      <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-      <title>Clerk Unsafe Update</title>
-  </head>
-  <body>
-      <h1>Clerk JavaScript Email + Password</h1>
-      <div id="birthday-update">
-          <input placeholder="your birthday" id="birthday" type="string"></input>
-          <button onclick="updateBirthday()">Update Birthday</button>
-      </div>
+    <CodeBlockTabs type="npm-script" options={["NPM module", "<script>"]}>
+    ```js filename="main.js"
+    import Clerk from '@clerk/clerk-js';
+
+    // Initialize Clerk with your Clerk publishable key
+    const clerk = new Clerk('{{pub_key}}');
+    await clerk.load();
+
+    if (clerk.user) {
+      await clerk.user.update({
+        unsafeMetadata: {
+          "birthday": "01-01-2000"
+        }
+      })
+      .then((res) => console.log(res))
+      .catch((error) => console.log("An error occurred:", error.errors));
+    } else {
+      document.getElementById("app").innerHTML = `
+        <div id="sign-in"></div>
+      `;
+
+      const signInDiv =
+        document.getElementById("sign-in");
+
+      clerk.mountSignIn(signInDiv);
+    }
+    ```
+
+    ```html filename="index.html"
+    <!DOCTYPE html>
+    <html lang="en">
+    <head>
+        <meta charset="UTF-8" />
+        <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+        <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+        <title>Clerk Unsafe Update</title>
+    </head>
+    <body>
+      <div id="app"></div>
+
+      <!-- Initialize Clerk with your
+      Clerk publishable key and Frontend API URL -->
+      <script
+        async
+        crossorigin="anonymous"
+        data-clerk-publishable-key='{{pub_key}}'
+        src="https://[your-domain].clerk.accounts.dev/npm/@clerk/clerk-js@latest/dist/clerk.browser.js"
+        type="text/javascript"
+      ></script>
+
       <script>
-          const updateBirthday = async () => {
-              const birthday = document.getElementById('birthday').value;
-              const {user} = window.Clerk;
-              user.update({
-                  unsafeMetadata: {
-                    "birthday": birthday
-                  }
-              })
-          };
+        window.addEventListener("load", async function () {
+          await Clerk.load();
+
+          if (Clerk.user) {
+            await Clerk.user.update({
+              unsafeMetadata: {
+                "birthday": "01-01-2000"
+              }
+            })
+            .then((res) => console.log(res))
+            .catch((error) => console.log("An error occurred:", error.errors));
+          } else {
+            document.getElementById("app").innerHTML = `
+              <div id="sign-in"></div>
+            `;
+
+            const signInDiv =
+              document.getElementById("sign-in");
+
+            Clerk.mountSignIn(signInDiv);
+          }
+        });
       </script>
-      // Script to load Clerk up
-      <script src="src/script.js" async crossorigin="anonymous"></script>
-  </body>
-  </html>
-  ```
+    </body>
+    </html>
+    ```
+    </CodeBlockTabs>
   </Tab>
 </Tabs>
 

--- a/docs/users/metadata.mdx
+++ b/docs/users/metadata.mdx
@@ -614,7 +614,7 @@ Updating this value overrides the previous value; it does not merge. To perform 
         async
         crossorigin="anonymous"
         data-clerk-publishable-key="{{pub_key}}"
-        src="https://{{fapi_key}}/npm/@clerk/clerk-js@latest/dist/clerk.browser.js"
+        src="https://{{fapi_url}}/npm/@clerk/clerk-js@latest/dist/clerk.browser.js"
         type="text/javascript"
       ></script>
 

--- a/docs/users/metadata.mdx
+++ b/docs/users/metadata.mdx
@@ -609,12 +609,12 @@ Updating this value overrides the previous value; it does not merge. To perform 
       <div id="app"></div>
 
       <!-- Initialize Clerk with your
-      Clerk publishable key and Frontend API URL -->
+      Clerk Publishable key and Frontend API URL -->
       <script
         async
         crossorigin="anonymous"
-        data-clerk-publishable-key='{{pub_key}}'
-        src="https://[your-domain].clerk.accounts.dev/npm/@clerk/clerk-js@latest/dist/clerk.browser.js"
+        data-clerk-publishable-key="{{pub_key}}"
+        src="https://{{fapi_key}}/npm/@clerk/clerk-js@latest/dist/clerk.browser.js"
         type="text/javascript"
       ></script>
 


### PR DESCRIPTION
This PR updates JS examples to include appropriate installation/Clerk instantiation instructions. It injects the Frontend API URL into `<script>` ClerkJS instantiation. It also removes installations instructions from the JS reference overview, and points users to the quickstart for detailed instructions.