### PR TITLE
Update url-based-session-syncing guide

### DIFF
--- a/docs/upgrade-guides/url-based-session-syncing.mdx
+++ b/docs/upgrade-guides/url-based-session-syncing.mdx
@@ -1,24 +1,28 @@
 ---
 title: URL-based session syncing
-description: Development instances communicating with the Frontend API without third-party cookies.
+description: Learn how Clerk development instances keep track of session state.
 ---
 
 # URL-based session syncing
 
-Development instances created before December 6, 2022 communicate with [Clerk's Frontend API](https://clerk.com/docs/reference/frontend-api) using third-party cookies. More concretely, the authentication state of the current session is transported via a long-lived third-party cookie, between your frontend (e.g. `localhost:3000`) and the Frontend API (e.g. `clerk.happy.hippo-1.lcl.dev`).
-
-URL-based session syncing (previously known as Cookieless Development mode) is a new, experimental mode of operation for development instances, in which communication with the Clerk Frontend API is done via URL decoration instead.
-
-<Callout type="info">
-  This mode only applies to development instances. Production instances remain unaffected and continue communicating with Frontend API using first-party, HttpOnly cookies.
+<Callout type="warning">
+All development instance Clerk apps created after December 6th, 2022 use URL-based session syncing by default, and cannot opt out.
 </Callout>
 
-## Migrating to URL-based session syncing
+URL-based session syncing (previously known as Cookieless Development mode) forces your frontend and your Clerk Frontend API to communicate information about the current session state via URL decoration.
 
-To opt-in to URL-based session syncing, perform the following steps:
+<Callout type="info">
+  This mode only applies to Development Instances. Production instances remain unaffected and continue communicating with Frontend API using first-party, HttpOnly cookies.
+</Callout>
 
-- In the Clerk Dashboard, navigate to your development instance's [Settings](https://dashboard.clerk.com/last-active?path=settings) page and toggle on **Enable URL-based session syncing**.
-- Upgrade `@clerk/clerk-react` to v4.4.5 or later. If your are importing `@clerk/clerk-js` to your project, use v4.18.0 or later.
+## Migrate to URL-based session syncing
+
+For Development instances of Clerk apps created before December 6th, 2022, by default the authentication state of the current session is passed between your frontend (e.g. `localhost:3000`) and your Frontend API (e.g. `clerk.happy.hippo-1.lcl.dev`) via a long-lived third-party cookie.
+
+To opt-in to URL-based session syncing instead, use the following steps:
+
+1. In the Clerk Dashboard, navigate to your development instance's [Settings](https://dashboard.clerk.com/last-active?path=settings) page and toggle on **Enable URL-based session syncing**.
+1. In your codebase, upgrade `@clerk/clerk-react` to v4.4.5 or later. If your are importing `@clerk/clerk-js` to your project, use v4.18.0 or later.
 
 ## Clerk Account Portal pages and redirects
 

--- a/docs/upgrade-guides/url-based-session-syncing.mdx
+++ b/docs/upgrade-guides/url-based-session-syncing.mdx
@@ -9,7 +9,7 @@ description: Learn how Clerk development instances keep track of session state.
 All development instance Clerk apps created after December 6th, 2022 use URL-based session syncing by default, and cannot opt out.
 </Callout>
 
-URL-based session syncing (previously known as Cookieless Development mode) forces your frontend and your Clerk Frontend API to communicate information about the current session state via URL decoration.
+URL-based session syncing (previously known as Cookieless Development mode) configures your frontend and your Clerk Frontend API to communicate information about the current session state via URL decoration.
 
 <Callout type="info">
   This mode only applies to Development Instances. Production instances remain unaffected and continue communicating with Frontend API using first-party, HttpOnly cookies.

--- a/docs/upgrade-guides/url-based-session-syncing.mdx
+++ b/docs/upgrade-guides/url-based-session-syncing.mdx
@@ -22,6 +22,7 @@ For Development instances of Clerk apps created before December 6th, 2022, by de
 To opt-in to URL-based session syncing instead, use the following steps:
 
 1. In the Clerk Dashboard, navigate to your development instance's [Settings](https://dashboard.clerk.com/last-active?path=settings) page and toggle on **Enable URL-based session syncing**.
+    - This toggle is not available in Clerk apps created after December 6th, 2022.
 1. In your codebase, upgrade `@clerk/clerk-react` to v4.4.5 or later. If your are importing `@clerk/clerk-js` to your project, use v4.18.0 or later.
 
 ## Clerk Account Portal pages and redirects


### PR DESCRIPTION
Cleans up and re-frames our url-based-session-syncing doc to communicate that this feature is on by default and cannot be opted out of, except in apps older than Dec 6 2022