### PR TITLE
Elements: Guide improvements

### DIFF
--- a/docs/elements/examples/sign-in.mdx
+++ b/docs/elements/examples/sign-in.mdx
@@ -28,7 +28,6 @@ Before you build your sign-in flow, you need to configure the appropriate settin
 ```tsx {{ filename: '/app/sign-in/[[...sign-in]]/page.tsx', collapsible: true }}
 'use client';
 
-// If you are getting type errors, please set 'moduleResolution' to 'bundler' in your tsconfig
 import * as Clerk from '@clerk/elements/common';
 import * as SignIn from '@clerk/elements/sign-in';
 
@@ -127,7 +126,6 @@ Before you build your sign-in flow, you need to configure the appropriate settin
 ```tsx {{ filename: '/app/sign-in/[[...sign-in]]/page.tsx', collapsible: true }}
 'use client';
 
-// If you are getting type errors, please set 'moduleResolution' to 'bundler' in your tsconfig
 import * as Clerk from '@clerk/elements/common';
 import * as SignIn from '@clerk/elements/sign-in';
 
@@ -209,7 +207,6 @@ Before you build your sign-in flow, you need to configure the appropriate settin
 ```tsx {{ filename: '/app/sign-in/[[...sign-in]]/page.tsx', collapsible: true }}
 'use client';
 
-// If you are getting type errors, please set 'moduleResolution' to 'bundler' in your tsconfig
 import * as Clerk from '@clerk/elements/common';
 import * as SignIn from '@clerk/elements/sign-in';
 
@@ -355,7 +352,6 @@ Before you build your sign-in flow, you need to configure the appropriate settin
 ```tsx {{ filename: '/app/sign-in/[[...sign-in]]/page.tsx', collapsible: true }}
 'use client';
 
-// If you are getting type errors, please set 'moduleResolution' to 'bundler' in your tsconfig
 import * as Clerk from '@clerk/elements/common';
 import * as SignIn from '@clerk/elements/sign-in';
 

--- a/docs/elements/examples/sign-up.mdx
+++ b/docs/elements/examples/sign-up.mdx
@@ -27,7 +27,6 @@ Before you build your sign-up flow, you need to configure the appropriate settin
 ```tsx {{ filename: '/app/sign-up/[[...sign-up]]/page.tsx', collapsible: true }}
 'use client';
 
-// If you are getting type errors, please set 'moduleResolution' to 'bundler' in your tsconfig
 import * as Clerk from '@clerk/elements/common';
 import * as SignUp from '@clerk/elements/sign-up';
 
@@ -162,7 +161,6 @@ Before you build your sign-up flow, you need to configure the appropriate settin
 ```tsx {{ filename: '/app/sign-up/[[...sign-up]]/page.tsx', collapsible: true }}
 'use client';
 
-// If you are getting type errors, please set 'moduleResolution' to 'bundler' in your tsconfig
 import * as Clerk from '@clerk/elements/common';
 import * as SignUp from '@clerk/elements/sign-up';
 

--- a/docs/elements/guides/sign-in.mdx
+++ b/docs/elements/guides/sign-in.mdx
@@ -41,7 +41,6 @@ Create a new route in your Next.js application. The route needs to be an [option
 ```tsx filename="/app/sign-in/[[...sign-in]]/page.tsx"
 'use client'
 
-// If you are getting type errors, please set 'moduleResolution' to 'bundler' in your tsconfig
 import * as Clerk from '@clerk/elements/common'
 import * as SignIn from '@clerk/elements/sign-in'
 
@@ -63,7 +62,6 @@ The Clerk authentication flows are made up of **steps**. Steps handle rendering 
 ```tsx filename="/app/sign-in/[[...sign-in]]/page.tsx" {9-11}
 'use client'
 
-// If you are getting type errors, please set 'moduleResolution' to 'bundler' in your tsconfig
 import * as Clerk from '@clerk/elements/common'
 import * as SignIn from '@clerk/elements/sign-in'
 
@@ -85,7 +83,6 @@ Make it functional by adding input fields. The following example uses the `<Cler
 ```tsx filename="/app/sign-in/[[...sign-in]]/page.tsx" {12-22}
 'use client'
 
-// If you are getting type errors, please set 'moduleResolution' to 'bundler' in your tsconfig
 import * as Clerk from '@clerk/elements/common'
 import * as SignIn from '@clerk/elements/sign-in'
 
@@ -127,7 +124,6 @@ The following example demonstrates how to conditionally render a form for the `e
 ```tsx filename="/app/sign-in/[[...sign-in]]/page.tsx" {25-38}
 'use client'
 
-// If you are getting type errors, please set 'moduleResolution' to 'bundler' in your tsconfig
 import * as Clerk from '@clerk/elements/common'
 import * as SignIn from '@clerk/elements/sign-in'
 
@@ -178,7 +174,6 @@ If your instance is configured to support authenticating with passwords, you mus
 ```tsx filename="/app/sign-in/[[...sign-in]]/page.tsx" {39-65,68-94}
 'use client'
 
-// If you are getting type errors, please set 'moduleResolution' to 'bundler' in your tsconfig
 import * as Clerk from '@clerk/elements/common'
 import * as SignIn from '@clerk/elements/sign-in'
 

--- a/docs/elements/guides/sign-in.mdx
+++ b/docs/elements/guides/sign-in.mdx
@@ -14,6 +14,10 @@ description: Learn how to build a complete sign-in form with Clerk Elements.
       title: "Upgrade to Core 2 (if necessary)",
       link: "https://clerk.com/docs/upgrade-guides/core-2/nextjs",
     },
+    {
+      title: "Install Clerk Elements",
+      link: "https://clerk.com/docs/elements/overview#getting-started",
+    },
   ]}
 >
 
@@ -33,31 +37,6 @@ description: Learn how to build a complete sign-in form with Clerk Elements.
 </Callout>
 
 <Steps>
-
-### Install `@clerk/elements`
-
-To get started using Clerk Elements, add the package to your project:
-
-<CodeBlockTabs type="installer" options={["npm", "yarn", "pnpm"]}>
-```bash filename="terminal"
-npm install @clerk/elements
-```
-
-```bash filename="terminal"
-yarn add @clerk/elements
-```
-
-```bash filename="terminal"
-pnpm add @clerk/elements
-```
-
-</CodeBlockTabs>
-
-<Callout type="important">
-
-If your project uses TypeScript, make sure that your [`moduleResolution`](https://www.typescriptlang.org/tsconfig/#moduleResolution) in `tsconfig.json` is set to `bundler`. Otherwise, you might run into issues with resolving TypeScript types from Clerk Elements.
-
-</Callout>
 
 ### Add a sign-in route
 

--- a/docs/elements/guides/sign-in.mdx
+++ b/docs/elements/guides/sign-in.mdx
@@ -53,7 +53,11 @@ pnpm add @clerk/elements
 
 </CodeBlockTabs>
 
+<Callout type="important">
+
 Also make sure that your [`moduleResolution`](https://www.typescriptlang.org/tsconfig/#moduleResolution) inside `tsconfig.json` is set to `bundler`. Otherwise you might run into issues with resolving TypeScript types from Clerk Elements.
+
+</Callout>
 
 ### Add a sign-in route
 

--- a/docs/elements/guides/sign-in.mdx
+++ b/docs/elements/guides/sign-in.mdx
@@ -59,6 +59,12 @@ export default function SignInPage() {
 
 You will use these two imports to build out the rest of the flow. `<SignIn.Root>` manages the sign-in state and handles connecting the components to Clerk's APIs.
 
+<Callout type="tip">
+
+If you're getting TypeScript errors on the `@clerk/elements` imports you probably have forgotten to set your [`moduleResolution`](https://www.typescriptlang.org/tsconfig/#moduleResolution) in `tsconfig.json` to `bundler`.
+
+</Callout>
+
 ### Add the start step
 
 The Clerk authentication flows are made up of **steps**. Steps handle rendering the UI for each part of the flow. To allow users to create a sign-in attempt, the `start` step needs to be rendered. The following example does so with the `<SignIn.Step>` component:

--- a/docs/elements/guides/sign-in.mdx
+++ b/docs/elements/guides/sign-in.mdx
@@ -55,7 +55,7 @@ pnpm add @clerk/elements
 
 <Callout type="important">
 
-Also make sure that your [`moduleResolution`](https://www.typescriptlang.org/tsconfig/#moduleResolution) inside `tsconfig.json` is set to `bundler`. Otherwise you might run into issues with resolving TypeScript types from Clerk Elements.
+If your project uses TypeScript, make sure that your [`moduleResolution`](https://www.typescriptlang.org/tsconfig/#moduleResolution) in `tsconfig.json` is set to `bundler`. Otherwise, you might run into issues with resolving TypeScript types from Clerk Elements.
 
 </Callout>
 

--- a/docs/elements/guides/sign-in.mdx
+++ b/docs/elements/guides/sign-in.mdx
@@ -34,6 +34,27 @@ description: Learn how to build a complete sign-in form with Clerk Elements.
 
 <Steps>
 
+### Install `@clerk/elements`
+
+To get started using Clerk Elements, add the package to your project:
+
+<CodeBlockTabs type="installer" options={["npm", "yarn", "pnpm"]}>
+```bash filename="terminal"
+npm install @clerk/elements
+```
+
+```bash filename="terminal"
+yarn add @clerk/elements
+```
+
+```bash filename="terminal"
+pnpm add @clerk/elements
+```
+
+</CodeBlockTabs>
+
+Also make sure that your [`moduleResolution`](https://www.typescriptlang.org/tsconfig/#moduleResolution) inside `tsconfig.json` is set to `bundler`. Otherwise you might run into issues with resolving TypeScript types from Clerk Elements.
+
 ### Add a sign-in route
 
 Create a new route in your Next.js application. The route needs to be an [optional catch-all route](https://nextjs.org/docs/pages/building-your-application/routing/dynamic-routes#optional-catch-all-segments) so the sign-in flow can handled nested paths, as shown in the following example:

--- a/docs/elements/guides/sign-up.mdx
+++ b/docs/elements/guides/sign-up.mdx
@@ -59,6 +59,12 @@ export default function SignUpPage() {
 
 You will use these two imports to build out the rest of the flow. `<SignUp.Root>` manages the sign-up state and handles connecting the components to Clerk's APIs.
 
+<Callout type="tip">
+
+If you're getting TypeScript errors on the `@clerk/elements` imports you probably have forgotten to set your [`moduleResolution`](https://www.typescriptlang.org/tsconfig/#moduleResolution) in `tsconfig.json` to `bundler`.
+
+</Callout>
+
 ### Add the start step
 
 The Clerk authentication flows are made up of **steps**. Steps handle rendering the UI for each part of the flow. To allow users to create a sign-up attempt, the `start` step needs to be rendered. The following example does so with the `<SignUp.Step>` component:

--- a/docs/elements/guides/sign-up.mdx
+++ b/docs/elements/guides/sign-up.mdx
@@ -41,7 +41,6 @@ Create a new route in your Next.js application. The route needs to be an [option
 ```tsx filename="/app/sign-up/[[...sign-up]]/page.tsx"
 'use client'
 
-// If you are getting type errors, please set 'moduleResolution' to 'bundler' in your tsconfig
 import * as Clerk from '@clerk/elements/common'
 import * as SignUp from '@clerk/elements/sign-up'
 
@@ -84,7 +83,6 @@ Make it functional by adding input fields. The following example uses the `<Cler
 ```tsx filename="/app/sign-up/[[...sign-up]]/page.tsx" {12-34}
 'use client'
 
-// If you are getting type errors, please set 'moduleResolution' to 'bundler' in your tsconfig
 import * as Clerk from '@clerk/elements/common'
 import * as SignUp from '@clerk/elements/sign-up'
 
@@ -134,7 +132,6 @@ The following example demonstrates how to conditionally render a form for the `p
 ```tsx filename="/app/sign-up/[[...sign-up]]/page.tsx" {37-61}
 'use client'
 
-// If you are getting type errors, please set 'moduleResolution' to 'bundler' in your tsconfig
 import * as Clerk from '@clerk/elements/common'
 import * as SignUp from '@clerk/elements/sign-up'
 
@@ -208,7 +205,6 @@ Should a user attempt to sign up via Google while a username is a required field
 ```tsx filename="/app/sign-up/[[...sign-up]]/page.tsx" {37-47}
 'use client'
 
-// If you are getting type errors, please set 'moduleResolution' to 'bundler' in your tsconfig
 import * as Clerk from '@clerk/elements/common'
 import * as SignUp from '@clerk/elements/sign-up'
 

--- a/docs/elements/guides/sign-up.mdx
+++ b/docs/elements/guides/sign-up.mdx
@@ -34,6 +34,27 @@ description: Learn how to build a complete sign-up form with Clerk Elements.
 
 <Steps>
 
+### Install `@clerk/elements`
+
+To get started using Clerk Elements, add the package to your project:
+
+<CodeBlockTabs type="installer" options={["npm", "yarn", "pnpm"]}>
+```bash filename="terminal"
+npm install @clerk/elements
+```
+
+```bash filename="terminal"
+yarn add @clerk/elements
+```
+
+```bash filename="terminal"
+pnpm add @clerk/elements
+```
+
+</CodeBlockTabs>
+
+Also make sure that your [`moduleResolution`](https://www.typescriptlang.org/tsconfig/#moduleResolution) inside `tsconfig.json` is set to `bundler`. Otherwise you might run into issues with resolving TypeScript types from Clerk Elements.
+
 ### Add a sign-up route
 
 Create a new route in your Next.js application. The route needs to be an [optional catch-all route](https://nextjs.org/docs/pages/building-your-application/routing/dynamic-routes#optional-catch-all-segments) so the sign-up flow can handled nested paths, as shown in the following example:

--- a/docs/elements/guides/sign-up.mdx
+++ b/docs/elements/guides/sign-up.mdx
@@ -55,7 +55,7 @@ pnpm add @clerk/elements
 
 <Callout type="important">
 
-Also make sure that your [`moduleResolution`](https://www.typescriptlang.org/tsconfig/#moduleResolution) inside `tsconfig.json` is set to `bundler`. Otherwise you might run into issues with resolving TypeScript types from Clerk Elements.
+If your project uses TypeScript, make sure that your [`moduleResolution`](https://www.typescriptlang.org/tsconfig/#moduleResolution) in `tsconfig.json` is set to `bundler`. Otherwise, you might run into issues with resolving TypeScript types from Clerk Elements.
 
 </Callout>
 

--- a/docs/elements/guides/sign-up.mdx
+++ b/docs/elements/guides/sign-up.mdx
@@ -53,7 +53,11 @@ pnpm add @clerk/elements
 
 </CodeBlockTabs>
 
+<Callout type="important">
+
 Also make sure that your [`moduleResolution`](https://www.typescriptlang.org/tsconfig/#moduleResolution) inside `tsconfig.json` is set to `bundler`. Otherwise you might run into issues with resolving TypeScript types from Clerk Elements.
+
+</Callout>
 
 ### Add a sign-up route
 

--- a/docs/elements/guides/sign-up.mdx
+++ b/docs/elements/guides/sign-up.mdx
@@ -14,6 +14,10 @@ description: Learn how to build a complete sign-up form with Clerk Elements.
       title: "Upgrade to Core 2 (if necessary)",
       link: "https://clerk.com/docs/upgrade-guides/core-2/nextjs",
     },
+    {
+      title: "Install Clerk Elements",
+      link: "https://clerk.com/docs/elements/overview#getting-started",
+    },
   ]}
 >
 
@@ -33,31 +37,6 @@ description: Learn how to build a complete sign-up form with Clerk Elements.
 </Callout>
 
 <Steps>
-
-### Install `@clerk/elements`
-
-To get started using Clerk Elements, add the package to your project:
-
-<CodeBlockTabs type="installer" options={["npm", "yarn", "pnpm"]}>
-```bash filename="terminal"
-npm install @clerk/elements
-```
-
-```bash filename="terminal"
-yarn add @clerk/elements
-```
-
-```bash filename="terminal"
-pnpm add @clerk/elements
-```
-
-</CodeBlockTabs>
-
-<Callout type="important">
-
-If your project uses TypeScript, make sure that your [`moduleResolution`](https://www.typescriptlang.org/tsconfig/#moduleResolution) in `tsconfig.json` is set to `bundler`. Otherwise, you might run into issues with resolving TypeScript types from Clerk Elements.
-
-</Callout>
 
 ### Add a sign-up route
 

--- a/docs/elements/guides/styling.mdx
+++ b/docs/elements/guides/styling.mdx
@@ -20,7 +20,6 @@ This guide will demonstrate multiple different styling approaches using the foll
 ```tsx filename="/app/sign-in/[[...sign-in]]/page.tsx"
 'use client'
 
-// If you are getting type errors, please set 'moduleResolution' to 'bundler' in your tsconfig
 import * as Clerk from '@clerk/elements/common'
 import * as SignIn from '@clerk/elements/sign-in'
 
@@ -59,7 +58,6 @@ If you are already using [Tailwind CSS](https://tailwindcss.com/), no additional
 ```tsx filename="/app/sign-in/[[...sign-in]]/page.tsx"
 'use client'
 
-// If you are getting type errors, please set 'moduleResolution' to 'bundler' in your tsconfig
 import * as Clerk from '@clerk/elements/common'
 import * as SignIn from '@clerk/elements/sign-in'
 
@@ -110,7 +108,6 @@ Many of the Clerk Elements components accept an `asChild` prop that allows you t
 ```tsx filename="/app/sign-in/[[...sign-in]]/page.tsx"
 'use client'
 
-// If you are getting type errors, please set 'moduleResolution' to 'bundler' in your tsconfig
 import * as Clerk from '@clerk/elements/common'
 import * as SignIn from '@clerk/elements/sign-in'
 
@@ -175,7 +172,6 @@ Classes from an imported CSS module can be applied to most Clerk Elements compon
 ```tsx filename="/app/sign-in/[[...sign-in]]/page.tsx"
 'use client'
 
-// If you are getting type errors, please set 'moduleResolution' to 'bundler' in your tsconfig
 import * as Clerk from '@clerk/elements/common'
 import * as SignIn from '@clerk/elements/sign-in'
 import styles from './sign-in.module.css'
@@ -213,7 +209,6 @@ You can also use inline styles with Clerk Elements. This is useful when you need
 ```tsx filename="/app/sign-in/[[...sign-in]]/page.tsx"
 'use client'
 
-// If you are getting type errors, please set 'moduleResolution' to 'bundler' in your tsconfig
 import * as Clerk from '@clerk/elements/common'
 import * as SignIn from '@clerk/elements/sign-in'
 

--- a/docs/elements/overview.mdx
+++ b/docs/elements/overview.mdx
@@ -49,6 +49,8 @@ To get started, install the Clerk Elements package:
   ```
 </CodeBlockTabs>
 
+Also make sure that your [`moduleResolution`](https://www.typescriptlang.org/tsconfig/#moduleResolution) inside `tsconfig.json` is set to `bundler`. Otherwise you might run into issues with resolving TypeScript types from Clerk Elements.
+
 Once you have your project set up, you can start building custom UIs with Clerk Elements using Clerk's guides and examples. For example, to use Clerk Elements to build a custom sign-in flow, you can explore:
 
 - [Build a sign-in flow](/docs/elements/guides/sign-in)

--- a/docs/elements/overview.mdx
+++ b/docs/elements/overview.mdx
@@ -49,7 +49,11 @@ To get started, install the Clerk Elements package:
   ```
 </CodeBlockTabs>
 
+<Callout type="important">
+
 Also make sure that your [`moduleResolution`](https://www.typescriptlang.org/tsconfig/#moduleResolution) inside `tsconfig.json` is set to `bundler`. Otherwise you might run into issues with resolving TypeScript types from Clerk Elements.
+
+</Callout>
 
 Once you have your project set up, you can start building custom UIs with Clerk Elements using Clerk's guides and examples. For example, to use Clerk Elements to build a custom sign-in flow, you can explore:
 

--- a/docs/elements/overview.mdx
+++ b/docs/elements/overview.mdx
@@ -51,7 +51,7 @@ To get started, install the Clerk Elements package:
 
 <Callout type="important">
 
-Also make sure that your [`moduleResolution`](https://www.typescriptlang.org/tsconfig/#moduleResolution) inside `tsconfig.json` is set to `bundler`. Otherwise you might run into issues with resolving TypeScript types from Clerk Elements.
+If your project uses TypeScript, make sure that your [`moduleResolution`](https://www.typescriptlang.org/tsconfig/#moduleResolution) in `tsconfig.json` is set to `bundler`. Otherwise, you might run into issues with resolving TypeScript types from Clerk Elements.
 
 </Callout>
 

--- a/docs/elements/reference/common.mdx
+++ b/docs/elements/reference/common.mdx
@@ -197,7 +197,7 @@ By having access to both `message` and `code` you can enrich the incoming `messa
 
 By default, renders as an `<img>` element with the logo of the parent `<Connection>` as the value of its `src` prop. **Must be a child of [`<Connection>`](#connection)**.
 
-<Callout type="info">
+<Callout type="tip">
 
 `<Icon>` is designed to give you access to Clerk's social connection logos and has intentionally limited customizability. If you need more customizability, consider options such as [Iconify](https://iconify.design/getting-started/).
 


### PR DESCRIPTION
Remove repetitive note about `moduleResolution` from code blocks (made every code block extra wide + messed up line highlighting) and move it to package install steps. Those install steps were missing from the guides.