### PR TITLE
Fix authMiddleware imports in the docs

### DIFF
--- a/docs/guides/add-onboarding-flow.mdx
+++ b/docs/guides/add-onboarding-flow.mdx
@@ -72,7 +72,7 @@ The following example demonstrates how to use Clerk's `authMiddleware()` to redi
 Note that the following example protects all routes. This is so that any user visiting your application is forced to authenticate, and then forced to onboard. You can customize the `publicRoutes` array to include any routes that should be accessible to all users, even unauthenticated ones.
 
 ```tsx filename="src/middleware.ts"
-import { authMiddleware } from "@clerk/nextjs";
+import { authMiddleware } from "@clerk/nextjs/server";
 import { redirectToSignIn } from "@clerk/nextjs/server";
 import { NextRequest, NextResponse } from "next/server";
 

--- a/docs/references/nextjs/auth-middleware.mdx
+++ b/docs/references/nextjs/auth-middleware.mdx
@@ -21,7 +21,7 @@ Create a `middleware.ts` file. If your application uses the `src/` directory, yo
 </Callout>
 
 ```ts filename="middleware.ts"
-import { authMiddleware } from "@clerk/nextjs";
+import { authMiddleware } from "@clerk/nextjs/server";
 
 export default authMiddleware();
 
@@ -49,7 +49,7 @@ Assuming that the `.env` based settings for sign-in and sign-up are set to `/sig
 <CodeBlockTabs options={["middleware.ts", ".env.local"]}>
 
 ```ts filename="middleware.ts" {3,4,5}
-import { authMiddleware } from "@clerk/nextjs";
+import { authMiddleware } from "@clerk/nextjs/server";
 
 export default authMiddleware({
   publicRoutes: ["/", "/contact"],
@@ -144,7 +144,7 @@ return NextResponse.next();
 If you need additional middleware handlers to execute before Clerk's authentication middleware, use `beforeAuth()`. An example where the middleware handler from `next-intl` is executed can be seen below.
 
 ```ts filename="middleware.ts"
-import { authMiddleware } from "@clerk/nextjs";
+import { authMiddleware } from "@clerk/nextjs/server";
 
 import createMiddleware from "next-intl/middleware";
 
@@ -174,7 +174,7 @@ export const config = {
 By default, Clerk's `authMiddleware()` treats all routes as private if the middleware runs. If you need to make specific routes public, use the `publicRoutes` option.
 
 ```ts filename="middleware.ts" {4}
-import { authMiddleware } from "@clerk/nextjs";
+import { authMiddleware } from "@clerk/nextjs/server";
 export default authMiddleware({
   // "/" will be accessible to all users
   publicRoutes: ["/"],
@@ -188,7 +188,7 @@ export const config = {
 Use the `req` object to match against urls. The following example makes all routes but `/dashboard` public.
 
 ```ts filename="middleware.ts" {4}
-import { authMiddleware } from "@clerk/nextjs";
+import { authMiddleware } from "@clerk/nextjs/server";
 
 export default authMiddleware({
   publicRoutes: (req) => !req.url.includes("/dashboard"),
@@ -202,7 +202,7 @@ export const config = {
 You can also use regex to match routes. The following is an example of a negative assertion that makes _only_ the `/admin` route protected.
 
 ```ts filename="middleware.ts" {4}
-import { authMiddleware } from "@clerk/nextjs";
+import { authMiddleware } from "@clerk/nextjs/server";
 
 export default authMiddleware({
   publicRoutes: ["((?!^/admin).*)"],
@@ -233,7 +233,7 @@ If you define an `afterAuth` function, it will run even if the request correspon
 If you are having issues getting your Middleware dialed in, or are trying to narrow down auth-related issues, you can use the debugging feature in `authMiddlware`. Add `debug: true` to `authMiddlware` and you will get debug logs in your terminal.
 
 ```ts filename="middleware.ts" {4}
-import { authMiddleware } from "@clerk/nextjs";
+import { authMiddleware } from "@clerk/nextjs/server";
 export default authMiddleware({
   publicRoutes: ["/"],
   debug: true

--- a/docs/upgrade-guides/core-2/nextjs.mdx
+++ b/docs/upgrade-guides/core-2/nextjs.mdx
@@ -141,7 +141,7 @@ Clerk strongly recommends migrating to the new `clerkMiddleware()` for an improv
 The most basic migration will be updating the import and changing out the default export, then mirroring the previous behavior of protecting all routes as such:
 
 ```diff
-- import { authMiddleware } from "@clerk/nextjs"
+- import { authMiddleware } from "@clerk/nextjs/server"
 + import { clerkMiddleware } from '@clerk/nextjs/server'
 
 - export default authMiddleware()
@@ -161,7 +161,7 @@ Of course, in most cases you'll have a more complicated setup than this. You can
     Before:
 
     ```ts filename="middleware.ts"
-    import { authMiddleware } from "@clerk/nextjs"
+    import { authMiddleware } from "@clerk/nextjs/server"
 
     export default authMiddleware({
       publicRoutes: ["/", "/contact"],
@@ -199,7 +199,7 @@ Of course, in most cases you'll have a more complicated setup than this. You can
     Before:
 
     ```ts filename="middleware.ts"
-    import { authMiddleware } from "@clerk/nextjs"
+    import { authMiddleware } from "@clerk/nextjs/server"
 
     export default authMiddleware({
       publicRoutes: (req) => !req.url.includes("/dashboard"),
@@ -236,7 +236,7 @@ Of course, in most cases you'll have a more complicated setup than this. You can
     Before:
 
     ```ts filename="middleware.ts"
-    import { authMiddleware } from "@clerk/nextjs"
+    import { authMiddleware } from "@clerk/nextjs/server"
     import createMiddleware from "next-intl/middleware"
 
     const intlMiddleware = createMiddleware({
@@ -290,7 +290,7 @@ Of course, in most cases you'll have a more complicated setup than this. You can
     Before:
 
     ```ts filename="middleware.ts"
-    import { authMiddleware, redirectToSignIn } from "@clerk/nextjs"
+    import { authMiddleware, redirectToSignIn } from "@clerk/nextjs/server"
 
     export default authMiddleware({
       if (someCondition) redirectToSignIn()
@@ -609,7 +609,7 @@ As part of this major version, a number of previously deprecated props, arugment
     The `apiKey` argument passed to `authMiddleware` must be changed to `secretKey`.
     
     ```diff
-    import { authMiddleware } from '@clerk/nextjs';
+    import { authMiddleware } from '@clerk/nextjs/server';
     
     - authMiddleware({ apiKey: '...' });
     + authMiddleware({ secretKey: '...' });
@@ -667,10 +667,10 @@ As part of this major version, a number of previously deprecated props, arugment
     If you are importing from `@clerk/nextjs/ssr`, you can use `@clerk/nextjs` instead. Our top-level import supports SSR functionality by default now, so the subpath on the import is no longer needed. This import can be directly replaced without any other considerations.
   </AccordionPanel>
   <AccordionPanel>    
-    This deprecated import has been replaced by `@clerk/nextjs`. Usage should now look as such: `import { authMiddleware } from @clerk/nextjs`. There may be changes in functionality between the two exports depending on how old the version used is, so upgrade with caution.
+    This deprecated import has been replaced by `@clerk/nextjs/server`. Usage should now look as such: `import { authMiddleware } from @clerk/nextjs/server`. There may be changes in functionality between the two exports depending on how old the version used is, so upgrade with caution.
   </AccordionPanel>
   <AccordionPanel>    
-    This deprecated import has been replaced by `@clerk/nextjs`. Usage should now look as such: `import { authMiddleware } from @clerk/nextjs`. There may be changes in functionality between the two exports depending on how old the version used is, so upgrade with caution.
+    This deprecated import has been replaced by `@clerk/nextjs/server`. Usage should now look as such: `import { authMiddleware } from @clerk/nextjs/server`. There may be changes in functionality between the two exports depending on how old the version used is, so upgrade with caution.
   </AccordionPanel>
   <AccordionPanel>    
     This deprecated constant has been removed as an export from `@clerk/nextjs`. Instead, set and use the `CLERK_API_URL` environment variable.


### PR DESCRIPTION
We list `authMiddleware` as being imported from `@clerk/nextjs`. This is wrong. It's from `@clerk/nextjs/server`.