### PR TITLE
DOCS-5460 Update organizations overview to better explain orgs and org features

### DIFF
--- a/docs/manifest.json
+++ b/docs/manifest.json
@@ -122,6 +122,7 @@
     [
       ["Overview", "/organizations/overview"],
       ["Roles and permissions", "/organizations/roles-permissions"],
+      ["Verified domains", "/organizations/verified-domains"],
       "# Prebuilt Components",
       ["<CreateOrganization />", "https://clerk.com/docs/components/organization/create-organization"],
       ["<OrganizationProfile />", "https://clerk.com/docs/components/organization/organization-profile"],
@@ -139,8 +140,7 @@
       ["Inviting users", "/organizations/inviting-users"],
       ["Managing roles", "/organizations/managing-roles"],
       ["Viewing memberships", "/organizations/viewing-memberships"],
-      ["Create a custom organization switcher", "/organizations/custom-organization-switcher"],
-      ["Verified domains", "/organizations/verified-domains"]
+      ["Create a custom organization switcher", "/organizations/custom-organization-switcher"]
     ]
   ],
   [

--- a/docs/organizations/overview.mdx
+++ b/docs/organizations/overview.mdx
@@ -9,6 +9,11 @@ Organizations play a crucial role in structuring user management within your app
 
 By utilizing organizations, you can assign specific roles and permissions to users, allowing you to finely control access to different parts of your application. Whether you're managing projects, coordinating teams, or facilitating partnerships, organizations offer a flexible and scalable way to structure user access and permissions.
 
+<Callout type="info">
+  To explore organizations in Clerk, check out this demo repo:
+  https://github.com/clerk/organizations-demo
+</Callout>
+
 ## Enable organizations in your application
 
 Organizations are disabled by default.
@@ -77,22 +82,13 @@ Clerk provides a set of prebuilt components to help your users manage their orga
 
 ### Admin membership management
 
-As an admin, you can manage organization memberships through the Clerk Dashboard. You can view and manage:
+As an admin, you can manage organization memberships
 
 - Membership list
 - Domains
 - Invitations (invite form, invitations list)
 - Membership suggestions
 - Membership requests
-
-## Implement organization features in your application
-
-Clerk provides [prebuilt components](/docs/components/overview), [React hooks](/docs/references/react/use-organization), and [APIs](/docs/references/javascript/organization/organization) to help you integrate organizations into your application. Using the [Organizations Backend API](https://clerk.com/docs/reference/backend-api/tag/Organizations), you can provide additional [private and public metadata for the organization](/docs/organizations/metadata) and set custom attributes.
-
-<Callout type="info">
-  To explore organizations in Clerk, check out this demo repo:
-  https://github.com/clerk/organizations-demo
-</Callout>
 
 ## Frequently asked questions (FAQ)
 

--- a/docs/organizations/overview.mdx
+++ b/docs/organizations/overview.mdx
@@ -5,26 +5,111 @@ description: Learn about how to create and manage Clerk organizations and their 
 
 # Organizations
 
-Organizations are a way of grouping your application's users. Organizations are shared accounts, useful for project and team leaders—think of GitHub Teams or the different departments of a company. Members of different organizations can usually collaborate across shared resources but might have different levels of access and permissions with different [roles](/docs/organizations/overview#roles).
+Organizations play a crucial role in structuring user management within your application, particularly in B2B, B2B2C, and collaborative environments. Think of a platform like GitHub Teams, or even departments within a company - organizations are a way to group and manage users and their access to resources.
 
-There is no limit to the number of organizations a user can be a member of. However, a user can only create up to 100 organizations in a given application instance.
+By utilizing organizations, you can assign specific roles and permissions to users, allowing you to finely control access to different parts of your application. Whether you're managing projects, coordinating teams, or facilitating partnerships, organizations offer a flexible and scalable way to structure user access and permissions.
 
 ## Enable organizations in your application
 
+Organizations are disabled by default.
+
 To enable organizations:
-1. Navigate to the [Clerk Dashboard](https://dashboard.clerk.com/last-active?path=organizations-settings) and select your application.
+
+1. Navigate to the [Clerk Dashboard](https://dashboard.clerk.com/last-active?path=organizations-settings).
 2. In the navigation sidebar, select **Organizations Settings**.
 3. Toggle on **Enable Organizations**.
+
+Once organizations are enabled, you will be presented with the default settings, roles, and permissions that are applied to all organizations in that application instance.
+
+### Roles and permissions
+
+Roles determine a user's level of access and permissions within an organization. [Learn more about how roles and permissions work and how to create your own with Clerk.](/docs/organizations/roles-permissions).
+
+### Default membership limit
+
+There is no limit to the number of organizations a user can be a member of.
+
+However, there is a limit to how many members total can be in a single organization. By default, the membership limit is set to 3 members. To change this limit, scroll to the **Default membership limit** section and update the membership limit.
+
+If you are on the Free plan, you can update the membership limit to a maximum of 5 members.
+
+If you have the Pro plan, you can set the membership limit to unlimited.
+
+You can also change this limit on a per-organization basis:
+
+1. Navigate to the [Clerk Dashboard](https://dashboard.clerk.com/last-active?path=organizations).
+2. In the navigation sidebar, select **Organizations**.
+3. Select the organization you want to update.
+4. In the **Membership limit** section, update the membership limit.
+
+### Default ability to delete
+
+By default, organizations are deletable. Any member with the "Delete organization" permission can delete an organization. To prevent organizations from being deleted, you can disable the ability to delete organizations by scrolling to the **Default ability to delete** section and unchecking the option.
+
+### Verified domains
+
+Verified domains can be used to streamline enrollment into an organization. For example, if the domain `@clerk.com` is verified, any user with an email address ending in `@clerk.com` can be automatically invited or be suggested to join an organization with that domain. This feature is useful for organizations that want to restrict membership to users with specific email domains. See the [verified domains](/docs/organizations/verified-domains) documentation for more information.
+
+## Active organization
+
+There are two types of accounts that a user can have in a Clerk application: a personal account and an organization account. A personal account is the default account type, and it is created when a user signs up for your application. An organization account is created when a user creates or joins an organization within your application.
+
+When a user is a member of an organization, they can switch between their personal account and their organization account. The organization account that a user is currently viewing is called the active organization. The active organization determines which organization-specific data the user can access and which roles and permissions they have within the organization.
+
+When a user signs in to your application, they are viewing their personal account and no organization is set as active. Even if they are a member of only one organization, they must explicitly switch to that organization to set it as active.
+
+The easiest way to allow users to switch between their personal account and their organization account is to use Clerk's [`<OrganizationSwitcher />`](/docs/components/organization/organization-switcher) component. Once a user selects an organization, that organization is set as the active organization.
+
+## Organization management
+
+1. Navigate to the [Clerk Dashboard](https://dashboard.clerk.com/last-active?path=organizations).
+2. In the navigation sidebar, select **Organizations**. Here, you can view and manage all organizations within your application - both those created by you and those create by your users.
+3. Select a specific organization to view its details, members, and settings. Here, you can update the organization's name, slug, and logo. You can also set the organization's [membership limit](#how-many-organizations-can-i-create) and public and private metadata.
+
+### User membership management
+
+Clerk provides a set of prebuilt components to help your users manage their organization memberships:
+
+- [`<CreateOrganization />`](/docs/components/organization/create-organization) - A form for a user to create a new organization.
+- [`<OrganizationProfile />`](/docs/components/organization/organization-profile) - A profile page for the user's currently active organization. Out of the box, this component's **General** tab displays the organization's information and the **Leave organization** option. The **Members** tab shows the organization's members along with their join dates and roles.
+- [`<OrganizationSwitcher />`](/docs/components/organization/organization-switcher) - A dropdown menu that allows a user to switch between their personal account and their organization account(s).
+- [`<OrganizationList />`](/docs/components/organization/organization-list) - A list of organizations that a user is a member of.
+
+### Admin membership management
+
+As an admin, you can manage organization memberships through the Clerk Dashboard. You can view and manage:
+
+- Membership list
+- Domains
+- Invitations (invite form, invitations list)
+- Membership suggestions
+- Membership requests
 
 ## Implement organization features in your application
 
 Clerk provides [prebuilt components](/docs/components/overview), [React hooks](/docs/references/react/use-organization), and [APIs](/docs/references/javascript/organization/organization) to help you integrate organizations into your application. Using the [Organizations Backend API](https://clerk.com/docs/reference/backend-api/tag/Organizations), you can provide additional [private and public metadata for the organization](/docs/organizations/metadata) and set custom attributes.
 
 <Callout type="info">
-  To explore Clerk's Organizations, check out this demo repo:
+  To explore organizations in Clerk, check out this demo repo:
   https://github.com/clerk/organizations-demo
 </Callout>
 
-## Roles and permissions
+## Frequently asked questions (FAQ)
 
-Roles determine a user's level of access and permissions within an organization. [Learn more about how roles and permissions work and how to create your own with Clerk.](/docs/organizations/roles-permissions).
+### How many organizations can a user belong to?
+
+There is no limit to the number of organizations a user can be a member of.
+
+### How many organizations can my users create?
+
+A user within one of your applications can create up to 100 organizations in that application. This limit is separate from the number of organizations *you* can create across your entire account.
+
+### How many organizations can I create?
+
+The number of monthly active organizations (MAOs) you can create depends on your [Clerk plan](/pricing).
+
+With the Free plan, you can create up to 100 MAOs across your entire account. Each MAO can have up to 5 members. So if you have 20 different Clerk applications, each of them can have 5 organizations (100 total across your account).
+
+With the Pro plan, you can create up to 100 MAOs across your entire account. Each MAO after the first 100 costs $1.00 per month. Each MAO can have an unlimited number of members. So if you have 20 applications, each of them can have 5 organizations (100 total across your account), and then each additional organization costs $1.00 per month.
+
+If you need more organizations, please contact [our sales team](https://clerk.com/contact/sales) to upgrade to the Enterprise plan.

--- a/docs/organizations/verified-domains.mdx
+++ b/docs/organizations/verified-domains.mdx
@@ -60,11 +60,11 @@ const { organization, domains } = useOrganization();
 const domain = await organization.createDomain("example.com")
 
 // prepare email verification
-domain.prepareAffiliationVerification({affiliationEmailAddress: "foo@example.com"})
+domain.prepareAffiliationVerification({ affiliationEmailAddress: "foo@example.com" })
 
 // attempt email verification
-domain.attemptAffiliationVerification({code: "123456"})
+domain.attemptAffiliationVerification({ code: "123456" })
 
 // update domain enrollment mode
-domain.updateEnrollmentMode({enrollmentMode: "automatic_invitation"})
+domain.updateEnrollmentMode({ enrollmentMode: "automatic_invitation" })
 ```

--- a/docs/organizations/verified-domains.mdx
+++ b/docs/organizations/verified-domains.mdx
@@ -1,11 +1,47 @@
 ---
-title: Verified Domains
+title: Verified domains
 description: Learn about how to use verified domains for organizations.
 ---
 
-# Creating and verifying a domain
+# Verified domains
 
-Domains can be added and verified under an organization by an administrator. In order to enable this feature, go to the Clerk Dashboard and navigate to the **[Organizations Settings](https://dashboard.clerk.com/last-active?path=organizations-settings)** page. Toggle on **Verified domains**. The only parameter needed to create an organization domain is the `name`.
+Verified domains can be used to streamline enrollment into an organization. For example, if the domain `@clerk.com` is verified, any user with an email address ending in `@clerk.com` can be automatically invited or be suggested to join an organization with that domain. This feature is useful for organizations that want to restrict membership to users with specific email domains.
+
+## Enable verified domains
+
+Enabling verified domains applies to all organizations and cannot currently be managed on a per-organization basis.
+
+In order to enable this feature:
+
+1. Navigate to the [Clerk Dashboard](https://dashboard.clerk.com/last-active?path=organizations-settings)
+2. In the navigation sidebar, select **Organizations Settings**.
+3. In the **Verified domains** section, check the **Enable verified domains** checkbox.
+4. The following settings will appear:
+  - [**Enrollment mode**](#enrollment-mode) - Choose between `automatic_invitation` and `automatic_suggestion`.
+  - [**Default role**](#default-role) - Choose the default role for users who join the organization through a verified domain.
+
+### Enrollment mode
+
+You can enable the following enrollment modes to be available for your application:
+
+- `automatic_invitation` - During sign-up, a user will receive an invitation for the organization if their email's domain matches the verified domain. The user will join the organization if they accept the automatic invitation.
+- `automatic_suggestion` - During sign-up, a user will receive a suggestion for the organization if their email's domain matches the verified domain. The user can request to join, and an administrator must accept this request before the user can join the organization.
+
+Once a domain is created and verified in your application, an administrator will have the option to enable whichever enrollment modes you made available.
+
+### Default role
+
+Once verified domains are enabled, you are required to define which role will be assigned to the user that will receive the organization invitation or organization suggestions in order to join your organization.
+
+By default, the options are "Member" and "Admin". However, you can also [create custom roles for your organization](/docs/organizations/create-roles-permissions).
+
+<Callout type="warning">
+  You can't delete an organization role if it's used as the verified domain's default role.
+</Callout>
+
+## Adding and verifying domains
+
+Domains can be added and verified under an organization by an organization administrator. The easiest way to do so is by using Clerk's [`<OrganizationSwitcher />`] component. In the **General** tab, there will be a **Verified domains** section where you can add and verify domains.
 
 Domains can be verified through an email verification code sent to an email that matches the domain. If the administrator adding the domain already has a verified email using that domain in their account, the domain will be automatically verified.
 
@@ -13,26 +49,9 @@ An application instance may only have one verified domain of the same name, and 
 
 You can create up to 10 domains per organization to meet your needs. If you need more than 10 domains, reach out to support@clerk.dev.
 
-## Default role
+### Custom flow
 
-When enabling the verified domains feature, you are also required to define which role will be assigned to the user that will receive the organization invitation or organization suggestions in order to join your organization.
-
-You can choose any of the available organization roles of your instance.
-
-<Callout type="warning">
-  You can't delete an organization role if it's used as the verified domain's default role.
-</Callout>
-
-To specify the verified domain's default role, in the Clerk Dashboard, go to the **[Organizations Settings](https://dashboard.clerk.com/last-active?path=organizations-settings)** page.
-
-## Enrollment modes
-
-Once a domain is created and verified, an administrator can choose between two enrollment modes to enable new ways for users to join organizations.
-
-- `automatic_invitation` - During sign-up, a user will receive an invitation for the organization if their email's domain matches the verified domain. The user will join the organization if they accept the automatic invitation.
-- `automatic_suggestion` - During sign-up, a user will receive a suggestion for the organization if their email's domain matches the verified domain. The user can request to join, and an administrator must accept this request before the user can join the organization.
-
-### Usage
+If Clerk's [`<OrganizationSwitcher />`] does not meet your specific needs or if you require more control over the logic, you can use the Clerk API to add and verify a domain and update the domain's enrollment mode. Here's an example of how you can do this:
 
 ```tsx copy
 const { organization, domains } = useOrganization();


### PR DESCRIPTION
Many user feedback tickets mention the organizations overview. You can see them as sub-issues to this parent ticket: [DOCS-5460](https://linear.app/clerk/issue/DOCS-5460/update-organizationsoverview). Also, internally, it's been talked about how we do not market our Organizations feature to best of our ability.

What is an organization? What is it used for and why is it helpful? 

We can also touch on what active organizations are - how one is not automatically set as active, and how to do so.

What is an organization invitation? 
An organization suggestion? 
An organization membership request? And how does a user send a membership request (through suggestions?)? 
An organization domain? We explain on this [page](https://clerk.com/docs/organizations/verified-domains#creating-and-verifying-a-domain) but it lives under "building custom flows" section of the organizations context - it doesn't look like a custom flow page to me...

We also need more context around organization limits. How many orgs can a user create? How many users can join an org? How many orgs can the application owner create? We should probably mention the pricing page (which also means the pricing page and this page need to be on the same page). 