### PR TITLE
Path prop not required for Next.js or Remix

### DIFF
--- a/docs/components/authentication/sign-in.mdx
+++ b/docs/components/authentication/sign-in.mdx
@@ -14,6 +14,10 @@ description: Clerk's <SignIn /> component renders a UI for signing in users.
 
 The `<SignIn />` component renders a UI for signing in users. The functionality of the `<SignIn />` component is controlled by the instance settings you specify in your [Clerk Dashboard](https://dashboard.clerk.com), such as [sign-in and sign-up options](/docs/authentication/configuration/sign-up-sign-in-options) and [social connections](/docs/authentication/social-connections/overview). You can further customize your `<SignIn />` component by passing additional [properties](#properties) at the time of rendering.
 
+<Callout type="info">
+  The `<SignUp/>` and `<SignIn/>` components cannot render when a user is already signed in, unless the application allows multiple sessions. If a user is already signed in and the application only allows a single session, Clerk will redirect the user to the Home URL instead.
+</Callout>
+
 ## Properties
 
 All props are optional.
@@ -23,10 +27,9 @@ All props are optional.
 | `appearance` | <code>[Appearance](/docs/components/customization/overview) \| undefined</code> | Optional object to style your components. Will only affect [Clerk Components](/docs/components/overview) and not [Account Portal](/docs/account-portal/overview) pages. |
 | `routing` | `'hash' \| 'path' \| 'virtual'` | The routing strategy for your pages.<br />Defaults to `'path'` in Next.js and Remix applications. Defaults to `hash` for all other SDK's. |
 | `path` | `string` | The path where the component is mounted on when `routing` is set to `path`. It is ignored in hash- and virtual-based routing.<br />For example: `/sign-in`. |
-| `redirectUrl` | `string` | The full URL or path to navigate to after successful sign in or sign up.<br /> The same as setting `afterSignInUrl` and `afterSignUpUrl` to the same value. |
-| `afterSignInUrl` | `string` | The full URL or path to navigate to after a successful sign in. Defaults to `/`. |
-| `signUpUrl` | `string` | The full URL or path to the sign up page. Use this property to provide the target of the 'Sign Up' link that's rendered. |
-| `afterSignUpUrl` | `string` | The full URL or path to navigate to after a successful sign up. Defaults to `/`. |
+| `signUpUrl` | `string` | Full URL or path to the sign up page. Use this property to provide the target of the 'Sign Up' link that's rendered. It's recommended to use [the environment variable](/docs/deployments/clerk-environment-variables#sign-in-and-sign-up-redirects) instead. |
+| `signInFallbackRedirectUrl?` | `string` | The fallback URL to redirect to after the user signs in, if there's no `redirect_url` in the path already. Defaults to `/`. It's recommended to use [the environment variable](/docs/deployments/clerk-environment-variables#sign-in-and-sign-up-redirects) instead. |
+| `signInForceRedirectUrl?` | `string` | If provided, this URL will always be redirected to after the user signs in. It's recommended to use [the environment variable](/docs/deployments/clerk-environment-variables#sign-in-and-sign-up-redirects) instead. |
 | `initialValues` | [`SignInInitialValues`](/docs/references/javascript/types/sign-in-initial-values) | The values used to prefill the sign-in fields with. |
 
 ## Usage with frameworks

--- a/docs/components/authentication/sign-in.mdx
+++ b/docs/components/authentication/sign-in.mdx
@@ -14,10 +14,6 @@ description: Clerk's <SignIn /> component renders a UI for signing in users.
 
 The `<SignIn />` component renders a UI for signing in users. The functionality of the `<SignIn />` component is controlled by the instance settings you specify in your [Clerk Dashboard](https://dashboard.clerk.com), such as [sign-in and sign-up options](/docs/authentication/configuration/sign-up-sign-in-options) and [social connections](/docs/authentication/social-connections/overview). You can further customize your `<SignIn />` component by passing additional [properties](#properties) at the time of rendering.
 
-<Callout type="info">
-  The `<SignUp/>` and `<SignIn/>` components cannot render when a user is already signed in, unless the application allows multiple sessions. If a user is already signed in and the application only allows a single session, Clerk will redirect the user to the Home URL instead.
-</Callout>
-
 ## Properties
 
 All props are optional.
@@ -25,11 +21,12 @@ All props are optional.
 | Name | Type | Description |
 | --- | --- | --- |
 | `appearance` | <code>[Appearance](/docs/components/customization/overview) \| undefined</code> | Optional object to style your components. Will only affect [Clerk Components](/docs/components/overview) and not [Account Portal](/docs/account-portal/overview) pages. |
-| `routing` | `'hash' \| 'path' \| 'virtual'` | The routing strategy for your pages. Defaults to `'path'`. |
-| `path` | `string` | The path where the component is mounted on when path-based routing is used. This prop will be required for Next.js and Remix applications that do not set the appropriate environment variables, and is required for all other SDK's.<br />This prop is ignored in hash- and virtual-based routing. |
-| `signUpUrl` | `string` | Full URL or path to the sign up page. Use this property to provide the target of the 'Sign Up' link that's rendered. It's recommended to use [the environment variable](/docs/deployments/clerk-environment-variables#sign-in-and-sign-up-redirects) instead. |
-| `signInFallbackRedirectUrl?`         | `string`                                                                              | The fallback URL to redirect to after the user signs in, if there's no `redirect_url` in the path already. Defaults to `/`. It's recommended to use [the environment variable](/docs/deployments/clerk-environment-variables#sign-in-and-sign-up-redirects) instead.                                                                                                                                                                            |
-| `signInForceRedirectUrl?`         | `string`                                                                              | If provided, this URL will always be redirected to after the user signs in. It's recommended to use [the environment variable](/docs/deployments/clerk-environment-variables#sign-in-and-sign-up-redirects) instead.                                                                                                                                                                            |
+| `routing` | `'hash' \| 'path' \| 'virtual'` | The routing strategy for your pages.<br />Defaults to `'path'` in Next.js and Remix applications. Defaults to `hash` for all other SDK's. |
+| `path` | `string` | The path where the component is mounted on when `routing` is set to `path`. It is ignored in hash- and virtual-based routing.<br />For example: `/sign-in`. |
+| `redirectUrl` | `string` | The full URL or path to navigate to after successful sign in or sign up.<br /> The same as setting `afterSignInUrl` and `afterSignUpUrl` to the same value. |
+| `afterSignInUrl` | `string` | The full URL or path to navigate to after a successful sign in. Defaults to `/`. |
+| `signUpUrl` | `string` | The full URL or path to the sign up page. Use this property to provide the target of the 'Sign Up' link that's rendered. |
+| `afterSignUpUrl` | `string` | The full URL or path to navigate to after a successful sign up. Defaults to `/`. |
 | `initialValues` | [`SignInInitialValues`](/docs/references/javascript/types/sign-in-initial-values) | The values used to prefill the sign-in fields with. |
 
 ## Usage with frameworks
@@ -37,24 +34,10 @@ All props are optional.
 The following example includes basic implementation of the `<SignIn />` component. You can use this as a starting point for your own implementation.
 
 <Tabs type="framework" items={["Next.js", "React", "Remix", "Gatsby"]}>
-<Tab>
-The following example demonstrates how you can use the `<SignIn />` component on a public page.
+  <Tab>
+    The following example demonstrates how you can use the `<SignIn />` component on a public page.
 
-    ```jsx filename="/app/sign-in/[[...sign-in]]/page.tsx"
-      import { SignIn } from "@clerk/nextjs";
-
-      export default function Page() {
-        return <SignIn path="/sign-in" signUpUrl="/sign-up" />
-      };
-    ```
-
-    You will notice a `path` prop is being passed to the `SignIn />` component. This is because, by default, the `routing` strategy is set to `path`, requiring the `path` prop to be passed. In Next.js applications, you can either pass the `path` prop to the `<SignIn />` component, or you can define the `NEXT_PUBLIC_CLERK_SIGN_IN_URL` and `NEXT_PUBLIC_CLERK_SIGN_UP_URL` environment variables.
-
-    The example below shows how to mount the `<SignIn />` component on a page without a `path` prop. Select the `.env.local` tab to see an example of how to define the appropriate environment variables.
-
-    <CodeBlockTabs options={["<SignIn /> without path prop", ".env.local"]}>
-      ```jsx filename="/app/sign-in/[[...sign-in]]/page.tsx"
-      import { SignIn } from "@clerk/nextjs";
+    If you would like to create a dedicated `/sign-in` page in your Next.js application, check out the [dedicated guide.](/docs/references/nextjs/custom-signup-signin-pages).
 
     ```tsx filename="app/page.tsx"
     import { SignIn, useUser } from "@clerk/nextjs";
@@ -66,11 +49,9 @@ The following example demonstrates how you can use the `<SignIn />` component on
         return <SignIn />;
       }
 
-      ```env filename=".env.local"
-      NEXT_PUBLIC_CLERK_SIGN_IN_URL=/sign-in
-      NEXT_PUBLIC_CLERK_SIGN_UP_URL=/sign-up
-      ```
-    </CodeBlockTabs>
+      return <div>Welcome!</div>;
+    }
+    ```
   </Tab>
 
   <Tab>
@@ -83,7 +64,6 @@ The following example demonstrates how you can use the `<SignIn />` component on
 
     export default SignInPage;
     ```
-
   </Tab>
 
   <Tab>
@@ -94,12 +74,11 @@ The following example demonstrates how you can use the `<SignIn />` component on
       return (
         <div style={{ border: "2px solid blue", padding: "2rem" }}>
           <h1>Sign In route</h1>
-          <SignIn path="/sign-in" />
+          <SignIn />
         </div>
       );
     }
     ```
-
   </Tab>
 
   <Tab>
@@ -109,13 +88,12 @@ The following example demonstrates how you can use the `<SignIn />` component on
     export default function SignInPage() {
       return (
         <div style={{ border: "2px solid blue", padding: "2rem" }}>
-          <h1>Sign In Up route</h1>
+          <h1>Sign In route</h1>
           <SignIn path="/sign-in" />
         </div>
       );
     }
     ```
-
   </Tab>
 </Tabs>
 
@@ -140,58 +118,58 @@ function mountSignIn(node: HTMLDivElement, props?: SignInProps): void;
 
 #### `mountSignIn()` params
 
-| Name     | Type                                                                                | Description                                                                |
-| -------- | ----------------------------------------------------------------------------------- | -------------------------------------------------------------------------- |
-| `node`   | [`HTMLDivElement`](https://developer.mozilla.org/en-US/docs/Web/API/HTMLDivElement) | The container `<div>` element used to render in the `<SignIn />` component |
-| `props?` | [`SignInProps`](#properties)                                                        | The properties to pass to the `<SignIn />` component                       |
+| Name | Type | Description |
+| --- | --- | --- |
+| `node` | [`HTMLDivElement`](https://developer.mozilla.org/en-US/docs/Web/API/HTMLDivElement) | The container `<div>` element used to render in the `<SignIn />` component |
+| `props?` | [`SignInProps`](#properties) | The properties to pass to the `<SignIn />` component |
 
 #### `mountSignIn()` usage
 
 <InjectKeys>
 
 <CodeBlockTabs type="npm-script" options={['NPM module', '<script>']}>
+  ```js filename="index.js" {14}
+  import Clerk from '@clerk/clerk-js';
 
-```js filename="index.js" {14}
-import Clerk from "@clerk/clerk-js";
+  // Initialize Clerk with your Clerk publishable key
+  const clerk = new Clerk('{{pub_key}}');
+  await clerk.load();
 
-// Initialize Clerk with your Clerk publishable key
-const clerk = new Clerk("{{pub_key}}");
-await clerk.load();
+  document.getElementById("app").innerHTML = `
+    <div id="sign-in"></div>
+  `;
 
-document.getElementById("app").innerHTML = `
+  const signInDiv =
+    document.getElementById("sign-in");
+
+  clerk.mountSignIn(signInDiv);
+  ```
+
+  ```html filename="index.html" {21}
+  <!-- Add a <div id="sign-in"> element to your HTML -->
   <div id="sign-in"></div>
-`;
 
-const signInDiv = document.getElementById("sign-in");
+  <!-- Initialize Clerk with your
+  Clerk Publishable key and Frontend API URL -->
+  <script
+    async
+    crossorigin="anonymous"
+    data-clerk-publishable-key="{{pub_key}}"
+    src="https://{{fapi_url}}/npm/@clerk/clerk-js@latest/dist/clerk.browser.js"
+    type="text/javascript"
+  ></script>
 
-clerk.mountSignIn(signInDiv);
-```
+  <script>
+    window.addEventListener("load", async function () {
+      await Clerk.load();
 
-```html filename="index.html" {21}
-<!-- Add a <div id="sign-in"> element to your HTML -->
-<div id="sign-in"></div>
+      const signInDiv =
+        document.getElementById('sign-in');
 
-<!-- Initialize Clerk with your
-Clerk Publishable key and Frontend API URL -->
-<script
-  async
-  crossorigin="anonymous"
-  data-clerk-publishable-key="{{pub_key}}"
-  src="https://{{fapi_url}}/npm/@clerk/clerk-js@latest/dist/clerk.browser.js"
-  type="text/javascript"
-></script>
-
-<script>
-  window.addEventListener("load", async function () {
-    await Clerk.load();
-
-    const signInDiv = document.getElementById("sign-in");
-
-    Clerk.mountSignIn(signInDiv);
-  });
-</script>
-```
-
+      Clerk.mountSignIn(signInDiv);
+    });
+  </script>
+  ```
 </CodeBlockTabs>
 
 </InjectKeys>
@@ -206,8 +184,8 @@ function unmountSignIn(node: HTMLDivElement): void;
 
 #### `unmountSignIn()` params
 
-| Name   | Type                                                                                | Description                                                                   |
-| ------ | ----------------------------------------------------------------------------------- | ----------------------------------------------------------------------------- |
+| Name | Type | Description |
+| --- | --- | --- |
 | `node` | [`HTMLDivElement`](https://developer.mozilla.org/en-US/docs/Web/API/HTMLDivElement) | The container `<div>` element with a rendered `<SignIn />` component instance |
 
 #### `unmountSignIn()` usage
@@ -215,56 +193,56 @@ function unmountSignIn(node: HTMLDivElement): void;
 <InjectKeys>
 
 <CodeBlockTabs type="npm-script" options={['NPM module', '<script>']}>
+  ```js filename="index.js" {18}
+  import Clerk from '@clerk/clerk-js';
 
-```js filename="index.js" {18}
-import Clerk from "@clerk/clerk-js";
+  // Initialize Clerk with your Clerk publishable key
+  const clerk = new Clerk('{{pub_key}}');
+  await clerk.load();
 
-// Initialize Clerk with your Clerk publishable key
-const clerk = new Clerk("{{pub_key}}");
-await clerk.load();
+  document.getElementById('app').innerHTML = `
+    <div id="sign-in"></div>
+  `
 
-document.getElementById("app").innerHTML = `
+  const signInDiv =
+    document.getElementById('sign-in');
+
+  clerk.mountSignIn(signInDiv);
+
+  // ...
+
+  clerk.unmountSignIn(signInDiv);
+  ```
+
+  ```html filename="index.html" {25}
+  <!-- Add a <div id="sign-in"> element to your HTML -->
   <div id="sign-in"></div>
-`;
 
-const signInDiv = document.getElementById("sign-in");
+  <!-- Initialize Clerk with your
+  Clerk Publishable key and Frontend API URL -->
+  <script
+    async
+    crossorigin="anonymous"
+    data-clerk-publishable-key="{{pub_key}}"
+    src="https://{{fapi_url}}/npm/@clerk/clerk-js@latest/dist/clerk.browser.js"
+    type="text/javascript"
+  ></script>
 
-clerk.mountSignIn(signInDiv);
+  <script>
+    window.addEventListener("load", async function () {
+      await Clerk.load();
 
-// ...
+      const signInDiv =
+        document.getElementById('sign-in');
 
-clerk.unmountSignIn(signInDiv);
-```
+      Clerk.mountSignIn(signInDiv);
 
-```html filename="index.html" {25}
-<!-- Add a <div id="sign-in"> element to your HTML -->
-<div id="sign-in"></div>
+      // ...
 
-<!-- Initialize Clerk with your
-Clerk Publishable key and Frontend API URL -->
-<script
-  async
-  crossorigin="anonymous"
-  data-clerk-publishable-key="{{pub_key}}"
-  src="https://{{fapi_url}}/npm/@clerk/clerk-js@latest/dist/clerk.browser.js"
-  type="text/javascript"
-></script>
-
-<script>
-  window.addEventListener("load", async function () {
-    await Clerk.load();
-
-    const signInDiv = document.getElementById("sign-in");
-
-    Clerk.mountSignIn(signInDiv);
-
-    // ...
-
-    Clerk.unmountSignIn(signInDiv);
-  });
-</script>
-```
-
+      Clerk.unmountSignIn(signInDiv);
+    });
+  </script>
+  ```
 </CodeBlockTabs>
 
 </InjectKeys>
@@ -279,8 +257,8 @@ function openSignIn(props?: SignInProps): void;
 
 #### `openSignIn()` params
 
-| Name     | Type                         | Desciption                                           |
-| -------- | ---------------------------- | ---------------------------------------------------- |
+| Name | Type | Desciption |
+| --- | --- | --- |
 | `props?` | [`SignInProps`](#properties) | The properties to pass to the `<SignIn />` component |
 
 #### `openSignIn()` usage
@@ -288,37 +266,35 @@ function openSignIn(props?: SignInProps): void;
 <InjectKeys>
 
 <CodeBlockTabs type="npm-script" options={['NPM module', '<script>']}>
+  ```js filename="index.js" {7}
+  import Clerk from '@clerk/clerk-js';
 
-```js filename="index.js" {7}
-import Clerk from "@clerk/clerk-js";
+  // Initialize Clerk with your Clerk publishable key
+  const clerk = new Clerk('{{pub_key}}');
+  await clerk.load();
 
-// Initialize Clerk with your Clerk publishable key
-const clerk = new Clerk("{{pub_key}}");
-await clerk.load();
+  clerk.openSignIn();
+  ```
 
-clerk.openSignIn();
-```
+  ```html filename="index.html" {15}
+  <!-- Initialize Clerk with your
+  Clerk Publishable key and Frontend API URL -->
+  <script
+    async
+    crossorigin="anonymous"
+    data-clerk-publishable-key="{{pub_key}}"
+    src="https://{{fapi_url}}/npm/@clerk/clerk-js@latest/dist/clerk.browser.js"
+    type="text/javascript"
+  ></script>
 
-```html filename="index.html" {15}
-<!-- Initialize Clerk with your
-Clerk Publishable key and Frontend API URL -->
-<script
-  async
-  crossorigin="anonymous"
-  data-clerk-publishable-key="{{pub_key}}"
-  src="https://{{fapi_url}}/npm/@clerk/clerk-js@latest/dist/clerk.browser.js"
-  type="text/javascript"
-></script>
+  <script>
+    window.addEventListener("load", async function () {
+      await Clerk.load();
 
-<script>
-  window.addEventListener("load", async function () {
-    await Clerk.load();
-
-    Clerk.openSignIn();
-  });
-</script>
-```
-
+      Clerk.openSignIn();
+    });
+  </script>
+  ```
 </CodeBlockTabs>
 
 </InjectKeys>
@@ -336,45 +312,43 @@ function closeSignIn(): void;
 <InjectKeys>
 
 <CodeBlockTabs type="npm-script" options={['NPM module', '<script>']}>
+  ```js filename="index.js" {11}
+  import Clerk from '@clerk/clerk-js';
 
-```js filename="index.js" {11}
-import Clerk from "@clerk/clerk-js";
+  // Initialize Clerk with your Clerk publishable key
+  const clerk = new Clerk('{{pub_key}}');
+  await clerk.load();
 
-// Initialize Clerk with your Clerk publishable key
-const clerk = new Clerk("{{pub_key}}");
-await clerk.load();
+  clerk.openSignIn();
 
-clerk.openSignIn();
+  // ...
 
-// ...
+  clerk.closeSignIn();
+  ```
 
-clerk.closeSignIn();
-```
+  ```html filename="index.html" {19}
+  <!-- Initialize Clerk with your
+  Clerk Publishable key and Frontend API URL -->
+  <script
+    async
+    crossorigin="anonymous"
+    data-clerk-publishable-key="{{pub_key}}"
+    src="https://{{fapi_url}}/npm/@clerk/clerk-js@latest/dist/clerk.browser.js"
+    type="text/javascript"
+  ></script>
 
-```html filename="index.html" {19}
-<!-- Initialize Clerk with your
-Clerk Publishable key and Frontend API URL -->
-<script
-  async
-  crossorigin="anonymous"
-  data-clerk-publishable-key="{{pub_key}}"
-  src="https://{{fapi_url}}/npm/@clerk/clerk-js@latest/dist/clerk.browser.js"
-  type="text/javascript"
-></script>
+  <script>
+    window.addEventListener("load", async function () {
+      await Clerk.load();
 
-<script>
-  window.addEventListener("load", async function () {
-    await Clerk.load();
+      Clerk.openSignIn();
 
-    Clerk.openSignIn();
+      // ...
 
-    // ...
-
-    Clerk.closeSignIn();
-  });
-</script>
-```
-
+      Clerk.closeSignIn();
+    });
+  </script>
+  ```
 </CodeBlockTabs>
 
 </InjectKeys>

--- a/docs/components/authentication/sign-up.mdx
+++ b/docs/components/authentication/sign-up.mdx
@@ -14,10 +14,6 @@ description: Clerk's <SignUp /> component renders a UI for signing up users.
 
 The `<SignUp />` component renders a UI for signing up users. The functionality of the `<SignUp />` component is controlled by the instance settings you specify in your [Clerk Dashboard](https://dashboard.clerk.com), such as [sign-in and sign-up options](/docs/authentication/configuration/sign-up-sign-in-options) and [social connections](/docs/authentication/social-connections/overview). You can further customize your `<SignUp />` component by passing additional [properties](#properties) at the time of rendering.
 
-<Callout type="info">
-  The `<SignUp/>` and `<SignIn/>` components cannot render when a user is already signed in, unless the application allows multiple sessions. If a user is already signed in and the application only allows a single session, Clerk will redirect the user to the Home URL instead.
-</Callout>
-
 ## Properties
 
 All props are optional.
@@ -25,12 +21,13 @@ All props are optional.
 | Name | Type | Description |
 | --- | --- | --- |
 | `appearance` | <code>[Appearance](/docs/components/customization/overview) \| undefined</code> | Optional object to style your components. Will only affect [Clerk Components](/docs/components/overview) and not [Account Portal](/docs/account-portal/overview) pages. |
-| `routing` | `'hash' \| 'path' \| 'virtual'` | The routing strategy for your pages.<br />Note: If you are using environment variables for Next.js or Remix to specify your routes, this will be set to `path`. |
-| `path` | `string` | The path where the component is mounted on when path-based routing is used<br />For example, `/sign-up`<br />This prop is ignored in hash- and virtual-based routing. |
-| `signInUrl` | `string` | Full URL or path to the sign in page. Use this property to provide the target of the 'Sign In' link that's rendered. It's recommended to use [the environment variable](/docs/deployments/clerk-environment-variables#sign-in-and-sign-up-redirects) instead. |
-| `signUpFallbackRedirectUrl?`         | `string`                                                                              | The fallback URL to redirect to after the user signs up, if there's no `redirect_url` in the path already. Defaults to `/`. It's recommended to use [the environment variable](/docs/deployments/clerk-environment-variables#sign-in-and-sign-up-redirects) instead.                                                                                                                                                                            |
-| `signUpForceRedirectUrl?`         | `string`                                                                              | If provided, this URL will always be redirected to after the user signs up. It's recommended to use [the environment variable](/docs/deployments/clerk-environment-variables#sign-in-and-sign-up-redirects) instead.                                                                                                                                                                            |
-| `unsafeMetadata` | `object` | An object with the key and value for unsafeMetadata that will be saved to the user after sign up.<br />E.g. `{ "company": "companyID1234" }` |
+| `routing` | `'hash' \| 'path' \| 'virtual'` | The routing strategy for your pages. <br />Defaults to `'path'` in Next.js and Remix applications. Defaults to `hash` for all other SDK's. |
+| `path` | `string` | The path where the component is mounted on when `routing` is set to `path`. It is ignored in hash- and virtual-based routing.<br />For example: `/sign-up`. |
+| `redirectUrl` | `string` | The full URL or path to navigate to after successful sign in or sign up.<br />The same as setting `afterSignInUrl` and `afterSignUpUrl` to the same value. |
+| `afterSignInUrl` | `string` | The full URL or path to navigate to after a successful sign in. Defaults to `/`. |
+| `signInUrl` | `string` | The full URL or path to the sign in page. Use this property to provide the target of the 'Sign In' link that's rendered. |
+| `afterSignUpUrl` | `string` | The full URL or path to navigate to after a successful sign up. Defaults to `/`. |
+| `unsafeMetadata` | `object` | An object with the key and value for `unsafeMetadata` that will be saved to the user after sign up.<br />For example: `{ "company": "companyID1234" }` |
 | `initialValues` | [`SignUpInitialValues`](/docs/references/javascript/types/sign-up-initial-values) | The values used to prefill the sign-up fields with. |
 
 ## Usage with frameworks
@@ -38,45 +35,35 @@ All props are optional.
 The following example includes basic implementation of the `<SignIn />` component. You can use this as a starting point for your own implementation.
 
 <Tabs type="framework" items={["Next.js", "React", "Remix", "Gatsby"]}>
-<Tab>
-The following example demonstrates how you can use the `<SignUp />` component on a public page.
+  <Tab>
+    The following example demonstrates how you can use the `<SignUp />` component on a public page.
 
-    ```jsx filename="/app/sign-up/[[...sign-up]]/page.tsx"
-    import { SignUp } from "@clerk/nextjs";
+    If you would like to create a dedicated `/sign-up` page in your Next.js application, check out the [dedicated guide.](/docs/references/nextjs/custom-signup-signin-pages).
 
-    export default function Page() {
-      return <SignUp path="/sign-up" signInUrl="/sign-in" />;
+    ```tsx filename="app/page.tsx"
+    import { SignUp, useUser } from "@clerk/nextjs";
+
+    export default function Home() {
+      const { user } = useUser();
+
+      if (!user) {
+        return <SignUp />;
+      }
+
+      return <div>Welcome!</div>;
     }
     ```
-
-    You will notice a `path` prop is being passed to the `SignUp />` component. This is because, by default, the `routing` strategy is set to `path`, requiring the `path` prop to be passed. In Next.js applications, you can either pass the `path` prop to the `<SignUp />` component, or you can define the `NEXT_PUBLIC_CLERK_SIGN_IN_URL` and `NEXT_PUBLIC_CLERK_SIGN_UP_URL` environment variables.
-
-    The example below shows how to mount the `<SignUp />` component on a page without a `path` prop. Select the `.env.local` tab to see an example of how to define the appropriate environment variables.
-
-    <CodeBlockTabs options={["<SignUp /> without path prop", ".env.local"]}>
-      ```jsx filename="/pages/sign-up/[[...index]].tsx"
-      import { SignUp } from "@clerk/nextjs";
-
-      const SignUpPage = () => (
-        <SignUp />
-      );
-      export default SignUpPage;
-      ```
-
-      ```env filename=".env.local"
-      CLERK_SIGN_IN_URL=/sign-in
-      CLERK_SIGN_UP_URL=/sign-up
-      ```
-    </CodeBlockTabs>
   </Tab>
 
   <Tab>
-    ```jsx filename="sign-up.jsx"
+    ```jsx filename="/src/sign-up/[[...index]].tsx"
     import { SignUp } from "@clerk/clerk-react";
 
-    function SignUpPage() {
-      return <SignUp path="/sign-up" />;
-    }
+    const SignUpPage = () => (
+      <SignUp path="/sign-up" />
+    );
+
+    export default SignUpPage;
     ```
     </Tab>
 
@@ -88,12 +75,11 @@ The following example demonstrates how you can use the `<SignUp />` component on
       return (
         <div style={{ border: "2px solid blue", padding: "2rem" }}>
           <h1>Sign Up route</h1>
-          <SignUp path="/sign-up" />
+          <SignUp />
         </div>
       );
     }
     ```
-
   </Tab>
 
   <Tab>
@@ -109,7 +95,6 @@ The following example demonstrates how you can use the `<SignUp />` component on
       );
     }
     ```
-
   </Tab>
 </Tabs>
 
@@ -134,58 +119,58 @@ function mountSignUp(node: HTMLDivElement, props?: SignUpProps): void;
 
 #### `mountSignUp()` params
 
-| Name     | Type                                                                                | Description                                                      |
-| -------- | ----------------------------------------------------------------------------------- | ---------------------------------------------------------------- |
-| `node `  | [`HTMLDivElement`](https://developer.mozilla.org/en-US/docs/Web/API/HTMLDivElement) | The `<div>` element used to render in the `<SignUp />` component |
-| `props?` | [`SignUpProps`](#sign-up-props)                                                     | The properties to pass to the `<SignUp />` component.            |
+| Name | Type | Description |
+| --- | --- | --- |
+| `node ` | [`HTMLDivElement`](https://developer.mozilla.org/en-US/docs/Web/API/HTMLDivElement) | The `<div>` element used to render in the `<SignUp />` component |
+| `props?` | [`SignUpProps`](#sign-up-props) | The properties to pass to the `<SignUp />` component. |
 
 #### `mountSignUp()` usage
 
 <InjectKeys>
 
 <CodeBlockTabs type="npm-script" options={['NPM module', '<script>']}>
+  ```typescript filename="index.ts" {14}
+  import Clerk from '@clerk/clerk-js';
 
-```typescript filename="index.ts" {14}
-import Clerk from "@clerk/clerk-js";
+  // Initialize Clerk with your Clerk publishable key
+  const clerk = new Clerk('{{pub_key}}');
+  await clerk.load();
 
-// Initialize Clerk with your Clerk publishable key
-const clerk = new Clerk("{{pub_key}}");
-await clerk.load();
+  document.getElementById("app").innerHTML = `
+    <div id="sign-up"></div>
+  `;
 
-document.getElementById("app").innerHTML = `
+  const signUpDiv =
+    document.getElementById("sign-up");
+
+  clerk.mountSignUp(signUpDiv);
+  ```
+
+  ```html filename="index.js" {21}
+  <!-- Add a <div id="sign-up"> element to your HTML -->
   <div id="sign-up"></div>
-`;
 
-const signUpDiv = document.getElementById("sign-up");
+  <!-- Initialize Clerk with your
+  Clerk Publishable key and Frontend API URL -->
+  <script
+    async
+    crossorigin="anonymous"
+    data-clerk-publishable-key="{{pub_key}}"
+    src="https://{{fapi_url}}/npm/@clerk/clerk-js@latest/dist/clerk.browser.js"
+    type="text/javascript"
+  ></script>
 
-clerk.mountSignUp(signUpDiv);
-```
+  <script>
+    window.addEventListener("load", async function () {
+      await Clerk.load();
 
-```html filename="index.js" {21}
-<!-- Add a <div id="sign-up"> element to your HTML -->
-<div id="sign-up"></div>
+      const signUpDiv =
+        document.getElementById('sign-up');
 
-<!-- Initialize Clerk with your
-Clerk Publishable key and Frontend API URL -->
-<script
-  async
-  crossorigin="anonymous"
-  data-clerk-publishable-key="{{pub_key}}"
-  src="https://{{fapi_url}}/npm/@clerk/clerk-js@latest/dist/clerk.browser.js"
-  type="text/javascript"
-></script>
-
-<script>
-  window.addEventListener("load", async function () {
-    await Clerk.load();
-
-    const signUpDiv = document.getElementById("sign-up");
-
-    Clerk.mountSignUp(signUpDiv);
-  });
-</script>
-```
-
+      Clerk.mountSignUp(signUpDiv);
+    });
+  </script>
+  ```
 </CodeBlockTabs>
 
 </InjectKeys>
@@ -200,8 +185,8 @@ function unmountSignUp(node: HTMLDivElement): void;
 
 #### `unmountSignUp()` params
 
-| Name    | Type                                                                                | Description                                                                   |
-| ------- | ----------------------------------------------------------------------------------- | ----------------------------------------------------------------------------- |
+| Name | Type | Description |
+| --- | --- | --- |
 | `node ` | [`HTMLDivElement`](https://developer.mozilla.org/en-US/docs/Web/API/HTMLDivElement) | The container `<div>` element with a rendered `<SignUp />` component instance |
 
 #### `unmountSignUp()` usage
@@ -209,56 +194,56 @@ function unmountSignUp(node: HTMLDivElement): void;
 <InjectKeys>
 
 <CodeBlockTabs type="npm-script" options={['NPM module', '<script>']}>
+  ```typescript filename="index.ts" {18}
+  import Clerk from '@clerk/clerk-js';
 
-```typescript filename="index.ts" {18}
-import Clerk from "@clerk/clerk-js";
+  // Initialize Clerk with your Clerk publishable key
+  const clerk = new Clerk('{{pub_key}}');
+  await clerk.load();
 
-// Initialize Clerk with your Clerk publishable key
-const clerk = new Clerk("{{pub_key}}");
-await clerk.load();
+  document.getElementById("app").innerHTML = `
+    <div id="sign-up"></div>
+  `;
 
-document.getElementById("app").innerHTML = `
+  const signUpDiv =
+    document.getElementById("sign-up");
+
+  clerk.mountSignUp(signUpDiv);
+
+  // ...
+
+  clerk.unmountSignUp(signUpDiv);
+  ```
+
+  ```html filename="index.js" {25}
+  <!-- Add a <div id="sign-up"> element to your HTML -->
   <div id="sign-up"></div>
-`;
 
-const signUpDiv = document.getElementById("sign-up");
+  <!-- Initialize Clerk with your
+  Clerk Publishable key and Frontend API URL -->
+  <script
+    async
+    crossorigin="anonymous"
+    data-clerk-publishable-key="{{pub_key}}"
+    src="https://{{fapi_url}}/npm/@clerk/clerk-js@latest/dist/clerk.browser.js"
+    type="text/javascript"
+  ></script>
 
-clerk.mountSignUp(signUpDiv);
+  <script>
+    window.addEventListener("load", async function () {
+      await Clerk.load();
 
-// ...
+      const signUpDiv =
+        document.getElementById('sign-up');
 
-clerk.unmountSignUp(signUpDiv);
-```
+      Clerk.mountSignUp(signUpDiv);
 
-```html filename="index.js" {25}
-<!-- Add a <div id="sign-up"> element to your HTML -->
-<div id="sign-up"></div>
+      // ...
 
-<!-- Initialize Clerk with your
-Clerk Publishable key and Frontend API URL -->
-<script
-  async
-  crossorigin="anonymous"
-  data-clerk-publishable-key="{{pub_key}}"
-  src="https://{{fapi_url}}/npm/@clerk/clerk-js@latest/dist/clerk.browser.js"
-  type="text/javascript"
-></script>
-
-<script>
-  window.addEventListener("load", async function () {
-    await Clerk.load();
-
-    const signUpDiv = document.getElementById("sign-up");
-
-    Clerk.mountSignUp(signUpDiv);
-
-    // ...
-
-    Clerk.unmountSignUp(signUpDiv);
-  });
-</script>
-```
-
+      Clerk.unmountSignUp(signUpDiv);
+    });
+  </script>
+  ```
 </CodeBlockTabs>
 
 </InjectKeys>
@@ -273,8 +258,8 @@ function openSignUp(props?: SignUpProps): void;
 
 #### `openSignUp()` params
 
-| Name     | Type                            | Description                                          |
-| -------- | ------------------------------- | ---------------------------------------------------- |
+| Name | Type | Description |
+| --- | --- | --- |
 | `props?` | [`SignUpProps`](#sign-up-props) | The properties to pass to the `<SignUp />` component |
 
 #### `openSignUp()` usage
@@ -282,37 +267,35 @@ function openSignUp(props?: SignUpProps): void;
 <InjectKeys>
 
 <CodeBlockTabs type="npm-script" options={['NPM module', '<script>']}>
+  ```js filename="index.ts" {7}
+  import Clerk from '@clerk/clerk-js';
 
-```js filename="index.ts" {7}
-import Clerk from "@clerk/clerk-js";
+  // Initialize Clerk with your Clerk publishable key
+  const clerk = new Clerk('{{pub_key}}');
+  await clerk.load();
 
-// Initialize Clerk with your Clerk publishable key
-const clerk = new Clerk("{{pub_key}}");
-await clerk.load();
+  clerk.openSignUp();
+  ```
 
-clerk.openSignUp();
-```
+  ```html filename="index.html" {15}
+  <!-- Initialize Clerk with your
+  Clerk Publishable key and Frontend API URL -->
+  <script
+    async
+    crossorigin="anonymous"
+    data-clerk-publishable-key="{{pub_key}}"
+    src="https://{{fapi_url}}/npm/@clerk/clerk-js@latest/dist/clerk.browser.js"
+    type="text/javascript"
+  ></script>
 
-```html filename="index.html" {15}
-<!-- Initialize Clerk with your
-Clerk Publishable key and Frontend API URL -->
-<script
-  async
-  crossorigin="anonymous"
-  data-clerk-publishable-key="{{pub_key}}"
-  src="https://{{fapi_url}}/npm/@clerk/clerk-js@latest/dist/clerk.browser.js"
-  type="text/javascript"
-></script>
+  <script>
+    window.addEventListener("load", async function () {
+      await Clerk.load();
 
-<script>
-  window.addEventListener("load", async function () {
-    await Clerk.load();
-
-    Clerk.openSignUp();
-  });
-</script>
-```
-
+      Clerk.openSignUp();
+    });
+  </script>
+  ```
 </CodeBlockTabs>
 
 </InjectKeys>
@@ -330,45 +313,43 @@ function closeSignUp(): void;
 <InjectKeys>
 
 <CodeBlockTabs type="npm-script" options={['NPM module', '<script>']}>
+  ```js filename="index.ts" {11}
+  import Clerk from '@clerk/clerk-js';
 
-```js filename="index.ts" {11}
-import Clerk from "@clerk/clerk-js";
+  // Initialize Clerk with your Clerk publishable key
+  const clerk = new Clerk('{{pub_key}}');
+  await clerk.load();
 
-// Initialize Clerk with your Clerk publishable key
-const clerk = new Clerk("{{pub_key}}");
-await clerk.load();
+  clerk.openSignUp();
 
-clerk.openSignUp();
+  // ...
 
-// ...
+  clerk.closeSignUp();
+  ```
 
-clerk.closeSignUp();
-```
+  ```html filename="index.html" {19}
+  <!-- Initialize Clerk with your
+  Clerk Publishable key and Frontend API URL -->
+  <script
+    async
+    crossorigin="anonymous"
+    data-clerk-publishable-key="{{pub_key}}"
+    src="https://{{fapi_url}}/npm/@clerk/clerk-js@latest/dist/clerk.browser.js"
+    type="text/javascript"
+  ></script>
 
-```html filename="index.html" {19}
-<!-- Initialize Clerk with your
-Clerk Publishable key and Frontend API URL -->
-<script
-  async
-  crossorigin="anonymous"
-  data-clerk-publishable-key="{{pub_key}}"
-  src="https://{{fapi_url}}/npm/@clerk/clerk-js@latest/dist/clerk.browser.js"
-  type="text/javascript"
-></script>
+  <script>
+    window.addEventListener("load", async function () {
+      await Clerk.load();
 
-<script>
-  window.addEventListener("load", async function () {
-    await Clerk.load();
+      Clerk.openSignUp();
 
-    Clerk.openSignUp();
+      // ...
 
-    // ...
-
-    Clerk.closeSignUp();
-  });
-</script>
-```
-
+      Clerk.closeSignUp();
+    });
+  </script>
+  ```
 </CodeBlockTabs>
 
 </InjectKeys>

--- a/docs/components/authentication/sign-up.mdx
+++ b/docs/components/authentication/sign-up.mdx
@@ -14,6 +14,10 @@ description: Clerk's <SignUp /> component renders a UI for signing up users.
 
 The `<SignUp />` component renders a UI for signing up users. The functionality of the `<SignUp />` component is controlled by the instance settings you specify in your [Clerk Dashboard](https://dashboard.clerk.com), such as [sign-in and sign-up options](/docs/authentication/configuration/sign-up-sign-in-options) and [social connections](/docs/authentication/social-connections/overview). You can further customize your `<SignUp />` component by passing additional [properties](#properties) at the time of rendering.
 
+<Callout type="info">
+  The `<SignUp/>` and `<SignIn/>` components cannot render when a user is already signed in, unless the application allows multiple sessions. If a user is already signed in and the application only allows a single session, Clerk will redirect the user to the Home URL instead.
+</Callout>
+
 ## Properties
 
 All props are optional.
@@ -23,11 +27,9 @@ All props are optional.
 | `appearance` | <code>[Appearance](/docs/components/customization/overview) \| undefined</code> | Optional object to style your components. Will only affect [Clerk Components](/docs/components/overview) and not [Account Portal](/docs/account-portal/overview) pages. |
 | `routing` | `'hash' \| 'path' \| 'virtual'` | The routing strategy for your pages. <br />Defaults to `'path'` in Next.js and Remix applications. Defaults to `hash` for all other SDK's. |
 | `path` | `string` | The path where the component is mounted on when `routing` is set to `path`. It is ignored in hash- and virtual-based routing.<br />For example: `/sign-up`. |
-| `redirectUrl` | `string` | The full URL or path to navigate to after successful sign in or sign up.<br />The same as setting `afterSignInUrl` and `afterSignUpUrl` to the same value. |
-| `afterSignInUrl` | `string` | The full URL or path to navigate to after a successful sign in. Defaults to `/`. |
-| `signInUrl` | `string` | The full URL or path to the sign in page. Use this property to provide the target of the 'Sign In' link that's rendered. |
-| `afterSignUpUrl` | `string` | The full URL or path to navigate to after a successful sign up. Defaults to `/`. |
-| `unsafeMetadata` | `object` | An object with the key and value for `unsafeMetadata` that will be saved to the user after sign up.<br />For example: `{ "company": "companyID1234" }` |
+| `signInUrl` | `string` | Full URL or path to the sign in page. Use this property to provide the target of the 'Sign In' link that's rendered. It's recommended to use [the environment variable](/docs/deployments/clerk-environment-variables#sign-in-and-sign-up-redirects) instead. |
+| `signUpFallbackRedirectUrl?` | `string` | The fallback URL to redirect to after the user signs up, if there's no `redirect_url` in the path already. Defaults to `/`. It's recommended to use [the environment variable](/docs/deployments/clerk-environment-variables#sign-in-and-sign-up-redirects) instead. |
+| `signUpForceRedirectUrl?` | `string` | If provided, this URL will always be redirected to after the user signs up. It's recommended to use [the environment variable](/docs/deployments/clerk-environment-variables#sign-in-and-sign-up-redirects) instead. |
 | `initialValues` | [`SignUpInitialValues`](/docs/references/javascript/types/sign-up-initial-values) | The values used to prefill the sign-up fields with. |
 
 ## Usage with frameworks

--- a/docs/components/organization/create-organization.mdx
+++ b/docs/components/organization/create-organization.mdx
@@ -22,8 +22,8 @@ All props are optional.
 | --- | --- | --- |
 | `appearance` | <code>[Appearance](/docs/components/customization/overview) \| undefined</code> | Optional object to style your components. Will only affect [Clerk Components](/docs/components/overview) and not [Account Portal](/docs/account-portal/overview) pages. |
 | `afterCreateOrganizationUrl` | `string` | Full URL or path to navigate to after creating a new organization. |
-| `routing` | `'hash' \| 'path' \| 'virtual'` | The routing strategy for your pages. |
-| `path` | `string` | The path where the component is mounted when path-based routing is used. <br />For example, `/create-org`<br />This prop is ignored in hash- and virtual-based routing. |
+| `routing` | `'hash' \| 'path' \| 'virtual'` | The routing strategy for your pages. <br />Defaults to `'path'` in Next.js and Remix applications. Defaults to `hash` for all other SDK's. |
+| `path` | `string` | The path where the component is mounted on when `routing` is set to `path`. It is ignored in hash- and virtual-based routing.<br />For example: `/create-organization`. |
 | `skipInvitationScreen` | `boolean` | Hides the screen for sending invitations after an organization is created. When left undefined, Clerk will automatically hide the screen if the number of max allowed members is equal to 1 |
 
 ## Usage with frameworks

--- a/docs/components/organization/organization-profile.mdx
+++ b/docs/components/organization/organization-profile.mdx
@@ -22,8 +22,8 @@ All props are optional.
 | --- | --- | --- |
 | `appearance` | <code>[Appearance](/docs/components/customization/overview) \| undefined</code> | Optional object to style your components. Will only affect [Clerk Components](/docs/components/overview) and not [Account Portal](/docs/account-portal/overview) pages. |
 | `afterLeaveOrganizationUrl` | `string` | Full URL or path to navigate to after leaving an organization. |
-| `routing` | `'hash' \| 'path' \| 'virtual'` | The routing strategy for your pages. |
-| `path` | `string` | The path where the component is mounted when path-based routing is used.<br />For example: `/organization-profile`<br />This prop is ignored in hash- and virtual-based routing. |
+| `routing` | `'hash' \| 'path' \| 'virtual'` | The routing strategy for your pages. <br />Defaults to `'path'` in Next.js and Remix applications. Defaults to `hash` for all other SDK's. |
+| `path` | `string` | The path where the component is mounted on when `routing` is set to `path`. It is ignored in hash- and virtual-based routing.<br />For example: `/organization-profile`. |
 
 ## Usage with frameworks
 

--- a/docs/components/user/user-profile.mdx
+++ b/docs/components/user/user-profile.mdx
@@ -21,8 +21,8 @@ All props are optional.
 | Name | Type | Description |
 | --- | --- | --- |
 | `appearance` | <code>[Appearance](/docs/components/customization/overview) \| undefined</code> | Optional object to style your components. Will only affect [Clerk Components](/docs/components/overview) and not [Account Portal](/docs/account-portal/overview) pages. |
-| `routing` | `'hash' \| 'path' \| 'virtual'` | The routing strategy for your pages. Defaults to `'path'`. |
-| `path` | `string` | The path where the component is mounted on when path-based routing is used.<br />For example: `/user-profile`<br />This prop is ignored in hash- and virtual-based routing.|
+| `routing` | `'hash' \| 'path' \| 'virtual'` | The routing strategy for your pages. <br />Defaults to `'path'` in Next.js and Remix applications. Defaults to `hash` for all other SDK's. |
+| `path` | `string` | The path where the component is mounted on when `routing` is set to `path`. It is ignored in hash- and virtual-based routing.<br />For example: `/user-profile`. |
 | `additionalOAuthScopes` | `object` | Specify additional scopes per OAuth provider that your users would like to provide if not already approved. <br />For example: `{google: ['foo', 'bar'], github: ['qux']}`. |
 
 ## Usage with frameworks

--- a/docs/deployments/clerk-environment-variables.mdx
+++ b/docs/deployments/clerk-environment-variables.mdx
@@ -12,7 +12,7 @@ This page is a reference for all available Clerk environment variables.
 
 Components, such as [`<ClerkProvider>`](/docs/components/clerk-provider), [`<UserButton>`](/docs/components/user/user-button), and more, provide props for you to specify where users will be redirected. You should use environment variables instead of these props whenever possible.
 
-See the [Custom Redirects guide](/docs/account-portal/custom-redirects) for more information.
+See the [Custom Redirects guide](/docs/guides/custom-redirects) for more information.
 
 <Tabs type="framework" items={["General", "Next.js", "React"]}>
 

--- a/docs/guides/routing.mdx
+++ b/docs/guides/routing.mdx
@@ -1,0 +1,49 @@
+---
+description: Learn how Clerk handles routing in your application.
+---
+
+# Routing in Clerk
+
+Some of Clerk's components have their own internal routing.
+
+For example, say a user uses their email address to fill out the [`<SignUp />`](/docs/components/authentication/sign-up) form. Once they submit the form, they are redirected from `/sign-up` to `/sign-up/verify-email-address`, which renders Clerk's UI for verifying a user's email address. This redirect is handled by Clerk's internal routing.
+
+## `routing` prop
+
+The following Clerk components accept a `routing` prop in order to define the routing strategy:
+
+- [`<SignUp />`](/docs/components/authentication/sign-up)
+- [`<SignIn />`](/docs/components/authentication/sign-in)
+- [`<UserProfile />`](/docs/components/user/user-profile)
+- [`<CreateOrganization />`](/docs/components/organization/create-organization)
+- [`<OrganizationProfile />`](/docs/components/organization/organization-profile)
+
+There are three routing strategies that can be passed:
+
+- [`path`](#path-routing)
+- [`hash`](#hash-routing)
+- [`virtual`](#virtual-routing)
+
+Out of the box, Clerk will attempt to select the routing strategy that best integrates with your framework of choice. If for some reason the default routing strategy doesn't work for you, use the information below to pick a strategy that will work for your setup.
+
+### `path` routing
+
+`path` routing uses the path in the URL to determine the route. This is useful for server-rendered pages where SEO and server-side routing are crucial, such as Next.js or Remix applications.
+
+For example, say you have a Clerk + Next.js application with the `<SignUp />` component on a dedicated `/sign-up` page. A user visit this page and uses their email address to fill out the `<SignUp />` form. Once they submit the form, they are redirected from `/sign-up` to `/sign-up/verify-email-address`.
+
+In Clerk applications that use the Next.js or Remix SDKs, `path` routing is set *by default* on all Clerk components, as these frameworks support server-side routing out-of-the-box. There is no need to pass the `routing` or `path` props to Clerk components in these frameworks.
+
+### `hash` routing
+
+`hash` routing uses [the hash (#) portion of the URL](https://developer.mozilla.org/en-US/docs/Web/API/URL/hash) to determine the route. This is useful for single-page applications that use client-side routing.
+
+For example, say you have a Clerk + React application with the `<SignUp />` component on a dedicated `/sign-up` page. A user visit this page and uses their email address to fill out the `<SignUp />` form. Once they submit the form, they are redirected from `/sign-up` to `/sign-up#verify-email-address`.
+
+In Clerk applications that use any SDK other than Next.js or Remix, `hash` routing is set *by default* on all Clerk components.
+
+### `virtual` routing
+
+`virtual` routing uses a memory router to determine the route. A memory router manages its own history stack in memory instead of using any part of the URL. This is useful for modals and other UI components that don't need to change the URL. **This option is considered experimental.**
+
+For example, say you have a Clerk + Next.js application with the `<UserButton />` component. When a user selects the `<UserButton />` and selects **Manage account**, a modal appears with the user's account information. The modal does not change the URL, but it does change the UI. You can navigate between both the tabs of the modal, **Profile** and **Security**, and initiate flows within the modal, such as adding a new email address, all without changing the URL.

--- a/docs/manifest.json
+++ b/docs/manifest.json
@@ -31,6 +31,7 @@
     [
       ["Overview", "/guides/overview"],
       ["Add custom onboarding to your authentication flow", "/guides/add-onboarding-flow"],
+      ["Routing in Clerk", "/guides/routing"],
       ["Custom redirects", "/guides/custom-redirects"],
       ["Transferring ownership of your App", "/guides/transferring-your-app"],
       ["Use image optimization to improve app performance", "/guides/image-optimization/imageurl-image-optimization"],

--- a/docs/upgrade-guides/core-2/chrome-extension.mdx
+++ b/docs/upgrade-guides/core-2/chrome-extension.mdx
@@ -114,7 +114,7 @@ The new version ships with improved design and UX across all of Clerk's [UI comp
 
 ### After sign up/in/out default value change
 
-Defining redirect URLs for after sign up, in, and/or out via the Clerk dashboard has been removed in Core 2. In your Clerk dashboard, under "paths", there is a section called "Component paths", where URLs could be defined that had a deprecation warning. In Core 2, this functionality has been removed, and specifying redirect paths via the dashboard will no longer work. If you need to pass a redirect URL for after sign in/up/out, there are [a few different ways this can be done](/docs/account-portal/custom-redirects), from environment variables to middleware to supplying them directly to the relevant components.
+Defining redirect URLs for after sign up, in, and/or out via the Clerk dashboard has been removed in Core 2. In your Clerk dashboard, under "paths", there is a section called "Component paths", where URLs could be defined that had a deprecation warning. In Core 2, this functionality has been removed, and specifying redirect paths via the dashboard will no longer work. If you need to pass a redirect URL for after sign in/up/out, there are [a few different ways this can be done](/docs/guides/custom-redirects), from environment variables to middleware to supplying them directly to the relevant components.
 
 As part of this change, the default URL for each of these props has been set to `/`, so if you are passing `/` explicitly to any one of the above props, that line is no longer necessary and can be removed.
 

--- a/docs/upgrade-guides/core-2/chrome-extension.mdx
+++ b/docs/upgrade-guides/core-2/chrome-extension.mdx
@@ -176,9 +176,9 @@ If you would like to have your JWT return all of the user's organizations, you c
 
 ### Path routing is now the default
 
-On components like [`<SignIn />`](/docs/components/authentication/sign-in) you can define the props `routing` and `path`. `routing` can be set to `'hash' | 'path' | 'virtual'` and describes the routing strategy that should be used. `path` defines where the component is mounted when `routing="path"` is used.
+On components like [`<SignIn />`](/docs/components/authentication/sign-in) you can define the props `routing` and `path`. `routing` can be set to `'hash' | 'path' | 'virtual'` and describes the routing strategy that should be used. `path` defines where the component is mounted when `routing="path"` is used. [Learn more about Clerk routing.](/docs/guides/routing)
 
-In the latest version, the **default** `routing` strategy has become `'path'`. Unless you change the `routing` prop, you'll need to define the `path` prop. The affected components are:
+In Core 2, the **default** `routing` strategy has become `'path'`. Unless you change the `routing` prop, you'll need to define the `path` prop. The affected components are:
 
 - `<SignIn />`
 - `<SignUp />`

--- a/docs/upgrade-guides/core-2/expo.mdx
+++ b/docs/upgrade-guides/core-2/expo.mdx
@@ -156,9 +156,9 @@ If you would like to have your JWT return all of the user's organizations, you c
 
 ### Path routing is now the default
 
-On components like [`<SignIn />`](/docs/components/authentication/sign-in) you can define the props `routing` and `path`. `routing` can be set to `'hash' | 'path' | 'virtual'` and describes the routing strategy that should be used. `path` defines where the component is mounted when `routing="path"` is used.
+On components like [`<SignIn />`](/docs/components/authentication/sign-in) you can define the props `routing` and `path`. `routing` can be set to `'hash' | 'path' | 'virtual'` and describes the routing strategy that should be used. `path` defines where the component is mounted when `routing="path"` is used. [Learn more about Clerk routing.](/docs/guides/routing)
 
-In the latest version, the **default** `routing` strategy has become `'path'`. Unless you change the `routing` prop, you'll need to define the `path` prop. The affected components are:
+In Core 2, the **default** `routing` strategy has become `'path'`. Unless you change the `routing` prop, you'll need to define the `path` prop. The affected components are:
 
 - `<SignIn />`
 - `<SignUp />`

--- a/docs/upgrade-guides/core-2/expo.mdx
+++ b/docs/upgrade-guides/core-2/expo.mdx
@@ -94,7 +94,7 @@ The new version ships with improved design and UX across all of Clerk's [UI comp
 
 ### After sign up/in/out default value change
 
-Defining redirect URLs for after sign up, in, and/or out via the Clerk dashboard has been removed in Core 2. In your Clerk dashboard, under "paths", there is a section called "Component paths", where URLs could be defined that had a deprecation warning. In Core 2, this functionality has been removed, and specifying redirect paths via the dashboard will no longer work. If you need to pass a redirect URL for after sign in/up/out, there are [a few different ways this can be done](/docs/account-portal/custom-redirects), from environment variables to middleware to supplying them directly to the relevant components.
+Defining redirect URLs for after sign up, in, and/or out via the Clerk dashboard has been removed in Core 2. In your Clerk dashboard, under "paths", there is a section called "Component paths", where URLs could be defined that had a deprecation warning. In Core 2, this functionality has been removed, and specifying redirect paths via the dashboard will no longer work. If you need to pass a redirect URL for after sign in/up/out, there are [a few different ways this can be done](/docs/guides/custom-redirects), from environment variables to middleware to supplying them directly to the relevant components.
 
 As part of this change, the default URL for each of these props has been set to `/`, so if you are passing `/` explicitly to any one of the above props, that line is no longer necessary and can be removed.
 

--- a/docs/upgrade-guides/core-2/javascript.mdx
+++ b/docs/upgrade-guides/core-2/javascript.mdx
@@ -151,9 +151,9 @@ If you would like to have your JWT return all of the user's organizations, you c
 
 ### Path routing is now the default
 
-On components like [`<SignIn />`](/docs/components/authentication/sign-in) you can define the props `routing` and `path`. `routing` can be set to `'hash' | 'path' | 'virtual'` and describes the routing strategy that should be used. `path` defines where the component is mounted when `routing="path"` is used.
+On components like [`<SignIn />`](/docs/components/authentication/sign-in) you can define the props `routing` and `path`. `routing` can be set to `'hash' | 'path' | 'virtual'` and describes the routing strategy that should be used. `path` defines where the component is mounted when `routing="path"` is used. [Learn more about Clerk routing.](/docs/guides/routing)
 
-In the latest version, the **default** `routing` strategy has become `'path'`. Unless you change the `routing` prop, you'll need to define the `path` prop. The affected components are:
+In Core 2, the **default** `routing` strategy has become `'path'`. Unless you change the `routing` prop, you'll need to define the `path` prop. The affected components are:
 
 - `<SignIn />`
 - `<SignUp />`

--- a/docs/upgrade-guides/core-2/javascript.mdx
+++ b/docs/upgrade-guides/core-2/javascript.mdx
@@ -69,7 +69,7 @@ The new version ships with improved design and UX across all of Clerk's [UI comp
 
 ### After sign up/in/out default value change
 
-Defining redirect URLs for after sign up, in, and/or out via the Clerk dashboard has been removed in Core 2. In your Clerk dashboard, under "paths", there is a section called "Component paths", where URLs could be defined that had a deprecation warning. In Core 2, this functionality has been removed, and specifying redirect paths via the dashboard will no longer work. If you need to pass a redirect URL for after sign in/up/out, there are [a few different ways this can be done](/docs/account-portal/custom-redirects), from environment variables to middleware to supplying them directly to the relevant components.
+Defining redirect URLs for after sign up, in, and/or out via the Clerk dashboard has been removed in Core 2. In your Clerk dashboard, under "paths", there is a section called "Component paths", where URLs could be defined that had a deprecation warning. In Core 2, this functionality has been removed, and specifying redirect paths via the dashboard will no longer work. If you need to pass a redirect URL for after sign in/up/out, there are [a few different ways this can be done](/docs/guides/custom-redirects), from environment variables to middleware to supplying them directly to the relevant components.
 
 As part of this change, the default URL for each of these props has been set to `/`, so if you are passing `/` explicitly to any one of the above props, that line is no longer necessary and can be removed.
 

--- a/docs/upgrade-guides/core-2/nextjs.mdx
+++ b/docs/upgrade-guides/core-2/nextjs.mdx
@@ -419,7 +419,7 @@ As part of this release, some of the top-level exports of `@clerk/nextjs` have b
 
 ### After sign up/in/out default value change
 
-Defining redirect URLs for after sign up, in, and/or out via the Clerk Dashboard has been removed in Core 2. Before Core 2, on the [Paths](https://dashboard.clerk.com/last-active?path=paths) page in the Clerk Dashboard, there was a section called **Component paths** where redirect URLs could be defined. In Core 2, this functionality has been removed, and specifying redirect paths via the Dashboard will no longer work. If you need to pass a redirect URL for after sign in/up/out, there are [a few different ways this can be done](/docs/account-portal/custom-redirects), from environment variables to Middleware to supplying them directly to the relevant components.
+Defining redirect URLs for after sign up, in, and/or out via the Clerk Dashboard has been removed in Core 2. Before Core 2, on the [Paths](https://dashboard.clerk.com/last-active?path=paths) page in the Clerk Dashboard, there was a section called **Component paths** where redirect URLs could be defined. In Core 2, this functionality has been removed, and specifying redirect paths via the Dashboard will no longer work. If you need to pass a redirect URL for after sign in/up/out, there are [a few different ways this can be done](/docs/guides/custom-redirects), from environment variables to Middleware to supplying them directly to the relevant components.
 
 As part of this change, the default redirect URL for each of these props has been set to `/`, so if you are passing `/` explicitly to any one of the above props, that line is no longer necessary and can be removed.
 

--- a/docs/upgrade-guides/core-2/nextjs.mdx
+++ b/docs/upgrade-guides/core-2/nextjs.mdx
@@ -501,45 +501,13 @@ If you would like to have your JWT return all of the user's organizations, you c
 
 ### Path routing is now the default
 
-On components like [`<SignIn />`](/docs/components/authentication/sign-in) you can define the props `routing` and `path`. `routing` describes the routing strategy that should be used and can be set to `'hash' | 'path' | 'virtual'`. `path` defines where the component is mounted when `routing='path'` is used.
+On components like [`<SignIn />`](/docs/components/authentication/sign-in) you can define the props `routing` and `path`. `routing` describes the routing strategy that should be used and can be set to `'hash' | 'path' | 'virtual'`. `path` defines where the component is mounted when `routing='path'` is used. [Learn more about Clerk routing.](/docs/guides/routing)
 
-In the latest version, the **default** `routing` strategy has become `'path'`. Unless you change the `routing` prop, you will need to define the `path` prop. The affected components are:
-
-- `<SignIn />`
-- `<SignUp />`
-- `<UserProfile />`
-- `<CreateOrganization />`
-- `<OrganizationProfile />`
-
-Here is how you would use the components going forward:
-
-```jsx
-<SignIn path="/sign-in" />
-<SignUp path="/sign-up" />
-<UserProfile path="/user-profile" />
-<CreateOrganization path="/create-org" />
-<OrganizationProfile path="/org-profile" />
-```
-
-If you do not define the `path` prop, an error will be thrown. Of course, you can still use `routing='hash'` or `routing='virtual'`.
+In Core 2, the **default** `routing` strategy has become `'path'` for the Next.js SDK. Of course, you can still use `routing='hash'` or `routing='virtual'`.
 
 ```jsx
 <UserProfile routing="hash" />
 <OrganizationProfile routing="virtual" />
-```
-
-For the `@clerk/nextjs` SDK, you can avoid needing to explicitly pass the path to the `<SignIn />` and `<SignUp />` components by setting environment variables for the sign in/up URLs like so:
-
-```env filename=".env.local"
-NEXT_PUBLIC_CLERK_SIGN_IN_URL=/sign-in
-NEXT_PUBLIC_CLERK_SIGN_UP_URL=/sign-up
-```
-
-If you have defined both environment variables as above, you can use the `<SignIn />` and `<SignUp />` components without any props:
-
-```jsx
-<SignIn />
-<SignUp />
 ```
 
 ### Image URL Name Consolidation
@@ -656,7 +624,7 @@ As part of this major version, a number of previously deprecated props, arugment
     The `@clerk/nextjs` import will work with both App Router and Pages Router.
   </AccordionPanel>
   <AccordionPanel>
-    If you are importing from `@clerk/nextjs/ssr`, you can use `@clerk/nextjs` instead. Our top-level import supports SSR functionality by default now, so the subpath on the import is no longer needed. This import can be directly replaced without any other considerations.
+    If you are importing from `@clerk/nextjs/ssr`, you can use `@clerk/nextjs` instead. Our top-level import supports SSR functionality by default now, so the subpath on the import is no longer needed. This import can be directly replaced without any other considerations.
   </AccordionPanel>
   <AccordionPanel>
     This deprecated import has been replaced by `@clerk/nextjs/server`. Usage should now look as such: `import { authMiddleware } from @clerk/nextjs/server`. There may be changes in functionality between the two exports depending on how old the version used is, so upgrade with caution.

--- a/docs/upgrade-guides/core-2/react.mdx
+++ b/docs/upgrade-guides/core-2/react.mdx
@@ -191,9 +191,9 @@ If you would like to have your JWT return all of the user's organizations, you c
 
 ### Path routing is now the default
 
-On components like [`<SignIn />`](/docs/components/authentication/sign-in) you can define the props `routing` and `path`. `routing` can be set to `'hash' | 'path' | 'virtual'` and describes the routing strategy that should be used. `path` defines where the component is mounted when `routing="path"` is used.
+On components like [`<SignIn />`](/docs/components/authentication/sign-in) you can define the props `routing` and `path`. `routing` can be set to `'hash' | 'path' | 'virtual'` and describes the routing strategy that should be used. `path` defines where the component is mounted when `routing="path"` is used. [Learn more about Clerk routing.](/docs/guides/routing)
 
-In the latest version, the **default** `routing` strategy has become `'path'`. Unless you change the `routing` prop, you'll need to define the `path` prop. The affected components are:
+In Core 2, the **default** `routing` strategy has become `'path'`. Unless you change the `routing` prop, you'll need to define the `path` prop. The affected components are:
 
 - `<SignIn />`
 - `<SignUp />`

--- a/docs/upgrade-guides/core-2/react.mdx
+++ b/docs/upgrade-guides/core-2/react.mdx
@@ -94,7 +94,7 @@ The new version ships with improved design and UX across all of Clerk's [UI comp
 
 ### After sign up/in/out default value change
 
-Defining redirect URLs for after sign up, in, and/or out via the Clerk dashboard has been removed in Core 2. In your Clerk dashboard, under "paths", there is a section called "Component paths", where URLs could be defined that had a deprecation warning. In Core 2, this functionality has been removed, and specifying redirect paths via the dashboard will no longer work. If you need to pass a redirect URL for after sign in/up/out, there are [a few different ways this can be done](/docs/account-portal/custom-redirects), from environment variables to middleware to supplying them directly to the relevant components.
+Defining redirect URLs for after sign up, in, and/or out via the Clerk dashboard has been removed in Core 2. In your Clerk dashboard, under "paths", there is a section called "Component paths", where URLs could be defined that had a deprecation warning. In Core 2, this functionality has been removed, and specifying redirect paths via the dashboard will no longer work. If you need to pass a redirect URL for after sign in/up/out, there are [a few different ways this can be done](/docs/guides/custom-redirects), from environment variables to middleware to supplying them directly to the relevant components.
 
 As part of this change, the default URL for each of these props has been set to `/`, so if you are passing `/` explicitly to any one of the above props, that line is no longer necessary and can be removed.
 

--- a/docs/upgrade-guides/core-2/remix.mdx
+++ b/docs/upgrade-guides/core-2/remix.mdx
@@ -114,7 +114,7 @@ The new version ships with improved design and UX across all of Clerk's [UI comp
 
 ### After sign up/in/out default value change
 
-Defining redirect URLs for after sign up, in, and/or out via the Clerk dashboard has been removed in Core 2. In your Clerk dashboard, under "paths", there is a section called "Component paths", where URLs could be defined that had a deprecation warning. In Core 2, this functionality has been removed, and specifying redirect paths via the dashboard will no longer work. If you need to pass a redirect URL for after sign in/up/out, there are [a few different ways this can be done](/docs/account-portal/custom-redirects), from environment variables to middleware to supplying them directly to the relevant components.
+Defining redirect URLs for after sign up, in, and/or out via the Clerk dashboard has been removed in Core 2. In your Clerk dashboard, under "paths", there is a section called "Component paths", where URLs could be defined that had a deprecation warning. In Core 2, this functionality has been removed, and specifying redirect paths via the dashboard will no longer work. If you need to pass a redirect URL for after sign in/up/out, there are [a few different ways this can be done](/docs/guides/custom-redirects), from environment variables to middleware to supplying them directly to the relevant components.
 
 As part of this change, the default URL for each of these props has been set to `/`, so if you are passing `/` explicitly to any one of the above props, that line is no longer necessary and can be removed.
 

--- a/docs/upgrade-guides/core-2/remix.mdx
+++ b/docs/upgrade-guides/core-2/remix.mdx
@@ -196,55 +196,14 @@ If you would like to have your JWT return all of the user's organizations, you c
 
 ### Path routing is now the default
 
-On components like [`<SignIn />`](/docs/components/authentication/sign-in) you can define the props `routing` and `path`. `routing` can be set to `'hash' | 'path' | 'virtual'` and describes the routing strategy that should be used. `path` defines where the component is mounted when `routing="path"` is used.
+On components like [`<SignIn />`](/docs/components/authentication/sign-in) you can define the props `routing` and `path`. `routing` describes the routing strategy that should be used and can be set to `'hash' | 'path' | 'virtual'`. `path` defines where the component is mounted when `routing='path'` is used. [Learn more about Clerk routing.](/docs/guides/routing)
 
-In the latest version, the **default** `routing` strategy has become `'path'`. Unless you change the `routing` prop, you'll need to define the `path` prop. The affected components are:
-
-- `<SignIn />`
-- `<SignUp />`
-- `<UserProfile />`
-- `<CreateOrganization />`
-- `<OrganizationProfile />`
-
-Here's how you'd use the components going forward:
-
-```jsx
-<SignIn path="/sign-in" />
-<SignUp path="/sign-up" />
-<UserProfile path="/user-profile" />
-<CreateOrganization path="/create-org" />
-<OrganizationProfile path="/org-profile" />
-```
-
-If you don't define the `path` prop an error will be thrown. Of course, you can still use `routing="hash"` or `routing="virtual"`.
+In Core 2, the **default** `routing` strategy has become `'path'` for the Remix SDK. Of course, you can still use `routing='hash'` or `routing='virtual'`.
 
 ```jsx
 <UserProfile routing="hash" />
 <OrganizationProfile routing="virtual" />
 ```
-
-
-For the @clerk/remix SDK, you can set environment variables for the sign up/in URLs and avoid needing to explicitly pass the path to the `<SignIn />` and `<SignUp />` components.
-
-
-
-
-```env filename=".env"
-CLERK_SIGN_IN_URL=/sign-in
-CLERK_SIGN_UP_URL=/sign-up
-```
-
-
-
-If you have defined both environment variables, you're able to use the `<SignIn />` and `<SignUp />` components without any props, as such:
-
-```jsx
-<SignIn />
-<SignUp />
-```
-
-
-
 ### Image URL Name Consolidation
 
 There are a number of Clerk primitives that contain images, and previously they each had different property names, like `avatarUrl`, `logoUrl`, `profileImageUrl`, etc. In order to promote consistency and make it simpler for developers to know where to find associated images, all image properties are now named `imageUrl`. See the list below for all affected classes:


### PR DESCRIPTION
Adds guide on routing in Clerk.
Updates places where `path` is defined for Next.js and Remix examples and it's inferred and no longer required to be explicitly set.
Updates upgrade guides accordingly.