### PR TITLE
Add explicit `icon` to `TutorialHero` links

### DIFF
--- a/docs/authentication/saml/azure.mdx
+++ b/docs/authentication/saml/azure.mdx
@@ -9,11 +9,13 @@ description: Learn how to integrate Microsoft Azure AD with Clerk using SAML SSO
   beforeYouStart={[
     {
       title: "Add the Enhanced authentication add-on to your Pro plan",
-      link: "https://clerk.com/pricing"
+      link: "https://clerk.com/pricing",
+      icon: "plus-circle",
     },
     {
       title: "Enable email address as an identifier for your application.",
       link: "/docs/authentication/configuration/sign-up-sign-in-options#identifiers",
+      icon: "key",
     }
   ]}
 >

--- a/docs/authentication/saml/custom-provider.mdx
+++ b/docs/authentication/saml/custom-provider.mdx
@@ -9,11 +9,13 @@ description: Learn how to integrate an Identity Provider with Clerk using SAML S
   beforeYouStart={[
     {
       title: "Add the Enhanced authentication add-on to your Pro plan",
-      link: "https://clerk.com/pricing"
+      link: "https://clerk.com/pricing",
+      icon: "plus-circle",
     },
     {
       title: "Enable email address as an identifier for your application.",
       link: "/docs/authentication/configuration/sign-up-sign-in-options#identifiers",
+      icon: "key",
     }
   ]}
 >

--- a/docs/authentication/saml/google.mdx
+++ b/docs/authentication/saml/google.mdx
@@ -9,11 +9,13 @@ description: Learn how to integrate Google Workspace with Clerk using SAML SSO.
   beforeYouStart={[
     {
       title: "Add the Enhanced authentication add-on to your Pro plan",
-      link: "https://clerk.com/pricing"
+      link: "https://clerk.com/pricing",
+      icon: "plus-circle",
     },
     {
       title: "Enable email address as an identifier for your application.",
       link: "/docs/authentication/configuration/sign-up-sign-in-options#identifiers",
+      icon: "key",
     }
   ]}
 >

--- a/docs/authentication/saml/okta.mdx
+++ b/docs/authentication/saml/okta.mdx
@@ -9,11 +9,13 @@ description: Learn how to integrate Okta Workforce with Clerk using SAML SSO.
   beforeYouStart={[
     {
       title: "Add the Enhanced authentication add-on to your Pro plan",
-      link: "https://clerk.com/pricing"
+      link: "https://clerk.com/pricing",
+      icon: "plus-circle",
     },
     {
       title: "Enable email address as an identifier for your application.",
       link: "/docs/authentication/configuration/sign-up-sign-in-options#identifiers",
+      icon: "key",
     }
   ]}
 >

--- a/docs/authentication/social-connections/linkedin-oidc.mdx
+++ b/docs/authentication/social-connections/linkedin-oidc.mdx
@@ -10,10 +10,12 @@ description: Learn how to set up a social connection with LinkedIn in your Clerk
     {
       title: 'Create a Clerk application in your Clerk Dashboard',
       link: 'https://clerk.com/docs/quickstarts/setup-clerk',
+      icon: 'clerk',
     },
     {
       title: 'Create a LinkedIn developer account',
       link: 'https://developer.linkedin.com/',
+      icon: 'linkedin',
     },
   ]}
 >

--- a/docs/authentication/social-connections/x-twitter.mdx
+++ b/docs/authentication/social-connections/x-twitter.mdx
@@ -10,10 +10,12 @@ description: Learn how to set up a social connection with X/Twitter v2 in your C
     {
       title: 'Create a Clerk application in your Clerk Dashboard',
       link: 'https://clerk.com/docs/quickstarts/setup-clerk',
+      icon: 'clerk',
     },
     {
       title: 'Create an X/Twitter developer account',
       link: 'https://developer.twitter.com/en/docs/apps/overview',
+      icon: 'x',
     },
   ]}
 >

--- a/docs/elements/guides/sign-in.mdx
+++ b/docs/elements/guides/sign-in.mdx
@@ -9,10 +9,12 @@ description: Learn how to build a complete sign-in form with Clerk Elements.
     {
       title: "Follow the Next.js quickstart",
       link: "https://clerk.com/docs/quickstarts/nextjs",
+      icon: "nextjs",
     },
     {
       title: "Upgrade to Core 2 (if necessary)",
       link: "https://clerk.com/docs/upgrade-guides/core-2/nextjs",
+      icon: "arrow-up-circle",
     },
   ]}
 >

--- a/docs/elements/guides/sign-up.mdx
+++ b/docs/elements/guides/sign-up.mdx
@@ -9,10 +9,12 @@ description: Learn how to build a complete sign-up form with Clerk Elements.
     {
       title: "Follow the Next.js quickstart",
       link: "https://clerk.com/docs/quickstarts/nextjs",
+      icon: "nextjs",
     },
     {
       title: "Upgrade to Core 2 (if necessary)",
       link: "https://clerk.com/docs/upgrade-guides/core-2/nextjs",
+      icon: "arrow-up-circle",
     },
   ]}
 >

--- a/docs/guides/authjs-migration.mdx
+++ b/docs/guides/authjs-migration.mdx
@@ -20,6 +20,7 @@ description: Learn how to migrate an application using Auth.js to use Clerk for 
     {
       title: "Set up a Clerk application",
       link: "https://clerk.com/docs/quickstarts/setup-clerk",
+      icon: "clerk",
     }
   ]}
 >

--- a/docs/guides/force-organizations.mdx
+++ b/docs/guides/force-organizations.mdx
@@ -9,11 +9,13 @@ description: Learn how to hide Personal Accounts and force organizations in your
   beforeYouStart={[
     {
       title: "Set up a Next.js + Clerk application",
-      link: "https://clerk.com/docs/quickstarts/nextjs"
+      link: "https://clerk.com/docs/quickstarts/nextjs",
+      icon: "nextjs",
     },
     {
       title: "Enable organizations for your instance",
-      link: "https://clerk.com/docs/organizations/overview"
+      link: "https://clerk.com/docs/organizations/overview",
+      icon: "globe",
     }
   ]}
 >

--- a/docs/integrations/databases/convex.mdx
+++ b/docs/integrations/databases/convex.mdx
@@ -10,10 +10,12 @@ description: Learn how to integrate Clerk into your Convex application.
     {
       title: "Set up a Clerk application",
       link: "https://clerk.com/docs/quickstarts/setup-clerk",
+      icon: "clerk",
     },
     {
       title: "Create a React + Convex application",
       link: "https://docs.convex.dev/quickstart/react",
+      icon: "react",
     },
   ]}
 >

--- a/docs/integrations/databases/firebase.mdx
+++ b/docs/integrations/databases/firebase.mdx
@@ -10,14 +10,17 @@ description: Learn how to integrate Clerk into your Firebase application.
     {
       title: "Set up a Clerk application",
       link: "/docs/quickstarts/setup-clerk",
+      icon: "clerk",
     },
     {
       title: "Set up a Firebase project with an app",
       link: "https://support.google.com/firebase/answer/9326094?hl=en",
+      icon: "cog-6-teeth",
     },
     {
       title: "Integrate the appropriate Clerk SDK in your local project",
       link: "/docs/quickstarts/overview",
+      icon: "code-bracket",
     },
   ]}
 >

--- a/docs/integrations/databases/supabase.mdx
+++ b/docs/integrations/databases/supabase.mdx
@@ -10,10 +10,12 @@ description: Learn how to integrate Clerk into your Supabase application.
     {
       title: "Set up a Clerk application",
       link: "/docs/quickstarts/setup-clerk",
+      icon: "clerk",
     },
     {
       title: "Integrate the appropriate Clerk SDK in your local project",
       link: "/docs/quickstarts/overview",
+      icon: "code-bracket",
     },
   ]}
 >

--- a/docs/integrations/webhooks/sync-data.mdx
+++ b/docs/integrations/webhooks/sync-data.mdx
@@ -8,7 +8,8 @@ description: Learn how to sync Clerk data to your application with webhooks.
   beforeYouStart={[
     {
       title: "Set up a Clerk + Next.js application",
-      link: "https://clerk.com/docs/quickstarts/nextjs"
+      link: "https://clerk.com/docs/quickstarts/nextjs",
+      icon: "nextjs",
     }
   ]}
 >

--- a/docs/quickstarts/javascript.mdx
+++ b/docs/quickstarts/javascript.mdx
@@ -18,6 +18,7 @@ description: Add authentication and user management to your JavaScript app with 
     {
       title: "Set up a Clerk application",
       link: "https://clerk.com/docs/quickstarts/setup-clerk",
+      icon: "clerk",
     },
   ]}
 >

--- a/docs/quickstarts/nextjs.mdx
+++ b/docs/quickstarts/nextjs.mdx
@@ -11,10 +11,12 @@ description: Add authentication and user management to your Next.js app with Cle
     {
       title: "Set up a Clerk application",
       link: "https://clerk.com/docs/quickstarts/setup-clerk",
+      icon: "clerk",
     },
     {
       title: "Create a Next.js application",
       link: "https://nextjs.org/docs/getting-started/installation",
+      icon: "nextjs",
     },
   ]}
 >

--- a/docs/quickstarts/react.mdx
+++ b/docs/quickstarts/react.mdx
@@ -17,7 +17,8 @@ description: Add authentication and user management to your React app with Clerk
   beforeYouStart={[
     {
       title: "Set up a Clerk application",
-      link: "https://clerk.com/docs/quickstarts/setup-clerk"
+      link: "https://clerk.com/docs/quickstarts/setup-clerk",
+      icon: "clerk",
     }
   ]}
 >

--- a/docs/references/nextjs/trpc.mdx
+++ b/docs/references/nextjs/trpc.mdx
@@ -10,6 +10,7 @@ description: Learn how to integrate Clerk into your Next.js Pages Router applica
     {
       title: "Integrate Clerk into your Next.js application",
       link: "https://clerk.com/docs/quickstarts/nextjs",
+      icon: "nextjs",
     },
   ]}
   exampleRepo={[

--- a/docs/references/react/add-react-router.mdx
+++ b/docs/references/react/add-react-router.mdx
@@ -15,11 +15,13 @@ description: Learn how to add React Router to your React application using their
   beforeYouStart={[
     {
       title: "Set up a Clerk application",
-      link: "https://clerk.com/docs/quickstarts/setup-clerk"
+      link: "https://clerk.com/docs/quickstarts/setup-clerk",
+      icon: "clerk"
     },
     {
       title: "Add authentication and user management to your React app with Clerk",
-      link: "https://clerk.com/docs/quickstarts/react"
+      link: "https://clerk.com/docs/quickstarts/react",
+      icon: "react"
     },
   ]}
 >


### PR DESCRIPTION
We can now set the `icon` for a `TutorialHero` link, which references one of the [available icons](https://github.com/clerk/clerk/blob/main/src/app/(website)/docs/icons.tsx)

This PR adds icons where they were missing, and specifies the icon explicitly where before the icon was automatically picked

Updated pages:

- [/docs/authentication/saml/azure](https://clerk.com/docs/pr/995/authentication/saml/azure)
- [/docs/authentication/saml/custom-provider](https://clerk.com/docs/pr/995/authentication/saml/custom-provider)
- [/docs/authentication/saml/google](https://clerk.com/docs/pr/995/authentication/saml/google)
- [/docs/authentication/saml/okta](https://clerk.com/docs/pr/995/authentication/saml/okta)
- [/docs/authentication/social-connections/linkedin-oidc](https://clerk.com/docs/pr/995/authentication/social-connections/linkedin-oidc)
- [/docs/authentication/social-connections/x-twitter](https://clerk.com/docs/pr/995/authentication/social-connections/x-twitter)
- [/docs/elements/guides/sign-in](https://clerk.com/docs/pr/995/elements/guides/sign-in)
- [/docs/elements/guides/sign-up](https://clerk.com/docs/pr/995/elements/guides/sign-up)
- [/docs/guides/authjs-migration](https://clerk.com/docs/pr/995/guides/authjs-migration)
- [/docs/guides/force-organizations](https://clerk.com/docs/pr/995/guides/force-organizations)
- [/docs/integrations/databases/convex](https://clerk.com/docs/pr/995/integrations/databases/convex)
- [/docs/integrations/databases/firebase](https://clerk.com/docs/pr/995/integrations/databases/firebase)
- [/docs/integrations/databases/supabase](https://clerk.com/docs/pr/995/integrations/databases/supabase)
- [/docs/integrations/webhooks/sync-data](https://clerk.com/docs/pr/995/integrations/webhooks/sync-data)
- [/docs/quickstarts/javascript](https://clerk.com/docs/pr/995/quickstarts/javascript)
- [/docs/quickstarts/nextjs](https://clerk.com/docs/pr/995/quickstarts/nextjs)
- [/docs/quickstarts/react](https://clerk.com/docs/pr/995/quickstarts/react)
- [/docs/references/nextjs/trpc](https://clerk.com/docs/pr/995/references/nextjs/trpc)
- [/docs/references/react/add-react-router](https://clerk.com/docs/pr/995/references/react/add-react-router)

Here's an example of the change:

Before

![CleanShot 2024-05-07 at 12 59 02@2x](https://github.com/clerk/clerk-docs/assets/2615508/125a5f1f-9c9b-4c4c-93d8-b67823170b32)

After

![CleanShot 2024-05-07 at 12 59 34@2x](https://github.com/clerk/clerk-docs/assets/2615508/b4635bcc-2b58-4242-b73f-ca0a678ff217)
