### PR TITLE
DOCS-5972 fix spacing in getOrganizationList() code snippet

### DIFF
--- a/docs/references/backend/organization/get-organization-list.mdx
+++ b/docs/references/backend/organization/get-organization-list.mdx
@@ -8,8 +8,7 @@ description: Retrieves a list of organizations.
 Retrieves a list of organizations.
 
 ```tsx
-const organizations = await clerkClient.organizations.
-getOrganizationList();
+const organizations = await clerkClient.organizations.getOrganizationList();
 ```
 
 ## `GetOrganizationListParams`


### PR DESCRIPTION
[User feedback ticket](https://linear.app/clerk/issue/DOCS-5972/feedback-for-referencesbackendorganizationget-organization-list) pointed out ugly spacing in code snippet