### PR TITLE
Core 2 removed isReady

### DIFF
--- a/docs/testing/cypress.mdx
+++ b/docs/testing/cypress.mdx
@@ -48,7 +48,7 @@ Cypress.Commands.add(`signIn`, () => {
   cy.window()
     .should((window) => {
       expect(window).to.not.have.property(`Clerk`, undefined);
-      expect(window.Clerk.isReady()).to.eq(true);
+      expect(window.Clerk.loaded).to.eq(true);
     })
     .then(async (window) => {
       await cy.clearCookies({ domain: window.location.domain });


### PR DESCRIPTION
The Cypress docs not reflecting the new loaded has caused confusion for some people upgrading to Core 2