### PR TITLE
DOCS-6045 reference getUserOAuthAccessToken working example in reference doc

### DIFF
--- a/docs/references/backend/user/get-user-oauth-access-token.mdx
+++ b/docs/references/backend/user/get-user-oauth-access-token.mdx
@@ -48,6 +48,8 @@ console.log(response);
 */
 ```
 
+You can also explore the [working example](/docs/authentication/social-connections/oauth#get-an-o-auth-access-token-for-a-social-sign-in-provider) that demonstrates how this method retrieves a social provider's OAuth access token, enabling access to user data from both the provider and Clerk.
+
 ## Backend API (BAPI) endpoint
 
 This method in the SDK is a wrapper around the BAPI endpoint `GET/users/{user_id}/oauth_access_tokens/{provider}`. See the [BAPI reference](https://clerk.com/docs/reference/backend-api/tag/Users#operation/GetOAuthAccessToken) for more details.


### PR DESCRIPTION
[User feedback ticket](https://linear.app/clerk/issue/DOCS-6045/%F0%9F%98%A2-feedback-for-referencesbackenduserget-user-oauth-access-token) reads:

> Example code is not so clear. A case handled in detailed would help better. Hard to grasp, how and where to use it.

This PR adds a reference to the working example in the reference doc.