### PR TITLE
Add note about how users cannot change domains for dev instances

### DIFF
--- a/docs/deployments/changing-domains.mdx
+++ b/docs/deployments/changing-domains.mdx
@@ -7,6 +7,10 @@ description: Learn how to change your production instance's domain or subdomain 
 
 Learn how to change your production instance's domain or subdomain on Clerk.
 
+<Callout type="Info">
+  You cannot change the domain of the [development instance](/docs/deployments/environments#development-instance) of your Clerk application.
+</Callout>
+
 ## Change domain
 
 Production domains can be changed in the [Clerk Dashboard](https://dashboard.clerk.com/) or via our [backend API](https://clerk.com/docs/reference/backend-api). Once you make the change to your domain, you will need to update the following:


### PR DESCRIPTION
Just a small callout. Based on customer feedback:

> It would be good to mention either how to add a custom domain for a development environment, or state that it's not possible. Thank you!

(https://linear.app/clerk/issue/DOCS-5442/add-a-note-about-how-users-cannot-change-domains-for-dev-instances)