### PR TITLE
Nodejs reference: Add missing publishable key

### DIFF
--- a/docs/backend-requests/handling/nodejs.mdx
+++ b/docs/backend-requests/handling/nodejs.mdx
@@ -15,7 +15,7 @@ The Clerk Node SDK offers two authentication middlewares specifically for [Expre
 
 <CodeBlockTabs type="js-ts" options={["JavaScript", "TypeScript"]}>
   ```js
-  import "dotenv/config"; // To read CLERK_SECRET_KEY
+  import "dotenv/config"; // To read CLERK_SECRET_KEY and CLERK_PUBLISHABLE_KEY
   import { ClerkExpressWithAuth } from "@clerk/clerk-sdk-node";
   import express from "express";
 

--- a/docs/backend-requests/handling/nodejs.mdx
+++ b/docs/backend-requests/handling/nodejs.mdx
@@ -40,7 +40,7 @@ app.listen(port, () => {
   ```
 
   ```typescript
-  import "dotenv/config"; // To read CLERK_SECRET_KEY
+  import "dotenv/config"; // To read CLERK_SECRET_KEY and CLERK_PUBLISHABLE_KEY
   import {
     ClerkExpressWithAuth,
     LooseAuthProp,
@@ -87,7 +87,7 @@ app.listen(port, () => {
 
 <CodeBlockTabs type="js-ts" options={["JavaScript", "TypeScript"]}>
   ```js
-  import "dotenv/config"; // To read CLERK_SECRET_KEY
+  import "dotenv/config"; // To read CLERK_SECRET_KEY and CLERK_PUBLISHABLE_KEY
   import { ClerkExpressRequireAuth } from '@clerk/clerk-sdk-node';
   import express from 'express';
 
@@ -117,7 +117,7 @@ app.listen(port, () => {
   ```
 
   ```typescript
-  import "dotenv/config"; // To read CLERK_SECRET_KEY
+  import "dotenv/config"; // To read CLERK_SECRET_KEY and CLERK_PUBLISHABLE_KEY
 import {
   ClerkExpressRequireAuth,
   RequireAuthProp,

--- a/docs/references/nodejs/overview.mdx
+++ b/docs/references/nodejs/overview.mdx
@@ -40,6 +40,7 @@ Below is an example of an `.env.local` file.
 <InjectKeys>
 
 ```env filename=".env.local"
+CLERK_PUBLISHABLE_KEY={{pub_key}}
 CLERK_SECRET_KEY={{secret}}
 ```
 


### PR DESCRIPTION
WARNING: In contrast to what the contributing guidelines say, I was NOT able to run `npm install` (and thus `npm run lint` ) because `npm install` errored out with `ReferenceError: unzipper is not defined` in the `\node_modules\@vvago\vale` folder (I'm on Windows). Despite that, I think a pull request might help you more than a simple issue.

---

This pull request
- adds the missing CLERK_PUBLISHABLE_KEY to the NodeJS reference page
- mentions CLERK_PUBLISHABLE_KEY on the backend requests page for nodejs

I think this change is important because when this env variable is not set, every expressjs authentication middleware errors out saying "Publishable key not valid". I just experienced this myself. It took me 30 minutes before seeing that the readme of the npm package (https://www.npmjs.com/package/@clerk/clerk-sdk-node) indeed mentions `CLERK_PUBLISHABLE_KEY` while the current documentation does not. Hope this helps.

Possible future work: 
- Error should be "Missing CLERK_PUBLISHABLE_KEY" instead of "Publishable key not valid"