### PR TITLE
feat: Document `orderBy` param of `getOrganizationList()`

### DIFF
--- a/docs/references/backend/organization/get-organization-list.mdx
+++ b/docs/references/backend/organization/get-organization-list.mdx
@@ -18,7 +18,7 @@ const organizations = await clerkClient.organizations.getOrganizationList();
 | `limit?` | `number` | The number of results to return. Must be an integer greater than zero and less than 501. |
 | `offset?` | `number` | The number of results to skip. |
 | `query?` | `string` | A search query to filter organizations by. |
-| `orderBy?` | `string` | The field to order by. Can be  `"name"`, `"updated_at"`, or `"members_count"`. Prefix with a `-` to reverse the order. Prefix with a `+` to list in ascending order. |
+| `orderBy?` | `name \| updated_at \| members_count` | The field to order by. Prefix with a `-` to reverse the order. Prefix with a `+` to list in ascending order. |
 
 ## Example
 

--- a/docs/references/backend/organization/get-organization-list.mdx
+++ b/docs/references/backend/organization/get-organization-list.mdx
@@ -18,7 +18,7 @@ const organizations = await clerkClient.organizations.getOrganizationList();
 | `limit?` | `number` | The number of results to return. Must be an integer greater than zero and less than 501. |
 | `offset?` | `number` | The number of results to skip. |
 | `query?` | `string` | A search query to filter organizations by. |
-| `orderBy?` | `name \| updated_at \| members_count` | The field to order by. Prefix with a `-` to reverse the order. Prefix with a `+` to list in ascending order. |
+| `orderBy?` | `string` | The field to order by. Can be  `"name"`, `"updated_at"`, or `"members_count"`. Prefix with a `-` to reverse the order. Prefix with a `+` to list in ascending order. |
 
 ## Example
 

--- a/docs/references/backend/organization/get-organization-list.mdx
+++ b/docs/references/backend/organization/get-organization-list.mdx
@@ -18,6 +18,7 @@ const organizations = await clerkClient.organizations.getOrganizationList();
 | `limit?` | `number` | The number of results to return. Must be an integer greater than zero and less than 501. |
 | `offset?` | `number` | The number of results to skip. |
 | `query?` | `string` | A search query to filter organizations by. |
+| `orderBy?` | `name \| updated_at \| members_count` | The field to order by. Prefix with a `-` to reverse the order. Prefix with a `+` to list in ascending order. |
 
 ## Example
 


### PR DESCRIPTION
This documents the `orderBy` parameter for the `getOrganizationList()` function.

The parameter was previously missing from the SDK, and it's being added in https://github.com/clerk/javascript/pull/3164