### PR TITLE
fix: Auto infer AuthObject type in trpc setup

### DIFF
--- a/docs/references/nextjs/trpc.mdx
+++ b/docs/references/nextjs/trpc.mdx
@@ -38,22 +38,12 @@ To add Clerk's authentication context (`Auth` object) to your tRPC server, creat
 ```ts filename="src/server/context.ts"
 import * as trpc from '@trpc/server';
 import * as trpcNext from '@trpc/server/adapters/next';
-import { getAuth, SignedInAuthObject, SignedOutAuthObject } from '@clerk/nextjs/server';
-
-interface AuthContext {
-  auth: SignedInAuthObject | SignedOutAuthObject;
-}
-
-export const createContextInner = async ({ auth }: AuthContext  ) => {
-  return {
-    auth,
-  }
-}
-
+import { getAuth } from '@clerk/nextjs/server';
+ 
 export const createContext = async (
   opts: trpcNext.CreateNextContextOptions
 ) => {
-  return await createContextInner({ auth: getAuth(opts.req) })
+  return { auth: getAuth(opts.req) }
 }
 
 export type Context = trpc.inferAsyncReturnType<typeof createContext>;


### PR DESCRIPTION
`AuthObject`, `SignedInAuthObject` and `SignedOutAuthObject` types were removed so the existing example is wrong.
We can infer the type returned.