### PR TITLE
fix(remix-quickstart): Update guide to reflect the root Layout export

### DIFF
--- a/docs/quickstarts/remix.mdx
+++ b/docs/quickstarts/remix.mdx
@@ -50,13 +50,13 @@ To configure Clerk in your Remix application, you will need to update your root 
 import type { MetaFunction, LoaderFunction } from "@remix-run/node";
 import {
   Links,
-  LiveReload,
   Meta,
   Outlet,
   Scripts,
   ScrollRestoration,
 } from "@remix-run/react";
 
+// Import rootAuthLoader
 import { rootAuthLoader } from "@clerk/remix/ssr.server";
 
 export const meta: MetaFunction = () => ([{
@@ -65,23 +65,29 @@ export const meta: MetaFunction = () => ([{
   viewport: "width=device-width,initial-scale=1",
 }]);
 
+// Export as the root route loader
 export const loader: LoaderFunction = (args) => rootAuthLoader(args);
 
-export default function App() {
+export function Layout({ children }: { children: React.ReactNode }) {
   return (
     <html lang="en">
       <head>
+        <meta charSet="utf-8" />
+        <meta name="viewport" content="width=device-width, initial-scale=1" />
         <Meta />
         <Links />
       </head>
       <body>
-        <Outlet />
+        {children}
         <ScrollRestoration />
         <Scripts />
-        <LiveReload />
       </body>
     </html>
   );
+}
+
+export default function App() {
+  return <Outlet />;
 }
 ```
 
@@ -111,7 +117,6 @@ import type { MetaFunction, LoaderFunction } from "@remix-run/node";
 
 import {
   Links,
-  LiveReload,
   Meta,
   Outlet,
   Scripts,
@@ -122,32 +127,36 @@ import { rootAuthLoader } from "@clerk/remix/ssr.server";
 // Import ClerkApp
 import { ClerkApp } from "@clerk/remix";
 
-export const meta: MetaFunction = () => ({
+export const meta: MetaFunction = () => ([{
   charset: "utf-8",
   title: "New Remix App",
   viewport: "width=device-width,initial-scale=1",
-});
+}]);
 
 export const loader: LoaderFunction = (args) => rootAuthLoader(args);
 
-function App() {
+export function Layout({ children }: { children: React.ReactNode }) {
   return (
     <html lang="en">
       <head>
+        <meta charSet="utf-8" />
+        <meta name="viewport" content="width=device-width, initial-scale=1" />
         <Meta />
         <Links />
       </head>
       <body>
-        <Outlet />
+        {children}
         <ScrollRestoration />
         <Scripts />
-        <LiveReload />
       </body>
     </html>
   );
 }
 
-// Wrap your app in ClerkApp(app)
+function App() {
+  return <Outlet />;
+}
+
 export default ClerkApp(App);
 ```
 
@@ -208,22 +217,36 @@ Clerk offers [Control Components](/docs/components/overview) that allow you to p
 
 ```tsx filename="routes/index.tsx"
 import {
+  SignOutButton,
   SignedIn,
   SignedOut,
   RedirectToSignIn,
   UserButton,
 } from "@clerk/remix";
+import { Link } from "@remix-run/react";
 
 export default function Index() {
   return (
     <div>
+      <h1>Index Route</h1>
       <SignedIn>
-        <h1>Index route</h1>
         <p>You are signed in!</p>
-        <UserButton />
+        <div>
+          <p>View your profile here 👇</p>
+          <UserButton />
+        </div>
+        <div>
+          <SignOutButton />
+        </div>
       </SignedIn>
       <SignedOut>
-        <RedirectToSignIn />
+        <p>You are signed out</p>
+        <div>
+          <Link to="/sign-in">Go to Sign in</Link>
+        </div>
+        <div>
+          <Link to="/sign-up">Go to Sign up</Link>
+        </div>
       </SignedOut>
     </div>
   );


### PR DESCRIPTION
Resolves #940 

Changes made
- Update content of `root.tsx` to reflect the `Layout` export
- Improve the `index.tsx` route content to better expose Clerk's features

How was this tested?
- Create a brand new remix app using `npx create-remix@latest`
- Follow the guide to step 6 to ensure the new documentation code is correct