### PR TITLE
Updating links to revolvapp product and docs.

### DIFF
--- a/docs/authentication/configuration/email-sms-templates.mdx
+++ b/docs/authentication/configuration/email-sms-templates.mdx
@@ -26,7 +26,7 @@ It will be useful to take a look at the following terms as they will reappear in
 
 ### Revolvapp WYSIWYG email editor plugin
 
-The email editor uses the [Revolvapp](https://imperavi.com/revolvapp) email template editor plugin by Imperavi. To acquaint yourself with the template markup syntax, please consult the corresponding [documentation page](https://imperavi.com/redactor/legacy/revolvapp/docs/syntax/quick-start).
+The email editor uses the [Revolvapp](https://imperavi.com/redactor/legacy/revolvapp) email template editor plugin by Imperavi. To acquaint yourself with the template markup syntax, please consult the corresponding [documentation page](https://imperavi.com/redactor/legacy/revolvapp/docs/syntax/quick-start).
 
 As you will see, the template markup is an HTML-like language and each type of node supports its own set of attributes which control its behavior. A lot of the attributes are borrowed from HTML itself.
 

--- a/docs/authentication/configuration/email-sms-templates.mdx
+++ b/docs/authentication/configuration/email-sms-templates.mdx
@@ -26,7 +26,7 @@ It will be useful to take a look at the following terms as they will reappear in
 
 ### Revolvapp WYSIWYG email editor plugin
 
-The email editor uses the [Revolvapp](https://imperavi.com/revolvapp) email template editor plugin by Imperavi. To acquaint yourself with the template markup syntax, please consult the corresponding [documentation page](https://imperavi.com/revolvapp/docs/syntax/quick-start).
+The email editor uses the [Revolvapp](https://imperavi.com/revolvapp) email template editor plugin by Imperavi. To acquaint yourself with the template markup syntax, please consult the corresponding [documentation page](https://imperavi.com/redactor/legacy/revolvapp/docs/syntax/quick-start).
 
 As you will see, the template markup is an HTML-like language and each type of node supports its own set of attributes which control its behavior. A lot of the attributes are borrowed from HTML itself.
 


### PR DESCRIPTION
The old links now redirect to the [redactor home page](https://imperavi.com/redactor/).

It's worth noting that the new links have a `/legacy/` path, and Revolvapp is now listed as "legacy" [on the imperavi home page](https://imperavi.com/#:~:text=Redactor%20Classic-,Revolvapp,-Books)