### PR TITLE
Staging and preview guides

### DIFF
--- a/docs/deployments/changing-domains.mdx
+++ b/docs/deployments/changing-domains.mdx
@@ -17,7 +17,7 @@ Production domains can be changed in the [Clerk Dashboard](https://dashboard.cle
 
 - Update DNS records
 - Generate new SSL certificates
-- [Update your publishable key](#updating-your-publishable-key)
+- [Update your publishable key](#update-your-publishable-key)
 - If using social connections, update the settings with your social connections so that the redirect URL they are using is correct.
 - If using JWT templates, update JWT issuer and JWKS endpoint in external JWT SSO services.
 

--- a/docs/deployments/deploy-to-vercel.mdx
+++ b/docs/deployments/deploy-to-vercel.mdx
@@ -79,4 +79,4 @@ This is done to ensure your users' security by restricting production redirects 
 
 > Please note that modifying the Preview Deployment Suffix is only available as an add-on to Vercel's Pro plans and above.
 
-See [Set up a preview environment](/docs/deployments/set-up-preview-environment) to learn more.
+See [the docs on preview environments](/docs/deployments/set-up-preview-environment) to learn more.

--- a/docs/deployments/deploy-to-vercel.mdx
+++ b/docs/deployments/deploy-to-vercel.mdx
@@ -37,7 +37,7 @@ On this page, make sure to add **[Environment Variables](https://vercel.com/docs
 
 The API keys added on this screen will be assigned to all deployments on Vercel, including preview URLs. To connect your first deployment to your Clerk app, be sure to **use your Clerk production API keys rather than your development API keys**.
 
-> [You'll need to take additional steps to make sure Vercel preview URLs work as intended.](#support-vercel-preview-urls)
+> [You'll need to take additional steps to make sure Vercel preview URLs work as intended.](#support-for-vercel-preview-ur-ls)
 
 Once you press **Deploy**, your app will deploy to production!
 
@@ -71,10 +71,12 @@ If you're using your Clerk development key for this Vercel preview deployment, e
 
 > We use Clerk magic to automatically detect the domain you're hosting from and handle redirects for you! ✨
 
-However, if you wish to use your production Clerk keys with a preview Vercel deployment, you'll need to utilize [Vercel's preview deploment suffix customization](https://vercel.com/docs/concepts/deployments/generated-urls#preview-deployment-suffix) to host preview URLs under your primary domain's subdomain.
+However, if you wish to use your production Clerk keys with a preview Vercel deployment, you'll need to utilize [Vercel's preview deployment suffix customization](https://vercel.com/docs/concepts/deployments/generated-urls#preview-deployment-suffix) to host preview URLs under your primary domain's subdomain.
 
 This is done to ensure your users' security by restricting production redirects to fall under your production domain. This prevents bad actors from maliciously requesting sign-in access to their own domains.
 
 > We take security very seriously at Clerk. To learn more about how Clerk ensures your user's security, [please refer to our docs on the subject.](/docs/security/overview)
 
 > Please note that modifying the Preview Deployment Suffix is only available as an add-on to Vercel's Pro plans and above.
+
+See [Set up a preview environment](/docs/deployments/set-up-preview-environment) to learn more.

--- a/docs/deployments/environments.mdx
+++ b/docs/deployments/environments.mdx
@@ -9,10 +9,10 @@ When creating a new application within Clerk, you are provided with two instance
 ## Development instance
 A `Development` instance is Clerk's default instance type and has characteristics that allow it to be more useful for local development. To facilitate development and local authentication, `Development` instances have a more relaxed security posture and are not suitable for production workloads.
 
-Some notable examples of `Development`-only characteristics in a Clerk application are: 
+Some notable examples of `Development`-only characteristics in a Clerk application are:
 - A `Development` banner is shown prominently in the Clerk Dashboard to make clear you're managing or configuring non-production data
 - Email and SMS templates are prefixed with the environment type to prevent against using `Development` instances for production purposes
-- Some social connections use shared credentials by default 
+- Some social connections use shared credentials by default
 - Certain functionality, like bot protection, is only available in `Production` mode
 - [The Account Portal](/docs/account-portal/overview) will use a Clerk development domain that ends with `accounts.dev` instead of your app's production domain
 - OAuth consent screens will show the development domain that ends with `accounts.dev` instead of your production domain
@@ -26,15 +26,15 @@ Some notable examples of `Development`-only characteristics in a Clerk applicati
 ## Production instance
 A `Production` instance is the more robust option of Clerk's instance types. `Production` instances are meant to support high volumes of traffic and by default, have a more strict security posture.
 
-Some notable differences between `Production` and `Development` instances in a Clerk application are: 
+Some notable differences between `Production` and `Development` instances in a Clerk application are:
 - You must associate a production domain within the Clerk Dashboard
-- You are required to provision your own SSO credentials 
+- You are required to provision your own SSO credentials
 
 When deploying to production, you must first activate your `Production` environment. Check out Clerk's [Deploying to Production](/docs/deployments/overview#deploying-to-production) guide to learn about the process and avoid common pitfalls.
 
 ## Staging environments
 
-Clerk does not currently support staging instances in Clerk apps, however you can configure Clerk to work with your staging environment. See [Set up staging](/docs/deployments/set-up-staging) to learn more.
+Clerk does not currently support staging instances in Clerk applications. However, you can configure Clerk to work with your staging environment. See [Set up staging](/docs/deployments/set-up-staging) to learn more.
 
 ## Preview environments
 

--- a/docs/deployments/environments.mdx
+++ b/docs/deployments/environments.mdx
@@ -35,3 +35,23 @@ When deploying to production, you must first activate your `Production` environm
 ## Staging environments
 
 Clerk does not currently support staging instances in Clerk apps, however you can configure Clerk to work with your staging environment. See [Set up staging](/docs/deployments/set-up-staging) to learn more.
+
+## Preview environments
+
+Popular hosting providers such as Cloudflare, Vercel, and more, offer preview deployments, which enable you to view changes to your site in a live environment before merging and deploying them to production.
+
+### Recommended preview setup
+
+It is recommended that you use your Clerk app's development instance API keys when accessing Clerk from a preview deployment.
+
+<Callout type="Info">
+  See the [development instance](#development-instance) section to learn about the limitations to development instance API keys.
+</Callout>
+
+### Vercel preview deployment suffix
+
+To use Clerk with Vercel's preview deployment suffix, you must have a Pro or Enterprise Vercel account. The following steps will teach you how to configure your Vercel preview deployment suffix with Clerk:
+
+1. **Acquire a separate domain** – This domain will be used for your preview environment, and _cannot be a subdomain_ of the domain used in your production environment. For example, if your production domain is `my-site.com`, you could use `my-site-previews.com`.
+1. **Follow the Deploy to Vercel guide** – See [the Preview URL section of the Deploy to Vercel guide](/docs/deployments/deploy-to-vercel#support-for-vercel-preview-ur-ls) to configure your app.
+1. **Contact Clerk support to provision a preview-specific Clerk app for free** – If you're on a Pro, Enterprise, or Startup plan, Clerk will provision a dedicated preview-specific Clerk application with all the same features as your main applicatin for free.

--- a/docs/deployments/environments.mdx
+++ b/docs/deployments/environments.mdx
@@ -38,20 +38,4 @@ Clerk does not currently support staging instances in Clerk apps, however you ca
 
 ## Preview environments
 
-Popular hosting providers such as Cloudflare, Vercel, and more, offer preview deployments, which enable you to view changes to your site in a live environment before merging and deploying them to production.
-
-### Recommended preview setup
-
-It is recommended that you use your Clerk app's development instance API keys when accessing Clerk from a preview deployment.
-
-<Callout type="Info">
-  See the [development instance](#development-instance) section to learn about the limitations to development instance API keys.
-</Callout>
-
-### Vercel preview deployment suffix
-
-To use Clerk with Vercel's preview deployment suffix, you must have a Pro or Enterprise Vercel account. The following steps will teach you how to configure your Vercel preview deployment suffix with Clerk:
-
-1. **Acquire a separate domain** – This domain will be used for your preview environment, and _cannot be a subdomain_ of the domain used in your production environment. For example, if your production domain is `my-site.com`, you could use `my-site-previews.com`.
-1. **Follow the Deploy to Vercel guide** – See [the Preview URL section of the Deploy to Vercel guide](/docs/deployments/deploy-to-vercel#support-for-vercel-preview-ur-ls) to configure your app.
-1. **Contact Clerk support to provision a preview-specific Clerk app for free** – If you're on a Pro, Enterprise, or Startup plan, Clerk will provision a dedicated preview-specific Clerk application with all the same features as your main applicatin for free.
+See [the preview environment guide](/docs/deployments/set-up-preview-environment) to learn how to use Clerk with your preview deployments.

--- a/docs/deployments/environments.mdx
+++ b/docs/deployments/environments.mdx
@@ -31,3 +31,7 @@ Some notable differences between `Production` and `Development` instances in a C
 - You are required to provision your own SSO credentials 
 
 When deploying to production, you must first activate your `Production` environment. Check out Clerk's [Deploying to Production](/docs/deployments/overview#deploying-to-production) guide to learn about the process and avoid common pitfalls.
+
+## Staging environments
+
+Clerk does not currently support staging instances in Clerk apps, however you can configure Clerk to work with your staging environment. See [Set up staging](/docs/deployments/set-up-staging) to learn more.

--- a/docs/deployments/environments.mdx
+++ b/docs/deployments/environments.mdx
@@ -34,7 +34,7 @@ When deploying to production, you must first activate your `Production` environm
 
 ## Staging environments
 
-Clerk does not currently support staging instances in Clerk applications. However, you can configure Clerk to work with your staging environment. See [Set up staging](/docs/deployments/set-up-staging) to learn more.
+Clerk does not currently support staging instances in Clerk applications. However, you can configure Clerk to work with a staging environment by using a separate domain. [Learn more.](/docs/deployments/set-up-staging)
 
 ## Preview environments
 

--- a/docs/deployments/environments.mdx
+++ b/docs/deployments/environments.mdx
@@ -34,7 +34,7 @@ When deploying to production, you must first activate your `Production` environm
 
 ## Staging environments
 
-Clerk does not currently support staging instances in Clerk applications. However, you can configure Clerk to work with a staging environment by using a separate domain. [Learn more.](/docs/deployments/set-up-staging)
+Clerk does not currently support staging instances in Clerk applications. However, you can set up a "staging environment" by creating a separate Clerk application with a separate domain. [Learn more.](/docs/deployments/set-up-staging)
 
 ## Preview environments
 

--- a/docs/deployments/set-up-preview-environment.mdx
+++ b/docs/deployments/set-up-preview-environment.mdx
@@ -4,3 +4,36 @@ description: Learn how to set up a preview environment with Clerk authentication
 
 # Set up a preview environment with Clerk
 
+Popular hosting providers such as Cloudflare, Vercel, and more, offer preview deployments, which enable you to view changes to your site in a live environment before merging and deploying them to production.
+
+## Recommended setup
+
+It is recommended that you use your Clerk app's development instance API keys when accessing Clerk from a preview deployment. You should add them to your environment variables.
+
+<Callout type="Info">
+  See the [development instance](#development-instance) section to learn about the limitations to development instance API keys.
+</Callout>
+
+The following are environment variable guides from some popular providers:
+    - [Vercel](https://vercel.com/docs/projects/environment-variables#declare-an-environment-variable)
+    - [Netlify](https://docs.netlify.com/environment-variables/get-started/#create-environment-variables)
+    - [Cloudflare](https://developers.cloudflare.com/workers/configuration/environment-variables/#add-environment-variables-via-the-dashboar)
+
+## Vercel preview deployment suffix
+
+To use Clerk with Vercel's preview deployment suffix, you must have a Pro or Enterprise Vercel account. The following steps will teach you how to configure your Vercel preview deployment suffix with Clerk:
+
+1. **Acquire a separate domain** – This domain will be used for your preview environment, and _cannot be a subdomain_ of the domain used in your production environment. For example, if your production domain is `my-site.com`, you could use `my-site-previews.com`.
+1. **Follow the Deploy to Vercel guide** – See [the Preview URL section of the Deploy to Vercel guide](/docs/deployments/deploy-to-vercel#support-for-vercel-preview-ur-ls) to configure your app.
+1. **Contact Clerk support to provision a preview-specific Clerk app for free** – If you're on a Pro, Enterprise, or Startup plan, Clerk will provision a dedicated preview-specific Clerk application with all the same features as your main applicatin for free.
+1. **Use production instance API keys** – Once Clerk support has provisioned your free preview-specific Clerk app, you should use its production instance API keys with your previews, as this offers better security and fewer limitations. See [the production instance documentation](/docs/deployments/environments.mdx#production-instance) to learn more.
+
+### Limitations
+
+- This approach requires a Vercel Pro or Enterprise account.
+- When you use a separate Clerk application for your preview environment, changes to this application will not be automatically mirrored in your main application for your production environment. You must manually make these changes yourself.
+- This approach locks you into using Vercel for preview environments.
+
+## Staging environments
+
+You can also use Clerk with [staging environments](/docs/deployments/set-up-preview-environment).

--- a/docs/deployments/set-up-preview-environment.mdx
+++ b/docs/deployments/set-up-preview-environment.mdx
@@ -21,7 +21,7 @@ The following steps will teach you how to configure your Vercel Preview Deployme
 
 1. **Acquire a separate domain** - This domain will be used for your preview environment, and *cannot be a subdomain* of the domain used in your production environment. For example, if your production domain is `my-site.com`, you could use `my-site-previews.com` but you cannot use `previews.my-site.com`.
 2. **Follow the Deploy to Vercel guide** - See [the Preview URL section of the Deploy to Vercel guide](/docs/deployments/deploy-to-vercel#support-for-vercel-preview-ur-ls) to configure your app.
-3. **Contact Clerk support to provision a preview-specific Clerk app for free** - If you're on a Pro, Enterprise, or Startup plan, Clerk will provision a dedicated preview-specific Clerk application with all the same features as your main application for free.
+3. **[Contact Clerk support](https://clerk.com/contact/support) to provision a preview-specific Clerk app for free** - If you are on a Pro, Enterprise, or Startup plan, Clerk will provision a dedicated preview-specific Clerk application with all the same features as your main application for free.
 4. **Use production instance API keys** - Once Clerk support has provisioned your free preview-specific Clerk app, you should use its production instance API keys with your previews, as this offers better security and fewer limitations. See [the production instance documentation](/docs/deployments/environments#production-instance) to learn more.
 
 ### Limitations

--- a/docs/deployments/set-up-preview-environment.mdx
+++ b/docs/deployments/set-up-preview-environment.mdx
@@ -6,18 +6,28 @@ description: Learn how to set up a preview environment with Clerk authentication
 
 Popular hosting providers such as Cloudflare, Vercel, and more, offer preview deployments, which enable you to view changes to your site in a live environment before merging and deploying them to production.
 
-## Recommended setup
+The recommended approach is to [use your app's development instance API keys](#use-your-development-api-keys) with your preview deployment.
 
-It is recommended that you use your Clerk app's development instance API keys when accessing Clerk from a preview deployment. You should add them to your environment variables.
+## Use your development API keys
 
-<Callout type="Info">
-  See the [development instance](#development-instance) section to learn about the limitations to development instance API keys.
-</Callout>
+It is recommended that you use your Clerk app's development instance API keys when accessing Clerk from a preview deployment. You should add them to your environment variables. See the limitations to this approach.
 
 The following are environment variable guides from some popular providers:
     - [Vercel](https://vercel.com/docs/projects/environment-variables#declare-an-environment-variable)
     - [Netlify](https://docs.netlify.com/environment-variables/get-started/#create-environment-variables)
     - [Cloudflare](https://developers.cloudflare.com/workers/configuration/environment-variables/#add-environment-variables-via-the-dashboar)
+
+### Limitations of using development keys 
+
+The limitations of using development instance API keys in preview environments are:
+
+- Added possibility of Clerk cookie errors. Remember to clear your cookies if you're encountering infinite redirects or authentication issues.
+- Changes to user data will only be reflected in your development instance.
+- There is a [maximum user limit](/docs/deployments/environments#development-instance).
+- Features enabled in your development instance will not be available in your production environment without upgrading your Clerk plan.
+- Development instance API keys offer less security overall compared to production instance keys.
+
+See [the development instance documentation](/docs/deployments/environments#development-instance) to learn more.
 
 ## Vercel preview deployment suffix
 

--- a/docs/deployments/set-up-preview-environment.mdx
+++ b/docs/deployments/set-up-preview-environment.mdx
@@ -10,18 +10,27 @@ The recommended approach is to [use your app's development instance API keys](#u
 
 ## Use your development API keys
 
-It is recommended that you use your Clerk app's development instance API keys when accessing Clerk from a preview deployment. You should add them to your environment variables. See the limitations to this approach.
+It is recommended that you use your Clerk app's development instance API keys when accessing Clerk from a preview deployment.
+
+To retrieve your development instance API keys:
+
+1. Navigate to the [Clerk Dashboard](https://dashboard.clerk.com/last-active?path=api-keys).
+2. Ensure that **Development** is selected at the top.
+3. In the navigation sidebar, select **API Keys**.
+4. Copy your keys.
+
+Once you have your development instance API keys, you can add them to your environment variables.
 
 The following are environment variable guides from some popular providers:
     - [Vercel](https://vercel.com/docs/projects/environment-variables#declare-an-environment-variable)
     - [Netlify](https://docs.netlify.com/environment-variables/get-started/#create-environment-variables)
     - [Cloudflare](https://developers.cloudflare.com/workers/configuration/environment-variables/#add-environment-variables-via-the-dashboar)
 
-### Limitations of using development keys 
+### Limitations of using development keys
 
 The limitations of using development instance API keys in preview environments are:
 
-- Added possibility of Clerk cookie errors. Remember to clear your cookies if you're encountering infinite redirects or authentication issues.
+- Added possibility of Clerk cookie errors. Remember to clear your cookies if you are encountering infinite redirects or authentication issues.
 - Changes to user data will only be reflected in your development instance.
 - There is a [maximum user limit](/docs/deployments/environments#development-instance).
 - Features enabled in your development instance will not be available in your production environment without upgrading your Clerk plan.
@@ -33,10 +42,10 @@ See [the development instance documentation](/docs/deployments/environments#deve
 
 To use Clerk with Vercel's preview deployment suffix, you must have a Pro or Enterprise Vercel account. The following steps will teach you how to configure your Vercel preview deployment suffix with Clerk:
 
-1. **Acquire a separate domain** – This domain will be used for your preview environment, and _cannot be a subdomain_ of the domain used in your production environment. For example, if your production domain is `my-site.com`, you could use `my-site-previews.com`.
-1. **Follow the Deploy to Vercel guide** – See [the Preview URL section of the Deploy to Vercel guide](/docs/deployments/deploy-to-vercel#support-for-vercel-preview-ur-ls) to configure your app.
-1. **Contact Clerk support to provision a preview-specific Clerk app for free** – If you're on a Pro, Enterprise, or Startup plan, Clerk will provision a dedicated preview-specific Clerk application with all the same features as your main applicatin for free.
-1. **Use production instance API keys** – Once Clerk support has provisioned your free preview-specific Clerk app, you should use its production instance API keys with your previews, as this offers better security and fewer limitations. See [the production instance documentation](/docs/deployments/environments#production-instance) to learn more.
+1. **Acquire a separate domain** – This domain will be used for your preview environment, and _cannot be a subdomain_ of the domain used in your production environment. For example, if your production domain is `my-site.com`, you could use `my-site-previews.com` but you cannot use `previews.my-site.com`.
+2. **Follow the Deploy to Vercel guide** – See [the Preview URL section of the Deploy to Vercel guide](/docs/deployments/deploy-to-vercel#support-for-vercel-preview-ur-ls) to configure your app.
+3. **Contact Clerk support to provision a preview-specific Clerk app for free** – If you're on a Pro, Enterprise, or Startup plan, Clerk will provision a dedicated preview-specific Clerk application with all the same features as your main application for free.
+4. **Use production instance API keys** – Once Clerk support has provisioned your free preview-specific Clerk app, you should use its production instance API keys with your previews, as this offers better security and fewer limitations. See [the production instance documentation](/docs/deployments/environments#production-instance) to learn more.
 
 ### Limitations
 

--- a/docs/deployments/set-up-preview-environment.mdx
+++ b/docs/deployments/set-up-preview-environment.mdx
@@ -26,7 +26,7 @@ To use Clerk with Vercel's preview deployment suffix, you must have a Pro or Ent
 1. **Acquire a separate domain** – This domain will be used for your preview environment, and _cannot be a subdomain_ of the domain used in your production environment. For example, if your production domain is `my-site.com`, you could use `my-site-previews.com`.
 1. **Follow the Deploy to Vercel guide** – See [the Preview URL section of the Deploy to Vercel guide](/docs/deployments/deploy-to-vercel#support-for-vercel-preview-ur-ls) to configure your app.
 1. **Contact Clerk support to provision a preview-specific Clerk app for free** – If you're on a Pro, Enterprise, or Startup plan, Clerk will provision a dedicated preview-specific Clerk application with all the same features as your main applicatin for free.
-1. **Use production instance API keys** – Once Clerk support has provisioned your free preview-specific Clerk app, you should use its production instance API keys with your previews, as this offers better security and fewer limitations. See [the production instance documentation](/docs/deployments/environments.mdx#production-instance) to learn more.
+1. **Use production instance API keys** – Once Clerk support has provisioned your free preview-specific Clerk app, you should use its production instance API keys with your previews, as this offers better security and fewer limitations. See [the production instance documentation](/docs/deployments/environments#production-instance) to learn more.
 
 ### Limitations
 

--- a/docs/deployments/set-up-preview-environment.mdx
+++ b/docs/deployments/set-up-preview-environment.mdx
@@ -36,4 +36,4 @@ To use Clerk with Vercel's preview deployment suffix, you must have a Pro or Ent
 
 ## Staging environments
 
-You can also use Clerk with [staging environments](/docs/deployments/set-up-preview-environment).
+You can also use Clerk with [staging environments](/docs/deployments/set-up-staging).

--- a/docs/deployments/set-up-preview-environment.mdx
+++ b/docs/deployments/set-up-preview-environment.mdx
@@ -1,0 +1,6 @@
+---
+description: Learn how to set up a preview environment with Clerk authentication.
+---
+
+# Set up a preview environment with Clerk
+

--- a/docs/deployments/set-up-preview-environment.mdx
+++ b/docs/deployments/set-up-preview-environment.mdx
@@ -6,11 +6,32 @@ description: Learn how to set up a preview environment with Clerk authentication
 
 Popular hosting providers such as Cloudflare, Vercel, and more, offer preview deployments, which enable you to view changes to your site in a live environment before merging and deploying them to production.
 
-The recommended approach is to [use your app's development instance API keys](#use-your-development-api-keys) with your preview deployment.
+There are two approaches to using Clerk in a preview environment:
+
+- If you want to share *production* data with your preview environment, [use Vercel's Preview Deployment Suffix.](#vercel-preview-deployment-suffix)
+- If you do not want to, or are not able to, expose *production* Clerk data to your preview environment, [use your development API keys.](#use-your-development-api-keys)
+
+## Vercel Preview Deployment Suffix
+
+If you would like your preview environment to share a userbase with your production environment, you can use [Vercel's Preview Deployment Suffix feature.](https://vercel.com/docs/deployments/generated-urls#preview-deployment-suffix) Preview Deployment Suffixes allow you to customize the URL of a preview deployment by replacing the default `vercel.app` suffix with a custom domain of your choice.
+
+To use Clerk with Vercel's Preview Deployment Suffix, you must have a Pro or Enterprise Vercel account.
+
+The following steps will teach you how to configure your Vercel Preview Deployment Suffix with Clerk:
+
+1. **Acquire a separate domain** - This domain will be used for your preview environment, and *cannot be a subdomain* of the domain used in your production environment. For example, if your production domain is `my-site.com`, you could use `my-site-previews.com` but you cannot use `previews.my-site.com`.
+2. **Follow the Deploy to Vercel guide** - See [the Preview URL section of the Deploy to Vercel guide](/docs/deployments/deploy-to-vercel#support-for-vercel-preview-ur-ls) to configure your app.
+3. **Contact Clerk support to provision a preview-specific Clerk app for free** - If you're on a Pro, Enterprise, or Startup plan, Clerk will provision a dedicated preview-specific Clerk application with all the same features as your main application for free.
+4. **Use production instance API keys** - Once Clerk support has provisioned your free preview-specific Clerk app, you should use its production instance API keys with your previews, as this offers better security and fewer limitations. See [the production instance documentation](/docs/deployments/environments#production-instance) to learn more.
+
+### Limitations
+
+- This approach requires a Vercel Pro or Enterprise account.
+- This approach locks you into using Vercel for preview environments.
 
 ## Use your development API keys
 
-It is recommended that you use your Clerk app's development instance API keys when accessing Clerk from a preview deployment.
+If you would like your preview environment to have a different userbase from your production environment, you can set up your preview environment to use your development instance API keys.
 
 To retrieve your development instance API keys:
 
@@ -31,27 +52,12 @@ The following are environment variable guides from some popular providers:
 The limitations of using development instance API keys in preview environments are:
 
 - Added possibility of Clerk cookie errors. Remember to clear your cookies if you are encountering infinite redirects or authentication issues.
-- Changes to user data will only be reflected in your development instance.
+- Changes to user data will not be automatically mirrored in your main application for your production environment.
 - There is a [maximum user limit](/docs/deployments/environments#development-instance).
 - Features enabled in your development instance will not be available in your production environment without upgrading your Clerk plan.
 - Development instance API keys offer less security overall compared to production instance keys.
 
 See [the development instance documentation](/docs/deployments/environments#development-instance) to learn more.
-
-## Vercel preview deployment suffix
-
-To use Clerk with Vercel's preview deployment suffix, you must have a Pro or Enterprise Vercel account. The following steps will teach you how to configure your Vercel preview deployment suffix with Clerk:
-
-1. **Acquire a separate domain** – This domain will be used for your preview environment, and _cannot be a subdomain_ of the domain used in your production environment. For example, if your production domain is `my-site.com`, you could use `my-site-previews.com` but you cannot use `previews.my-site.com`.
-2. **Follow the Deploy to Vercel guide** – See [the Preview URL section of the Deploy to Vercel guide](/docs/deployments/deploy-to-vercel#support-for-vercel-preview-ur-ls) to configure your app.
-3. **Contact Clerk support to provision a preview-specific Clerk app for free** – If you're on a Pro, Enterprise, or Startup plan, Clerk will provision a dedicated preview-specific Clerk application with all the same features as your main application for free.
-4. **Use production instance API keys** – Once Clerk support has provisioned your free preview-specific Clerk app, you should use its production instance API keys with your previews, as this offers better security and fewer limitations. See [the production instance documentation](/docs/deployments/environments#production-instance) to learn more.
-
-### Limitations
-
-- This approach requires a Vercel Pro or Enterprise account.
-- When you use a separate Clerk application for your preview environment, changes to this application will not be automatically mirrored in your main application for your production environment. You must manually make these changes yourself.
-- This approach locks you into using Vercel for preview environments.
 
 ## Staging environments
 

--- a/docs/deployments/set-up-staging.mdx
+++ b/docs/deployments/set-up-staging.mdx
@@ -22,11 +22,10 @@ Alternatively, you can [use Clerk with your preview deployments]().
 
 When setting up staging with Clerk, it is recommended that you use a separate domain from your production domain. Doing so will enable you to create a new Clerk app for your staging environment, preventing you from using production environment data and API keys. **This staging Clerk app will be upgraded free of charge**.
 
-### Benefits of this approach
+### Benefits of using a staging domain
 
-Using a separate domain and Clerk application enables you to:
+Using a staging-specific domain and Clerk application enables you to:
 
-- Use a Clerk production instance for your staging environment, offering improved security over development instances. See [Instances / Environments](/docs/deployments/environments#production-instance) for more information.
 - Fetch and modify data from Clerk without affecting your production data
 - Avoid using live customer data in your staging environment
 - Prevent your production application's users from being able to sign in to your staging environment
@@ -39,10 +38,35 @@ Using a separate domain and Clerk application enables you to:
 
 The following steps will help you set up a new Clerk application with a staging-specific domain:
 
-1. **Acquire a new domain** – This new domain will be used for your staging environment. **This cannot be a subdomain**. For example, if your production domain is `my-site.com`, you could use `my-site-staging.com`. To use a subdomain instead, see [its dedication section](#use-a-subdomain).
+1. **Acquire a separate domain** – This domain will be used for your staging environment. _This cannot be a subdomain_ of the domain used in your production environment. For example, if your production domain is `my-site.com`, you could use `my-site-staging.com`. If you don't want to use a new domain, see [the instructions for using a subdomain](#use-a-subdomain).
 1. **Create a new Clerk app** – Your staging environment will connect to this app instead of your main Clerk application. See [the Clerk quickstart guide](/docs/quickstarts/setup-clerk#create-a-clerk-application) to learn how to create a Clerk app.
 1. **Deploy and configure your staging app's production instance** – Using production API keys will make your staging app more secure. Follow the [Deploy to production](/docs/deployments/overview#deploying-to-production) guide to do so.
 1. **Contact Clerk support to upgrade your staging app for free** – If you're on a Pro, Enterprise, or Startup plan, Clerk will fully upgrade your staging app for free.
 
 ## Use a subdomain
 
+You can use a subdomain of your production domain to set up a staging environment. Doing so will enable you to connect to the Clerk application you use in your production environment from your staging environment by sharing API keys between them.
+
+### Benefits of using a subdomain
+
+Using a subdomain and connecting to the Clerk app associated with your production environment enables you to:
+
+- Mirror your production environment perfectly in staging, because you're sharing the same Clerk configuration and data across both
+- Avoid acquiring a new domain and integrating it into your workflow
+
+#### Limitations
+
+- Changes to data from your staging environment will be reflected in production.
+- You will have live customer data in your staging environment
+- When you enable Clerk features to test in staging, they will be enabled in your Production environment as well.
+- Adds another set of production key pairs to manage in you environment variables.
+
+### Set up staging with a subdomain
+
+The following steps will help you connect your staging environment to your Clerk app if it uses a subdomain of your production domain:
+
+1. **Add your subdomain to your hosting provider** – Ensure that your subdomain is associated with your staging branch so that it will point to new staging deployments. This process will vary based on your provider. The following are some guides from popular hosting providers:
+    - [Vercel](https://vercel.com/guides/set-up-a-staging-environment-on-vercel)
+    - [Netlify](https://docs.netlify.com/domains-https/netlify-dns/delegate-a-subdomain-to-netlify-dns/)
+    - [AWS](https://docs.aws.amazon.com/amplify/latest/userguide/to-manage-subdomains.html#to-add-a-subdomain-only)
+1. **** – 

--- a/docs/deployments/set-up-staging.mdx
+++ b/docs/deployments/set-up-staging.mdx
@@ -12,6 +12,7 @@ There are two recommended approaches to using Clerk in a staging environment at 
 
 1. [Using a separate domain from your production app's domain](#use-a-staging-domain). **Recommended**. You should consider this approach if you don't want to or are not able to expose production Clerk data to a staging environment.
 1. [Using a subdomain of your production app's domain](#use-a-subdomain). Consider choosing this approach if you can't currently integrate a new staging-specific domain into your workflow, and can safely expose production Clerk data to a staging environment.
+    - This approach requires sharing credentials and data between your staging and production environments. See [the limitations section](#limitations-of-using-a-subdomain) for more information.
 
 ## Use a staging domain
 
@@ -25,9 +26,9 @@ Using a staging-specific domain and Clerk application enables you to:
 - Avoid using live customer data in your staging environment
 - Prevent your production application's users from being able to sign in to your staging environment
 
-#### Limitations
+#### Limitations of using a staging domain
 
-- When you use a separate Clerk application for your staging environment, changes to this application will not be automatically mirrored in your main application for your production environment. You must manually make these changes yourself. 
+When you use a separate Clerk application for your staging environment, changes to this application will not be automatically mirrored in your main application for your production environment. You must manually make these changes yourself. 
 
 ### Set up a staging Clerk app
 
@@ -49,10 +50,13 @@ Using a subdomain and connecting to the Clerk app associated with your productio
 - Mirror your production environment perfectly in staging, because you're sharing the same Clerk configuration and data across both
 - Avoid acquiring a new domain and integrating it into your workflow
 
-#### Limitations
+#### Limitations of using a subdomain
 
+The limitations of using a subdomain to set up a staging environment with Clerk include:
+
+- Using your production API keys with your staging environment means you'll be sharing credentials across both.
 - Changes to data from your staging environment will be reflected in production.
-- You will have live customer data in your staging environment
+- You will have live customer data in your staging environment.
 - When you enable Clerk features to test in staging, they will be enabled in your Production environment as well.
 - Adds another set of production key pairs to manage in you environment variables.
 

--- a/docs/deployments/set-up-staging.mdx
+++ b/docs/deployments/set-up-staging.mdx
@@ -1,5 +1,5 @@
 ---
-description: Learn how to set up staging with Clerk authentication.
+description: Learn how to set up a staging environment with Clerk authentication.
 ---
 
 # Set up a staging environment with Clerk
@@ -63,12 +63,12 @@ The following steps will help you connect your staging environment to your Clerk
 1. **Add your subdomain to your hosting provider** – Ensure that your subdomain is associated with your staging branch so that it will point to new staging deployments. This process will vary based on your provider. The following are some guides from popular hosting providers:
     - [Vercel](https://vercel.com/guides/set-up-a-staging-environment-on-vercel)
     - [Netlify](https://docs.netlify.com/domains-https/netlify-dns/delegate-a-subdomain-to-netlify-dns/)
-    - [AWS](https://docs.aws.amazon.com/amplify/latest/userguide/to-manage-subdomains.html#to-add-a-subdomain-only)
+    - [Cloudflare](https://developers.cloudflare.com/dns/manage-dns-records/how-to/create-subdomain/)
 1. **Add your CNAME record to your domain provider** – Depending on the provider, the verification process for this can take hours or days.
 1. **Add your production instance API keys to your staging deployment** – Using environment variables, add the API keys from your Clerk app's production instance to your staging deployment. Visit the [**API Keys**](https://dashboard.clerk.com/last-active?path=api-keys) section of your Clerk dashboard to find them. The following are environment variable guides from some popular providers:
     - [Vercel](https://vercel.com/docs/projects/environment-variables#declare-an-environment-variable)
     - [Netlify](https://docs.netlify.com/environment-variables/get-started/#create-environment-variables)
-    - [AWS Amplify](https://docs.aws.amazon.com/amplify/latest/userguide/environment-variables.html#setting-env-vars)
+    - [Cloudflare](https://developers.cloudflare.com/workers/configuration/environment-variables/#add-environment-variables-via-the-dashboar)
 
 ## Staging with development instances
 
@@ -76,4 +76,4 @@ It is not recommended to connect your staging environment to a development insta
 
 ## Preview deployments
 
-You can also use Clerk with staging or production [preview deployments]().
+You can also use Clerk with staging in a [preview environment](/docs/deployments/set-up-preview-environment).

--- a/docs/deployments/set-up-staging.mdx
+++ b/docs/deployments/set-up-staging.mdx
@@ -69,4 +69,12 @@ The following steps will help you connect your staging environment to your Clerk
     - [Vercel](https://vercel.com/guides/set-up-a-staging-environment-on-vercel)
     - [Netlify](https://docs.netlify.com/domains-https/netlify-dns/delegate-a-subdomain-to-netlify-dns/)
     - [AWS](https://docs.aws.amazon.com/amplify/latest/userguide/to-manage-subdomains.html#to-add-a-subdomain-only)
-1. **** – 
+1. **Add your CNAME record to your domain provider** – Depending on the provider, the verification process for this can take hours or days.
+1. **Add your production instance API keys to your staging deployment** – Using environment variables, add the API keys from your Clerk app's production instance to your staging deployment. Visit the [**API Keys**](https://dashboard.clerk.com/last-active?path=api-keys) section of your Clerk dashboard to find them. The following are environment variable guides from some popular providers:
+    - [Vercel](https://vercel.com/docs/projects/environment-variables#declare-an-environment-variable)
+    - [Netlify](https://docs.netlify.com/environment-variables/get-started/#create-environment-variables)
+    - [AWS Amplify](https://docs.aws.amazon.com/amplify/latest/userguide/environment-variables.html#setting-env-vars)
+
+## Staging with development instances
+
+It is not recommended to connect your staging environment to a development instance. If you want to use a development instance with your staging environment, see the [Instances / Environments](/docs/deployments/environments#development-instance) documentation to learn about possible limitations.

--- a/docs/deployments/set-up-staging.mdx
+++ b/docs/deployments/set-up-staging.mdx
@@ -4,80 +4,27 @@ description: Learn how to set up a staging environment with Clerk authentication
 
 # Set up a staging environment with Clerk
 
-Staging environments enable you to internally test and demo changes to your application or website before deploying them to production. Official support for staging is still on [Clerk's roadmap](https://feedback.clerk.com/roadmap/de417dd1-fa2e-4997-868f-4c9248027e7d), however you can use Clerk in your staging environments with the approaches described in this guide.
+Staging environments enable you to internally test and demo changes to your application or website before deploying them to production. Currently, Clerk only offers **Development** and **Production** instances. Official support for **Staging** instances is still on [Clerk's roadmap](https://feedback.clerk.com/roadmap/de417dd1-fa2e-4997-868f-4c9248027e7d). However, you can set up a "staging environment" by creating a separate Clerk application with a separate domain.
 
-## Choose an approach
+Creating a separate Clerk application will prevent you from using live production environment data in your staging environment. And if you are on a Pro, Enterprise, or Startup plan, **Clerk will fully upgrade your staging application for free.**
 
-There are two recommended approaches to using Clerk in a staging environment at this time:
+It is important to note that when you use a separate Clerk application for your staging environment, changes to this application will not be automatically mirrored in your main application for your production environment. You must manually make these changes yourself if you want them to be reflected in both applications.
 
-1. [Using a separate domain from your production app's domain](#use-a-staging-domain). **Recommended**. You should consider this approach if you don't want to or are not able to expose production Clerk data to a staging environment.
-2. [Using a subdomain of your production app's domain](#use-a-subdomain). Consider choosing this approach if you can't currently integrate a new staging-specific domain into your workflow, and can safely expose production Clerk data to a staging environment.
-    - This approach requires sharing credentials and data between your staging and production environments. See [the limitations section](#limitations-of-using-a-subdomain) for more information.
-
-## Use a staging domain
-
-When setting up staging with Clerk, it is recommended that you use a separate domain from your production domain. Doing so will enable you to create a new Clerk app for your staging environment, preventing you from using production environment data and API keys. **This staging Clerk app will be upgraded free of charge**.
-
-### Benefits of using a staging domain
-
-Using a staging-specific domain and Clerk application enables you to:
-
-- Fetch and modify data from Clerk without affecting your production data
-- Avoid using live customer data in your staging environment
-- Prevent your production application's users from being able to sign in to your staging environment
-
-#### Limitations of using a staging domain
-
-When you use a separate Clerk application for your staging environment, changes to this application will not be automatically mirrored in your main application for your production environment. You must manually make these changes yourself.
-
-### Set up a staging Clerk app
+## Set up a staging Clerk application
 
 The following steps will help you set up a new Clerk application with a staging-specific domain:
 
-1. **Acquire a separate domain** - This domain will be used for your staging environment. _This cannot be a subdomain_ of the domain used in your production environment. For example, if your production domain is `my-site.com`, you could use `my-site-staging.com`. If you don't want to use a new domain, see [the instructions for using a subdomain](#use-a-subdomain).
-2. **Create a new Clerk app** - Your staging environment will connect to this app instead of your main Clerk application. See [the Clerk quickstart guide](/docs/quickstarts/setup-clerk#create-a-clerk-application) to learn how to create a Clerk app.
-3. **Deploy and configure your staging app's production instance** - Using production API keys will make your staging app more secure. Follow the [Deploy to production](/docs/deployments/overview#deploying-to-production) guide to do so.
-4. **Contact Clerk support to upgrade your staging app for free** - If you're on a Pro, Enterprise, or Startup plan, Clerk will fully upgrade your staging app for free.
+1. **Acquire a separate domain** - This domain will be used for your staging environment. _This cannot be a subdomain_ of the domain used in your production environment. For example, if your production domain is `my-site.com`, you could use `my-site-staging.com`. If you do not want to use a new domain, see [the instructions for using a subdomain](#use-a-subdomain).
+2. **Create a new Clerk app** - Your staging environment will connect to this app instead of your main Clerk application. See [the Clerk quickstart guide](/docs/quickstarts/setup-clerk) to learn how to create a Clerk app.
+3. **Deploy and configure your staging app's production instance** - Using production API keys will make your staging app more secure. Follow the [Deploy to production](/docs/deployments/overview) guide to do so.
+4. **Contact Clerk support to upgrade your staging app for free** - If you are on a Pro, Enterprise, or Startup plan, Clerk will fully upgrade your staging app for free.
 
-## Use a subdomain
+## Alternatives to using a separate domain
 
-You can use a subdomain of your production domain to set up a staging environment. Doing so will enable you to connect to the Clerk application you use in your production environment from your staging environment by sharing API keys between them.
-
-### Benefits of using a subdomain
-
-Using a subdomain and connecting to the Clerk app associated with your production environment enables you to:
-
-- Mirror your production environment perfectly in staging, because you're sharing the same Clerk configuration and data across both
-- Avoid acquiring a new domain and integrating it into your workflow
-
-#### Limitations of using a subdomain
-
-The limitations of using a subdomain to set up a staging environment with Clerk include:
-
-- Using your production API keys with your staging environment means you'll be sharing credentials across both.
-- Changes to data from your staging environment will be reflected in production.
-- You will have live customer data in your staging environment.
-- When you enable Clerk features to test in staging, they will be enabled in your Production environment as well.
-- Adds another set of production key pairs to manage in you environment variables.
-
-### Set up staging with a subdomain
-
-The following steps will help you connect your staging environment to your Clerk app if it uses a subdomain of your production domain:
-
-1. **Add your subdomain to your hosting provider** – Ensure that your subdomain is associated with your staging branch so that it will point to new staging deployments. This process will vary based on your provider. The following are some guides from popular hosting providers:
-    - [Vercel](https://vercel.com/guides/set-up-a-staging-environment-on-vercel)
-    - [Netlify](https://docs.netlify.com/domains-https/netlify-dns/delegate-a-subdomain-to-netlify-dns/)
-    - [Cloudflare](https://developers.cloudflare.com/dns/manage-dns-records/how-to/create-subdomain/)
-2. **Add your CNAME record to your domain provider** – Depending on the provider, the verification process for this can take hours or days.
-3. **Add your production instance API keys to your staging deployment** – Using environment variables, add the API keys from your Clerk app's production instance to your staging deployment. Visit the [**API Keys**](https://dashboard.clerk.com/last-active?path=api-keys) section of your Clerk dashboard to find them. The following are environment variable guides from some popular providers:
-    - [Vercel](https://vercel.com/docs/projects/environment-variables#declare-an-environment-variable)
-    - [Netlify](https://docs.netlify.com/environment-variables/get-started/#create-environment-variables)
-    - [Cloudflare](https://developers.cloudflare.com/workers/configuration/environment-variables/#add-environment-variables-via-the-dashboar)
-
-## Staging with development instances
-
-It is not recommended to connect your staging environment to a development instance. If you want to use a development instance with your staging environment, see the [Instances / Environments](/docs/deployments/environments#development-instance) documentation to learn about possible limitations.
-
-## Preview deployments
+### Preview environments
 
 While staging environments are typically long-lived, preview environments are typically generated on-demand for specific pull requests. See [the guide on using Clerk in a preview environment](/docs/deployments/set-up-preview-environment) to learn about your options.
+
+### Shared production credentials
+
+If you do not want to purchase a separate domain, or if you would like to share settings and data between your production and staging environments, see the [Staging alternatives](/docs/deployments/staging-alternatives) guide. This is not recommended because you will be sharing a user table between your production and staging environments.

--- a/docs/deployments/set-up-staging.mdx
+++ b/docs/deployments/set-up-staging.mdx
@@ -11,7 +11,7 @@ Staging environments enable you to internally test and demo changes to your appl
 There are two recommended approaches to using Clerk in a staging environment at this time:
 
 1. [Using a separate domain from your production app's domain](#use-a-staging-domain). **Recommended**. You should consider this approach if you don't want to or are not able to expose production Clerk data to a staging environment.
-1. [Using a subdomain of your production app's domain](#use-a-subdomain). Consider choosing this approach if you can't currently integrate a new staging-specific domain into your workflow, and can safely expose production Clerk data to a staging environment.
+2. [Using a subdomain of your production app's domain](#use-a-subdomain). Consider choosing this approach if you can't currently integrate a new staging-specific domain into your workflow, and can safely expose production Clerk data to a staging environment.
     - This approach requires sharing credentials and data between your staging and production environments. See [the limitations section](#limitations-of-using-a-subdomain) for more information.
 
 ## Use a staging domain
@@ -28,16 +28,16 @@ Using a staging-specific domain and Clerk application enables you to:
 
 #### Limitations of using a staging domain
 
-When you use a separate Clerk application for your staging environment, changes to this application will not be automatically mirrored in your main application for your production environment. You must manually make these changes yourself. 
+When you use a separate Clerk application for your staging environment, changes to this application will not be automatically mirrored in your main application for your production environment. You must manually make these changes yourself.
 
 ### Set up a staging Clerk app
 
 The following steps will help you set up a new Clerk application with a staging-specific domain:
 
-1. **Acquire a separate domain** – This domain will be used for your staging environment. _This cannot be a subdomain_ of the domain used in your production environment. For example, if your production domain is `my-site.com`, you could use `my-site-staging.com`. If you don't want to use a new domain, see [the instructions for using a subdomain](#use-a-subdomain).
-1. **Create a new Clerk app** – Your staging environment will connect to this app instead of your main Clerk application. See [the Clerk quickstart guide](/docs/quickstarts/setup-clerk#create-a-clerk-application) to learn how to create a Clerk app.
-1. **Deploy and configure your staging app's production instance** – Using production API keys will make your staging app more secure. Follow the [Deploy to production](/docs/deployments/overview#deploying-to-production) guide to do so.
-1. **Contact Clerk support to upgrade your staging app for free** – If you're on a Pro, Enterprise, or Startup plan, Clerk will fully upgrade your staging app for free.
+1. **Acquire a separate domain** - This domain will be used for your staging environment. _This cannot be a subdomain_ of the domain used in your production environment. For example, if your production domain is `my-site.com`, you could use `my-site-staging.com`. If you don't want to use a new domain, see [the instructions for using a subdomain](#use-a-subdomain).
+2. **Create a new Clerk app** - Your staging environment will connect to this app instead of your main Clerk application. See [the Clerk quickstart guide](/docs/quickstarts/setup-clerk#create-a-clerk-application) to learn how to create a Clerk app.
+3. **Deploy and configure your staging app's production instance** - Using production API keys will make your staging app more secure. Follow the [Deploy to production](/docs/deployments/overview#deploying-to-production) guide to do so.
+4. **Contact Clerk support to upgrade your staging app for free** - If you're on a Pro, Enterprise, or Startup plan, Clerk will fully upgrade your staging app for free.
 
 ## Use a subdomain
 
@@ -68,8 +68,8 @@ The following steps will help you connect your staging environment to your Clerk
     - [Vercel](https://vercel.com/guides/set-up-a-staging-environment-on-vercel)
     - [Netlify](https://docs.netlify.com/domains-https/netlify-dns/delegate-a-subdomain-to-netlify-dns/)
     - [Cloudflare](https://developers.cloudflare.com/dns/manage-dns-records/how-to/create-subdomain/)
-1. **Add your CNAME record to your domain provider** – Depending on the provider, the verification process for this can take hours or days.
-1. **Add your production instance API keys to your staging deployment** – Using environment variables, add the API keys from your Clerk app's production instance to your staging deployment. Visit the [**API Keys**](https://dashboard.clerk.com/last-active?path=api-keys) section of your Clerk dashboard to find them. The following are environment variable guides from some popular providers:
+2. **Add your CNAME record to your domain provider** – Depending on the provider, the verification process for this can take hours or days.
+3. **Add your production instance API keys to your staging deployment** – Using environment variables, add the API keys from your Clerk app's production instance to your staging deployment. Visit the [**API Keys**](https://dashboard.clerk.com/last-active?path=api-keys) section of your Clerk dashboard to find them. The following are environment variable guides from some popular providers:
     - [Vercel](https://vercel.com/docs/projects/environment-variables#declare-an-environment-variable)
     - [Netlify](https://docs.netlify.com/environment-variables/get-started/#create-environment-variables)
     - [Cloudflare](https://developers.cloudflare.com/workers/configuration/environment-variables/#add-environment-variables-via-the-dashboar)

--- a/docs/deployments/set-up-staging.mdx
+++ b/docs/deployments/set-up-staging.mdx
@@ -10,13 +10,8 @@ Staging environments enable you to internally test and demo changes to your appl
 
 There are two recommended approaches to using Clerk in a staging environment at this time:
 
-1. [Using a separate domain from your production app's domain](#use-a-staging-domain). Choose this if you:
-    - Don't already have a subdomain of your production app
-    - Can integrate a new staging-specific domain into your current workflow
-1. [Using a subdomain of your production app's domain](#use-a-subdomain). Choose this if you:
-    - Can't currently integrate a new staging-specific domain into your workflow
-
-Alternatively, you can [use Clerk with your preview deployments]().
+1. [Using a separate domain from your production app's domain](#use-a-staging-domain). **Recommended**. You should consider this approach if you don't want to or are not able to expose production Clerk data to a staging environment.
+1. [Using a subdomain of your production app's domain](#use-a-subdomain). Consider choosing this approach if you can't currently integrate a new staging-specific domain into your workflow, and can safely expose production Clerk data to a staging environment.
 
 ## Use a staging domain
 
@@ -78,3 +73,7 @@ The following steps will help you connect your staging environment to your Clerk
 ## Staging with development instances
 
 It is not recommended to connect your staging environment to a development instance. If you want to use a development instance with your staging environment, see the [Instances / Environments](/docs/deployments/environments#development-instance) documentation to learn about possible limitations.
+
+## Preview deployments
+
+You can also use Clerk with staging or production [preview deployments]().

--- a/docs/deployments/set-up-staging.mdx
+++ b/docs/deployments/set-up-staging.mdx
@@ -1,0 +1,48 @@
+---
+description: Learn how to set up staging with Clerk authentication.
+---
+
+# Set up a staging environment with Clerk
+
+Staging environments enable you to internally test and demo changes to your application or website before deploying them to production. Official support for staging is still on [Clerk's roadmap](https://feedback.clerk.com/roadmap/de417dd1-fa2e-4997-868f-4c9248027e7d), however you can use Clerk in your staging environments with the approaches described in this guide.
+
+## Choose an approach
+
+There are two recommended approaches to using Clerk in a staging environment at this time:
+
+1. [Using a separate domain from your production app's domain](#use-a-staging-domain). Choose this if you:
+    - Don't already have a subdomain of your production app
+    - Can integrate a new staging-specific domain into your current workflow
+1. [Using a subdomain of your production app's domain](#use-a-subdomain). Choose this if you:
+    - Can't currently integrate a new staging-specific domain into your workflow
+
+Alternatively, you can [use Clerk with your preview deployments]().
+
+## Use a staging domain
+
+When setting up staging with Clerk, it is recommended that you use a separate domain from your production domain. Doing so will enable you to create a new Clerk app for your staging environment, preventing you from using production environment data and API keys. **This staging Clerk app will be upgraded free of charge**.
+
+### Benefits of this approach
+
+Using a separate domain and Clerk application enables you to:
+
+- Use a Clerk production instance for your staging environment, offering improved security over development instances. See [Instances / Environments](/docs/deployments/environments#production-instance) for more information.
+- Fetch and modify data from Clerk without affecting your production data
+- Avoid using live customer data in your staging environment
+- Prevent your production application's users from being able to sign in to your staging environment
+
+#### Limitations
+
+- When you use a separate Clerk application for your staging environment, changes to this application will not be automatically mirrored in your main application for your production environment. You must manually make these changes yourself. 
+
+### Set up a staging Clerk app
+
+The following steps will help you set up a new Clerk application with a staging-specific domain:
+
+1. **Acquire a new domain** – This new domain will be used for your staging environment. **This cannot be a subdomain**. For example, if your production domain is `my-site.com`, you could use `my-site-staging.com`. To use a subdomain instead, see [its dedication section](#use-a-subdomain).
+1. **Create a new Clerk app** – Your staging environment will connect to this app instead of your main Clerk application. See [the Clerk quickstart guide](/docs/quickstarts/setup-clerk#create-a-clerk-application) to learn how to create a Clerk app.
+1. **Deploy and configure your staging app's production instance** – Using production API keys will make your staging app more secure. Follow the [Deploy to production](/docs/deployments/overview#deploying-to-production) guide to do so.
+1. **Contact Clerk support to upgrade your staging app for free** – If you're on a Pro, Enterprise, or Startup plan, Clerk will fully upgrade your staging app for free.
+
+## Use a subdomain
+

--- a/docs/deployments/set-up-staging.mdx
+++ b/docs/deployments/set-up-staging.mdx
@@ -80,4 +80,4 @@ It is not recommended to connect your staging environment to a development insta
 
 ## Preview deployments
 
-You can also use Clerk with staging in a [preview environment](/docs/deployments/set-up-preview-environment).
+While staging environments are typically long-lived, preview environments are typically generated on-demand for specific pull requests. See [the guide on using Clerk in a preview environment](/docs/deployments/set-up-preview-environment) to learn about your options.

--- a/docs/deployments/staging-alternatives.mdx
+++ b/docs/deployments/staging-alternatives.mdx
@@ -1,0 +1,32 @@
+---
+description:
+---
+
+# Staging alternatives
+
+## Shared production credentials
+
+<Callout type="danger">
+  This is not recommended. Instead, you should either [set up a staging environment with a separate domain](/docs/deployments/set-up-staging) or [use a preview deployment](/docs/deployments/set-up-preview-environment).
+</Callout>
+
+If you do not want to purchase a separate domain, or if you would like to share settings and data between your production and staging environments, you can use a subdomain of your production domain to set up a staging environment.
+
+### Limitations of using a subdomain
+
+The limitations of using a subdomain to set up a staging environment with Clerk include:
+
+- You will be combining staging data with live production data.
+- When you enable Clerk features to test in staging, they will be enabled in your Production environment as well.
+
+### Set up staging with a subdomain
+
+1. **Add your subdomain to your hosting provider** - Ensure that your subdomain is associated with your staging branch so that it will point to new staging deployments. This process will vary based on your provider. The following are some guides from popular hosting providers:
+    - [Vercel](https://vercel.com/guides/set-up-a-staging-environment-on-vercel)
+    - [Netlify](https://docs.netlify.com/domains-https/netlify-dns/delegate-a-subdomain-to-netlify-dns/)
+    - [Cloudflare](https://developers.cloudflare.com/dns/manage-dns-records/how-to/create-subdomain/)
+2. **Add your CNAME record to your domain provider** - Depending on the provider, the verification process for this can take hours or days.
+3. **Add your production instance API keys to your staging deployment** - In your staging deployment's environment variables, add your Clerk app's production instance API keys. Visit the [**API Keys**](https://dashboard.clerk.com/last-active?path=api-keys) section in the Clerk Dashboard to find them, and ensure that the instance at the top of the Dashboard is set to **Production**. The following are environment variable guides from some popular providers:
+    - [Vercel](https://vercel.com/docs/projects/environment-variables#declare-an-environment-variable)
+    - [Netlify](https://docs.netlify.com/environment-variables/get-started/#create-environment-variables)
+    - [Cloudflare](https://developers.cloudflare.com/workers/configuration/environment-variables/#add-environment-variables-via-the-dashboar)

--- a/docs/manifest.json
+++ b/docs/manifest.json
@@ -337,6 +337,7 @@
       "# Deployment",
       ["Deploy to production", "/deployments/overview"],
       ["Deploy to Vercel", "/deployments/deploy-to-vercel"],
+      ["Set up a staging environment", "/deployments/set-up-staging"],
       ["Changing domains", "/deployments/changing-domains"],
       "# Migrations",
       ["Migrate to Clerk", "/deployments/migrate-overview"],

--- a/docs/manifest.json
+++ b/docs/manifest.json
@@ -338,6 +338,7 @@
       ["Deploy to production", "/deployments/overview"],
       ["Deploy to Vercel", "/deployments/deploy-to-vercel"],
       ["Set up a staging environment", "/deployments/set-up-staging"],
+      ["Set up a preview environment", "/deployments/set-up-preview-environment"],
       ["Changing domains", "/deployments/changing-domains"],
       "# Migrations",
       ["Migrate to Clerk", "/deployments/migrate-overview"],


### PR DESCRIPTION
This pr:

- [Adds a "Staging environment" guide](https://docs-preview-900.clerkpreview.com/docs/deployments/set-up-staging) that talks about setting up a new Clerk app with a new domain that will act as a user's "staging environment"
- [Adds a kind of hidden "Staging alternatives" guide](https://docs-preview-900.clerkpreview.com/docs/deployments/staging-alternatives) that talks about setting up a subdomain for your production app to use as "staging"
- [Adds a preview environment guide](https://docs-preview-900.clerkpreview.com/docs/deployments/set-up-preview-environment) that talks about the two approaches for preview environments:
  - Sharing production credentials by using Vercel's Preview Deployment Suffix feature
  - Using development API keys for a preview deployment
- [Updates the environments page with preview and staging sections](https://docs-preview-900.clerkpreview.com/docs/deployments/environments#staging-environments)
- Fixes a broken link in the changing domains guide
- Fixes a broken link in the deploy to vercel guide