### PR TITLE
Modify SAML provider guides ordering

### DIFF
--- a/docs/manifest.json
+++ b/docs/manifest.json
@@ -93,11 +93,11 @@
       ],
       "# SAML",
       ["Overview", "/authentication/saml/overview"],
+      ["Authentication flows", "/authentication/saml/authentication-flows"],
+      ["Account linking", "/authentication/saml/account-linking"],
       ["Azure", "/authentication/saml/azure"],
       ["Google", "/authentication/saml/google"],
-      ["Okta", "/authentication/saml/okta"],
-      ["Authentication flows", "/authentication/saml/authentication-flows"],
-      ["Account linking", "/authentication/saml/account-linking"]
+      ["Okta", "/authentication/saml/okta"]
     ]
   ],
   [


### PR DESCRIPTION
We change the menu ordering of the SAML pages and place the SAML provider guides at the bottom in order to be aligned with OAuth