### PR TITLE
DOCS-6072 update usage examples for sign in and sign up components

### DIFF
--- a/docs/components/authentication/sign-in.mdx
+++ b/docs/components/authentication/sign-in.mdx
@@ -35,27 +35,23 @@ The following example includes basic implementation of the `<SignIn />` componen
 
 <Tabs type="framework" items={["Next.js", "React", "Remix", "Gatsby"]}>
   <Tab>
-    You can embed the `<SignIn />` component using the [Next.js optional catch-all route](https://nextjs.org/docs/pages/building-your-application/routing/dynamic-routes#optional-catch-all-routes). This allows you to redirect the user inside your application. The `<SignIn />` component should be mounted on a public page.
+    The following example demonstrates how you can use the `<SignIn />` component on a public page.
 
-    <CodeBlockTabs type="router" options={["App Router", "Pages Router"]}>
-      ```jsx filename="/app/sign-in/[[...sign-in]]/page.tsx"
-      import { SignIn } from "@clerk/nextjs";
+    If you would like to create a dedicated `/sign-in` page in your Next.js application, check out the [dedicated guide.](/docs/references/nextjs/custom-signup-signin-pages).
 
-      export default function Page() {
+    ```tsx filename="app/page.tsx"
+    import { SignIn, useUser } from "@clerk/nextjs";
+
+    export default function Home() {
+      const { user } = useUser();
+
+      if (!user) {
         return <SignIn />;
       }
-      ```
 
-      ```jsx filename="/pages/sign-in/[[...index]].tsx"
-      import { SignIn } from "@clerk/nextjs";
-
-      const SignInPage = () => (
-        <SignIn path="/sign-in" routing="path" signUpUrl="/sign-up" />
-      );
-
-      export default SignInPage;
-      ```
-    </CodeBlockTabs>
+      return <div>Welcome!</div>;
+    }
+    ```
   </Tab>
 
   <Tab>

--- a/docs/components/authentication/sign-up.mdx
+++ b/docs/components/authentication/sign-up.mdx
@@ -36,26 +36,23 @@ The following example includes basic implementation of the `<SignIn />` componen
 
 <Tabs type="framework" items={["Next.js", "React", "Remix", "Gatsby"]}>
   <Tab>
-    You can embed the `<SignUp />` component using the [Next.js optional catch-all route](https://nextjs.org/docs/pages/building-your-application/routing/dynamic-routes#optional-catch-all-routes). This allows you to redirect the user inside your application. The `<SignUp />` component should be mounted on a public page.
+    The following example demonstrates how you can use the `<SignUp />` component on a public page.
 
-    <CodeBlockTabs type="router" options={["App Router", "Pages Router"]}>
-      ```jsx filename="/app/sign-up/[[...sign-up]]/page.tsx"
-      import { SignUp } from "@clerk/nextjs";
+    If you would like to create a dedicated `/sign-up` page in your Next.js application, check out the [dedicated guide.](/docs/references/nextjs/custom-signup-signin-pages).
 
-      export default function Page() {
+    ```tsx filename="app/page.tsx"
+    import { SignUp, useUser } from "@clerk/nextjs";
+
+    export default function Home() {
+      const { user } = useUser();
+
+      if (!user) {
         return <SignUp />;
       }
-      ```
 
-      ```jsx filename="/pages/sign-up/[[...index]].tsx"
-      import { SignUp } from "@clerk/nextjs";
-
-      const SignUpPage = () => (
-        <SignUp path="/sign-up" routing="path" signInUrl="/sign-in" />
-      );
-      export default SignUpPage;
-      ```
-    </CodeBlockTabs>
+      return <div>Welcome!</div>;
+    }
+    ```
   </Tab>
 
   <Tab>


### PR DESCRIPTION
[DOCS-6072](https://linear.app/clerk/issue/DOCS-6072/add-link-to-creating-custom-sign-inup-pages-to-the-components-page) reads:

> On [the component page for sign up/in](https://clerk.com/docs/components/authentication/sign-in), we show a short example of "framework usage", but it's not complete like [the full instructions](https://clerk.com/docs/references/nextjs/custom-signup-signin-pages) - perhaps we can expand or just link to the full instructions here? 
>
> This came directly from [a user report](https://app.plain.com/workspace/w_01GT53BQWV3DFW6ECTWZNQ1E9K/thread/th_01HT3BSAFDVZ6TTYAW7P7KZ5K2?entryId=t_01HTJVMDMDR5P2EJ1X9CSD1CK8)

🔎 [Sign in component](https://docs-preview-894.clerkpreview.com/docs/components/authentication/sign-in#usage-with-frameworks)
🔎 [Sign up component](https://docs-preview-894.clerkpreview.com/docs/components/authentication/sign-up#usage-with-frameworks)