### PR TITLE
SAML SP-initiated and IdP-initiated flows

### DIFF
--- a/docs/authentication/saml/authentication-flows.mdx
+++ b/docs/authentication/saml/authentication-flows.mdx
@@ -1,0 +1,55 @@
+---
+title: Authentication flows
+description: Learn about the SAML SSO Authentication flows.
+---
+
+# Authentication flows
+
+The SAML protocol supports two different methods in order to start an SSO flow: SP-initiated and IdP-initiated. This guide will explore the differences between the two.
+
+## SP-initiated flow
+In an SP-initiated flow:
+- The user starts the authentication flow from your application (SP), by providing the email address.
+- The user is redirected to the SAML provider (IdP) where they must authenticate themselves.
+- After successful authentication, the user is redirected back to your application, gaining access to their account.
+
+## IdP-initiated flow
+In an IdP-initiated flow:
+- The user starts the authentication flow from the SAML provider (IdP), by selecting which application (SP) they would like to access.
+- The user is redirected to the application of their choice, gaining access to their account.
+
+<Callout type="info">
+    IdP-Initiated flow carries a security risk. We recommend using a SP-Initiated flow whenever possible.
+</Callout>
+
+To allow IdP-initiated flows for your Enterprise Connection:
+
+1. Navigate to the [**Enterprise Connections**](https://dashboard.clerk.com/last-active?path=user-authentication/enterprise-connections) page in the Clerk Dashboard and select the desired connection.
+
+2. Select the **Advanced** tab at the top.
+
+3. Enable by checking the **Allow IdP-Initiated flow** toggle.
+
+### Risks of IdP-initiated flow
+By enabling IdP-Initiated flow, you allow Clerk to receive unsolicited authentication requests by the Identity Provider. Neither the Service Provider or the Identity Provider will be able to verify that the flow was initiated by the specified user.
+
+As a result, the flow is susceptible to MITM (man-in-the-middle) attacks in which a bad actor hijacks the IdP response and uses it to gain access to a compromised account.
+
+A bad actor could also can intercept the IdP response and replace it with another to make the target user to sign in as the attacker, performing a Login CSRF attack.
+
+Even if the IdP-initiated flow is considered insecure, Clerk tries to mitigate those flaws in order to protect and offer the best possible security for your application and users.
+
+#### Unsolicited `InResponseTo` attribute
+In accordance with the [SAML 2.0 profiles specification](https://docs.oasis-open.org/security/saml/v2.0/saml-profiles-2.0-os.pdf), Clerk ensures that an unsolicited response does not contain an `InResponseTo` attribute.
+This prevents bad actors from stealing a response used in an SP-initiated flow and using it in an IdP-initiated flow.
+
+#### Replay detection
+We prevent responses from being re-used by consuming them and remembering which have already been used.
+This prevents bad actors from stealing and reusing a response to gain access to a user's account.
+
+#### Use small validation periods
+Each SAML response defines when they were issued and when they will expire. As an IdP-initiated flow is expected to be completed
+within a timeframe of seconds, you must ensure that these validation periods are as small as possible.
+
+#### Multi-Factor
+MFA is available for the SAML IdP-initiated flow.

--- a/docs/manifest.json
+++ b/docs/manifest.json
@@ -93,6 +93,7 @@
       ],
       "# SAML",
       ["Overview", "/authentication/saml/overview"],
+      ["Authentication flows", "/authentication/saml/authentication-flows"],
       ["Account linking", "/authentication/saml/account-linking"]
     ]
   ],


### PR DESCRIPTION
Introduce a new page that explains how the two different authentication flows, SP-initiated and IdP-initiated, work and their differences