### PR TITLE
Update backend docs to explain error handling

### DIFF
--- a/docs/references/backend/overview.mdx
+++ b/docs/references/backend/overview.mdx
@@ -42,3 +42,9 @@ Clerk SDKs expose an instance of the Clerk Backend SDK for use in server environ
   ```
   </Tab>
 </Tabs>
+ 
+## Error handling
+
+Backend SDK functions do not throw errors when something goes wrong. Instead, they return a [`ClerkBackendApiResponse`](/docs/references/javascript/types/clerk-backend-api-response) object, just as they would if there were no errors. You can check for errors on the `.errors` property of the response.
+
+This approach to error handling allows Clerk to produce strongly-typed errors for those using TypeScript, and can reduce the need for `try/catch` blocks in your code.

--- a/docs/references/backend/overview.mdx
+++ b/docs/references/backend/overview.mdx
@@ -45,6 +45,10 @@ Clerk SDKs expose an instance of the Clerk Backend SDK for use in server environ
  
 ## Error handling
 
-Backend SDK functions do not throw errors when something goes wrong. Instead, they return a [`ClerkBackendApiResponse`](/docs/references/javascript/types/clerk-backend-api-response) object, just as they would if there were no errors. You can check for errors on the `.errors` property of the response.
+Backend SDK functions do not throw errors when something goes wrong. Instead, they return a [`ClerkBackendApiResponse`](/docs/references/javascript/types/clerk-backend-api-response) object, just as they would if there were no errors. You can check for errors on the `.errors` property of the response. For example:
+
+```ts filename="example.ts"
+const { data, errors } = someBackendApiCall();
+```
 
 This approach to error handling allows Clerk to produce strongly-typed errors for those using TypeScript, and can reduce the need for `try/catch` blocks in your code.

--- a/docs/references/javascript/types/clerk-backend-api-response.mdx
+++ b/docs/references/javascript/types/clerk-backend-api-response.mdx
@@ -1,0 +1,19 @@
+---
+title: ClerkBackendApiResponse
+description: A generic type that describes the response of a method that calls the Clerk Backend API.
+---
+
+# `ClerkBackendApiResponse`
+
+A generic type that describes the response of a method that calls the Clerk Backend API.
+
+## Properties
+
+| Name | Type | Description |
+| --- | --- | --- |
+| `data` | `<T> \| null` | The payload of the request. `<T>` represents the type of the data, which depends on which API request was made. |
+| `errors` | `ClerkAPIError[] \| null` | An array of errors that have occurred. |
+| `totalCount?` | `never` | The number of items in the response. Useful because Clerk's API responses are paginated. |
+| `clerkTraceId?` | `string` | The ID associated with the function trace for your API call. Clerk support can use this to check any logs associated with your API call and help you debug issues. |
+| `status?` | `number` | The [HTTP response status code](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status). |
+| `statusText?` | `string` | The [status message](https://developer.mozilla.org/en-US/docs/Web/API/Response/statusText) associated with the HTTP response code. |

--- a/docs/references/nodejs/overview.mdx
+++ b/docs/references/nodejs/overview.mdx
@@ -104,7 +104,11 @@ const session = await sessions.verifySession(sessionId, clientToken);
  
 ## Error handling
 
-Node SDK functions do not throw errors when something goes wrong. Instead, they return a [`ClerkBackendApiResponse`](/docs/references/javascript/types/clerk-backend-api-response) object, just as they would if there were no errors. You can check for errors on the `.errors` property of the response.
+Node SDK functions do not throw errors when something goes wrong. Instead, they return a [`ClerkBackendApiResponse`](/docs/references/javascript/types/clerk-backend-api-response) object, just as they would if there were no errors. You can check for errors on the `.errors` property of the response. For example:
+
+```ts filename="example.ts"
+const { data, errors } = someBackendApiCall();
+```
 
 This approach to error handling allows Clerk to produce strongly-typed errors for those using TypeScript, and can reduce the need for `try/catch` blocks in your code.
 

--- a/docs/references/nodejs/overview.mdx
+++ b/docs/references/nodejs/overview.mdx
@@ -100,3 +100,12 @@ const sessionId = client.lastActiveSessionId;
 
 const session = await sessions.verifySession(sessionId, clientToken);
 ```
+
+ 
+## Error handling
+
+Node SDK functions do not throw errors when something goes wrong. Instead, they return a [`ClerkBackendApiResponse`](/docs/references/javascript/types/clerk-backend-api-response) object, just as they would if there were no errors. You can check for errors on the `.errors` property of the response.
+
+This approach to error handling allows Clerk to produce strongly-typed errors for those using TypeScript, and can reduce the need for `try/catch` blocks in your code.
+
+> See the guide on [using Clerk with Node.js and Express](/docs/backend-requests/handling/nodejs#express-error-handlers) to learn about Express error handling.


### PR DESCRIPTION
[This plain issue](https://app.plain.com/workspace/w_01GT53BQWV3DFW6ECTWZNQ1E9K/thread/th_01HTJD9HCQFTGG0EEFA3N5KPAW/) has the following note:

> We need to make it clear in our docs for backend and node sdk that if there's an error, the methods won't throw, they will instead return the error.

This PR handles that.