### PR TITLE
DOCS-6079 fix paths for /sign-in and /sign-up when used with React Router

### DIFF
--- a/docs/references/react/add-react-router.mdx
+++ b/docs/references/react/add-react-router.mdx
@@ -3,13 +3,13 @@ title: Add React Router to your Clerk-powered React application
 description: Learn how to add React Router to your React application using their Data API router.
 ---
 
-<TutorialHero 
+<TutorialHero
   framework="reactrouter"
-  exampleRepo={[ 
+  exampleRepo={[
     {
       title: "React Quickstart Repo",
       link: "https://github.com/clerk/clerk-react-quickstart"
-      
+
     }
   ]}
   beforeYouStart={[
@@ -55,7 +55,7 @@ React Router's `react-router-dom` is a mature, battle tested routing package for
 
 ### Create components for your routes
 
-The exact routes you will need depends on your application. For this guide, you will create `/`, `/contact`, `/dashboard`, `/sign-in`, and `sign-up` routes. The `/dashboard` route will contain a default route (`/dashbard/`) and an invoices route (`/dashboard/invoices`). The first step will be creating basic components for these routes. 
+The exact routes you will need depends on your application. For this guide, you will create `/`, `/contact`, `/dashboard`, `/sign-in`, and `sign-up` routes. The `/dashboard` route will contain a default route (`/dashbard/`) and an invoices route (`/dashboard/invoices`). The first step will be creating basic components for these routes.
 
 Use the tabs below to find the example components and recreate these files using the path from each tab.
 
@@ -130,7 +130,7 @@ export default function DashboardPage() {
     </>
   );
 }
-``` 
+```
 
 ```tsx filename="src/routes/dashboard.invoices.tsx"
 import { Link } from "react-router-dom";
@@ -172,7 +172,7 @@ if (!PUBLISHABLE_KEY) {
 
 export default function RootLayout() {
   const navigate = useNavigate();
-  
+
   return (
     <ClerkProvider navigate={navigate} publishableKey={PUBLISHABLE_KEY}>
       <header className="header">
@@ -231,9 +231,9 @@ export default function DashboardLayout() {
 
 With all the routes and layouts you need created, you now need to wire up the layouts and the routes with the `createBrowserRouter` function from `react-router-dom`. This will use the Data API (aka Data Router) to configure your application.
 
-You can start by removing `src/App.tsx`—the contents of that file were moved to `src/layouts/root-layout.tsx`. 
+You can start by removing `src/App.tsx`—the contents of that file were moved to `src/layouts/root-layout.tsx`.
 
-In `src/main.tsx`, import `RouterProvider` and `createBrowserRouter()` from `react-router-dom`, as well as all of the default components from the layouts and routes you created. Replace the contents inside of `<React.StrictMode />` with only ` <RouterProvider router={router} />`. Lastly, you will build the `router` using `createBrowserRouter()`. 
+In `src/main.tsx`, import `RouterProvider` and `createBrowserRouter()` from `react-router-dom`, as well as all of the default components from the layouts and routes you created. Replace the contents inside of `<React.StrictMode />` with only ` <RouterProvider router={router} />`. Lastly, you will build the `router` using `createBrowserRouter()`.
 
 ```tsx filename="src/main.tsx"
 import React from 'react'
@@ -259,8 +259,8 @@ const router = createBrowserRouter([
     children: [
       { path: "/", element: <IndexPage /> },
       { path: "/contact", element: <ContactPage /> },
-      { path: "/sign-in", element: <SignInPage /> },
-      { path: "/sign-up", element: <SignUpPage /> },
+      { path: "/sign-in/*", element: <SignInPage /> },
+      { path: "/sign-up/*", element: <SignUpPage /> },
       {
         element: <DashboardLayout />,
         path: "dashboard",


### PR DESCRIPTION
[User feedback ticket](https://linear.app/clerk/issue/DOCS-6079/feedback-for-referencesreactadd-react-router) reads:

> Hi Folks,
>
> I had to use glob routes (i.e path: "/sign-in/*") instead of what's in here - otherwise I got redirected to a non-existent "/sign-in/factor-one" path :)
>
> Hopefully that helps others!
>
> Nik

🔎 [React router guide](https://docs-preview-893.clerkpreview.com/docs/references/react/add-react-router#wire-layouts-and-routes-up-with-create-browser-router)