### PR TITLE
Tweak to middleware section in Next.js guide

### DIFF
--- a/docs/quickstarts/nextjs.mdx
+++ b/docs/quickstarts/nextjs.mdx
@@ -82,8 +82,9 @@ The final result should resemble the following:
 
 [`clerkMiddleware()`](/docs/references/nextjs/clerk-middleware#clerk-middleware) grants you access to user authentication state throughout your application, on any route or page. It also allows you to protect specific routes from unauthenticated users. To add `clerkMiddleware()` to your application, follow these steps:
 
-
-1. Create a `middleware.ts` file. Your `middleware.ts` file should be placed inside the root directory alongside `.env.local`, or inside the `src/` directory if you are using it.
+1. Create a `middleware.ts` file. The location of the middleware depends on if you are using the `/src` directory in your project:
+  - If you _are_ using the `/src` directory, the `middleware.ts` file should be placed inside the `/src` directory
+  - If you _are not_ using the `/src` directory, place `middleware.ts` in the root directory alongside `.env.local`
 2. In your middleware.ts, export Clerk's `clerkMiddleware()` helper:
   ```tsx filename="middleware.ts"
   import { clerkMiddleware } from "@clerk/nextjs/server";

--- a/docs/quickstarts/nextjs.mdx
+++ b/docs/quickstarts/nextjs.mdx
@@ -82,7 +82,8 @@ The final result should resemble the following:
 
 [`clerkMiddleware()`](/docs/references/nextjs/clerk-middleware#clerk-middleware) grants you access to user authentication state throughout your application, on any route or page. It also allows you to protect specific routes from unauthenticated users. To add `clerkMiddleware()` to your application, follow these steps:
 
-1. Create a `middleware.ts` file. The location of the middleware depends on if you are using the `/src` directory in your project:
+1. Create a `middleware.ts` file. 
+
   - If you _are_ using the `/src` directory, the `middleware.ts` file should be placed inside the `/src` directory
   - If you _are not_ using the `/src` directory, place `middleware.ts` in the root directory alongside `.env.local`
 2. In your middleware.ts, export Clerk's `clerkMiddleware()` helper:


### PR DESCRIPTION
I've seen a few people on Twitter say they miss where middleware should be placed if using /src. 

I'm hoping this makes that a bit more clear by breaking both options into separate bullet points.