### PR TITLE
[DOCS-6039] Add pagination params in invitations/get-invitation-list

### DIFF
--- a/docs/references/backend/invitations/get-invitation-list.mdx
+++ b/docs/references/backend/invitations/get-invitation-list.mdx
@@ -16,6 +16,8 @@ function getInvitationList: (params: GetInvitationListParams) => Promise<Paginat
 | Name | Type | Description |
 | --- | --- | --- |
 | `status?` | `accepted \| pending \| revoked` | Filter by invitation status. |
+| `limit?` | `number` | The number of results to return. Must be an integer greater than zero and less than 501. |
+| `offset?` | `number` | The number of results to skip. |
 
 ## `getInvitationList()` examples
 
@@ -49,7 +51,7 @@ Retrieves list of invitations that have been revoked.
 
 ```tsx
 // get all revoked invitations
-const response = await clerkClient.invitations.getInvitationList({ status: 'revoked'});
+const response = await clerkClient.invitations.getInvitationList({ status: 'revoked' });
 
 console.log(response);
 /* In this example, you can see that data is an array of Invitation objects, and is populated with only one Invitation.
@@ -68,6 +70,30 @@ console.log(response);
   totalCount: 1
 }
 */
+```
+
+### `getInvitationList({ status, limit })`
+
+Retrieves list of invitations that have been revoked that is filtered by the number of results.
+
+```tsx
+const { data, totalCount } = await clerkClient.invitations.getInvitationList({ 
+  status: 'revoked',
+   // returns the first 10 results
+  limit: 10 
+  });
+```
+
+### `getInvitationList({ status, offset })`
+
+Retrieves list of invitations that have been revoked that is filtered by the number of results to skip.
+
+```tsx
+const { data, totalCount } = await clerkClient.invitations.getInvitationList({ 
+  status: 'revoked',
+   // skips the first 10 results
+  offset: 10 
+  });
 ```
 
 ## Backend API (BAPI) endpoint

--- a/docs/references/backend/sessions/get-session-list.mdx
+++ b/docs/references/backend/sessions/get-session-list.mdx
@@ -20,7 +20,7 @@ function getSessionList: (queryParams: QueryParams) => Promise<PaginatedResource
 | `clientId?` | `string` | The client ID to retrieve the list of sessions for. |
 | `userId?` | `string` | The user ID to retrieve the list of sessions for. |
 | `status?` | [`SessionStatus`](#session-status) | The status of the session. |
-| `limit?` | `number` | The number of results to return. Must be an integer greater than zero and less than 500. |
+| `limit?` | `number` | The number of results to return. Must be an integer greater than zero and less than 501. |
 | `offset?` | `number` | The number of results to skip. |
 
 ### `SessionStatus`

--- a/docs/references/backend/user/get-organization-membership-list.mdx
+++ b/docs/references/backend/user/get-organization-membership-list.mdx
@@ -16,7 +16,7 @@ function getOrganizationMembershipList: (params: GetOrganizationMembershipListPa
 | Name | Type | Description |
 | --- | --- | --- |
 | `userId` | `string` | The ID of the user to retrieve the list of organization memberships for. |
-| `limit?` | `number` | The number of results to return. Must be an integer greater than zero and less than 500. |
+| `limit?` | `number` | The number of results to return. Must be an integer greater than zero and less than 501. |
 | `offset?` | `number` | The number of results to skip. |
 
 ## `getOrganizationMembershipList()` examples


### PR DESCRIPTION
Changes:

- Add pagination params in invitations/get-invitation-list
- Update limit description for sessions & users to be consistent with the other APIs