### PR TITLE
add reference links to roles and perms conceptual guide

### DIFF
--- a/docs/organizations/roles-permissions.mdx
+++ b/docs/organizations/roles-permissions.mdx
@@ -28,6 +28,8 @@ You can create up to 10 custom organization roles per application instance to me
 
 Custom roles can be granted permissions and access. For example, you can create a new role of **Billing** (`org:billing`) which can be used to group users who belong to a specific department of the organization and have permission to manage credit card information, invoices, and other resources related to billing.
 
+To learn more about creating custom roles, see the [Create roles and permissions](/docs/organizations/create-roles-permissions) guide.
+
 ### The **Creator** role
 
 When a user creates a new organization, that user is automatically added as the organization's first member and is assigned the **Creator** role. By default, **Admin** (`org:admin`) is the **Creator** role.
@@ -53,7 +55,7 @@ Clerk’s System Permissions consist of the following:
 - Read domains (`org:sys_domains:read`)
 - Manage domains (`org:sys_domains:manage`)
 
-You can assign these System Permissions to any role. 
+You can assign these System Permissions to any role.
 
 ### Custom permissions
 
@@ -61,9 +63,11 @@ When creating a new permission, follow the format `org:<resource>:<action>`. You
 
 For example, you could create a new role called **Sales** (`org:sales`) and a new permission called **Create invoices** (`org:invoices:create`) which allows only users with this permission to edit invoices. You could also grant this permission to the **Billing** role.
 
+To learn more about creating custom permissions, see the [Create roles and permissions](/docs/organizations/create-roles-permissions) guide.
+
 ## Next steps
 
-* [Learn how to create roles and permissions in the Clerk Dashboard](/docs/organizations/create-roles-permissions)
-* [Learn how to use roles and permissions to limit the content a user can see with Clerk's pre-built `<Protect>` component](/docs/components/protect)
-* [Learn how to allow and limit access to resources by role and permissions](/docs/organizations/verify-user-permissions)
-* [Learn how to reassign the **Creator** role](/docs/organizations/creator-role)
+- [Learn how to create roles and permissions in the Clerk Dashboard](/docs/organizations/create-roles-permissions)
+- [Learn how to use roles and permissions to limit the content a user can see with Clerk's pre-built `<Protect>` component](/docs/components/protect)
+- [Learn how to allow and limit access to resources by role and permissions](/docs/organizations/verify-user-permissions)
+- [Learn how to reassign the **Creator** role](/docs/organizations/creator-role)


### PR DESCRIPTION
[User feedback ticket](https://linear.app/clerk/issue/DOCS-5840/%F0%9F%98%A2-feedback-for-organizationsroles-permissionsroles-and-permissions) couldn't find examples/implementation for creating custom roles and perms.

This PR adds reference links to the Create roles and permissions guide where appropriate, to make its existence more evident to users.