### PR TITLE
Update env var guide

### DIFF
--- a/docs/deployments/clerk-environment-variables.mdx
+++ b/docs/deployments/clerk-environment-variables.mdx
@@ -8,13 +8,17 @@ You can use environment variables to configure how your Clerk app behaves, such 
 
 This page is a reference for all available Clerk environment variables.
 
+## Compatibility
+
+In the frontend, Clerk's environment variables work for most popular meta-frameworks, such as Next.js or Remix. If you're building a pure React app, you should use the props on the components you're using.
+
+For example, to force users to redirect to a specific URL after signing in, you would use the `signInForceRedirectUrl` prop on [`<ClerkProvider>`](/docs/components/clerk-provider) rather than the `CLERK_SIGN_IN_FORCE_REDIRECT_URL` environment variable.
+
 ## Sign-in and sign-up redirects
 
 Components, such as [`<ClerkProvider>`](/docs/components/clerk-provider), [`<UserButton>`](/docs/components/user/user-button), and more, provide props for you to specify where users will be redirected. You should use environment variables instead of these props whenever possible.
 
-See the [Custom Redirects guide](/docs/guides/custom-redirects) for more information.
-
-<Tabs type="framework" items={["General", "Next.js", "React"]}>
+<Tabs type="framework" items={["General", "Next.js"]}>
 
   <Tab>
   | Variable | Description |
@@ -36,17 +40,6 @@ See the [Custom Redirects guide](/docs/guides/custom-redirects) for more informa
   | `NEXT_PUBLIC_CLERK_SIGN_IN_FALLBACK_REDIRECT_URL` | The fallback URL to redirect to after the user signs in, if there's no `redirect_url` in the path already. Defaults to `/`. |
   | `NEXT_PUBLIC_CLERK_SIGN_UP_FALLBACK_REDIRECT_URL` | The fallback URL to redirect to after the user signs up, if there's no `redirect_url` in the path already. Defaults to `/`. |
   </Tab>
-  <Tab>
-  | Variable | Description |
-  | -------- | ----------- |
-  | `VITE_CLERK_SIGN_IN_URL` | Full URL or path to the sign in page. Use this variable to provide the target of the 'Sign In' link that's rendered in the `<SignUp />` component. |
-  | `VITE_CLERK_SIGN_UP_URL` | Full URL or path to the sign up page. Use this variable to provide the target of the 'Sign Up' link that's rendered in the `<SignIn />` component. |
-  | `VITE_CLERK_SIGN_IN_FORCE_REDIRECT_URL` | If provided, this URL will always be redirected to after the user signs in. |
-  | `VITE_CLERK_SIGN_UP_FORCE_REDIRECT_URL` | If provided, this URL will always be redirected to after the user signs up. |
-  | `VITE_CLERK_SIGN_IN_FALLBACK_REDIRECT_URL` | The fallback URL to redirect to after the user signs in, if there's no `redirect_url` in the path already. Defaults to `/`. |
-  | `VITE_CLERK_SIGN_UP_FALLBACK_REDIRECT_URL` | The fallback URL to redirect to after the user signs up, if there's no `redirect_url` in the path already. Defaults to `/`. |
-  </Tab>
-
 </Tabs>
 
 ## Clerk publishable and secret keys
@@ -55,7 +48,7 @@ To access your Clerk app in your local project, you must specify your app's publ
 
 You can find these keys in the Clerk Dashboard on the [API Keys](https://dashboard.clerk.com/last-active?path=api-keys) page.
 
-<Tabs type="framework" items={["General", "Next.js", "React"]}>
+<Tabs type="framework" items={["General", "Next.js"]}>
 
   <Tab>
   | Variable | Description |
@@ -69,11 +62,6 @@ You can find these keys in the Clerk Dashboard on the [API Keys](https://dashboa
   | `NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY` | Your Clerk app's publishable key, which you can find in the Clerk dashboard. It will be prefixed with `pk_test_` in development instances and `pk_live_` in production instances. |
   | `CLERK_SECRET_KEY` | Your Clerk app's secret key, which you can find in the Clerk dashboard. It will be prefixed with `sk_test_` in development instances and `sk_live_` in production instances. **Do not expose this on the frontend with a public environment variable**. |
   </Tab>
-  <Tab>
-  | Variable | Description |
-  | -------- | ----------- |
-  | `VITE_CLERK_PUBLISHABLE_KEY` | Your Clerk app's publishable key, which you can find in the Clerk dashboard. It will be prefixed with `pk_test_` in development instances and `pk_live_` in production instances. |
-  </Tab>
 
 </Tabs>
 
@@ -81,7 +69,7 @@ You can find these keys in the Clerk Dashboard on the [API Keys](https://dashboa
 
 The following environment variables enable you to configure API and SDK behavior, such as what version of the SDK your project uses, what proxy URL you use to connect to Clerk's Frontend API, and more.
 
-<Tabs type="framework" items={["General", "Next.js", "React"]}>
+<Tabs type="framework" items={["General", "Next.js"]}>
 
   <Tab>
   | Variable | Description |
@@ -105,17 +93,6 @@ The following environment variables enable you to configure API and SDK behavior
   | `NEXT_PUBLIC_CLERK_FAPI` | Sets the URL to your Clerk app's Frontend API. |
   | `NEXT_PUBLIC_CLERK_PROXY_URL` | Sets the URL for your proxy. |
   </Tab>
-  <Tab>
-  | Variable | Description |
-  | -------- | ----------- |
-  | `VITE_CLERK_JS_URL` | Sets the URL that `@clerk/clerk-react` should hot-load `@clerk/clerk-js` from. `VITE_CLERK_JS` does the same but is deprecated. |
-  | `VITE_CLERK_JS_VERSION` | Sets the npm version for `@clerk/clerk-js`. |
-  | `VITE_CLERK_API_URL` | Sets the Clerk API URL for debugging. Defaults to `"https://api.clerk.com"` |
-  | `VITE_CLERK_API_VERSION` | Sets the version of the Clerk API to use. Defaults to `"v1"` |
-  | `CLERK_JWT_KEY` | Sets the JWT verification key that Clerk will use to provide networkless JWT session token verification. See [Networkless Token Verification](/docs/references/nodejs/token-verification#validate-the-authorized-party-of-a-session-token) to learn more. |
-  | `VITE_CLERK_FAPI` | Sets the URL to your Clerk apps' Frontend API. |
-  | `VITE_CLERK_PROXY_URL` | Sets the URL for your proxy. |
-  </Tab>
 
 </Tabs>
 
@@ -123,7 +100,7 @@ The following environment variables enable you to configure API and SDK behavior
 
 Clerk supports sharing sessions across different domains by adding one or many satellite domains to an application. See [the sattelite domains guide](/docs/advanced-usage/satellite-domains) for more information.
 
-<Tabs type="framework" items={["General", "Next.js", "React"]}>
+<Tabs type="framework" items={["General", "Next.js"]}>
 
   <Tab>
   | Variable | Description |
@@ -137,19 +114,13 @@ Clerk supports sharing sessions across different domains by adding one or many s
   | `NEXT_PUBLIC_CLERK_DOMAIN` | Sets your satellite application's domain. Required to share sessions across multiple domains. |
   | `NEXT_PUBLIC_CLERK_IS_SATELLITE` | Indicates whether or not the application is a satellite application. |
   </Tab>
-  <Tab>
-  | Variable | Description |
-  | -------- | ----------- |
-  | `VITE_CLERK_DOMAIN` | Sets your satellite application's domain. Required to share sessions across multiple domains. |
-  | `VITE_CLERK_IS_SATELLITE` | Indicates whether or not the application is a satellite application. |
-  </Tab>
 </Tabs>
 
 ## Telemetry
 
 Clerk provides environment variables for opting out of telemetry data collection. See [the telemetry documentation](/docs/telemetry) for more information.
 
-<Tabs type="framework" items={["General", "Next.js", "React"]}>
+<Tabs type="framework" items={["General", "Next.js"]}>
 
   <Tab>
   | Variable | Description |
@@ -162,8 +133,5 @@ Clerk provides environment variables for opting out of telemetry data collection
   | -------- | ----------- |
   | `NEXT_PUBLIC_CLERK_TELEMETRY_DISABLED` | Set this to `1` to disable Clerk's telemetry data collection. |
   | `NEXT_PUBLIC_CLERK_TELEMETRY_DEBUG` | Set this to `1` to prevent telemetry data from being sent to Clerk. It will be logged to the console instead. |
-  </Tab>
-  <Tab>
-  If you are using `@clerk/clerk-react` directly, or using an SDK that doesn't have environment variable support, you can opt out by passing the `telemetry` prop to `<ClerkProvider />`. See [the telemetry documentation](/docs/telemetry) for more information.
   </Tab>
 </Tabs>

--- a/docs/deployments/clerk-environment-variables.mdx
+++ b/docs/deployments/clerk-environment-variables.mdx
@@ -10,9 +10,9 @@ This page is a reference for all available Clerk environment variables.
 
 ## Compatibility
 
-In the frontend, Clerk's environment variables work for most popular meta-frameworks, such as Next.js or Remix. If you're building a pure React app, you should use the props on the components you're using.
+In the frontend, Clerk's environment variables work for most popular meta-frameworks, such as Next.js or Remix. 
 
-For example, to force users to redirect to a specific URL after signing in, you would use the `signInForceRedirectUrl` prop on [`<ClerkProvider>`](/docs/components/clerk-provider) rather than the `CLERK_SIGN_IN_FORCE_REDIRECT_URL` environment variable.
+If you're building a pure React app, you should use the props on the components you're using. For example, to force users to redirect to a specific URL after signing in, you would use the `signInForceRedirectUrl` prop on [`<ClerkProvider>`](/docs/components/clerk-provider) rather than the `CLERK_SIGN_IN_FORCE_REDIRECT_URL` environment variable.
 
 ## Sign-in and sign-up redirects
 


### PR DESCRIPTION
This PR:

- Explains that our env vars work with meta-frameworks, and pure React users should stick to the ClerkProvider props ([per this discussion](https://clerkinc.slack.com/archives/C04KENP2GFL/p1712946780211689?thread_ts=1712946018.335729&cid=C04KENP2GFL))
- Removes React env var examples, as VITE env vars would only work for users deploying React with Vite