### PR TITLE
Replace authMiddleware where appropriate

### DIFF
--- a/docs/deployments/clerk-environment-variables.mdx
+++ b/docs/deployments/clerk-environment-variables.mdx
@@ -12,7 +12,7 @@ This page is a reference for all available Clerk environment variables.
 
 Components, such as [`<ClerkProvider>`](/docs/components/clerk-provider), [`<UserButton>`](/docs/components/user/user-button), and more, provide props for you to specify where users will be redirected. You should use environment variables instead of these props whenever possible.
 
-See the [Custom Redirects guide](/docs/account-portal/custom-redirects) for more information.
+See the [Custom Redirects guide](/docs/guides/custom-redirects) for more information.
 
 <Tabs type="framework" items={["General", "Next.js", "React"]}>
 

--- a/docs/guides/add-onboarding-flow.mdx
+++ b/docs/guides/add-onboarding-flow.mdx
@@ -72,7 +72,7 @@ The following example demonstrates how to use Clerk's `clerkMiddleware()` to red
 Note that the following example protects all routes except one. This is so that any user visiting your application is forced to authenticate, and then forced to onboard. You can customize the array in the `createRouteMatcher()` function assigned to `isPublicRoute` to include any routes that should be accessible to all users, even unauthenticated ones.
 
 ```tsx filename="src/middleware.ts"
-import { clerkMiddleware } from "@clerk/nextjs/server";
+import { clerkMiddleware, createRouteMatcher } from "@clerk/nextjs/server";
 import { redirectToSignIn } from "@clerk/nextjs/server";
 import { NextRequest, NextResponse } from "next/server";
 

--- a/docs/guides/add-onboarding-flow.mdx
+++ b/docs/guides/add-onboarding-flow.mdx
@@ -65,31 +65,30 @@ declare global {
 
 ## Configure your Middleware to read session data
 
-Clerk's [`authMiddleware()`](https://clerk.com/docs/references/nextjs/auth-middleware#usage) allows you to configure access to your routes with fine grained control. It also allows you to retrieve claims directly from the session and redirect your user accordingly.
+Clerk's [`clerkMiddleware()`](https://clerk.com/docs/references/nextjs/clerk-middleware) allows you to configure access to your routes with fine grained control. It also allows you to retrieve claims directly from the session and redirect your user accordingly.
 
-The following example demonstrates how to use Clerk's `authMiddleware()` to redirect users based on their onboarding status. If the user is signed in and has not completed onboarding, they will be redirected to the onboarding page.
+The following example demonstrates how to use Clerk's `clerkMiddleware()` to redirect users based on their onboarding status. If the user is signed in and has not completed onboarding, they will be redirected to the onboarding page.
 
 Note that the following example protects all routes. This is so that any user visiting your application is forced to authenticate, and then forced to onboard. You can customize the `publicRoutes` array to include any routes that should be accessible to all users, even unauthenticated ones.
 
 ```tsx filename="src/middleware.ts"
-import { authMiddleware } from "@clerk/nextjs/server";
+import { clerkMiddleware } from "@clerk/nextjs/server";
 import { redirectToSignIn } from "@clerk/nextjs/server";
 import { NextRequest, NextResponse } from "next/server";
 
-export default authMiddleware({
-  // Define which routes are public
-  publicRoutes: [],
+const isOnboardingRoute = createRouteMatcher(["/onboarding"])
+const isProtectedRoute = createRouteMatcher(["/protected-route-example"])
 
-  afterAuth: async (auth, req: NextRequest) => {
-    const { userId, sessionClaims } = auth;
+export default clerkMiddleware((auth, req: NextRequest) => {
+    const { userId, sessionClaims } = auth();
 
     // For users visiting /onboarding, don't try to redirect
-    if (userId && req.nextUrl.pathname === "/onboarding") {
+    if (userId && isOnboardingRoute(req)) {
       return NextResponse.next();
     }
 
     // If the user isn't signed in and the route is private, redirect to sign-in
-    if (!userId && !auth.isPublicRoute)
+    if (!userId && isProtectedRoute(req))
       return redirectToSignIn({ returnBackUrl: req.url });
 
     // Catch users who do not have `onboardingComplete: true` in their publicMetadata
@@ -100,12 +99,12 @@ export default authMiddleware({
     }
 
     // If the user is logged in and the route is protected, let them view.
-    if (userId && !auth.isPublicRoute) return NextResponse.next();
+    if (userId && isProtectedRoute(req)) return NextResponse.next();
 
     // If the route is public, anyone can view it.
-    if (auth.isPublicRoute) return NextResponse.next();
-  },
-});
+    if (!isProtectedRoute(req)) return NextResponse.next();
+  }
+);
 
 export const config = {
   matcher: ["/((?!.+\\.[\\w]+$|_next).*)", "/", "/(api|trpc)(.*)"],

--- a/docs/guides/add-onboarding-flow.mdx
+++ b/docs/guides/add-onboarding-flow.mdx
@@ -69,7 +69,7 @@ Clerk's [`clerkMiddleware()`](https://clerk.com/docs/references/nextjs/clerk-mid
 
 The following example demonstrates how to use Clerk's `clerkMiddleware()` to redirect users based on their onboarding status. If the user is signed in and has not completed onboarding, they will be redirected to the onboarding page.
 
-Note that the following example protects all routes. This is so that any user visiting your application is forced to authenticate, and then forced to onboard. You can customize the `publicRoutes` array to include any routes that should be accessible to all users, even unauthenticated ones.
+Note that the following example protects all routes except one. This is so that any user visiting your application is forced to authenticate, and then forced to onboard. You can customize the array in the `createRouteMatcher()` function assigned to `isPublicRoute` to include any routes that should be accessible to all users, even unauthenticated ones.
 
 ```tsx filename="src/middleware.ts"
 import { clerkMiddleware } from "@clerk/nextjs/server";
@@ -77,7 +77,7 @@ import { redirectToSignIn } from "@clerk/nextjs/server";
 import { NextRequest, NextResponse } from "next/server";
 
 const isOnboardingRoute = createRouteMatcher(["/onboarding"])
-const isProtectedRoute = createRouteMatcher(["/protected-route-example"])
+const isPublicRoute = createRouteMatcher(["/public-route-example"])
 
 export default clerkMiddleware((auth, req: NextRequest) => {
     const { userId, sessionClaims } = auth();
@@ -88,7 +88,7 @@ export default clerkMiddleware((auth, req: NextRequest) => {
     }
 
     // If the user isn't signed in and the route is private, redirect to sign-in
-    if (!userId && isProtectedRoute(req))
+    if (!userId && !isPublicRoute(req))
       return redirectToSignIn({ returnBackUrl: req.url });
 
     // Catch users who do not have `onboardingComplete: true` in their publicMetadata
@@ -99,10 +99,10 @@ export default clerkMiddleware((auth, req: NextRequest) => {
     }
 
     // If the user is logged in and the route is protected, let them view.
-    if (userId && isProtectedRoute(req)) return NextResponse.next();
+    if (userId && !isPublicRoute(req)) return NextResponse.next();
 
     // If the route is public, anyone can view it.
-    if (!isProtectedRoute(req)) return NextResponse.next();
+    if (isPublicRoute(req)) return NextResponse.next();
   }
 );
 

--- a/docs/guides/add-onboarding-flow.mdx
+++ b/docs/guides/add-onboarding-flow.mdx
@@ -100,9 +100,6 @@ export default clerkMiddleware((auth, req: NextRequest) => {
 
     // If the user is logged in and the route is protected, let them view.
     if (userId && !isPublicRoute(req)) return NextResponse.next();
-
-    // If the route is public, anyone can view it.
-    if (isPublicRoute(req)) return NextResponse.next();
   }
 );
 

--- a/docs/references/nextjs/overview.mdx
+++ b/docs/references/nextjs/overview.mdx
@@ -51,9 +51,9 @@ Clerk continues to provide drop-in support for the Next.js Pages Router. In addi
 
 Both `auth()` and `getAuth()` return an `Auth` object. This JavaScript object contains important information like session data, your user's ID, as well as their organization ID. Learn more about the `Auth` object [here](/docs/references/nextjs/auth-object).
 
-### `authMiddleware()`
+### `clerkMiddleware()`
 
-The `authMiddleware()` helper integrates Clerk authentication into your Next.js application through middleware. It allows you to integrate authorization into both the client and server of your application. You can learn more [here](/docs/references/nextjs/auth-middleware).
+The `clerkMiddleware()` helper integrates Clerk authentication into your Next.js application through middleware. It allows you to integrate authorization into both the client and server of your application. You can learn more [here](/docs/references/nextjs/clerk-middleware).
 
 ### Demo repositories
 

--- a/docs/upgrade-guides/core-2/chrome-extension.mdx
+++ b/docs/upgrade-guides/core-2/chrome-extension.mdx
@@ -114,7 +114,7 @@ The new version ships with improved design and UX across all of Clerk's [UI comp
 
 ### After sign up/in/out default value change
 
-Defining redirect URLs for after sign up, in, and/or out via the Clerk dashboard has been removed in Core 2. In your Clerk dashboard, under "paths", there is a section called "Component paths", where URLs could be defined that had a deprecation warning. In Core 2, this functionality has been removed, and specifying redirect paths via the dashboard will no longer work. If you need to pass a redirect URL for after sign in/up/out, there are [a few different ways this can be done](/docs/account-portal/custom-redirects), from environment variables to middleware to supplying them directly to the relevant components.
+Defining redirect URLs for after sign up, in, and/or out via the Clerk dashboard has been removed in Core 2. In your Clerk dashboard, under "paths", there is a section called "Component paths", where URLs could be defined that had a deprecation warning. In Core 2, this functionality has been removed, and specifying redirect paths via the dashboard will no longer work. If you need to pass a redirect URL for after sign in/up/out, there are [a few different ways this can be done](/docs/guides/custom-redirects), from environment variables to middleware to supplying them directly to the relevant components.
 
 As part of this change, the default URL for each of these props has been set to `/`, so if you are passing `/` explicitly to any one of the above props, that line is no longer necessary and can be removed.
 

--- a/docs/upgrade-guides/core-2/expo.mdx
+++ b/docs/upgrade-guides/core-2/expo.mdx
@@ -94,7 +94,7 @@ The new version ships with improved design and UX across all of Clerk's [UI comp
 
 ### After sign up/in/out default value change
 
-Defining redirect URLs for after sign up, in, and/or out via the Clerk dashboard has been removed in Core 2. In your Clerk dashboard, under "paths", there is a section called "Component paths", where URLs could be defined that had a deprecation warning. In Core 2, this functionality has been removed, and specifying redirect paths via the dashboard will no longer work. If you need to pass a redirect URL for after sign in/up/out, there are [a few different ways this can be done](/docs/account-portal/custom-redirects), from environment variables to middleware to supplying them directly to the relevant components.
+Defining redirect URLs for after sign up, in, and/or out via the Clerk dashboard has been removed in Core 2. In your Clerk dashboard, under "paths", there is a section called "Component paths", where URLs could be defined that had a deprecation warning. In Core 2, this functionality has been removed, and specifying redirect paths via the dashboard will no longer work. If you need to pass a redirect URL for after sign in/up/out, there are [a few different ways this can be done](/docs/guides/custom-redirects), from environment variables to middleware to supplying them directly to the relevant components.
 
 As part of this change, the default URL for each of these props has been set to `/`, so if you are passing `/` explicitly to any one of the above props, that line is no longer necessary and can be removed.
 

--- a/docs/upgrade-guides/core-2/javascript.mdx
+++ b/docs/upgrade-guides/core-2/javascript.mdx
@@ -69,7 +69,7 @@ The new version ships with improved design and UX across all of Clerk's [UI comp
 
 ### After sign up/in/out default value change
 
-Defining redirect URLs for after sign up, in, and/or out via the Clerk dashboard has been removed in Core 2. In your Clerk dashboard, under "paths", there is a section called "Component paths", where URLs could be defined that had a deprecation warning. In Core 2, this functionality has been removed, and specifying redirect paths via the dashboard will no longer work. If you need to pass a redirect URL for after sign in/up/out, there are [a few different ways this can be done](/docs/account-portal/custom-redirects), from environment variables to middleware to supplying them directly to the relevant components.
+Defining redirect URLs for after sign up, in, and/or out via the Clerk dashboard has been removed in Core 2. In your Clerk dashboard, under "paths", there is a section called "Component paths", where URLs could be defined that had a deprecation warning. In Core 2, this functionality has been removed, and specifying redirect paths via the dashboard will no longer work. If you need to pass a redirect URL for after sign in/up/out, there are [a few different ways this can be done](/docs/guides/custom-redirects), from environment variables to middleware to supplying them directly to the relevant components.
 
 As part of this change, the default URL for each of these props has been set to `/`, so if you are passing `/` explicitly to any one of the above props, that line is no longer necessary and can be removed.
 

--- a/docs/upgrade-guides/core-2/nextjs.mdx
+++ b/docs/upgrade-guides/core-2/nextjs.mdx
@@ -138,7 +138,7 @@ See the [`clerkMiddleware()`](/docs/references/nextjs/clerk-middleware) docs for
 
 Clerk strongly recommends migrating to the new `clerkMiddleware()` for an improved DX and access to all present and upcoming features. However, `authMiddleware()`, while deprecated, will continue to work in v5 and will not be removed until the next major version, so you do not _need_ to make any changes to your Middleware setup this version.
 
-The most basic migration will be updating the import and changing out the default export, then mirroring the previous behavior of protecting all routes as such:
+The most basic migration will be updating the import and changing out the default export, then mirroring the previous behavior of protecting all routes except `/sign-in` or `/sign-up` by doing the following:
 
 ```diff
 - import { authMiddleware } from "@clerk/nextjs/server"

--- a/docs/upgrade-guides/core-2/nextjs.mdx
+++ b/docs/upgrade-guides/core-2/nextjs.mdx
@@ -425,7 +425,7 @@ As part of this release, some of the top-level exports of `@clerk/nextjs` have b
 
 ### After sign up/in/out default value change
 
-Defining redirect URLs for after sign up, in, and/or out via the Clerk Dashboard has been removed in Core 2. Before Core 2, on the [Paths](https://dashboard.clerk.com/last-active?path=paths) page in the Clerk Dashboard, there was a section called **Component paths** where redirect URLs could be defined. In Core 2, this functionality has been removed, and specifying redirect paths via the Dashboard will no longer work. If you need to pass a redirect URL for after sign in/up/out, there are [a few different ways this can be done](/docs/account-portal/custom-redirects), from environment variables to Middleware to supplying them directly to the relevant components.
+Defining redirect URLs for after sign up, in, and/or out via the Clerk Dashboard has been removed in Core 2. Before Core 2, on the [Paths](https://dashboard.clerk.com/last-active?path=paths) page in the Clerk Dashboard, there was a section called **Component paths** where redirect URLs could be defined. In Core 2, this functionality has been removed, and specifying redirect paths via the Dashboard will no longer work. If you need to pass a redirect URL for after sign in/up/out, there are [a few different ways this can be done](/docs/guides/custom-redirects), from environment variables to Middleware to supplying them directly to the relevant components.
 
 As part of this change, the default redirect URL for each of these props has been set to `/`, so if you are passing `/` explicitly to any one of the above props, that line is no longer necessary and can be removed.
 

--- a/docs/upgrade-guides/core-2/nextjs.mdx
+++ b/docs/upgrade-guides/core-2/nextjs.mdx
@@ -142,10 +142,16 @@ The most basic migration will be updating the import and changing out the defaul
 
 ```diff
 - import { authMiddleware } from "@clerk/nextjs/server"
-+ import { clerkMiddleware } from '@clerk/nextjs/server'
++ import { clerkMiddleware, createRouteMatcher } from '@clerk/nextjs/server'
+
++ const isPublicRoute = createRouteMatcher(['/sign-in', '/sign-up']);
 
 - export default authMiddleware()
-+ export default clerkMiddleware((auth) => auth().protect())
++ export default clerkMiddleware((auth, request) =>{ 
++   if(!isPublicRoute(request)){
++     auth().protect();
++   }
++ });
 
   export const config = {
     matcher: ["/((?!.*\\..*|_next).*)", "/", "/(api|trpc)(.*)"],

--- a/docs/upgrade-guides/core-2/react.mdx
+++ b/docs/upgrade-guides/core-2/react.mdx
@@ -94,7 +94,7 @@ The new version ships with improved design and UX across all of Clerk's [UI comp
 
 ### After sign up/in/out default value change
 
-Defining redirect URLs for after sign up, in, and/or out via the Clerk dashboard has been removed in Core 2. In your Clerk dashboard, under "paths", there is a section called "Component paths", where URLs could be defined that had a deprecation warning. In Core 2, this functionality has been removed, and specifying redirect paths via the dashboard will no longer work. If you need to pass a redirect URL for after sign in/up/out, there are [a few different ways this can be done](/docs/account-portal/custom-redirects), from environment variables to middleware to supplying them directly to the relevant components.
+Defining redirect URLs for after sign up, in, and/or out via the Clerk dashboard has been removed in Core 2. In your Clerk dashboard, under "paths", there is a section called "Component paths", where URLs could be defined that had a deprecation warning. In Core 2, this functionality has been removed, and specifying redirect paths via the dashboard will no longer work. If you need to pass a redirect URL for after sign in/up/out, there are [a few different ways this can be done](/docs/guides/custom-redirects), from environment variables to middleware to supplying them directly to the relevant components.
 
 As part of this change, the default URL for each of these props has been set to `/`, so if you are passing `/` explicitly to any one of the above props, that line is no longer necessary and can be removed.
 

--- a/docs/upgrade-guides/core-2/remix.mdx
+++ b/docs/upgrade-guides/core-2/remix.mdx
@@ -114,7 +114,7 @@ The new version ships with improved design and UX across all of Clerk's [UI comp
 
 ### After sign up/in/out default value change
 
-Defining redirect URLs for after sign up, in, and/or out via the Clerk dashboard has been removed in Core 2. In your Clerk dashboard, under "paths", there is a section called "Component paths", where URLs could be defined that had a deprecation warning. In Core 2, this functionality has been removed, and specifying redirect paths via the dashboard will no longer work. If you need to pass a redirect URL for after sign in/up/out, there are [a few different ways this can be done](/docs/account-portal/custom-redirects), from environment variables to middleware to supplying them directly to the relevant components.
+Defining redirect URLs for after sign up, in, and/or out via the Clerk dashboard has been removed in Core 2. In your Clerk dashboard, under "paths", there is a section called "Component paths", where URLs could be defined that had a deprecation warning. In Core 2, this functionality has been removed, and specifying redirect paths via the dashboard will no longer work. If you need to pass a redirect URL for after sign in/up/out, there are [a few different ways this can be done](/docs/guides/custom-redirects), from environment variables to middleware to supplying them directly to the relevant components.
 
 As part of this change, the default URL for each of these props has been set to `/`, so if you are passing `/` explicitly to any one of the above props, that line is no longer necessary and can be removed.
 


### PR DESCRIPTION
[Request from this thread](https://clerkinc.slack.com/archives/C01QFRQNHSN/p1713890512288219)

- Also fixes broken links to the custom-redirects guide, which was breaking the linter