### PR TITLE
DOCS-6094 update users overview

### DIFF
--- a/docs/users/overview.mdx
+++ b/docs/users/overview.mdx
@@ -5,22 +5,30 @@ description: Learn how to manage your users in your Clerk application.
 
 # Users
 
-Clerk provides the prebuilt components [`<UserButton />`](/docs/components/user/user-button) and [`<UserProfile />`](/docs/components/user/user-profile) in order to help your users manage their profile data. However, if you would like to manage user authentication and profile data yourself, or if you would like to build your own profile management flow, Clerk provides a set of APIs to help you do that.
+Depending on your need, Clerk provides a set of tools to manage your users. You can manage user information [in the frontend](#manage-user-information-in-the-frontend) using Clerk's prebuilt components, React hooks, or JavaScript methods, or [in the backend](#manage-user-information-in-the-backend) using the Clerk Backend SDK.
 
-## `User` object
+## Understand the `User` object
 
-The `User` object holds all of the information for a single user of your application and provides a set of methods to manage their account. Each user has a unique authentication identifier which might be their email address, phone number, or a username.
+[The `User` object](/docs/references/javascript/user/user) holds all of the information for a single user of your application and provides a set of methods to manage their account.
 
-A user can be contacted at their primary email address or primary phone number. They can have more than one registered email address, but only one of them will be their primary email address. This goes for phone numbers as well; a user can have more than one, but only one phone number will be their primary. At the same time, a user can also have one or more external accounts by connecting to [OAuth providers](/docs/authentication/social-connections/overview) such as Google, Apple, Facebook, and many more.
+A `User` object holds profile data like the user's name, profile picture, and a set of [metadata](/docs/users/metadata) that can be used internally to store arbitrary information. The metadata are split into `publicMetadata` and `privateMetadata`. Both types are set from the [Backend API](https://clerk.com/docs/reference/backend-api), but public metadata can be accessed from the [Frontend API](https://clerk.com/docs/reference/frontend-api) as well.
 
-Finally, a `User` object holds profile data like the user's name, profile picture, and a set of [metadata](/docs/users/metadata) that can be used internally to store arbitrary information. The metadata are split into `publicMetadata` and `privateMetadata`. Both types are set from the [Backend API](https://clerk.com/docs/reference/backend-api), but public metadata can be accessed from the [Frontend API](https://clerk.com/docs/reference/frontend-api) as well.
+Each `User` has at least one authentication [identifier](/docs/authentication/configuration/sign-up-sign-in-options#identifiers), which might be their email address, phone number, or a username.
+
+A user can be contacted at their primary email address or primary phone number. They can have more than one verified email address, but only one of them will be their primary email address. This goes for phone numbers as well; a user can have more than one, but only one phone number will be their primary. At the same time, a user can also have one or more external accounts by connecting to [OAuth providers](/docs/authentication/social-connections/overview) such as Google, Apple, Facebook, and many more.
 
 For more information on the `User` object, such as helper methods for retrieving and updating user information and authentication status, checkout the [ClerkJS SDK documentation](/docs/references/javascript/user/user).
 
+## Manage user information in the frontend
+
+Clerk provides the prebuilt components [`<UserButton />`](/docs/components/user/user-button) and [`<UserProfile />`](/docs/components/user/user-profile) in order to help your users manage their profile data.
+
 If you are using React, the [React SDK](/docs/references/react/use-user) provides hooks to help manage user authentication and profile data.
 
-## `User` operations
+If Clerk's prebuilt components don't meet your specific needs or if you require more control over the logic, you can use React hooks and JavaScript methods to [rebuild existing Clerk flows.](https://clerk.com/docs/custom-flows/overview)
 
-The [Clerk Backend SDK](https://github.com/clerk/javascript/tree/main/packages/backend) exposes Clerk's backend API resources and low-level authentication utilities for JavaScript environments. While the backend SDK is mainly used as a building block for Clerk's higher-level SDKs, it can also be used on its own for advanced flows and custom integrations.
+## Manage user information in the backend
 
-For information about the `User` operations available, such as `getUser()`, `createUser()`, and `deleteUser()`, check out the [Backend SDK documentation](/docs/references/backend/overview).
+The [Clerk Backend SDK](/docs/references/backend/overview) exposes Clerk's backend API resources and low-level authentication utilities for JavaScript environments.
+
+For information about the `User` operations available, such as `getUser()`, `createUser()`, and `deleteUser()`, check out the [Backend SDK reference docs](/docs/references/backend/overview).


### PR DESCRIPTION
[User feedback ticket](https://linear.app/clerk/issue/DOCS-6094/%F0%9F%98%A2-feedback-for-usersoverview) for [/docs/users/overview](https://clerk.com/docs/users/overview) reads:

> not clear mentioning of page links.

I went ahead and cleaned this page up a bit - it's fine for now, but it's just one of those weird conceptual pages that will definitely get another look at after the IA rework

🔎 [Users overview](https://docs-preview-892.clerkpreview.com/docs/users/overview)