### PR TITLE
DOCS-6075 Add reference to auth in getAuth doc

### DIFF
--- a/docs/references/nextjs/auth.mdx
+++ b/docs/references/nextjs/auth.mdx
@@ -5,11 +5,11 @@ description: Access minimal authentication data for managing sessions and data f
 
 # `auth()`
 
-The `auth()` helper returns the [`Authentication`](/docs/references/nextjs/auth-object) object of the currently active user. This is the same `Authentication` object that is returned by the [`getAuth()`](/docs/references/nextjs/get-auth) hook. However, it can be used in Server Components, Route Handlers, and Server Actions.
+The `auth()` helper returns the [`Auth`](/docs/references/nextjs/auth-object) object of the currently active user. This is the same `Auth` object that is returned by the [`getAuth()`](/docs/references/nextjs/get-auth) hook. However, it can be used in Server Components, Route Handlers, and Server Actions.
 
 The `auth()` helper does require [Middleware](/docs/references/nextjs/clerk-middleware).
 
-## Return type of `auth()`
+## Returns
 
 `auth()` returns the [`Auth`](/docs/references/nextjs/auth-object) object with a few extra properties:
 
@@ -30,7 +30,7 @@ You can use the `protect()` helper in two ways:
 - to check if a user is authenticated
 - to check if a user is authorized to access something, such as a component or a route handler
 
-`protect()` will return the `Authentication` object if the user is authenticated or authorized. If the user is not authenticated or authorized, `protect()` will redirect the user to the sign-in page or to a custom URL that you provide as a parameter.
+`protect()` will return the `Auth` object if the user is authenticated or authorized. If the user is not authenticated or authorized, `protect()` will redirect the user to the sign-in page or to a custom URL that you provide as a parameter.
 
 `protect()` accepts the following parameters:
 
@@ -148,7 +148,7 @@ Use the [`protect()`](#protect) helper to protect a route handler from unauthori
 In the following example:
 - `protect()` helper is used to check if a user is authorized to access a route handler.
 - If the user is not authorized, the `protect()` helper will redirect the user to the sign-in route.
-- If the user is authorized, the `protect()` helper will return the `Authentication` object, which has the `userId` property.
+- If the user is authorized, the `protect()` helper will return the `Auth` object, which has the `userId` property.
 
 ```tsx filename="app/api/route.ts"
 import { auth } from "@clerk/nextjs/server";
@@ -164,7 +164,7 @@ export const POST = () => {
 
 In some cases, you need to check your user's current organization role before displaying data or allowing certain actions to be performed.
 
-Check the current user's role with the `orgRole` property of the `Authentication` object returned by `auth()`, as shown in the following example:
+Check the current user's role with the `orgRole` property of the `Auth` object returned by `auth()`, as shown in the following example:
 
 ```tsx filename="app/page.tsx"
 import { auth } from '@clerk/nextjs/server';

--- a/docs/references/nextjs/get-auth.mdx
+++ b/docs/references/nextjs/get-auth.mdx
@@ -86,7 +86,7 @@ export default async function handler(
 
 ### Usage with `clerkClient`
 
-`clerkClient` is used to access the [Backend SDK](/docs/references/backend/overview), which exposes Clerk's backend API resources. You can use `getauth()` to pass authentication information that many of the Backend SDK methods require, like in the following example:
+`clerkClient` is used to access the [Backend SDK](/docs/references/backend/overview), which exposes Clerk's backend API resources. You can use `getAuth()` to pass authentication information that many of the Backend SDK methods require, like in the following example:
 
 ```tsx filename="app/api/example/route.ts"
 import { clerkClient, getAuth } from "@clerk/nextjs/server";

--- a/docs/references/nextjs/get-auth.mdx
+++ b/docs/references/nextjs/get-auth.mdx
@@ -5,13 +5,23 @@ description: The getAuth() helper retrieves the authentication state allowing yo
 
 # `getAuth()`
 
-The `getAuth()` helper retrieves the authentication state, allowing you to protect your API routes or gather relevant data. The variables available in the response can be found [here](/docs/references/nextjs/auth-object).
+The `getAuth()` helper retrieves the authentication state, allowing you to protect your API routes or gather relevant data.
+
+<Callout type="info">
+  The `getAuth()` counterpart in App Router applications is the [`auth()`](/docs/references/nextjs/auth) helper.
+</Callout>
+
+## Returns
+
+The variables available in the response can be found [here](/docs/references/nextjs/auth-object).
 
 ## Usage
 
-#### Basic usage
+### Basic usage
 
-```tsx filename="pages/api/example.ts"
+The following example demonstrates how to use `getAuth()` to retrieve authentication information in an API route.
+
+```tsx filename="app/api/example/route.ts"
 import { getAuth } from "@clerk/nextjs/server";
 import type { NextApiRequest, NextApiResponse } from "next";
 
@@ -20,16 +30,18 @@ export default async function handler(
   res: NextApiResponse
 ) {
   const { userId } = getAuth(req);
-  // Load any data your application needs for the API route
+
+  // Add logic that retrieves the data for the API route
+
   return res.status(200).json({ userId: userId });
 }
 ```
 
-#### Protecting API routes
+### Protect API routes
 
-It is important to protect your API routes to ensure that only authenticated users can access them. You can do this by checking if the `userId` is present in the `getAuth()` response.
+It is important to protect your API routes to ensure that only authenticated users can access them. You can do this by checking if the `userId` is present in the `getAuth()` response, like in the following example:
 
-```tsx filename="pages/api/example.ts"
+```tsx filename="app/api/example/route.ts"
 import { getAuth } from "@clerk/nextjs/server";
 import type { NextApiRequest, NextApiResponse } from "next";
 
@@ -38,19 +50,22 @@ export default async function handler(
   res: NextApiResponse
 ) {
   const { userId } = getAuth(req);
+
   if (!userId) {
     return res.status(401).json({ error: "Not authenticated" });
   }
-  // Load any data your application needs for the API route
+
+  // Add logic that retrieves the data for the API route
+
   return res.status(200).json({ userId: userId });
 }
 ```
 
-#### Usage with `getToken`
+### Usage with `getToken()`
 
-The `getToken()` function returns a promise that resolves to the current user's session token. You can also use this function to retrieve a custom JWT template.
+`getAuth()` returns `getToken()`, which is a method that returns the current user's session token. You can also use this function to retrieve a custom JWT template, like in the following example:
 
-```tsx filename="pages/api/example.ts"
+```tsx filename="app/api/example/route.ts"
 import { getAuth } from "@clerk/nextjs/server";
 import type { NextApiRequest, NextApiResponse } from "next";
 
@@ -59,18 +74,22 @@ export default async function handler(
   res: NextApiResponse
 ) {
   const { getToken } = getAuth(req);
+
   const token = await getToken({ template: "supabase" });
-  // Retrieve the data from your database
+
+  // Add logic that retrieves the data
+  // from your database using the token
+
   return res.status(200).json({});
 }
 ```
 
-#### Usage with `clerkClient`
+### Usage with `clerkClient`
 
-The `clerkClient` allows you to access the Clerk API. You can use this to retrieve or update data.
+`clerkClient` is used to access the [Backend SDK](/docs/references/backend/overview), which exposes Clerk's backend API resources. You can use `getauth()` to pass authentication information that many of the Backend SDK methods require, like in the following example:
 
-```tsx filename="pages/api/example.ts"
-import { getAuth, clerkClient } from "@clerk/nextjs/server";
+```tsx filename="app/api/example/route.ts"
+import { clerkClient, getAuth } from "@clerk/nextjs/server";
 import type { NextApiRequest, NextApiResponse } from "next";
 
 export default async function handler(
@@ -78,7 +97,9 @@ export default async function handler(
   res: NextApiResponse
 ) {
   const { userId } = getAuth(req);
+
   const user = userId ? await clerkClient.users.getUser(userId) : null;
+
   return res.status(200).json({});
 }
 ```

--- a/docs/references/nextjs/get-auth.mdx
+++ b/docs/references/nextjs/get-auth.mdx
@@ -13,7 +13,7 @@ The `getAuth()` helper retrieves the authentication state, allowing you to prote
 
 ## Returns
 
-The variables available in the response can be found [here](/docs/references/nextjs/auth-object).
+`getAuth()` returns the [`Auth`](/docs/references/nextjs/auth-object) object.
 
 ## Usage
 

--- a/docs/references/nextjs/get-auth.mdx
+++ b/docs/references/nextjs/get-auth.mdx
@@ -8,7 +8,7 @@ description: The getAuth() helper retrieves the authentication state allowing yo
 The `getAuth()` helper retrieves the authentication state, allowing you to protect your API routes or gather relevant data.
 
 <Callout type="info">
-  The `getAuth()` counterpart in App Router applications is the [`auth()`](/docs/references/nextjs/auth) helper.
+  If you are using App Router, use the [`auth()` helper](/docs/references/nextjs/auth) instead.
 </Callout>
 
 ## Returns


### PR DESCRIPTION
https://linear.app/clerk/issue/DOCS-6075/link-to-auth-docs-from-getauth-page-and-vice-versa

🔎 [getAuth()](https://docs-preview-903.clerkpreview.com/docs/references/nextjs/get-auth)
🔎 [auth()](https://docs-preview-903.clerkpreview.com/docs/references/nextjs/auth)