### PR TITLE
Update core 1 docs link

### DIFF
--- a/docs/manifest.json
+++ b/docs/manifest.json
@@ -480,7 +480,16 @@
       ["Programmatically lock and unlock accounts", "/security/programmatically-lock-user-accounts"]
     ]
   ],
-  ["Core 1 Documentation", "/docs/core-1"],
+  [
+    { 
+      "title": "Previous Version Docs", 
+      "icon": "", 
+      "root": "/docs" 
+    },
+    [
+      ["Core 1", "/docs/core-1"]
+    ]
+  ],
   "# SDK References",
   [
     { "title": "Next.js", "icon": "nextjs", "root": "references/nextjs" },


### PR DESCRIPTION
We need to add an icon and change it from a simple link to a dropdown that says something like "Previous Docs", with "Core 1" being the only item in the list.

Icon changes must happen in a pr to clerk/clerk