### PR TITLE
DOCS-749 update copy around rate limits in firebase migration guide

### DIFF
--- a/docs/deployments/migrate-from-firebase.mdx
+++ b/docs/deployments/migrate-from-firebase.mdx
@@ -142,7 +142,7 @@ node migrate-to-clerk.js
 ```
 
 <Callout type="warning">
-Note that this implementation does not take rate limiting into account. If you have a large user base, you may want to implement a retry mechanism. Clerk will return a 429 status code if you exceed the rate limit. The current rate limit is 20 requests per 10 seconds.
+This implementation does not take rate limiting into account. If you have a large user base, you may want to implement a retry mechanism. Clerk will return a `429` status code if you exceed the rate limit. You can find more information about Clerk's rate limits [here](/docs/backend-requests/resources/rate-limits). Keep [Firebase's rate limits](https://firebase.google.com/docs/functions/quotas) in mind as well when exporting your users.
 </Callout
 >
 Once the script has finished running, your user base will be fully migrated to Clerk.


### PR DESCRIPTION
[User feedback ticket](https://linear.app/clerk/issue/DOCS-749/adjust-copy-about-rate-limits-on-firebase-migration-page) reminds Docs that we should link to *our* and *firebase's* rate limit pages.