### PR TITLE
Tweak manifest formatting

### DIFF
--- a/docs/manifest.json
+++ b/docs/manifest.json
@@ -10,6 +10,7 @@
             {
               "title": "Quickstarts",
               "collapse": true,
+              "icon": "checkmark-circle",
               "items": [
                 [
                   { "title": "Overview", "href": "/docs/quickstarts/overview" },
@@ -47,12 +48,12 @@
                     "items": [[{ "title": "Fastify", "href": "/docs/quickstarts/fastify" }]]
                   }
                 ]
-              ],
-              "icon": "checkmark-circle"
+              ]
             },
             {
               "title": "Guides",
               "collapse": true,
+              "icon": "book",
               "items": [
                 [
                   { "title": "Overview", "href": "/docs/guides/overview" },
@@ -83,14 +84,14 @@
                     "href": "/docs/guides/authjs-migration"
                   }
                 ]
-              ],
-              "icon": "book"
+              ]
             }
           ],
           [
             {
               "title": "Sign Up & Sign In",
               "collapse": true,
+              "icon": "door",
               "items": [
                 [
                   { "title": "Overview", "href": "/docs/authentication/overview" },
@@ -264,12 +265,12 @@
                     ]
                   }
                 ]
-              ],
-              "icon": "door"
+              ]
             },
             {
               "title": "Users",
               "collapse": true,
+              "icon": "user-circle",
               "items": [
                 [
                   { "title": "Overview", "href": "/docs/users/overview" },
@@ -280,12 +281,12 @@
                     "items": [[{ "title": "Web3 authentication", "href": "/docs/users/web3" }]]
                   }
                 ]
-              ],
-              "icon": "user-circle"
+              ]
             },
             {
               "title": "Organizations, Roles, and Permissions",
               "collapse": true,
+              "icon": "globe",
               "items": [
                 [
                   { "title": "Overview", "href": "/docs/organizations/overview" },
@@ -340,12 +341,12 @@
                     ]
                   }
                 ]
-              ],
-              "icon": "globe"
+              ]
             },
             {
               "title": "Backend Requests",
               "collapse": true,
+              "icon": "stacked-rectangle",
               "items": [
                 [
                   { "title": "Overview", "href": "/docs/backend-requests/overview" },
@@ -433,14 +434,14 @@
                     ]
                   }
                 ]
-              ],
-              "icon": "stacked-rectangle"
+              ]
             }
           ],
           [
             {
               "title": "Account Portal",
               "collapse": true,
+              "icon": "user-dotted-circle",
               "items": [
                 [
                   { "title": "Overview", "href": "/docs/account-portal/overview" },
@@ -462,12 +463,12 @@
                     ]
                   }
                 ]
-              ],
-              "icon": "user-dotted-circle"
+              ]
             },
             {
               "title": "Component Reference",
               "collapse": true,
+              "icon": "box",
               "items": [
                 [
                   { "title": "Overview", "href": "/docs/components/overview" },
@@ -685,12 +686,12 @@
                     ]
                   }
                 ]
-              ],
-              "icon": "box"
+              ]
             },
             {
               "title": "Custom Flows",
               "collapse": true,
+              "icon": "route",
               "items": [
                 [
                   { "title": "Overview", "href": "/docs/custom-flows/overview" },
@@ -722,13 +723,13 @@
                     "href": "/docs/custom-flows/bot-sign-up-protection"
                   }
                 ]
-              ],
-              "icon": "route"
+              ]
             },
             {
               "title": "Elements",
               "tag": "(Beta)",
               "collapse": true,
+              "icon": "application-2",
               "items": [
                 [
                   { "title": "Overview", "href": "/docs/elements/overview" },
@@ -770,14 +771,14 @@
                     ]
                   }
                 ]
-              ],
-              "icon": "application-2"
+              ]
             }
           ],
           [
             {
               "title": "Integrations",
               "collapse": true,
+              "icon": "plug",
               "items": [
                 [
                   { "title": "Overview", "href": "/docs/integrations/overview" },
@@ -827,12 +828,12 @@
                     ]
                   }
                 ]
-              ],
-              "icon": "plug"
+              ]
             },
             {
               "title": "Deployments & Migrations",
               "collapse": true,
+              "icon": "rocket",
               "items": [
                 [
                   { "title": "Instances / Environments", "href": "/docs/deployments/environments" },
@@ -895,12 +896,12 @@
                     ]
                   }
                 ]
-              ],
-              "icon": "rocket"
+              ]
             },
             {
               "title": "Testing",
               "collapse": true,
+              "icon": "speedometer",
               "items": [
                 [
                   { "title": "Overview", "href": "/docs/testing/overview" },
@@ -921,12 +922,12 @@
                     ]
                   }
                 ]
-              ],
-              "icon": "speedometer"
+              ]
             },
             {
               "title": "Advanced Usage",
               "collapse": true,
+              "icon": "chart",
               "items": [
                 [
                   {
@@ -942,12 +943,12 @@
                     "href": "/docs/advanced-usage/using-proxies"
                   }
                 ]
-              ],
-              "icon": "chart"
+              ]
             },
             {
               "title": "Error Handling",
               "collapse": true,
+              "icon": "block",
               "items": [
                 [
                   { "title": "Overview", "href": "/docs/errors/overview" },
@@ -977,12 +978,12 @@
                   { "title": "Sign-up", "href": "/docs/errors/sign-up" },
                   { "title": "Sign-in-tokens", "href": "/docs/errors/sign-in-tokens" }
                 ]
-              ],
-              "icon": "block"
+              ]
             },
             {
               "title": "Troubleshooting",
               "collapse": true,
+              "icon": "bolt",
               "items": [
                 [
                   { "title": "Overview", "href": "/docs/troubleshooting/overview" },
@@ -1005,12 +1006,12 @@
                     ]
                   }
                 ]
-              ],
-              "icon": "bolt"
+              ]
             },
             {
               "title": "Upgrade Guides",
               "collapse": true,
+              "icon": "arrow-up-circle",
               "items": [
                 [
                   { "title": "Overview", "href": "/docs/upgrade-guides/overview" },
@@ -1098,12 +1099,12 @@
                     ]
                   }
                 ]
-              ],
-              "icon": "arrow-up-circle"
+              ]
             },
             {
               "title": "Security & Privacy",
               "collapse": true,
+              "icon": "lock",
               "items": [
                 [
                   { "title": "Overview", "href": "/docs/security/overview" },
@@ -1147,8 +1148,7 @@
                     ]
                   }
                 ]
-              ],
-              "icon": "lock"
+              ]
             },
             { "title": "Core 1 Documentation", "href": "/docs/core-1", "icon": "link" }
           ]
@@ -1161,6 +1161,7 @@
             {
               "title": "Next.js",
               "collapse": true,
+              "icon": "nextjs",
               "items": [
                 [
                   { "title": "Overview", "href": "/docs/references/nextjs/overview" },
@@ -1270,12 +1271,12 @@
                     ]
                   }
                 ]
-              ],
-              "icon": "nextjs"
+              ]
             },
             {
               "title": "React",
               "collapse": true,
+              "icon": "react",
               "items": [
                 [
                   { "title": "Overview", "href": "/docs/references/react/overview" },
@@ -1343,12 +1344,12 @@
                     ]
                   }
                 ]
-              ],
-              "icon": "react"
+              ]
             },
             {
               "title": "JavaScript",
               "collapse": true,
+              "icon": "javascript",
               "items": [
                 [
                   { "title": "Overview", "href": "/docs/references/javascript/overview" },
@@ -1641,12 +1642,12 @@
                     ]
                   }
                 ]
-              ],
-              "icon": "javascript"
+              ]
             },
             {
               "title": "Node.js",
               "collapse": true,
+              "icon": "nodejs",
               "items": [
                 [
                   { "title": "Overview", "href": "/docs/references/nodejs/overview" },
@@ -1663,12 +1664,12 @@
                     "href": "/docs/references/nodejs/token-verification"
                   }
                 ]
-              ],
-              "icon": "nodejs"
+              ]
             },
             {
               "title": "Remix",
               "collapse": true,
+              "icon": "remix",
               "items": [
                 [
                   {
@@ -1677,12 +1678,12 @@
                     "href": "/docs/references/remix/clerk-app"
                   }
                 ]
-              ],
-              "icon": "remix"
+              ]
             },
             {
               "title": "Go",
               "collapse": true,
+              "icon": "go",
               "items": [
                 [
                   { "title": "Overview", "href": "/docs/references/go/overview" },
@@ -1696,12 +1697,12 @@
                   },
                   { "title": "Go SDK repository", "href": "https://github.com/clerk/clerk-sdk-go" }
                 ]
-              ],
-              "icon": "go"
+              ]
             },
             {
               "title": "Gatsby",
               "collapse": true,
+              "icon": "gatsby",
               "items": [
                 [
                   {
@@ -1710,12 +1711,12 @@
                     "href": "/docs/references/gatsby/with-server-auth"
                   }
                 ]
-              ],
-              "icon": "gatsby"
+              ]
             },
             {
               "title": "Ruby / Rails",
               "collapse": true,
+              "icon": "ruby",
               "items": [
                 [
                   { "title": "Overview", "href": "/docs/references/ruby/overview" },
@@ -1729,12 +1730,12 @@
                     "href": "https://github.com/clerk/clerk-sdk-ruby"
                   }
                 ]
-              ],
-              "icon": "ruby"
+              ]
             },
             {
               "title": "Backend SDK",
               "collapse": true,
+              "icon": "clerk",
               "items": [
                 [
                   { "title": "Overview", "href": "/docs/references/backend/overview" },
@@ -2120,13 +2121,13 @@
                     ]
                   }
                 ]
-              ],
-              "icon": "clerk"
+              ]
             },
             {
               "title": "Redwood",
               "tag": "Community",
               "collapse": true,
+              "icon": "redwood",
               "items": [
                 [
                   { "title": "Overview", "href": "/docs/references/redwood/overview" },
@@ -2136,8 +2137,7 @@
                     "icon": "redwood"
                   }
                 ]
-              ],
-              "icon": "redwood"
+              ]
             },
             {
               "title": "Svelte",

--- a/docs/manifest.schema.json
+++ b/docs/manifest.schema.json
@@ -110,6 +110,7 @@
         "home",
         "hono",
         "javascript",
+        "link",
         "linkedin",
         "lock",
         "nextjs",


### PR DESCRIPTION
Just moving the `icon` property above `items` in the manifest because when `items` is a large array the `icon` prop gets shunted way down and it can be hard to find/figure out which item the icon belongs to

This PR also adds `link` to the list of available icons since it was added in https://github.com/clerk/clerk/pull/376