### PR TITLE
Add explicit `icon` for "Install Clerk Elements"

### DIFF
--- a/docs/elements/guides/sign-in.mdx
+++ b/docs/elements/guides/sign-in.mdx
@@ -19,6 +19,7 @@ description: Learn how to build a complete sign-in form with Clerk Elements.
     {
       title: "Install Clerk Elements",
       link: "https://clerk.com/docs/elements/overview#getting-started",
+      icon: "application-2",
     },
   ]}
 >

--- a/docs/elements/guides/sign-up.mdx
+++ b/docs/elements/guides/sign-up.mdx
@@ -19,6 +19,7 @@ description: Learn how to build a complete sign-up form with Clerk Elements.
     {
       title: "Install Clerk Elements",
       link: "https://clerk.com/docs/elements/overview#getting-started",
+      icon: "application-2",
     },
   ]}
 >


### PR DESCRIPTION
This PR adds an explicit `icon` property for the "Install Clerk Elements" link used in the `TutorialHero` on the following pages:

- [Build a sign-in flow with Clerk Elements](https://clerk.com/docs/elements/guides/sign-in)
- [Build a sign-up flow with Clerk Elements](https://clerk.com/docs/elements/guides/sign-up)

We have some logic in `clerk/clerk` that selects an icon automatically based on the link text, but I want to remove this and require setting the `icon` property if you want to display an icon. I also think this icon (which matches the "Elements" nav item) is better than the generic "clerk" one in this context

| Before | After |
| - | - |
| ![CleanShot 2024-05-10 at 11 09 34@2x](https://github.com/clerk/clerk-docs/assets/2615508/605cbd7d-e4e0-4a4d-8459-e19cf2e4e36e) | ![CleanShot 2024-05-10 at 11 10 08@2x](https://github.com/clerk/clerk-docs/assets/2615508/cf653449-8374-44c4-a6c5-6f2e1ec43ae5) |