### PR TITLE
Added isLoading to useEffect deps.

### DIFF
--- a/docs/references/react/add-react-router.mdx
+++ b/docs/references/react/add-react-router.mdx
@@ -207,7 +207,7 @@ export default function DashboardLayout() {
 
     console.log('test', userId)
 
-    useEffect(() => {
+    React.useEffect(() => {
         if (isLoaded && !userId) {
             navigate("/sign-in")
         }

--- a/docs/references/react/add-react-router.mdx
+++ b/docs/references/react/add-react-router.mdx
@@ -202,22 +202,22 @@ import { useAuth } from "@clerk/clerk-react"
 import { Outlet, useNavigate } from "react-router-dom"
 
 export default function DashboardLayout() {
-  const { userId, isLoaded } = useAuth()
-  const navigate = useNavigate()
+    const { userId, isLoaded } = useAuth()
+    const navigate = useNavigate()
 
-  console.log('test', userId)
+    console.log('test', userId)
 
     useEffect(() => {
         if (isLoaded && !userId) {
-            navigate("/login")
+            navigate("/sign-in")
         }
     }, [isLoaded])
 
-  if (!isLoaded) return "Loading..."
+    if (!isLoaded) return "Loading..."
 
-  return (
-    <Outlet />
-  )
+    return (
+        <Outlet />
+    )
 }
 ```
 </CodeBlockTabs>

--- a/docs/references/react/add-react-router.mdx
+++ b/docs/references/react/add-react-router.mdx
@@ -207,11 +207,11 @@ export default function DashboardLayout() {
 
   console.log('test', userId)
 
-  React.useEffect(() => {
-    if (!userId) {
-      navigate("/sign-in")
-    }
-  }, [])
+    useEffect(() => {
+        if (isLoaded && !userId) {
+            navigate("/login")
+        }
+    }, [isLoaded])
 
   if (!isLoaded) return "Loading..."
 


### PR DESCRIPTION
Without waiting for loading to complete, the useEffect was always forwarding to `/sign-in` , added isLoading to dependency and forward only when loading is complete and userId doesn't exist. 