### PR TITLE
DOCS-5112 update rate limiting doc

### DIFF
--- a/docs/backend-requests/resources/rate-limits.mdx
+++ b/docs/backend-requests/resources/rate-limits.mdx
@@ -5,15 +5,19 @@ description: Learn about rate limiting on Clerk's APIs.
 
 # Rate limits
 
-Clerk rate limits certain endpoints to help protect users against brute-force attacks or to stop abuse of Clerk's platform. Rate limiting is based on IP addresses.
+Clerk rate limits certain endpoints to help protect users against brute-force attacks or to stop abuse of Clerk's platform.
+
+Rate limiting is based on IP addresses.
 
 ## Errors
 
-If you receive a 429 error code, that means your IP address has been rate limited. All subsequent requests to that specific endpoint coming from your IP address will be blocked for a given amount of time.
+If you receive a `429` error code, your IP address has been rate limited. All subsequent requests to that specific endpoint coming from your IP address will be blocked for a given amount of time.
 
-Requests that have been rate limited, will receive the `Retry-After` response header, which contains the number of seconds after which the block expires.
+Requests that have been rate limited will receive the `Retry-After` response header, which contains the number of seconds after which the block expires.
 
 ## Frontend API requests
+
+Frontend API requests are rate limited per user.
 
 | Name | Type | Description |
 | --- | --- | --- |
@@ -24,7 +28,14 @@ Requests that have been rate limited, will receive the `Retry-After` response he
 
 ## Backend API requests
 
+Backend API requests are rate limited per application instance.
+
 | Name | Type | Description |
 | --- | --- | --- |
 | Create users | `POST /v1/users` | 20 requests per 10 seconds |
 | All other endpoints | | 100 requests per 10 seconds |
+| Get the JWKS of the instance | `GET /v1/jwks` | No rate limit |
+
+<Callout type="info">
+  The `currentUser()` helper uses the `GET /v1/users/me` endpoint, so it is subject to the 100 requests per 10 seconds rate limit.
+</Callout>

--- a/docs/references/nextjs/current-user.mdx
+++ b/docs/references/nextjs/current-user.mdx
@@ -9,7 +9,7 @@ The `currentUser` helper returns the [`Backend API User`](https://clerk.com/docs
 
 Under the hood, this helper:
 - calls `fetch()`, so it is automatically deduped per request.
-- uses the `GET /v1/users/me` endpoint, so it is subject to the 100 requests per 10 seconds rate limit.
+- uses the `GET /v1/users/me` endpoint, so it is subject to [rate limits](/docs/backend-requests/resources/rate-limits).
 
 ```tsx filename="app/page.tsx"
 import { currentUser } from '@clerk/nextjs';

--- a/docs/references/nextjs/current-user.mdx
+++ b/docs/references/nextjs/current-user.mdx
@@ -5,7 +5,11 @@ description: Use the currentUser() helper to access information about your user 
 
 # `currentUser()`
 
-The `currentUser` helper returns the [`Backend API User`](https://clerk.com/docs/reference/backend-api/tag/Users#operation/GetUser) object of the currently active user. It can be used in Server Components, Route Handlers, and Server Actions. Under the hood, this helper calls `fetch()` so it is automatically deduped per request.
+The `currentUser` helper returns the [`Backend API User`](https://clerk.com/docs/reference/backend-api/tag/Users#operation/GetUser) object of the currently active user. It can be used in Server Components, Route Handlers, and Server Actions.
+
+Under the hood, this helper:
+- calls `fetch()`, so it is automatically deduped per request.
+- uses the `GET /v1/users/me` endpoint, so it is subject to the 100 requests per 10 seconds rate limit.
 
 ```tsx filename="app/page.tsx"
 import { currentUser } from '@clerk/nextjs';


### PR DESCRIPTION
From [this ticket](https://linear.app/clerk/issue/DOCS-5112/update-rate-limiting-page):

- [X] confirm that the JWKS endpoint is not rate limited — @kylemac confirms it is not.
- [X] because JWKS endpoint  is not rate limited, we can add it to the Backend API Requests table
- [X] add a note that currentUser() is using the getUser() BAPI endpoint so all currentUser() uses count against the 100 reqs / 10 seconds rate limit
- [X] add a note that the FAPI rate limits are per user, while the BAPI endpoints are per application

🔎 https://docs-preview-871.clerkpreview.com/docs/backend-requests/resources/rate-limits
🔎 https://docs-preview-871.clerkpreview.com/docs/references/nextjs/current-user