### PR TITLE
Fix email and password example for javascript

### DIFF
--- a/docs/custom-flows/email-password.mdx
+++ b/docs/custom-flows/email-password.mdx
@@ -1177,12 +1177,12 @@ In email/password authentication, the sign-in is a process that requires users t
       </div>
       <script>
           const SignIn = async () => {
-              const emailAddress = document.getElementById('email').value;
+              const identifier = document.getElementById('email').value;
               const password = document.getElementById('password').value;
               const {client} = window.Clerk;
               try {
                 const signInAttempt = await client.signIn.create({
-                      emailAddress,
+                      identifier,
                       password
                   });
                 if (signInAttempt.status === "complete") {

--- a/docs/custom-flows/email-password.mdx
+++ b/docs/custom-flows/email-password.mdx
@@ -1179,7 +1179,7 @@ In email/password authentication, the sign-in is a process that requires users t
           const SignIn = async () => {
               const identifier = document.getElementById('email').value;
               const password = document.getElementById('password').value;
-              const {client} = window.Clerk;
+              const {client, setActive} = window.Clerk;
               try {
                 const signInAttempt = await client.signIn.create({
                       identifier,


### PR DESCRIPTION
Current javascript example for sign in generates 
```
{"errors":[{"message":"is unknown","long_message":"email_address is not a valid parameter for this request.","code":"form_param_unknown","meta":{"param_name":"email_address"}}],"clerk_trace_id":"89afc5e93845ef1e7bedb54ab80e3ef7"}
```
Should be `identifier` instead of `emailAddress`. Also there was no `setActive` function defined.