### PR TITLE
DOCS-6057 add app router example to clerkloading reference

### DIFF
--- a/docs/components/control/clerk-loaded.mdx
+++ b/docs/components/control/clerk-loaded.mdx
@@ -13,38 +13,81 @@ The `<ClerkLoaded>` component guarantees that the Clerk object has loaded and wi
 
 <Tabs type="framework" items={["Next.js", "React", "Remix"]}>
   <Tab>
-  ```tsx filename="pages/_app.tsx"
-  import "@/styles/globals.css";
-  import { ClerkLoaded, ClerkProvider } from "@clerk/nextjs";
-  import { AppProps } from "next/app";
+  <Tabs type="router" items={["App Router", "Pages Router"]}>
+  <Tab>
+    ```tsx filename="app/layout.tsx"
+      import { ClerkProvider } from '@clerk/nextjs'
+      import './globals.css';
 
-  function MyApp({ Component, pageProps }: AppProps) {
-    return (
+      export default function RootLayout({
+        children,
+      }: {
+        children: React.ReactNode
+      }) {
+        return (
+          <ClerkProvider>
+            <html lang="en">
+              <body>
+                <ClerkLoaded>
+                  {children}
+                </ClerkLoaded>
+              </body>
+            </html>
+          </ClerkProvider>
+        )
+      }
+    ```
 
-    <ClerkProvider {...pageProps}>
-      <ClerkLoaded>
-        <Component {...pageProps} />
-      </ClerkLoaded>
-    </ClerkProvider>
-    ); 
-  }
+    Once you have wrapped your app with `<ClerkLoaded>`, you can access the `Clerk` object without the need to check if it exists.
 
-  export default MyApp;
-  ```
-
-  Once you have wrapped your app with `<ClerkLoaded>`, you can access the `Clerk` object without the need to check if it exists.
-
-  ```tsx filename="pages/index.tsx"
-  declare global {
-    interface Window {
-      Clerk: any;
+    ```tsx filename="app/page.tsx"
+    declare global {
+      interface Window {
+        Clerk: any;
+      }
     }
-  }
 
-  export default function Home() {
-    return <div>This page uses Clerk {window.Clerk.version}; </div>;
-  }
-  ```
+    export default function Home() {
+      return <div>This page uses Clerk {window.Clerk.version}; </div>;
+    }
+    ```
+    </Tab>
+
+    <Tab>
+    ```tsx filename="pages/_app.tsx"
+    import "@/styles/globals.css";
+    import { ClerkLoaded, ClerkProvider } from "@clerk/nextjs";
+    import { AppProps } from "next/app";
+
+    function MyApp({ Component, pageProps }: AppProps) {
+      return (
+
+      <ClerkProvider {...pageProps}>
+        <ClerkLoaded>
+          <Component {...pageProps} />
+        </ClerkLoaded>
+      </ClerkProvider>
+      );
+    }
+
+    export default MyApp;
+    ```
+
+    Once you have wrapped your app with `<ClerkLoaded>`, you can access the `Clerk` object without the need to check if it exists.
+
+    ```tsx filename="pages/index.tsx"
+    declare global {
+      interface Window {
+        Clerk: any;
+      }
+    }
+
+    export default function Home() {
+      return <div>This page uses Clerk {window.Clerk.version}; </div>;
+    }
+    ```
+    </Tab>
+    </Tabs>
   </Tab>
 
   <Tab>
@@ -65,7 +108,7 @@ The `<ClerkLoaded>` component guarantees that the Clerk object has loaded and wi
           <Page />
         </ClerkLoaded>
       </ClerkProvider>
-    ); 
+    );
   }
 
   function Page() {
@@ -77,7 +120,7 @@ The `<ClerkLoaded>` component guarantees that the Clerk object has loaded and wi
 
     return (
       <div>The content </div>
-    ); 
+    );
   }
 
   export default App;

--- a/docs/components/control/clerk-loaded.mdx
+++ b/docs/components/control/clerk-loaded.mdx
@@ -16,7 +16,7 @@ The `<ClerkLoaded>` component guarantees that the Clerk object has loaded and wi
   <Tabs type="router" items={["App Router", "Pages Router"]}>
   <Tab>
     ```tsx filename="app/layout.tsx"
-      import { ClerkProvider } from '@clerk/nextjs'
+      import { ClerkProvider, ClerkLoaded, ClerkLoading } from '@clerk/nextjs'
       import './globals.css';
 
       export default function RootLayout({

--- a/docs/components/control/clerk-loading.mdx
+++ b/docs/components/control/clerk-loading.mdx
@@ -13,52 +13,53 @@ The `<ClerkLoading>` renders its children while Clerk is loading, and is helpful
 
 <Tabs type="framework" items={["Next.js", "React", "Remix"]}>
   <Tab>
-  <CodeBlockTabs type="router" options={["App Router", "Pages Router"]}>
-  ```tsx filename="layout.tsx"
-    import { ClerkProvider } from '@clerk/nextjs'
-    import './globals.css';
+    <CodeBlockTabs type="router" options={["App Router", "Pages Router"]}>
+    ```tsx filename="layout.tsx"
+      import { ClerkProvider } from '@clerk/nextjs'
+      import './globals.css';
 
-    export default function RootLayout({
-      children,
-    }: {
-      children: React.ReactNode
-    }) {
+      export default function RootLayout({
+        children,
+      }: {
+        children: React.ReactNode
+      }) {
+        return (
+          <ClerkProvider>
+            <html lang="en">
+              <ClerkLoading>
+                <div>Clerk is loading...</div>
+              </ClerkLoading>
+              <ClerkLoaded>
+                <body>{children}</body>
+              </ClerkLoaded>
+            </html>
+          </ClerkProvider>
+        )
+      }
+    ```
+
+    ```tsx filename="pages/_app.tsx"
+    import "@/styles/globals.css";
+    import { ClerkLoaded, ClerkLoading, ClerkProvider } from "@clerk/nextjs";
+    import { AppProps } from "next/app";
+
+    function MyApp({ Component, pageProps }: AppProps) {
       return (
-        <ClerkProvider>
-          <html lang="en">
-            <ClerkLoading>
-              <div>Clerk is loading...</div>
-            </ClerkLoading>
-            <ClerkLoaded>
-              <body>{children}</body>
-            </ClerkLoaded>
-          </html>
-        </ClerkProvider>
-      )
+
+      <ClerkProvider {...pageProps}>
+        <ClerkLoading>
+          <div>Clerk is loading</div>
+        </ClerkLoading>
+        <ClerkLoaded>
+          <Component {...pageProps} />
+        </ClerkLoaded>
+      </ClerkProvider>
+      );
     }
-  ```
 
-  ```tsx filename="pages/_app.tsx"
-  import "@/styles/globals.css";
-  import { ClerkLoaded, ClerkLoading, ClerkProvider } from "@clerk/nextjs";
-  import { AppProps } from "next/app";
-
-  function MyApp({ Component, pageProps }: AppProps) {
-    return (
-
-    <ClerkProvider {...pageProps}>
-      <ClerkLoading>
-        <div>Clerk is loading</div>
-      </ClerkLoading>
-      <ClerkLoaded>
-        <Component {...pageProps} />
-      </ClerkLoaded>
-    </ClerkProvider>
-    );
-  }
-
-  export default MyApp;
-  ```
+    export default MyApp;
+    ```
+    </CodeBlockTabs>
   </Tab>
 
   <Tab>

--- a/docs/components/control/clerk-loading.mdx
+++ b/docs/components/control/clerk-loading.mdx
@@ -15,7 +15,7 @@ The `<ClerkLoading>` renders its children while Clerk is loading, and is helpful
   <Tab>
     <CodeBlockTabs type="router" options={["App Router", "Pages Router"]}>
     ```tsx filename="app/layout.tsx"
-      import { ClerkProvider } from '@clerk/nextjs'
+      import { ClerkProvider, ClerkLoaded, ClerkLoading } from '@clerk/nextjs'
       import './globals.css';
 
       export default function RootLayout({

--- a/docs/components/control/clerk-loading.mdx
+++ b/docs/components/control/clerk-loading.mdx
@@ -13,6 +13,31 @@ The `<ClerkLoading>` renders its children while Clerk is loading, and is helpful
 
 <Tabs type="framework" items={["Next.js", "React", "Remix"]}>
   <Tab>
+  <CodeBlockTabs type="router" options={["App Router", "Pages Router"]}>
+  ```tsx filename="layout.tsx"
+    import { ClerkProvider } from '@clerk/nextjs'
+    import './globals.css';
+
+    export default function RootLayout({
+      children,
+    }: {
+      children: React.ReactNode
+    }) {
+      return (
+        <ClerkProvider>
+          <html lang="en">
+            <ClerkLoading>
+              <div>Clerk is loading...</div>
+            </ClerkLoading>
+            <ClerkLoaded>
+              <body>{children}</body>
+            </ClerkLoaded>
+          </html>
+        </ClerkProvider>
+      )
+    }
+  ```
+
   ```tsx filename="pages/_app.tsx"
   import "@/styles/globals.css";
   import { ClerkLoaded, ClerkLoading, ClerkProvider } from "@clerk/nextjs";
@@ -29,7 +54,7 @@ The `<ClerkLoading>` renders its children while Clerk is loading, and is helpful
         <Component {...pageProps} />
       </ClerkLoaded>
     </ClerkProvider>
-    ); 
+    );
   }
 
   export default MyApp;

--- a/docs/components/control/clerk-loading.mdx
+++ b/docs/components/control/clerk-loading.mdx
@@ -14,7 +14,7 @@ The `<ClerkLoading>` renders its children while Clerk is loading, and is helpful
 <Tabs type="framework" items={["Next.js", "React", "Remix"]}>
   <Tab>
     <CodeBlockTabs type="router" options={["App Router", "Pages Router"]}>
-    ```tsx filename="layout.tsx"
+    ```tsx filename="app/layout.tsx"
       import { ClerkProvider } from '@clerk/nextjs'
       import './globals.css';
 
@@ -26,12 +26,14 @@ The `<ClerkLoading>` renders its children while Clerk is loading, and is helpful
         return (
           <ClerkProvider>
             <html lang="en">
-              <ClerkLoading>
-                <div>Clerk is loading...</div>
-              </ClerkLoading>
-              <ClerkLoaded>
-                <body>{children}</body>
-              </ClerkLoaded>
+              <body>
+                <ClerkLoading>
+                  <div>Clerk is loading...</div>
+                </ClerkLoading>
+                <ClerkLoaded>
+                  {children}
+                </ClerkLoaded>
+              </body>
             </html>
           </ClerkProvider>
         )


### PR DESCRIPTION
[User feedback ticket](https://linear.app/clerk/issue/DOCS-6057/add-app-router-example-to-clerkloading-reference) for https://clerk.com/docs/components/control/clerk-loading reads:

> I want with app router


Please check the code example and make sure I wrote the App Router example to use ClerkLoading correctly