### PR TITLE
Remove screenshots from deployments docs

### DIFF
--- a/docs/deployments/changing-domains.mdx
+++ b/docs/deployments/changing-domains.mdx
@@ -1,11 +1,11 @@
 ---
 title: Change domain or subdomain
-description: Learn how to change your production instance's domain or subdomain on Clerk.
+description: Learn how to change your Clerk production instance's domain or subdomain.
 ---
 
 # Change domain or subdomain
 
-Learn how to change your production instance's domain or subdomain on Clerk.
+Learn how to change your Clerk production instance's domain or subdomain.
 
 <Callout type="Info">
   You cannot change the domain of the [development instance](/docs/deployments/environments#development-instance) of your Clerk application.
@@ -13,43 +13,49 @@ Learn how to change your production instance's domain or subdomain on Clerk.
 
 ## Change domain
 
-Production domains can be changed in the [Clerk Dashboard](https://dashboard.clerk.com/) or via our [backend API](https://clerk.com/docs/reference/backend-api). Once you make the change to your domain, you will need to update the following:
-
-- Update DNS records
-- Generate new SSL certificates
-- [Update your publishable key](#update-your-publishable-key)
-- If using social connections, update the settings with your social connections so that the redirect URL they are using is correct.
-- If using JWT templates, update JWT issuer and JWKS endpoint in external JWT SSO services.
+1. Update your production domain in two ways:
+    - [the Clerk Dashboard](#update-your-domain-via-clerk-dashboard)
+    - [Clerk's backend API](#update-your-domain-via-backend-api)
+2. Once you make the change to your domain, you will need to update the following:
+    - Update DNS records
+    - Generate new SSL certificates
+    - [Update your publishable key](#updating-your-publishable-key)
+    - If using social connections, update the settings with your social connections so that the redirect URL they are using is correct.
+    - If using JWT templates, update JWT issuer and JWKS endpoint in external JWT SSO services.
 
 ### Update your domain via Clerk Dashboard
 
-To update the production URL from the Clerk Dashboard, navigate to the **[Domains](https://dashboard.clerk.com/last-active?path=domains)** page and select the **Danger** tab. Select **Change domain**. 
+To update your production domain in the Clerk Dashboard:
 
-<Images
-  width={3024}
-  height={1650}
-  src="/docs/images/deployment-guides/change-domain.webp"
-  alt="The 'Danger' tab of the Domains page in the Clerk Dashboard.There is a red arrow pointing to the 'Change domain' button."
-/>
-
-You will receive a prompt to enter your new production domain.
-
-<Images
-  width={3024}
-  height={1650}
-  src="/docs/images/deployment-guides/change-domain-settings.webp"
-  alt="The 'Change domain' modal in the Clerk Dashboard."
-/>
+1. In the navigation sidebar, select **[Domains](https://dashboard.clerk.com/last-active?path=domains)**.
+2. Select the **Danger** tab.
+3. Select **Change domain**.
 
 ### Update your domain via backend API
 
-To update the production URL using the backend API, you can copy the following cURL code. You will want to replace `YOUR_SECRET_KEY` with your Clerk secret key, which can be found on the **[API Keys](https://dashboard.clerk.com/last-active?path=api-keys)** page of the Clerk Dashboard. Then, make sure to update the `home_url` field with your new production URL.
+To update your production domain using Clerk's backend API, you will need to make a POST request to the `change_domain` endpoint. You will need to provide your new domain in the request body.
+
+  1. Copy the following cURL command.
+<SignedIn>
+  2. Your secret key is required to authenticate the request. It is injected into the cURL command after `Authorization`. However, you can also find it on the [API Keys](https://dashboard.clerk.com/last-active?path=api-keys) page of the Clerk Dashboard.
+</SignedIn>
+<SignedOut>
+  2. Your secret key is required to authenticate the request.
+      - Navigate to the [Clerk Dashboard](https://dashboard.clerk.com/last-active?path=api-keys) and sign in.
+      - In the navigation sidebar, select **API Keys** to copy your secret key.
+      - Paste your secret key into the cURL command after `Authorization`, replacing `sk_...`.
+</SignedOut>
+  3. Replace `YOUR_PROD_URL` with your new production domain.
+
+<InjectKeys>
 
 ```bash
-curl -XPOST -H 'Authorization: <YOUR_SECRET_KEY>' -H "Content-type: application/json" -d '{
+curl -XPOST -H 'Authorization: {{secret}}' -H "Content-type: application/json" -d '{
 "home_url": "YOUR_PROD_URL"
 }' 'https://api.clerk.com/v1/instance/change_domain'
 ```
+
+</InjectKeys>
 
 For more information on how to update your instance settings using the backend API, see our [backend API reference](https://clerk.com/docs/reference/backend-api/tag/Beta-Features#operation/UpdateInstanceAuthConfig).
 
@@ -58,36 +64,14 @@ For more information on how to update your instance settings using the backend A
 After changing your domain, a new **Publishable key** will be automatically generated for your application. You will need to update your environment variables with this new key and redeploy your application. You can find your **Publishable key** on the **[API Keys](https://dashboard.clerk.com/last-active?path=api-keys)** page of the Clerk Dashboard.
 
 <Callout>
-  Failing to update your **Publishable key** will result in Clerk failing to load. 
+  Failing to update your **Publishable key** will result in Clerk failing to load.
 </Callout>
 
-## Specify subdomain
+## Set, change, or remove subdomain
 
-If you would like to specify your subdomain of your application, go to the Clerk Dashboard and navigate to the **[Domains](https://dashboard.clerk.com/last-active?path=paths)** page. Select the **Danger** tab.
+To set, change, or remove a subdomain for your production instance:
 
-<Images
-  width={3024}
-  height={1650}
-  src="/docs/images/deployment-guides/set-subdomain.webp"
-  alt="The 'Danger' tab of the Domains page in the Clerk Dashboard.There is a red arrow pointing to the 'Set subdomain' button."
-/>
-
-## Change subdomain
-
-You can update your subdomain via the Clerk Dashboard. Navigate to the **[Domains](https://dashboard.clerk.com/last-active?path=domains)** page and select the **Danger** tab. Select **Change subdomain**. 
-
-<Images
-  width={3024}
-  height={1650}
-  src="/docs/images/deployment-guides/change-subdomain.webp"
-  alt="The 'Danger' tab of the Domains page in the Clerk Dashboard.There is a red arrow pointing to the 'Change subdomain' button."
-/>
-
-You will receive a prompt to enter your new subdomain.
-
-<Images
-  width={3024}
-  height={1650}
-  src="/docs/images/deployment-guides/change-subdomain-settings.webp"
-  alt="The 'Change subdomain' modal in the Clerk Dashboard."
-/>
+1. Navigate to the [Clerk Dashboard](https://dashboard.clerk.com/last-active?path=domains).
+2. In the navigation sidebar, select **Domains**.
+3. Select the **Danger** tab.
+4. You will see the **Change subdomain** section where you can set, change, or remove your subdomain.

--- a/docs/deployments/overview.mdx
+++ b/docs/deployments/overview.mdx
@@ -1,31 +1,26 @@
 ---
-title: Deploying to Production
+title: Deploy your Clerk app to production
 description: Learn how to deploy your Clerk app to production.
 ---
 
-# Deploying to production
+# Deploy your Clerk app to production
 
-Learn how to deploy your Clerk app to production.
+Before you begin:
 
-## Before you begin
 1. You will need to have a domain you own.
 2. You will need to be able to add DNS records on your domain.
-3. You will need social sign-in (OAuth) credentials for any providers that you would like to use in production.
+3. You will need social sign-in (OAuth) credentials for any providers that you would like to use in production. Each [OAuth provider](/docs/authentication/social-connections/overview) has a dedicated guide on how to set up OAuth credentials for Clerk production apps.
 
 ## Create your production instance
 
-From your application dashboard, select the instance dropdown and click **Production**. Once you select **Production**, you will be prompted with a modal to either clone your development instance or create a new production instance.
+1. Navigate to the [Clerk Dashboard](https://dashboard.clerk.com).
+2. At the top of the Dashboard, select the **Development** button to reveal the instance selection dropdown. Select **Create production instance**.
+3. You will be prompted with a modal to either clone your development instance settings to your production instance or create your production instance with Clerk's default settings.
+4. The homepage of the dashboard will show you what is still required to deploy your production instance.
 
-<Images
-width={1200}
-height={675}
-  src="/docs/images/production/production-modal.png"
-  alt="Production Modal"
-/>
-
-In most cases, you will want to clone your development instance. This will copy most of your settings from your development instance to your production instance.
-
-<Callout type="warning">For security reasons, **Social Login, Integrations and Paths** settings do not copy over, you will need to set these values again.</Callout>
+<Callout type="warning">
+  For security reasons, **[Social Connections](https://dashboard.clerk.dev/last-active?path=user-authentication/social-connections)**, **[Integrations](https://dashboard.clerk.dev/last-active?path=integrations)**, and **[Paths](https://dashboard.clerk.dev/last-active?path=paths)** settings do not copy over. You will need to set these values again.
+</Callout>
 
 ## API keys and environment variables
 
@@ -35,32 +30,24 @@ A common mistake when deploying to production is forgetting to change your API k
 
 2. **Secret Key:** Formatted as `sk_test_` in development and `sk_live_` in production. These values are used to access Clerk's Backend API.
 
-3. **OAuth credentials:** In development, Clerk provides you with a set of shared OAuth credentials. These are not secure in production and you will need to provide your own.
+3. **OAuth credentials:** In development, for most OAuth providers, Clerk provides you with a set of shared OAuth credentials. These are not secure in production and you will need to provide your own. Each [OAuth provider](/docs/authentication/social-connections/overview) has a dedicated guide on how to set up OAuth credentials for Clerk production apps.
 
 ## DNS records
 
-Clerk uses DNS records to provide session management, and emails verified from your domain. You will need to go to DNS section to see the records that you need to set.
+Clerk uses DNS records to provide session management and emails verified from your domain.
 
-<Callout type="info">It can take up to 24hrs for DNS Records to fully propagate, so be patient.</Callout>
+To see what DNS records you need to add:
 
-<Images
-  width={1200}
-  height={675}
-  src="/docs/images/production/production-dns.png"
-  alt="Production DNS Records"
-/>
+1. Navigate to the [Clerk Dashboard](https://dashboard.clerk.com/last-active?path=domains).
+2. In the navigation sidebar, select **Domains**.
+
+<Callout type="info">
+  It can take up to 24hrs for DNS Records to fully propagate, so be patient.
+</Callout>
 
 ## Deploy certificates
 
-Once you've completed all the above steps, you're ready to go to the home page, and press Deploy to set SSL certificates and finalize the instance deployment.
-
-<Images
-  width={1200}
-  height={675}
-  src="/docs/images/production/production-certificate.png"
-  alt="Production Certificate Records"
-/>
-
+The Clerk Dashboard home page will tell you what steps are still required to deploy your production instance. Once you have completed all of the necessary steps, a **Deploy certificates** button will appear. Selecting this button will deploy your production instance.
 
 ## Troubleshooting
 
@@ -78,10 +65,4 @@ Therefore, ensure that you don't have any CAA records on your primary domain (e.
 
 ### Incorrect domain
 
-If you accidently set the wrong domain, you can change it by using our backend API. You can find the Secret key in the settings page of your production instance. You can then use the following curl command to change the domain:
-
-```bash
-curl -XPOST -H 'Authorization: CLERK-SECRET-KEY' -H "Content-type: application/json" -d '{
-"home_url": "https://www.example.com"
-}' 'https://api.clerk.com/v1/instance/change_domain'
-```
+If you accidently set the wrong domain, you can change it through the Clerk Dashboard or Clerk's backend API. For more information, see the [dedicated guide.](/docs/deployments/changing-domains)


### PR DESCRIPTION
While adding guides for "Staging environments with Clerk" and "Preview deployments", I noticed the /deployments guides need some love.

🔎 [Deploy your Clerk app to production](https://docs-preview-913.clerkpreview.com/docs/deployments/overview)
🔎 [Change domain or subdomain](https://docs-preview-913.clerkpreview.com/docs/deployments/changing-domains)