### PR TITLE
Docs for rejecting compromised passwords on sign-in

### DIFF
--- a/docs/authentication/configuration/sign-up-sign-in-options.mdx
+++ b/docs/authentication/configuration/sign-up-sign-in-options.mdx
@@ -49,7 +49,7 @@ Authentication strategies are the methods that users can use to sign up and sign
 
 Clerk offers two kinds of authentication strategies: **password** and **passwordless**.
 
-Choosing the **password** strategy requires users to set a password during the sign up process. Clerk offers out of the box protection against weak and leaked passwords and the only requirement enforced is that the password be a miminum of 8 characters. (**Note**: passwordless authentication is still available to users even if password strategy is selected.)
+Choosing the **password** strategy requires users to set a password during the sign up process. Clerk offers out of the box protection against weak and compromised passwords and the only requirement enforced is that the password be a miminum of 8 characters. (**Note**: passwordless authentication is still available to users even if password strategy is selected.)
 
 There are two types of **passwordless** authentication strategies:
 

--- a/docs/custom-flows/forgot-password.mdx
+++ b/docs/custom-flows/forgot-password.mdx
@@ -155,3 +155,9 @@ const ForgotPasswordPage: NextPage = () => {
 export default ForgotPasswordPage;
 ```
 </CodeBlockTabs>
+
+## Prompting users to reset compromised passwords during sign-in
+
+If you have enabled [rejection of compromised passwords also on sign-in](/docs/security/password-protection#reject-compromised-passwords-on-sign-in), then it is possible for the sign-in attempt to be rejected with the `form_password_pwned` error code.
+
+In this case, you can prompt the user to reset their password using the exact same logic detailed in the previous section.

--- a/docs/security/password-protection.mdx
+++ b/docs/security/password-protection.mdx
@@ -13,20 +13,52 @@ Clerk refers to the National Institute of Standards and Technology (NIST) guidel
 
 [NIST Special Publication 800-63B](https://pages.nist.gov/800-63-3/sp800-63b.html#sec5)
 
-While these rules might seem lax independently, NIST's additional leaked password protection guidelines do more to prevent the use of unsafe passwords.
+While these rules might seem lax independently, NIST's additional compromised password protection guidelines do more to prevent the use of unsafe passwords.
 
 Also, please bear in mind, that passwords are not a requirement for using Clerk. Applications can be configured to use a passwordless strategy that relies on your users being sent one-time passwords instead.
 
-## Leaked password protection
-Clerk refers to the National Institute of Standards and Technology (NIST) guidelines to determine its handling of leaked passwords:
+## Reject compromised passwords
+
+Clerk refers to the National Institute of Standards and Technology (NIST) guidelines to determine its handling of compromised passwords:
 
 When processing requests to establish and change memorized secrets, verifiers SHALL compare the prospective secrets against a list that contains values known to be commonly-used, expected, or compromised. For example, the list MAY include, but is not limited to: [NIST Special Publication 800-63B](https://pages.nist.gov/800-63-3/sp800-63b.html#sec5)
 
 - Passwords obtained from previous breach corpuses.
 
-Specifically, Clerk contracts with have [i been pwned](https://haveibeenpwned.com/) to compare prospective passwords against its corpus of over 10 billion leaked credentials.
+Specifically, Clerk contracts with [HaveIBeenPwned](https://haveibeenpwned.com/) to compare prospective passwords against its corpus of over 10 billion compromised credentials.
+
+Rejection of compromised passwords is enabled by default for sign-up and password changes. It is disabled by default for sign-in - learn more in the [Reject compromised passwords on sign-in](/docs/security/password-protection#reject-compromised-passwords-on-sign-in) section.
+
+To configure this feature:
+
+1. Navigate to the [Clerk Dashboard](https://dashboard.clerk.com/last-active).
+2. In the navigation sidenav, select **User & Authentication > Email, Phone, Username**.
+3. In the **Authentication strategies** section, next to **Password**, select the settings cog icon.
+4. You can enable or disable **Reject compromised passwords on sign-up or password change, powered by HaveIBeenPwned**.
+5. You can also enable or disable **Reject compromised passwords also on sign-in**. Learn more about this feature in the following section.
+
+### Reject compromised passwords on sign-in
+
+Clerk also offers the ability to check for compromised passwords on sign-in.
+When the user provides the correct password, if it has been found in online breach data, they will be prompted to reset their password.
+
+This is useful for blocking password sign-ins in the case that:
+
+- The password has recently been added to the compromised password database
+- The user was able to set a compromised password because protection was off at the time
+- The user was migrated to Clerk along with their existing password digest
+
+<Callout type="Info">
+Password reset for compromised passwords uses the same flow as "forgot password". The user will need to authenticate first via an OTP code sent to their email or phone and only then they will be able to set a new — more secure — password.
+</Callout>
+
+#### Limitations
+
+- Before enabling rejection of compromised passwords on sign-in, please ensure your app has support for the password reset flow. You can do so by using Clerk components or [implementing a custom flow](/docs/custom-flows/forgot-password#prompting-users-to-reset-compromised-passwords-during-sign-in).
+- If the user has no way of resetting their password — such as when your application does not require an email, phone number, or other communication method for sign-up — Clerk will not reject compromised passwords on sign-in.
 
 ## Password strength
+
 Clerk uses [zxcvbn-ts](https://zxcvbn-ts.github.io/zxcvbn/) for estimating the strength of passwords and leverages the [Open Web Application Security Project (OWASP) guidelines](https://cheatsheetseries.owasp.org/cheatsheets/Password_Storage_Cheat_Sheet.html) to determine its handling of password strength:
 
 > OWASP recommends using a password strength estimation library like zxcvbn to evaluate the strength of passwords. This can help identify weak passwords and prevent their use.


### PR DESCRIPTION
Note:

Replaces all instances of "leaked" with "compromised" as it is the wording we use in the dashboard.