### PR TITLE
Call out redirect behaviour for active sessions

### DIFF
--- a/docs/components/authentication/sign-in.mdx
+++ b/docs/components/authentication/sign-in.mdx
@@ -14,28 +14,32 @@ description: Clerk's <SignIn /> component renders a UI for signing in users.
 
 The `<SignIn />` component renders a UI for signing in users. The functionality of the `<SignIn />` component is controlled by the instance settings you specify in your [Clerk Dashboard](https://dashboard.clerk.com), such as [sign-in and sign-up options](/docs/authentication/configuration/sign-up-sign-in-options) and [social connections](/docs/authentication/social-connections/overview). You can further customize your `<SignIn />` component by passing additional [properties](#properties) at the time of rendering.
 
+<Callout type="info">
+  The `<SignUp/>` and `<SignIn/>` components cannot render when a user is already signed in, unless the application allows multiple sessions. If a user is already signed in and the application only allows a single session, Clerk will redirect the user to the Home URL instead.
+</Callout>
+
 ## Properties
 
 All props are optional.
 
-| Name | Type | Description |
-| --- | --- | --- |
-| `appearance` | <code>[Appearance](/docs/components/customization/overview) \| undefined</code> | Optional object to style your components. Will only affect [Clerk Components](/docs/components/overview) and not [Account Portal](/docs/account-portal/overview) pages. |
-| `routing` | `'hash' \| 'path' \| 'virtual'` | The routing strategy for your pages.<br />Note: If you are using environment variables for Next.js or Remix to specify your routes, such as `NEXT_PUBLIC_CLERK_SIGN_IN_URL`, this will be set to `path`. |
-| `path` | `string` | The path where the component is mounted on when path-based routing is used.<br />For example: `/sign-in`<br />This prop is ignored in hash- and virtual-based routing. |
-| `redirectUrl` | `string` | Full URL or path to navigate to after successful sign in or sign up.<br /> The same as setting `afterSignInUrl` and `afterSignUpUrl` to the same value. |
-| `afterSignInUrl` | `string` | The full URL or path to navigate to after a successful sign in. |
-| `signUpUrl` | `string` | Full URL or path to the sign up page. Use this property to provide the target of the 'Sign Up' link that's rendered. |
-| `afterSignUpUrl` | `string` | The full URL or path to navigate to after a successful sign up. |
-| `initialValues` | [`SignInInitialValues`](/docs/references/javascript/types/sign-in-initial-values) | The values used to prefill the sign-in fields with. |
+| Name             | Type                                                                              | Description                                                                                                                                                                                              |
+| ---------------- | --------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `appearance`     | <code>[Appearance](/docs/components/customization/overview) \| undefined</code>   | Optional object to style your components. Will only affect [Clerk Components](/docs/components/overview) and not [Account Portal](/docs/account-portal/overview) pages.                                  |
+| `routing`        | `'hash' \| 'path' \| 'virtual'`                                                   | The routing strategy for your pages.<br />Note: If you are using environment variables for Next.js or Remix to specify your routes, such as `NEXT_PUBLIC_CLERK_SIGN_IN_URL`, this will be set to `path`. |
+| `path`           | `string`                                                                          | The path where the component is mounted on when path-based routing is used.<br />For example: `/sign-in`<br />This prop is ignored in hash- and virtual-based routing.                                   |
+| `redirectUrl`    | `string`                                                                          | Full URL or path to navigate to after successful sign in or sign up.<br /> The same as setting `afterSignInUrl` and `afterSignUpUrl` to the same value.                                                  |
+| `afterSignInUrl` | `string`                                                                          | The full URL or path to navigate to after a successful sign in.                                                                                                                                          |
+| `signUpUrl`      | `string`                                                                          | Full URL or path to the sign up page. Use this property to provide the target of the 'Sign Up' link that's rendered.                                                                                     |
+| `afterSignUpUrl` | `string`                                                                          | The full URL or path to navigate to after a successful sign up.                                                                                                                                          |
+| `initialValues`  | [`SignInInitialValues`](/docs/references/javascript/types/sign-in-initial-values) | The values used to prefill the sign-in fields with.                                                                                                                                                      |
 
 ## Usage with frameworks
 
 The following example includes basic implementation of the `<SignIn />` component. You can use this as a starting point for your own implementation.
 
 <Tabs type="framework" items={["Next.js", "React", "Remix", "Gatsby"]}>
-  <Tab>
-    The following example demonstrates how you can use the `<SignIn />` component on a public page.
+<Tab>
+The following example demonstrates how you can use the `<SignIn />` component on a public page.
 
     If you would like to create a dedicated `/sign-in` page in your Next.js application, check out the [dedicated guide.](/docs/references/nextjs/custom-signup-signin-pages).
 
@@ -52,6 +56,7 @@ The following example includes basic implementation of the `<SignIn />` componen
       return <div>Welcome!</div>;
     }
     ```
+
   </Tab>
 
   <Tab>
@@ -64,6 +69,7 @@ The following example includes basic implementation of the `<SignIn />` componen
 
     export default SignInPage;
     ```
+
   </Tab>
 
   <Tab>
@@ -79,6 +85,7 @@ The following example includes basic implementation of the `<SignIn />` componen
       );
     }
     ```
+
   </Tab>
 
   <Tab>
@@ -94,6 +101,7 @@ The following example includes basic implementation of the `<SignIn />` componen
       );
     }
     ```
+
   </Tab>
 </Tabs>
 
@@ -118,58 +126,58 @@ function mountSignIn(node: HTMLDivElement, props?: SignInProps): void;
 
 #### `mountSignIn()` params
 
-| Name | Type | Description |
-| --- | --- | --- |
-| `node` | [`HTMLDivElement`](https://developer.mozilla.org/en-US/docs/Web/API/HTMLDivElement) | The container `<div>` element used to render in the `<SignIn />` component |
-| `props?` | [`SignInProps`](#properties) | The properties to pass to the `<SignIn />` component |
+| Name     | Type                                                                                | Description                                                                |
+| -------- | ----------------------------------------------------------------------------------- | -------------------------------------------------------------------------- |
+| `node`   | [`HTMLDivElement`](https://developer.mozilla.org/en-US/docs/Web/API/HTMLDivElement) | The container `<div>` element used to render in the `<SignIn />` component |
+| `props?` | [`SignInProps`](#properties)                                                        | The properties to pass to the `<SignIn />` component                       |
 
 #### `mountSignIn()` usage
 
 <InjectKeys>
 
 <CodeBlockTabs type="npm-script" options={['NPM module', '<script>']}>
-  ```js filename="index.js" {14}
-  import Clerk from '@clerk/clerk-js';
 
-  // Initialize Clerk with your Clerk publishable key
-  const clerk = new Clerk('{{pub_key}}');
-  await clerk.load();
+```js filename="index.js" {14}
+import Clerk from "@clerk/clerk-js";
 
-  document.getElementById("app").innerHTML = `
-    <div id="sign-in"></div>
-  `;
+// Initialize Clerk with your Clerk publishable key
+const clerk = new Clerk("{{pub_key}}");
+await clerk.load();
 
-  const signInDiv =
-    document.getElementById("sign-in");
-
-  clerk.mountSignIn(signInDiv);
-  ```
-
-  ```html filename="index.html" {21}
-  <!-- Add a <div id="sign-in"> element to your HTML -->
+document.getElementById("app").innerHTML = `
   <div id="sign-in"></div>
+`;
 
-  <!-- Initialize Clerk with your
-  Clerk Publishable key and Frontend API URL -->
-  <script
-    async
-    crossorigin="anonymous"
-    data-clerk-publishable-key="{{pub_key}}"
-    src="https://{{fapi_url}}/npm/@clerk/clerk-js@latest/dist/clerk.browser.js"
-    type="text/javascript"
-  ></script>
+const signInDiv = document.getElementById("sign-in");
 
-  <script>
-    window.addEventListener("load", async function () {
-      await Clerk.load();
+clerk.mountSignIn(signInDiv);
+```
 
-      const signInDiv =
-        document.getElementById('sign-in');
+```html filename="index.html" {21}
+<!-- Add a <div id="sign-in"> element to your HTML -->
+<div id="sign-in"></div>
 
-      Clerk.mountSignIn(signInDiv);
-    });
-  </script>
-  ```
+<!-- Initialize Clerk with your
+Clerk Publishable key and Frontend API URL -->
+<script
+  async
+  crossorigin="anonymous"
+  data-clerk-publishable-key="{{pub_key}}"
+  src="https://{{fapi_url}}/npm/@clerk/clerk-js@latest/dist/clerk.browser.js"
+  type="text/javascript"
+></script>
+
+<script>
+  window.addEventListener("load", async function () {
+    await Clerk.load();
+
+    const signInDiv = document.getElementById("sign-in");
+
+    Clerk.mountSignIn(signInDiv);
+  });
+</script>
+```
+
 </CodeBlockTabs>
 
 </InjectKeys>
@@ -184,8 +192,8 @@ function unmountSignIn(node: HTMLDivElement): void;
 
 #### `unmountSignIn()` params
 
-| Name | Type | Description |
-| --- | --- | --- |
+| Name   | Type                                                                                | Description                                                                   |
+| ------ | ----------------------------------------------------------------------------------- | ----------------------------------------------------------------------------- |
 | `node` | [`HTMLDivElement`](https://developer.mozilla.org/en-US/docs/Web/API/HTMLDivElement) | The container `<div>` element with a rendered `<SignIn />` component instance |
 
 #### `unmountSignIn()` usage
@@ -193,56 +201,56 @@ function unmountSignIn(node: HTMLDivElement): void;
 <InjectKeys>
 
 <CodeBlockTabs type="npm-script" options={['NPM module', '<script>']}>
-  ```js filename="index.js" {18}
-  import Clerk from '@clerk/clerk-js';
 
-  // Initialize Clerk with your Clerk publishable key
-  const clerk = new Clerk('{{pub_key}}');
-  await clerk.load();
+```js filename="index.js" {18}
+import Clerk from "@clerk/clerk-js";
 
-  document.getElementById('app').innerHTML = `
-    <div id="sign-in"></div>
-  `
+// Initialize Clerk with your Clerk publishable key
+const clerk = new Clerk("{{pub_key}}");
+await clerk.load();
 
-  const signInDiv =
-    document.getElementById('sign-in');
-
-  clerk.mountSignIn(signInDiv);
-
-  // ...
-
-  clerk.unmountSignIn(signInDiv);
-  ```
-
-  ```html filename="index.html" {25}
-  <!-- Add a <div id="sign-in"> element to your HTML -->
+document.getElementById("app").innerHTML = `
   <div id="sign-in"></div>
+`;
 
-  <!-- Initialize Clerk with your
-  Clerk Publishable key and Frontend API URL -->
-  <script
-    async
-    crossorigin="anonymous"
-    data-clerk-publishable-key="{{pub_key}}"
-    src="https://{{fapi_url}}/npm/@clerk/clerk-js@latest/dist/clerk.browser.js"
-    type="text/javascript"
-  ></script>
+const signInDiv = document.getElementById("sign-in");
 
-  <script>
-    window.addEventListener("load", async function () {
-      await Clerk.load();
+clerk.mountSignIn(signInDiv);
 
-      const signInDiv =
-        document.getElementById('sign-in');
+// ...
 
-      Clerk.mountSignIn(signInDiv);
+clerk.unmountSignIn(signInDiv);
+```
 
-      // ...
+```html filename="index.html" {25}
+<!-- Add a <div id="sign-in"> element to your HTML -->
+<div id="sign-in"></div>
 
-      Clerk.unmountSignIn(signInDiv);
-    });
-  </script>
-  ```
+<!-- Initialize Clerk with your
+Clerk Publishable key and Frontend API URL -->
+<script
+  async
+  crossorigin="anonymous"
+  data-clerk-publishable-key="{{pub_key}}"
+  src="https://{{fapi_url}}/npm/@clerk/clerk-js@latest/dist/clerk.browser.js"
+  type="text/javascript"
+></script>
+
+<script>
+  window.addEventListener("load", async function () {
+    await Clerk.load();
+
+    const signInDiv = document.getElementById("sign-in");
+
+    Clerk.mountSignIn(signInDiv);
+
+    // ...
+
+    Clerk.unmountSignIn(signInDiv);
+  });
+</script>
+```
+
 </CodeBlockTabs>
 
 </InjectKeys>
@@ -257,8 +265,8 @@ function openSignIn(props?: SignInProps): void;
 
 #### `openSignIn()` params
 
-| Name | Type | Desciption |
-| --- | --- | --- |
+| Name     | Type                         | Desciption                                           |
+| -------- | ---------------------------- | ---------------------------------------------------- |
 | `props?` | [`SignInProps`](#properties) | The properties to pass to the `<SignIn />` component |
 
 #### `openSignIn()` usage
@@ -266,35 +274,37 @@ function openSignIn(props?: SignInProps): void;
 <InjectKeys>
 
 <CodeBlockTabs type="npm-script" options={['NPM module', '<script>']}>
-  ```js filename="index.js" {7}
-  import Clerk from '@clerk/clerk-js';
 
-  // Initialize Clerk with your Clerk publishable key
-  const clerk = new Clerk('{{pub_key}}');
-  await clerk.load();
+```js filename="index.js" {7}
+import Clerk from "@clerk/clerk-js";
 
-  clerk.openSignIn();
-  ```
+// Initialize Clerk with your Clerk publishable key
+const clerk = new Clerk("{{pub_key}}");
+await clerk.load();
 
-  ```html filename="index.html" {15}
-  <!-- Initialize Clerk with your
-  Clerk Publishable key and Frontend API URL -->
-  <script
-    async
-    crossorigin="anonymous"
-    data-clerk-publishable-key="{{pub_key}}"
-    src="https://{{fapi_url}}/npm/@clerk/clerk-js@latest/dist/clerk.browser.js"
-    type="text/javascript"
-  ></script>
+clerk.openSignIn();
+```
 
-  <script>
-    window.addEventListener("load", async function () {
-      await Clerk.load();
+```html filename="index.html" {15}
+<!-- Initialize Clerk with your
+Clerk Publishable key and Frontend API URL -->
+<script
+  async
+  crossorigin="anonymous"
+  data-clerk-publishable-key="{{pub_key}}"
+  src="https://{{fapi_url}}/npm/@clerk/clerk-js@latest/dist/clerk.browser.js"
+  type="text/javascript"
+></script>
 
-      Clerk.openSignIn();
-    });
-  </script>
-  ```
+<script>
+  window.addEventListener("load", async function () {
+    await Clerk.load();
+
+    Clerk.openSignIn();
+  });
+</script>
+```
+
 </CodeBlockTabs>
 
 </InjectKeys>
@@ -312,43 +322,45 @@ function closeSignIn(): void;
 <InjectKeys>
 
 <CodeBlockTabs type="npm-script" options={['NPM module', '<script>']}>
-  ```js filename="index.js" {11}
-  import Clerk from '@clerk/clerk-js';
 
-  // Initialize Clerk with your Clerk publishable key
-  const clerk = new Clerk('{{pub_key}}');
-  await clerk.load();
+```js filename="index.js" {11}
+import Clerk from "@clerk/clerk-js";
 
-  clerk.openSignIn();
+// Initialize Clerk with your Clerk publishable key
+const clerk = new Clerk("{{pub_key}}");
+await clerk.load();
 
-  // ...
+clerk.openSignIn();
 
-  clerk.closeSignIn();
-  ```
+// ...
 
-  ```html filename="index.html" {19}
-  <!-- Initialize Clerk with your
-  Clerk Publishable key and Frontend API URL -->
-  <script
-    async
-    crossorigin="anonymous"
-    data-clerk-publishable-key="{{pub_key}}"
-    src="https://{{fapi_url}}/npm/@clerk/clerk-js@latest/dist/clerk.browser.js"
-    type="text/javascript"
-  ></script>
+clerk.closeSignIn();
+```
 
-  <script>
-    window.addEventListener("load", async function () {
-      await Clerk.load();
+```html filename="index.html" {19}
+<!-- Initialize Clerk with your
+Clerk Publishable key and Frontend API URL -->
+<script
+  async
+  crossorigin="anonymous"
+  data-clerk-publishable-key="{{pub_key}}"
+  src="https://{{fapi_url}}/npm/@clerk/clerk-js@latest/dist/clerk.browser.js"
+  type="text/javascript"
+></script>
 
-      Clerk.openSignIn();
+<script>
+  window.addEventListener("load", async function () {
+    await Clerk.load();
 
-      // ...
+    Clerk.openSignIn();
 
-      Clerk.closeSignIn();
-    });
-  </script>
-  ```
+    // ...
+
+    Clerk.closeSignIn();
+  });
+</script>
+```
+
 </CodeBlockTabs>
 
 </InjectKeys>

--- a/docs/components/authentication/sign-up.mdx
+++ b/docs/components/authentication/sign-up.mdx
@@ -14,29 +14,33 @@ description: Clerk's <SignUp /> component renders a UI for signing up users.
 
 The `<SignUp />` component renders a UI for signing up users. The functionality of the `<SignUp />` component is controlled by the instance settings you specify in your [Clerk Dashboard](https://dashboard.clerk.com), such as [sign-in and sign-up options](/docs/authentication/configuration/sign-up-sign-in-options) and [social connections](/docs/authentication/social-connections/overview). You can further customize your `<SignUp />` component by passing additional [properties](#properties) at the time of rendering.
 
+<Callout type="info">
+  The `<SignUp/>` and `<SignIn/>` components cannot render when a user is already signed in, unless the application allows multiple sessions. If a user is already signed in and the application only allows a single session, Clerk will redirect the user to the Home URL instead.
+</Callout>
+
 ## Properties
 
 All props are optional.
 
-| Name | Type | Description |
-| --- | --- | --- |
-| `appearance` | <code>[Appearance](/docs/components/customization/overview) \| undefined</code> | Optional object to style your components. Will only affect [Clerk Components](/docs/components/overview) and not [Account Portal](/docs/account-portal/overview) pages. |
-| `routing` | `'hash' \| 'path' \| 'virtual'` | The routing strategy for your pages.<br />Note: If you are using environment variables for Next.js or Remix to specify your routes, such as `NEXT_PUBLIC_CLERK_SIGN_IN_URL`, this will be set to `path`. |
-| `path` | `string` | The path where the component is mounted on when path-based routing is used<br />For example: `/sign-up`.<br />This prop is ignored in hash- and virtual-based routing. |
-| `redirectUrl` | `string` | Full URL or path to navigate to after successful sign in or sign up.<br />The same as setting `afterSignInUrl` and `afterSignUpUrl` to the same value. |
-| `afterSignInUrl` | `string` | The full URL or path to navigate to after a successful sign in. |
-| `signInUrl` | `string` | Full URL or path to the sign in page. Use this property to provide the target of the 'Sign In' link that's rendered. |
-| `afterSignUpUrl` | `string` | The full URL or path to navigate to after a successful sign up. |
-| `unsafeMetadata` | `object` | An object with the key and value for `unsafeMetadata` that will be saved to the user after sign up.<br />For example: `{ "company": "companyID1234" }` |
-| `initialValues` | [`SignUpInitialValues`](/docs/references/javascript/types/sign-up-initial-values) | The values used to prefill the sign-up fields with. |
+| Name             | Type                                                                              | Description                                                                                                                                                                                              |
+| ---------------- | --------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `appearance`     | <code>[Appearance](/docs/components/customization/overview) \| undefined</code>   | Optional object to style your components. Will only affect [Clerk Components](/docs/components/overview) and not [Account Portal](/docs/account-portal/overview) pages.                                  |
+| `routing`        | `'hash' \| 'path' \| 'virtual'`                                                   | The routing strategy for your pages.<br />Note: If you are using environment variables for Next.js or Remix to specify your routes, such as `NEXT_PUBLIC_CLERK_SIGN_IN_URL`, this will be set to `path`. |
+| `path`           | `string`                                                                          | The path where the component is mounted on when path-based routing is used<br />For example: `/sign-up`.<br />This prop is ignored in hash- and virtual-based routing.                                   |
+| `redirectUrl`    | `string`                                                                          | Full URL or path to navigate to after successful sign in or sign up.<br />The same as setting `afterSignInUrl` and `afterSignUpUrl` to the same value.                                                   |
+| `afterSignInUrl` | `string`                                                                          | The full URL or path to navigate to after a successful sign in.                                                                                                                                          |
+| `signInUrl`      | `string`                                                                          | Full URL or path to the sign in page. Use this property to provide the target of the 'Sign In' link that's rendered.                                                                                     |
+| `afterSignUpUrl` | `string`                                                                          | The full URL or path to navigate to after a successful sign up.                                                                                                                                          |
+| `unsafeMetadata` | `object`                                                                          | An object with the key and value for `unsafeMetadata` that will be saved to the user after sign up.<br />For example: `{ "company": "companyID1234" }`                                                   |
+| `initialValues`  | [`SignUpInitialValues`](/docs/references/javascript/types/sign-up-initial-values) | The values used to prefill the sign-up fields with.                                                                                                                                                      |
 
 ## Usage with frameworks
 
 The following example includes basic implementation of the `<SignIn />` component. You can use this as a starting point for your own implementation.
 
 <Tabs type="framework" items={["Next.js", "React", "Remix", "Gatsby"]}>
-  <Tab>
-    The following example demonstrates how you can use the `<SignUp />` component on a public page.
+<Tab>
+The following example demonstrates how you can use the `<SignUp />` component on a public page.
 
     If you would like to create a dedicated `/sign-up` page in your Next.js application, check out the [dedicated guide.](/docs/references/nextjs/custom-signup-signin-pages).
 
@@ -53,6 +57,7 @@ The following example includes basic implementation of the `<SignIn />` componen
       return <div>Welcome!</div>;
     }
     ```
+
   </Tab>
 
   <Tab>
@@ -78,6 +83,7 @@ The following example includes basic implementation of the `<SignIn />` componen
       );
     }
     ```
+
   </Tab>
 
   <Tab>
@@ -93,6 +99,7 @@ The following example includes basic implementation of the `<SignIn />` componen
       );
     }
     ```
+
   </Tab>
 </Tabs>
 
@@ -117,58 +124,58 @@ function mountSignUp(node: HTMLDivElement, props?: SignUpProps): void;
 
 #### `mountSignUp()` params
 
-| Name | Type | Description |
-| --- | --- | --- |
-| `node ` | [`HTMLDivElement`](https://developer.mozilla.org/en-US/docs/Web/API/HTMLDivElement) | The `<div>` element used to render in the `<SignUp />` component |
-| `props?` | [`SignUpProps`](#sign-up-props) | The properties to pass to the `<SignUp />` component. |
+| Name     | Type                                                                                | Description                                                      |
+| -------- | ----------------------------------------------------------------------------------- | ---------------------------------------------------------------- |
+| `node `  | [`HTMLDivElement`](https://developer.mozilla.org/en-US/docs/Web/API/HTMLDivElement) | The `<div>` element used to render in the `<SignUp />` component |
+| `props?` | [`SignUpProps`](#sign-up-props)                                                     | The properties to pass to the `<SignUp />` component.            |
 
 #### `mountSignUp()` usage
 
 <InjectKeys>
 
 <CodeBlockTabs type="npm-script" options={['NPM module', '<script>']}>
-  ```typescript filename="index.ts" {14}
-  import Clerk from '@clerk/clerk-js';
 
-  // Initialize Clerk with your Clerk publishable key
-  const clerk = new Clerk('{{pub_key}}');
-  await clerk.load();
+```typescript filename="index.ts" {14}
+import Clerk from "@clerk/clerk-js";
 
-  document.getElementById("app").innerHTML = `
-    <div id="sign-up"></div>
-  `;
+// Initialize Clerk with your Clerk publishable key
+const clerk = new Clerk("{{pub_key}}");
+await clerk.load();
 
-  const signUpDiv =
-    document.getElementById("sign-up");
-
-  clerk.mountSignUp(signUpDiv);
-  ```
-
-  ```html filename="index.js" {21}
-  <!-- Add a <div id="sign-up"> element to your HTML -->
+document.getElementById("app").innerHTML = `
   <div id="sign-up"></div>
+`;
 
-  <!-- Initialize Clerk with your
-  Clerk Publishable key and Frontend API URL -->
-  <script
-    async
-    crossorigin="anonymous"
-    data-clerk-publishable-key="{{pub_key}}"
-    src="https://{{fapi_url}}/npm/@clerk/clerk-js@latest/dist/clerk.browser.js"
-    type="text/javascript"
-  ></script>
+const signUpDiv = document.getElementById("sign-up");
 
-  <script>
-    window.addEventListener("load", async function () {
-      await Clerk.load();
+clerk.mountSignUp(signUpDiv);
+```
 
-      const signUpDiv =
-        document.getElementById('sign-up');
+```html filename="index.js" {21}
+<!-- Add a <div id="sign-up"> element to your HTML -->
+<div id="sign-up"></div>
 
-      Clerk.mountSignUp(signUpDiv);
-    });
-  </script>
-  ```
+<!-- Initialize Clerk with your
+Clerk Publishable key and Frontend API URL -->
+<script
+  async
+  crossorigin="anonymous"
+  data-clerk-publishable-key="{{pub_key}}"
+  src="https://{{fapi_url}}/npm/@clerk/clerk-js@latest/dist/clerk.browser.js"
+  type="text/javascript"
+></script>
+
+<script>
+  window.addEventListener("load", async function () {
+    await Clerk.load();
+
+    const signUpDiv = document.getElementById("sign-up");
+
+    Clerk.mountSignUp(signUpDiv);
+  });
+</script>
+```
+
 </CodeBlockTabs>
 
 </InjectKeys>
@@ -183,8 +190,8 @@ function unmountSignUp(node: HTMLDivElement): void;
 
 #### `unmountSignUp()` params
 
-| Name | Type | Description |
-| --- | --- | --- |
+| Name    | Type                                                                                | Description                                                                   |
+| ------- | ----------------------------------------------------------------------------------- | ----------------------------------------------------------------------------- |
 | `node ` | [`HTMLDivElement`](https://developer.mozilla.org/en-US/docs/Web/API/HTMLDivElement) | The container `<div>` element with a rendered `<SignUp />` component instance |
 
 #### `unmountSignUp()` usage
@@ -192,56 +199,56 @@ function unmountSignUp(node: HTMLDivElement): void;
 <InjectKeys>
 
 <CodeBlockTabs type="npm-script" options={['NPM module', '<script>']}>
-  ```typescript filename="index.ts" {18}
-  import Clerk from '@clerk/clerk-js';
 
-  // Initialize Clerk with your Clerk publishable key
-  const clerk = new Clerk('{{pub_key}}');
-  await clerk.load();
+```typescript filename="index.ts" {18}
+import Clerk from "@clerk/clerk-js";
 
-  document.getElementById("app").innerHTML = `
-    <div id="sign-up"></div>
-  `;
+// Initialize Clerk with your Clerk publishable key
+const clerk = new Clerk("{{pub_key}}");
+await clerk.load();
 
-  const signUpDiv =
-    document.getElementById("sign-up");
-
-  clerk.mountSignUp(signUpDiv);
-
-  // ...
-
-  clerk.unmountSignUp(signUpDiv);
-  ```
-
-  ```html filename="index.js" {25}
-  <!-- Add a <div id="sign-up"> element to your HTML -->
+document.getElementById("app").innerHTML = `
   <div id="sign-up"></div>
+`;
 
-  <!-- Initialize Clerk with your
-  Clerk Publishable key and Frontend API URL -->
-  <script
-    async
-    crossorigin="anonymous"
-    data-clerk-publishable-key="{{pub_key}}"
-    src="https://{{fapi_url}}/npm/@clerk/clerk-js@latest/dist/clerk.browser.js"
-    type="text/javascript"
-  ></script>
+const signUpDiv = document.getElementById("sign-up");
 
-  <script>
-    window.addEventListener("load", async function () {
-      await Clerk.load();
+clerk.mountSignUp(signUpDiv);
 
-      const signUpDiv =
-        document.getElementById('sign-up');
+// ...
 
-      Clerk.mountSignUp(signUpDiv);
+clerk.unmountSignUp(signUpDiv);
+```
 
-      // ...
+```html filename="index.js" {25}
+<!-- Add a <div id="sign-up"> element to your HTML -->
+<div id="sign-up"></div>
 
-      Clerk.unmountSignUp(signUpDiv);
-    });
-  </script>
-  ```
+<!-- Initialize Clerk with your
+Clerk Publishable key and Frontend API URL -->
+<script
+  async
+  crossorigin="anonymous"
+  data-clerk-publishable-key="{{pub_key}}"
+  src="https://{{fapi_url}}/npm/@clerk/clerk-js@latest/dist/clerk.browser.js"
+  type="text/javascript"
+></script>
+
+<script>
+  window.addEventListener("load", async function () {
+    await Clerk.load();
+
+    const signUpDiv = document.getElementById("sign-up");
+
+    Clerk.mountSignUp(signUpDiv);
+
+    // ...
+
+    Clerk.unmountSignUp(signUpDiv);
+  });
+</script>
+```
+
 </CodeBlockTabs>
 
 </InjectKeys>
@@ -256,8 +263,8 @@ function openSignUp(props?: SignUpProps): void;
 
 #### `openSignUp()` params
 
-| Name | Type | Description |
-| --- | --- | --- |
+| Name     | Type                            | Description                                          |
+| -------- | ------------------------------- | ---------------------------------------------------- |
 | `props?` | [`SignUpProps`](#sign-up-props) | The properties to pass to the `<SignUp />` component |
 
 #### `openSignUp()` usage
@@ -265,35 +272,37 @@ function openSignUp(props?: SignUpProps): void;
 <InjectKeys>
 
 <CodeBlockTabs type="npm-script" options={['NPM module', '<script>']}>
-  ```js filename="index.ts" {7}
-  import Clerk from '@clerk/clerk-js';
 
-  // Initialize Clerk with your Clerk publishable key
-  const clerk = new Clerk('{{pub_key}}');
-  await clerk.load();
+```js filename="index.ts" {7}
+import Clerk from "@clerk/clerk-js";
 
-  clerk.openSignUp();
-  ```
+// Initialize Clerk with your Clerk publishable key
+const clerk = new Clerk("{{pub_key}}");
+await clerk.load();
 
-  ```html filename="index.html" {15}
-  <!-- Initialize Clerk with your
-  Clerk Publishable key and Frontend API URL -->
-  <script
-    async
-    crossorigin="anonymous"
-    data-clerk-publishable-key="{{pub_key}}"
-    src="https://{{fapi_url}}/npm/@clerk/clerk-js@latest/dist/clerk.browser.js"
-    type="text/javascript"
-  ></script>
+clerk.openSignUp();
+```
 
-  <script>
-    window.addEventListener("load", async function () {
-      await Clerk.load();
+```html filename="index.html" {15}
+<!-- Initialize Clerk with your
+Clerk Publishable key and Frontend API URL -->
+<script
+  async
+  crossorigin="anonymous"
+  data-clerk-publishable-key="{{pub_key}}"
+  src="https://{{fapi_url}}/npm/@clerk/clerk-js@latest/dist/clerk.browser.js"
+  type="text/javascript"
+></script>
 
-      Clerk.openSignUp();
-    });
-  </script>
-  ```
+<script>
+  window.addEventListener("load", async function () {
+    await Clerk.load();
+
+    Clerk.openSignUp();
+  });
+</script>
+```
+
 </CodeBlockTabs>
 
 </InjectKeys>
@@ -311,43 +320,45 @@ function closeSignUp(): void;
 <InjectKeys>
 
 <CodeBlockTabs type="npm-script" options={['NPM module', '<script>']}>
-  ```js filename="index.ts" {11}
-  import Clerk from '@clerk/clerk-js';
 
-  // Initialize Clerk with your Clerk publishable key
-  const clerk = new Clerk('{{pub_key}}');
-  await clerk.load();
+```js filename="index.ts" {11}
+import Clerk from "@clerk/clerk-js";
 
-  clerk.openSignUp();
+// Initialize Clerk with your Clerk publishable key
+const clerk = new Clerk("{{pub_key}}");
+await clerk.load();
 
-  // ...
+clerk.openSignUp();
 
-  clerk.closeSignUp();
-  ```
+// ...
 
-  ```html filename="index.html" {19}
-  <!-- Initialize Clerk with your
-  Clerk Publishable key and Frontend API URL -->
-  <script
-    async
-    crossorigin="anonymous"
-    data-clerk-publishable-key="{{pub_key}}"
-    src="https://{{fapi_url}}/npm/@clerk/clerk-js@latest/dist/clerk.browser.js"
-    type="text/javascript"
-  ></script>
+clerk.closeSignUp();
+```
 
-  <script>
-    window.addEventListener("load", async function () {
-      await Clerk.load();
+```html filename="index.html" {19}
+<!-- Initialize Clerk with your
+Clerk Publishable key and Frontend API URL -->
+<script
+  async
+  crossorigin="anonymous"
+  data-clerk-publishable-key="{{pub_key}}"
+  src="https://{{fapi_url}}/npm/@clerk/clerk-js@latest/dist/clerk.browser.js"
+  type="text/javascript"
+></script>
 
-      Clerk.openSignUp();
+<script>
+  window.addEventListener("load", async function () {
+    await Clerk.load();
 
-      // ...
+    Clerk.openSignUp();
 
-      Clerk.closeSignUp();
-    });
-  </script>
-  ```
+    // ...
+
+    Clerk.closeSignUp();
+  });
+</script>
+```
+
 </CodeBlockTabs>
 
 </InjectKeys>


### PR DESCRIPTION
Adds a callout for the redirect behaviour when using `<SignIn />` or `<SignUp />` components when a user already has an active session.

This is similar to the message we log in development. However, it's easy to miss at times and results in recurring support tickets:

<img width="658" alt="Screenshot 2024-04-15 at 11 14 46" src="https://github.com/clerk/clerk-docs/assets/165281975/b0776ceb-5ba9-410e-b08e-b50071b57d6c">
