### PR TITLE
Update email-password custom flows guide

### DIFF
--- a/docs/custom-flows/email-password.mdx
+++ b/docs/custom-flows/email-password.mdx
@@ -5,36 +5,32 @@ description: Clerk provides the useSignUp and useSignIn hooks, which allow you t
 
 # Custom email/password flow
 
-Clerk supports password authentication, which allows users to sign up and sign in using their email address and password. This guide will walk you through how to build a custom email/password sign-up and sign-in flow using the [`useSignUp()`](/docs/references/react/use-sign-up) and [`useSignIn()`](/docs/references/react/use-sign-up) React hooks.
+Clerk supports password authentication, which allows users to sign-up and sign-in using their email address and password. This guide will teach you how to build a custom email/password sign-up and sign-in flow using [`useSignUp()`](/docs/references/react/use-sign-up) and [`useSignIn()`](/docs/references/react/use-sign-up).
 
 <Steps>
 
 ### Enable password and email
 
-In the Clerk dashboard, you will need to enable both email and password as a sign-in and sign-up method. Go to **User & Authentication > [Email, Phone, and Username](https://dashboard.clerk.com/last-active?path=user-authentication/email-phone-username)**.Toggle on **Email address** and **Password**.
+You must enable both email and password as a sign-in and sign-up method in your Clerk app instance.
 
-<Images
-  width={3024}
-  height={1654}
-  src="/docs/images/custom-flows/enable-email-password.jpg"
-  alt="The 'Email, Phone, and Username' page in the Clerk dashboard. There is a red arrow pointing the title of the page. There are also red arrows pointing to the toggles for 'Email address' and 'Password', both toggled on."
-/>
+1. In the Clerk Dashboard, go to **User & Authentication > [Email, Phone, and Username](https://dashboard.clerk.com/last-active?path=user-authentication/email-phone-username)**.
+1. Toggle on **Email address** and **Password**.
 
-### Create sign up flow
+### Create sign-up flow
 
-The email/password sign-up flow requires users to provide their email address and their password and returns a newly-created user with an active session.
+The email/password sign-up flow requires users to provide their email address and password, and returns a newly-created user with an active session.
 
-A successful sign-up consists of the following steps:
+A successful sign-up flow consists of the following steps:
 
 1. Initiate the sign-up process by collecting the user's email address and password.
-2. Prepare the email address verification, which sends a one-time code to the given address.
-3. Attempt to complete the email address verification by supplying the one-time code.
-4. If the email address verification is successful, complete the sign-up process by creating the user account and setting their session as active.
+1. Prepare the email address verification, which sends a one-time code to the given address.
+1. Attempt to complete the email address verification by supplying the one-time code.
+1. If the email address verification is successful, complete the sign-up process by creating the user account and setting their session as active.
 
 <Tabs type="framework" items={["Next.js","React","Remix", "Gatsby", "Expo", "JavaScript"]}>
   <Tab>
     <CodeBlockTabs type="router" options={["App Router", "Pages Router"]}>
-    ```tsx filename="app/sign-up/[[...sign-up]]/page.tsx
+    ```tsx filename="app/sign-up/[[...sign-up]]/page.tsx"
     'use client'
 
     import * as React from 'react';
@@ -248,6 +244,7 @@ A successful sign-up consists of the following steps:
 
   <Tab>
   ```tsx filename="signup.tsx"
+  import React from "react";
   import { useState } from "react";
   import { useSignUp } from "@clerk/clerk-react";
 
@@ -896,6 +893,7 @@ In email/password authentication, the sign-in is a process that requires users t
 
   <Tab>
   ```tsx filename="signin.tsx"
+  import React from "react";
   import { useState } from "react";
   import { useSignIn } from "@clerk/clerk-react";
 

--- a/docs/custom-flows/email-password.mdx
+++ b/docs/custom-flows/email-password.mdx
@@ -11,10 +11,15 @@ Clerk supports password authentication, which allows users to sign-up and sign-i
 
 ### Enable password and email
 
-You must enable both email and password as a sign-in and sign-up method in your Clerk app instance.
+You must enable Password and Email address as sign-in and sign-up methods in your Clerk app instance.
 
 1. In the Clerk Dashboard, go to **User & Authentication > [Email, Phone, and Username](https://dashboard.clerk.com/last-active?path=user-authentication/email-phone-username)**.
 1. Toggle on **Email address** and **Password**.
+
+This guide will teach you how to create a sign-up flow that uses an email verification code to verify new users. To enable this functionality in your Clerk app instance:
+
+1. In the [Email, Phone, and Username](https://dashboard.clerk.com/last-active?path=user-authentication/email-phone-username) page of the Clerk Dashboard, select the gear symbol next to **Email address** to open up the configuration settings. A modal titled **Email address** should open.
+1. Near the bottom of this modal, enable **Email verification code**.
 
 ### Create sign-up flow
 
@@ -1206,3 +1211,7 @@ In email/password authentication, the sign-in is a process that requires users t
   </Tab>
 </Tabs>
 </Steps>
+
+## Store user data outside of Clerk
+
+The sign-up and sign-in flows described in this guide will store user credentials and session data in Clerk by default. To use Clerk with other services, such as [Supabase](/docs/integrations/databases/supabase) or [Firebase](/docs/integrations/databases/firebase), see [the Integrations documentation](/docs/integrations/overview).


### PR DESCRIPTION
This pr:

- Updates our instructions on enabling authentication options. The current steps lead to a 422 error.
- Adds a React import to the React examples to prevent errors
- Clarifies that user credentials will be stored in Clerk, but other services can still be used with Clerk auth

These are all in response to user feedback [you can find in this linear issue](https://linear.app/clerk/issue/DOCS-6138/test-and-update-our-custom-flows-email-password-docs).