### PR TITLE
Change env file name for Remix Quickstart

### DIFF
--- a/docs/quickstarts/remix.mdx
+++ b/docs/quickstarts/remix.mdx
@@ -29,13 +29,13 @@ Once you have a Remix application ready, you need to install Clerk's Remix SDK. 
 
 ### Set environment variables
 
-Below is an example of an `.env.local` file.
+Below is an example of an `.env` file.
 
 **Pro tip!** If you are signed into your Clerk Dashboard, your secret key should become visible by clicking on the eye icon. Otherwise, you can find your keys in the Clerk Dashboard on the [API Keys](https://dashboard.clerk.com/last-active?path=api-keys) page.
 
 <InjectKeys>
 
-```sh filename=".env.local"
+```sh filename=".env"
 CLERK_PUBLISHABLE_KEY={{pub_key}}
 CLERK_SECRET_KEY={{secret}}
 ```


### PR DESCRIPTION
This PR changes the `.env.local` file to `.env` for the Remix quick start guide.