### PR TITLE
(eslint) turn off jsx-no-undef rule

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -28,5 +28,6 @@ module.exports = {
   },
   rules: {
     indent: ["off", "tab"],
+    "react/jsx-no-undef": "off"
   },
 };


### PR DESCRIPTION
The eslint rule is warning against our custom components because they are "undefined". But we don't import our components - they are rendered from `clerk-marketing` so they aren't going to be "defined" in `clerk-docs`

<img width="1114" alt="Screenshot 2024-04-15 at 15 57 02" src="https://github.com/clerk/clerk-docs/assets/98043211/1b7ca634-96de-4b59-bf81-155198456ef8">
