### PR TITLE
Document `target` property for nav links and apply to some links in manifest

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -146,6 +146,10 @@ type LinkItem = {
    * @default true
    */
   wrap?: boolean
+  /**
+   * Set to "_blank" to open link in a new tab
+   */
+  target?: '_blank'
 }
 type SubNavItem = {
   /**

--- a/docs/manifest.json
+++ b/docs/manifest.json
@@ -999,8 +999,8 @@
                           "title": "Create a minimal reproduction",
                           "href": "/docs/troubleshooting/create-a-minimal-reproduction"
                         },
-                        { "title": "Community Discord", "href": "/discord" },
-                        { "title": "Contact Support", "href": "/support" }
+                        { "title": "Community Discord", "href": "/discord", "target": "_blank" },
+                        { "title": "Contact Support", "href": "/support", "target": "_blank" }
                       ]
                     ]
                   }
@@ -2188,8 +2188,8 @@
         "title": "API References",
         "items": [
           [
-            { "title": "Backend API", "href": "/docs/reference/backend-api" },
-            { "title": "Frontend API", "href": "/docs/reference/frontend-api" }
+            { "title": "Backend API", "href": "/docs/reference/backend-api", "target": "_blank" },
+            { "title": "Frontend API", "href": "/docs/reference/frontend-api", "target": "_blank" }
           ]
         ]
       }

--- a/docs/manifest.schema.json
+++ b/docs/manifest.schema.json
@@ -51,6 +51,10 @@
         },
         "icon": {
           "$ref": "#/$defs/icon"
+        },
+        "target": {
+          "type": "string",
+          "enum": ["_blank"]
         }
       }
     },


### PR DESCRIPTION
This PR documents the new `target` property for manifest nav links, and adds `"target": "_blank"` to the following nav links:

- Troubleshooting > Community Discord
- Troubleshooting > Contact Support
- Backend API
- Frontend API

### [Preview →](https://clerk-git-nav-link-target.clerkstage.dev/docs/pr/1012)