### PR TITLE
docs: Minor typo fix

### DIFF
--- a/docs/integrations/webhooks/sync-data.mdx
+++ b/docs/integrations/webhooks/sync-data.mdx
@@ -116,7 +116,7 @@ pnpm add svix
 
       // If there are no headers, error out
       if (!svix_id || !svix_timestamp || !svix_signature) {
-        return new Response('Error occured -- no svix headers', {
+        return new Response('Error occurred -- no svix headers', {
           status: 400
         })
       }


### PR DESCRIPTION
Minor typo in [Webhooks example](https://clerk.com/docs/integrations/webhooks/sync-data#create-the-endpoint-in-your-application) page