### PR TITLE
Remove backtick escapes that were accidentally left in

### DIFF
--- a/docs/components/overview.mdx
+++ b/docs/components/overview.mdx
@@ -8,67 +8,67 @@ description: Learn about the available Clerk Components and how easy it is to in
 Clerk provides a suite of components that let you quickly add authenticaton to your app, customize the look and feel of your auth components and pages, and control what the user sees and customize the auth flow.
 
 - Clerk's prebuilt **UI components** give you a beautiful, fully-functional user management experience in minutes.
-- Clerk's **control components** render at \`<Loading />\` and \`<Loaded />\` states for assertions on the [Clerk object](/docs/references/javascript/clerk/clerk). Control components allow you to build custom user flows with Clerk.
+- Clerk's **control components** render at `<Loading />` and `<Loaded />` states for assertions on the [Clerk object](/docs/references/javascript/clerk/clerk). Control components allow you to build custom user flows with Clerk.
 
 ## Authentication Components
 
 ### UI Components
 
-- [\`<SignIn />\`](/docs/components/authentication/sign-in)
-- [\`<SignUp />\`](/docs/components/authentication/sign-up)
-- [\`<SignInButton />\`](/docs/components/unstyled/sign-in-button)
-- [\`<SignUpButton />\`](/docs/components/unstyled/sign-up-button)
-- [\`<SignOutButton />\`](/docs/components/unstyled/sign-out-button)
+- [`<SignIn />`](/docs/components/authentication/sign-in)
+- [`<SignUp />`](/docs/components/authentication/sign-up)
+- [`<SignInButton />`](/docs/components/unstyled/sign-in-button)
+- [`<SignUpButton />`](/docs/components/unstyled/sign-up-button)
+- [`<SignOutButton />`](/docs/components/unstyled/sign-out-button)
 
 ### Control Components
 
-- [\`<RedirectToSignIn />\`](/docs/components/control/redirect-to-signin)
-- [\`<RedirectToSignUp />\`](/docs/components/control/redirect-to-signup)
-- [\`<SignedIn />\`](/docs/components/control/signed-in)
-- [\`<SignedOut />\`](/docs/components/control/signed-out)
+- [`<RedirectToSignIn />`](/docs/components/control/redirect-to-signin)
+- [`<RedirectToSignUp />`](/docs/components/control/redirect-to-signup)
+- [`<SignedIn />`](/docs/components/control/signed-in)
+- [`<SignedOut />`](/docs/components/control/signed-out)
 
 ## User Components
 
 ### UI Components
 
-- [\`<UserButton />\`](/docs/components/user/user-button)
-- [\`<UserProfile />\`](/docs/components/user/user-profile)
+- [`<UserButton />`](/docs/components/user/user-button)
+- [`<UserProfile />`](/docs/components/user/user-profile)
 
 ### Control Components
 
-- [\`<RedirectToUserProfile />\`](/docs/components/control/redirect-to-userprofile)
+- [`<RedirectToUserProfile />`](/docs/components/control/redirect-to-userprofile)
 
 ## Organization Components
 
 ### UI Components
 
-- [\`<CreateOrganization />\`](/docs/components/organization/create-organization)
-- [\`<OrganizationProfile />\`](/docs/components/organization/organization-profile)
-- [\`<OrganizationSwitcher />\`](/docs/components/organization/organization-switcher)
-- [\`<OrganizationList />\`](/docs/components/organization/organization-list)
+- [`<CreateOrganization />`](/docs/components/organization/create-organization)
+- [`<OrganizationProfile />`](/docs/components/organization/organization-profile)
+- [`<OrganizationSwitcher />`](/docs/components/organization/organization-switcher)
+- [`<OrganizationList />`](/docs/components/organization/organization-list)
 
 ### Control Components
 
-- [\`<RedirectToOrganizationProfile />\`](/docs/components/control/redirect-to-organizationprofile)
-- [\`<RedirectToCreateOrganization />\`](/docs/components/control/redirect-to-createorganization)
+- [`<RedirectToOrganizationProfile />`](/docs/components/control/redirect-to-organizationprofile)
+- [`<RedirectToCreateOrganization />`](/docs/components/control/redirect-to-createorganization)
 
 ## Utility Components
 
-- [\`<ClerkLoaded />\`](/docs/components/control/clerk-loaded)
-- [\`<ClerkLoading />\`](/docs/components/control/clerk-loading)
+- [`<ClerkLoaded />`](/docs/components/control/clerk-loaded)
+- [`<ClerkLoading />`](/docs/components/control/clerk-loading)
 
 ## Advanced Components
 
-- [\`<AuthenticateWithRedirectCallback />\`](/docs/components/control/authenticate-with-callback)
-- [\`<MultisessionAppSupport />\`](/docs/components/control/multi-session)
-- [\`<SignInWithMetamaskButton />\`](/docs/components/unstyled/sign-in-with-metamask)
+- [`<AuthenticateWithRedirectCallback />`](/docs/components/control/authenticate-with-callback)
+- [`<MultisessionAppSupport />`](/docs/components/control/multi-session)
+- [`<SignInWithMetamaskButton />`](/docs/components/unstyled/sign-in-with-metamask)
 
 ## Customization Guides
 
 - [Theme components with the appearance prop](/docs/components/customization/overview)
-- [Localize components with the \`localization\` prop (experimental)](/docs/components/control/clerk-loaded)
-- [Add pages to the \`<UserProfile />\` component](/docs/components/customization/user-profile)
-- [Add pages to the \`<OrganizationProfile />\` component](/docs/components/customization/organization-profile)
+- [Localize components with the `localization` prop (experimental)](/docs/components/control/clerk-loaded)
+- [Add pages to the `<UserProfile />` component](/docs/components/customization/user-profile)
+- [Add pages to the `<OrganizationProfile />` component](/docs/components/customization/organization-profile)
 
 <Cards variant="cta" level={2}>
 


### PR DESCRIPTION
Follow up to #1020: I accidentally left some escapes in `docs/components/overview.mdx` that shouldn't be there and are causing the build to fail 🤦‍♂️ 