### PR TITLE
Reinstate revalidate workflow for PR previews

### DIFF
--- a/.github/workflows/revalidate.yml
+++ b/.github/workflows/revalidate.yml
@@ -1,0 +1,49 @@
+name: Revalidate
+
+env:
+  API_BASE_URL: https://clerk.com
+
+on:
+  pull_request:
+    types: [synchronize]
+    paths:
+      - 'docs/**'
+
+jobs:
+  revalidate:
+    # skip if `deploy-preview` label has not been added
+    if: ${{ contains(github.event.pull_request.labels.*.name, 'deploy-preview') }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 10 # Fetch more than just the latest commit so we can accurately compare
+
+      - name: Get changed files
+        id: changed-files
+        uses: tj-actions/changed-files@v44
+        with:
+          files: docs/**
+          json: true
+
+      - name: Get files to revalidate
+        id: files-to-revalidate
+        run: |
+          files_to_revalidate=$(echo ${{ toJSON(steps.changed-files.outputs.all_changed_files) }})
+          pr_number=$(echo ${{ toJSON(github.event.number) }})
+          echo "files=$files_to_revalidate" >> "$GITHUB_OUTPUT"
+          echo "pr_number=$pr_number"       >> "$GITHUB_OUTPUT"
+          echo "### PR number"           >> $GITHUB_STEP_SUMMARY
+          echo ""                        >> $GITHUB_STEP_SUMMARY
+          echo "$pr_number"              >> $GITHUB_STEP_SUMMARY
+          echo "### Files to revalidate" >> $GITHUB_STEP_SUMMARY
+          echo ""                        >> $GITHUB_STEP_SUMMARY
+          echo "$files_to_revalidate"    >> $GITHUB_STEP_SUMMARY
+
+      - name: Trigger revalidate
+        run: |
+          curl -X POST ${{ env.API_BASE_URL }}/docs/revalidate \
+            -H "Content-Type: application/json" \
+            -H "Authorization: Bearer ${{ secrets.REVALIDATE_DOCS_SECRET }}" \
+            -d "{\"files\": ${{ steps.files-to-revalidate.outputs.files }}, \"pr\": ${{ steps.files-to-revalidate.outputs.pr_number }}}"


### PR DESCRIPTION
When pull requests are updated we grab the changed files in the `docs` directory (using [`tj-actions/changed-files`](https://github.com/marketplace/actions/changed-files)) and send them to the `/docs/revalidate` [endpoint](https://github.com/clerk/clerk/blob/main/src/app/docs/revalidate/route.ts):

```bash
curl -X POST https://clerk.com/docs/revalidate \
  -H "Content-Type: application/json" \
  -H "Authorization: Bearer SECRET" \
  -d "{\"files\": [\"docs/quickstarts/nextjs.mdx\"], \"pr\": 890}"
```