### PR TITLE
fix typo in docs

### DIFF
--- a/docs/quickstarts/setup-clerk.mdx
+++ b/docs/quickstarts/setup-clerk.mdx
@@ -23,7 +23,7 @@ description: Set up a new Clerk account and integrate it into a new application.
 
 ### Sign into Clerk
 
-[Create a Clerk account](https://dashboard.clerk.com/sign-up) or [sign into your Clerk dasbhoard](https://dashboard.clerk.com/).
+[Create a Clerk account](https://dashboard.clerk.com/sign-up) or [sign into your Clerk dashboard](https://dashboard.clerk.com/).
 
 ### Create a Clerk application
 


### PR DESCRIPTION
fixed spelling of "dashboard"
the typo can be seen [here](https://clerk.com/docs/quickstarts/setup-clerk#:~:text=into%20your%20Clerk-,dasbhoard,-.)