### PR TITLE
Update GitHub workflows for docs redesign

### DIFF
--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -13,7 +13,6 @@ jobs:
     if: ${{ github.event.label.name == 'deploy-preview' }}
     runs-on: ubuntu-latest
     permissions:
-      contents: write
       pull-requests: write
     steps:
       - name: Revalidate PR preview

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -1,160 +1,36 @@
-name: Deploy Preview
+name: Pull Request Preview
 
 env:
-  COMMENT_HEADER: clerk-docs-preview
+  API_BASE_URL: https://clerk.com
+  PREVIEW_BASE_URL: https://clerk.com
 
 on:
-  pull_request_target:
-    types: [labeled, synchronize]
+  pull_request:
+    types: [labeled, unlabeled]
 
 jobs:
-  # When a PR is labeled with the `deploy-preview` label, we manually trigger a preview deployment of the site and assign it a stable URL.
-  # A comment is kept up-to-date on the PR as the deployment progresses.
-  #
-  # Forks are handled by using the gh CLI to checkout the forked branch, and then we push up a branch to the origin.
-  # This should be safe as it requires someone with triage permissions on the repository to apply the label.
-  deploy:
-    env:
-      VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
-      VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
+  pr_preview:
+    if: ${{ github.event.label.name == 'deploy-preview' }}
+    runs-on: ubuntu-latest
     permissions:
       contents: write
       pull-requests: write
-    if: ${{ github.event.action == 'labeled' && github.event.label.name == 'deploy-preview' }}
-    runs-on: ubuntu-latest
-
     steps:
-      - name: Get date
+      - name: Revalidate PR preview
         run: |
-          echo "DATE=$(date -u +"%b %d, %Y %I:%M %p")" >> $GITHUB_ENV
-
-      - uses: actions/checkout@v3.5.3
-
-      - name: Checkout fork
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        id: checkout-fork
-        if: ${{ github.event.pull_request.head.repo.fork == true }}
-        run: |
-          gh pr checkout ${{ github.event.pull_request.number }}
-          git_branch=$(git rev-parse --abbrev-ref HEAD)
-          git push origin $git_branch
-          echo "branch=$git_branch" >> $GITHUB_OUTPUT
-
-      - name: Checkout application
-        uses: actions/checkout@v3.5.3
-        with:
-          repository: clerk/clerk-marketing
-          token: ${{ secrets.CLERK_GH_TOKEN }}
-          path: app
-          ref: production
-
-      - run: npm install --global vercel@latest
-
-      - name: Pull Vercel environment information
-        run: |
-          vercel pull --yes --environment=preview --token=${{ secrets.VERCEL_TOKEN }}
-
-      - name: Deploy to Vercel
-        id: vercel-deploy
-        env:
-          DOCS_BRANCH: ${{ steps.checkout-fork.outputs.branch || github.event.pull_request.head.ref }}
-        run: |
-          cd app
-          git checkout -b preview/$DOCS_BRANCH
-          vercel deploy --token=${{ secrets.VERCEL_TOKEN }} --build-env DOCS_BRANCH=$DOCS_BRANCH --env DOCS_BRANCH=$DOCS_BRANCH --no-wait > deployment_url.txt
-          echo "url=$(cat deployment_url.txt)" >> $GITHUB_OUTPUT
-
-      - name: Create preview comment - baking
-        uses: marocchino/sticky-pull-request-comment@v2.8.0
-        with:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          number: ${{ github.event.pull_request.number }}
-          header: ${{ env.COMMENT_HEADER}}
-          message: |
-            Hey @${{ github.event.sender.login }}, your docs preview is currently baking and should be available shortly.
-
-            | Status | Preview | Updated (UTC) |
-            | :-- | :-- | :-- |
-            | :cook: _Baking..._ | [Inspect](${{ steps.vercel-deploy.outputs.url }}) | ${{ env.DATE }} |
-
-      - name: Get date
-        run: |
-          echo "DATE=$(date -u +"%b %d, %Y %I:%M %p")" >> $GITHUB_ENV
-
-      - name: Wait for deployment
-        id: vercel-wait-for-deploy
-        run: |
-          vercel inspect --token=${{ secrets.VERCEL_TOKEN }} --wait ${{ steps.vercel-deploy.outputs.url }} --timeout 10m --scope clerk-production
-          vercel alias set ${{ steps.vercel-deploy.outputs.url }} docs-preview-${{ github.event.pull_request.number }}.clerkpreview.com --token=${{ secrets.VERCEL_TOKEN }} --scope clerk-production
-          echo "stable_url=https://docs-preview-${{ github.event.pull_request.number }}.clerkpreview.com" >> $GITHUB_OUTPUT
-
-      - name: Create preview comment - deployed
-        uses: marocchino/sticky-pull-request-comment@v2.8.0
-        with:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          number: ${{ github.event.pull_request.number }}
-          header: ${{ env.COMMENT_HEADER }}
-          message: |
-            Hey @${{ github.event.sender.login }}, your docs preview is available.
-
-            | Status | Preview | Updated (UTC) |
-            | :-- | :-- | :-- |
-            | :cookie: Deployed | [Visit preview](${{ steps.vercel-wait-for-deploy.outputs.stable_url }}/docs) | ${{ env.DATE }} |
-
-            <!-- deployed:true -->
-
-  # On PR sync, trigger a revalidate of the existing deploy preview. This is much faster than a full re-deploy.
-  revalidate:
-    if: ${{ github.event.action == 'synchronize' }}
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      pull-requests: write
-    env:
-      CLERK_COM_BASE_URL: https://docs-preview-${{ github.event.pull_request.number }}.clerkpreview.com
-    steps:
-      - name: Find comment
-        uses: peter-evans/find-comment@v2.4.0
-        id: find-comment
-        with:
-          issue-number: ${{ github.event.pull_request.number }}
-          body-includes: deployed:true
-
-      - name: Update fork
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        id: checkout-fork
-        if: ${{ github.event.pull_request.head.repo.fork == true && steps.find-comment.outputs.comment-id != 0}}
-        run: |
-          gh pr checkout ${{ github.event.pull_request.number }}
-          git_branch=$(git rev-parse --abbrev-ref HEAD)
-          git push origin $git_branch
-
-      - name: Get date
-        run: |
-          echo "DATE=$(date -u +"%b %d, %Y %I:%M %p")" >> $GITHUB_ENV
-
-      - name: Trigger revalidate
-        if: ${{ steps.find-comment.outputs.comment-id != 0 }}
-        run: |
-          curl -X POST ${{ env.CLERK_COM_BASE_URL }}/api/revalidate-docs \
+          curl -X POST ${{ env.API_BASE_URL }}/docs/revalidate \
             -H "Content-Type: application/json" \
             -H "Authorization: Bearer ${{ secrets.REVALIDATE_DOCS_SECRET }}" \
-            -d "{\"paths\": \"*\"}"
+            -d "{\"tags\": [\"docs:pr:${{ github.event.pull_request.number }}\"]}"
 
-      - name: Create preview comment - updated
-        if: ${{ steps.find-comment.outputs.comment-id != 0 }}
-        uses: marocchino/sticky-pull-request-comment@v2.8.0
+      - name: Share PR preview URL
+        if: ${{ github.event.action == 'labeled' }}
+        uses: actions/github-script@v7
         with:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          number: ${{ github.event.pull_request.number }}
-          header: ${{ env.COMMENT_HEADER }}
-          message: |
-            Hey @${{ github.event.sender.login }}, your docs preview is available.
-
-            | Status | Preview | Updated (UTC) |
-            | :-- | :-- | :-- |
-            | :cookie: Updated | [Visit preview](${{ env.CLERK_COM_BASE_URL }}/docs) | ${{ env.DATE }} |
-
-            <!-- deployed:true -->
+          script: |
+            github.rest.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: 'Hey, here’s your docs preview: ' + process.env.PREVIEW_BASE_URL + '/docs/pr/' + context.issue.number,
+            })

--- a/.github/workflows/revalidate.yml
+++ b/.github/workflows/revalidate.yml
@@ -1,7 +1,7 @@
-name: Revalidate Production Pages
+name: Revalidate
 
 env:
-  CLERK_COM_BASE_URL: https://clerk.com
+  API_BASE_URL: https://clerk.com
 
 on:
   workflow_dispatch:
@@ -9,37 +9,45 @@ on:
     branches:
       - main
     paths:
-      - "docs/**"
+      - 'docs/**'
+  pull_request:
+    paths:
+      - 'docs/**'
 
 jobs:
-  trigger_revalidate:
+  revalidate:
+    if: ${{ github.event_name != 'pull_request' || (github.event_name == 'pull_request' && github.event.action != 'opened' && contains(github.event.pull_request.labels.*.name, 'deploy-preview')) }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 10 # Fetch more than just the latest commit so we can accurately compare
 
       - name: Get changed files
         id: changed-files
-        uses: tj-actions/changed-files@v37
+        uses: tj-actions/changed-files@v44
         with:
           files: docs/**
           json: true
 
-      - name: Get paths to revalidate
-        id: paths-to-revalidate
+      - name: Get files to revalidate
+        id: files-to-revalidate
         run: |
-          paths_to_revalidate=$(echo ${{ contains(steps.changed-files.outputs.all_changed_files, 'docs/manifest.json') && '\\\"*\\\"' || toJSON(steps.changed-files.outputs.all_changed_files) }} | sed 's/.mdx//g' | sed 's/\/index//g')
-          echo "paths=$paths_to_revalidate" >> "$GITHUB_OUTPUT"
+          files_to_revalidate=$(echo ${{ toJSON(steps.changed-files.outputs.all_changed_files) }})
+          pr_number=$(echo ${{ toJSON(github.event.number) }})
+          echo "paths=$files_to_revalidate" >> "$GITHUB_OUTPUT"
+          echo "pr_number=$pr_number"       >> "$GITHUB_OUTPUT"
+          echo "### PR number"           >> $GITHUB_STEP_SUMMARY
+          echo ""                        >> $GITHUB_STEP_SUMMARY
+          echo "$pr_number"              >> $GITHUB_STEP_SUMMARY
           echo "### Paths to revalidate" >> $GITHUB_STEP_SUMMARY
           echo ""                        >> $GITHUB_STEP_SUMMARY
-          echo "$paths_to_revalidate"    >> $GITHUB_STEP_SUMMARY
+          echo "$files_to_revalidate"    >> $GITHUB_STEP_SUMMARY
 
       - name: Trigger revalidate
-        if: github.ref_name == 'main'
         run: |
-          curl -X POST ${{ env.CLERK_COM_BASE_URL }}/api/revalidate-docs \
+          curl -X POST ${{ env.API_BASE_URL }}/docs/revalidate \
             -H "Content-Type: application/json" \
             -H "Authorization: Bearer ${{ secrets.REVALIDATE_DOCS_SECRET }}" \
-            -d "{\"paths\": ${{ steps.paths-to-revalidate.outputs.paths }}}"
+            -d "{\"files\": ${{ steps.files-to-revalidate.outputs.paths }}, \"pr\": ${{ steps.files-to-revalidate.outputs.pr_number }}}"

--- a/.github/workflows/revalidate.yml
+++ b/.github/workflows/revalidate.yml
@@ -2,6 +2,7 @@ name: Revalidate
 
 env:
   API_BASE_URL: https://clerk.com
+  PR_API_BASE_URL: https://clerk.com
 
 on:
   workflow_dispatch:
@@ -47,7 +48,7 @@ jobs:
 
       - name: Trigger revalidate
         run: |
-          curl -X POST ${{ env.API_BASE_URL }}/docs/revalidate \
+          curl -X POST ${{ github.event_name == 'pull_request' && env.PR_API_BASE_URL || env.API_BASE_URL }}/docs/revalidate \
             -H "Content-Type: application/json" \
             -H "Authorization: Bearer ${{ secrets.REVALIDATE_DOCS_SECRET }}" \
             -d "{\"files\": ${{ steps.files-to-revalidate.outputs.files }}, \"pr\": ${{ steps.files-to-revalidate.outputs.pr_number }}}"

--- a/.github/workflows/revalidate.yml
+++ b/.github/workflows/revalidate.yml
@@ -36,12 +36,12 @@ jobs:
         run: |
           files_to_revalidate=$(echo ${{ toJSON(steps.changed-files.outputs.all_changed_files) }})
           pr_number=$(echo ${{ toJSON(github.event.number) }})
-          echo "paths=$files_to_revalidate" >> "$GITHUB_OUTPUT"
+          echo "files=$files_to_revalidate" >> "$GITHUB_OUTPUT"
           echo "pr_number=$pr_number"       >> "$GITHUB_OUTPUT"
           echo "### PR number"           >> $GITHUB_STEP_SUMMARY
           echo ""                        >> $GITHUB_STEP_SUMMARY
           echo "$pr_number"              >> $GITHUB_STEP_SUMMARY
-          echo "### Paths to revalidate" >> $GITHUB_STEP_SUMMARY
+          echo "### Files to revalidate" >> $GITHUB_STEP_SUMMARY
           echo ""                        >> $GITHUB_STEP_SUMMARY
           echo "$files_to_revalidate"    >> $GITHUB_STEP_SUMMARY
 
@@ -50,4 +50,4 @@ jobs:
           curl -X POST ${{ env.API_BASE_URL }}/docs/revalidate \
             -H "Content-Type: application/json" \
             -H "Authorization: Bearer ${{ secrets.REVALIDATE_DOCS_SECRET }}" \
-            -d "{\"files\": ${{ steps.files-to-revalidate.outputs.paths }}, \"pr\": ${{ steps.files-to-revalidate.outputs.pr_number }}}"
+            -d "{\"files\": ${{ steps.files-to-revalidate.outputs.files }}, \"pr\": ${{ steps.files-to-revalidate.outputs.pr_number }}}"


### PR DESCRIPTION
> [!IMPORTANT]
> Should not be merged until docs redesign is live

This PR updates the GitHub workflows to work with the upcoming docs redesign.

- There's no longer a need to create a new website deployment to preview pull requests, instead these will be immediately available at `{preview_url}/pr/{number}`
- The `deploy-preview` label is still required to activate a pull request preview
- Website revalidation now works based on _files_ rather than _paths_. i.e. we revalidate `docs/quickstarts/nextjs.mdx` instead of `/docs/quickstarts/nextjs` – gives us greater flexibility and accuracy when revalidating
- Changes to images and/or `docs/manifest.json` will not require redeployment