### PR TITLE
feat(elements): add shadcn otp demo section

### DIFF
--- a/docs/elements/examples/shadcn-ui.mdx
+++ b/docs/elements/examples/shadcn-ui.mdx
@@ -553,7 +553,8 @@ export default function SignInPage() {
 
 ## OTP Input
 
-The following example demonstrates how to make a one-time password (OTP) input with Clerk Elements.
+The following example demonstrates how to make a one-time password (OTP) input with Clerk Elements. This example will only work if placed within a `Step` in a sign-up or sign-in authentication flow, as shown in [the sign-in](#sign-in) and [sign-up](#sign-up) examples.
+
 <CodeBlockDemo demos={[
   {
     key: 'otp-input',

--- a/docs/elements/examples/shadcn-ui.mdx
+++ b/docs/elements/examples/shadcn-ui.mdx
@@ -45,6 +45,7 @@ import { Card, CardContent, CardDescription, CardFooter, CardHeader, CardTitle }
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { Icons } from '@/components/ui/icons';
+import { cn } from '@/lib/utils';
 
 export default function SignUpPage() {
   return (
@@ -191,9 +192,20 @@ export default function SignUpPage() {
                                   return (
                                     <div
                                       data-status={status}
-                                      className="relative flex h-9 w-9 items-center justify-center border-y border-r border-input text-sm shadow-sm transition-all first:rounded-l-md first:border-l last:rounded-r-md data-[status=cursor]:ring-1 data-[status=selected]:ring-1 data-[status=cursor]:ring-ring data-[status=selected]:ring-ring"
+                                      className={cn(
+                                        'relative flex size-10 items-center justify-center border-y border-r border-input text-sm transition-all first:rounded-l-md first:border-l last:rounded-r-md',
+                                        {
+                                          'z-10 ring-2 ring-ring ring-offset-background':
+                                            status === 'cursor' || status === 'selected',
+                                        },
+                                      )}
                                     >
                                       {value}
+                                      {status === 'cursor' && (
+                                        <div className="pointer-events-none absolute inset-0 flex items-center justify-center">
+                                          <div className="animate-caret-blink h-4 w-px bg-foreground duration-1000" />
+                                        </div>
+                                      )}
                                     </div>
                                   );
                                 }}
@@ -268,6 +280,7 @@ import { Card, CardContent, CardDescription, CardFooter, CardHeader, CardTitle }
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { Icons } from '@/components/ui/icons';
+import { cn } from '@/lib/utils';
 
 export default function SignInPage() {
   return (
@@ -442,15 +455,26 @@ export default function SignInPage() {
                           <div className="flex justify-center text-center">
                             <Clerk.Input
                               type="otp"
-                              autoSubmit
                               className="flex justify-center has-[:disabled]:opacity-50"
+                              autoSubmit
                               render={({ value, status }) => {
                                 return (
                                   <div
                                     data-status={status}
-                                    className="relative flex h-9 w-9 items-center justify-center border-y border-r border-input text-sm shadow-sm transition-all first:rounded-l-md first:border-l last:rounded-r-md data-[status=cursor]:ring-1 data-[status=selected]:ring-1 data-[status=cursor]:ring-ring data-[status=selected]:ring-ring"
+                                    className={cn(
+                                      'relative flex size-10 items-center justify-center border-y border-r border-input text-sm transition-all first:rounded-l-md first:border-l last:rounded-r-md',
+                                      {
+                                        'z-10 ring-2 ring-ring ring-offset-background':
+                                          status === 'cursor' || status === 'selected',
+                                      },
+                                    )}
                                   >
                                     {value}
+                                    {status === 'cursor' && (
+                                      <div className="pointer-events-none absolute inset-0 flex items-center justify-center">
+                                        <div className="animate-caret-blink h-4 w-px bg-foreground duration-1000" />
+                                      </div>
+                                    )}
                                   </div>
                                 );
                               }}
@@ -504,5 +528,49 @@ export default function SignInPage() {
     </div>
   );
 }
+```
+</CodeBlockDemo>
+
+
+## OTP Input
+
+<CodeBlockDemo demos={[
+  {
+    key: 'otp-input',
+    demo: '/demo/shadcn/elements/otp-input',
+    style: {
+      height: `${528 / 16}rem`,
+      backgroundColor: 'rgb(10, 10, 10)'
+    },
+    bordered: true
+  },
+]}>
+```tsx {{ title: 'OTP Input', collapsible: true }}
+<Clerk.Input
+  type="otp"
+  className="flex justify-center has-[:disabled]:opacity-50"
+  autoSubmit
+  render={({ value, status }) => {
+    return (
+      <div
+        data-status={status}
+        className={cn(
+          'relative flex size-10 items-center justify-center border-y border-r border-input text-sm transition-all first:rounded-l-md first:border-l last:rounded-r-md',
+          {
+            'z-10 ring-2 ring-ring ring-offset-background':
+              status === 'cursor' || status === 'selected',
+          },
+        )}
+      >
+        {value}
+        {status === 'cursor' && (
+          <div className="pointer-events-none absolute inset-0 flex items-center justify-center">
+            <div className="animate-caret-blink h-4 w-px bg-foreground duration-1000" />
+          </div>
+        )}
+      </div>
+    );
+  }}
+/>
 ```
 </CodeBlockDemo>

--- a/docs/elements/examples/shadcn-ui.mdx
+++ b/docs/elements/examples/shadcn-ui.mdx
@@ -553,6 +553,7 @@ export default function SignInPage() {
 
 ## OTP Input
 
+The following example demonstrates how to make a one-time password (OTP) input with Clerk Elements.
 <CodeBlockDemo demos={[
   {
     key: 'otp-input',

--- a/docs/elements/examples/shadcn-ui.mdx
+++ b/docs/elements/examples/shadcn-ui.mdx
@@ -15,6 +15,25 @@ To use these examples, you must first:
   npx shadcn-ui@latest add button card input label
   ```
 - Add the [`Icons` component from the shadcn/ui docs](https://github.com/shadcn-ui/ui/blob/main/apps/www/components/icons.tsx) to an `icons.tsx` file within your `component/ui/` directory.
+- Add the following animations to your `tailwind.config.js` file:
+  ```js
+  /** @type {import('tailwindcss').Config} */
+  module.exports = {
+    theme: {
+      extend: {
+        keyframes: {
+          "caret-blink": {
+            "0%,70%,100%": { opacity: "1" },
+            "20%,50%": { opacity: "0" },
+          },
+        },
+        animation: {
+          "caret-blink": "caret-blink 1.25s ease-out infinite",
+        },
+      },
+    },
+  }
+  ```
 
 You must also configure the appropriate settings in Clerk:
 

--- a/docs/elements/examples/shadcn-ui.mdx
+++ b/docs/elements/examples/shadcn-ui.mdx
@@ -11,12 +11,12 @@ To use these examples, you must first:
 
 - Complete the [shadcn/ui Next.js installation guide](https://ui.shadcn.com/docs/installation/next)
 - Install the [Button](https://ui.shadcn.com/docs/components/button), [Card](https://ui.shadcn.com/docs/components/card), [Input](https://ui.shadcn.com/docs/components/input), and [Label](https://ui.shadcn.com/docs/components/label) components within your project
-  ```shell
+  ```shell {{ title: 'Install shadcn/ui components' }}
   npx shadcn-ui@latest add button card input label
   ```
 - Add the [`Icons` component from the shadcn/ui docs](https://github.com/shadcn-ui/ui/blob/main/apps/www/components/icons.tsx) to an `icons.tsx` file within your `component/ui/` directory.
 - Add the following animations to your `tailwind.config.js` file:
-  ```js
+  ```js {{ filename: 'tailwind.config.js' }}
   /** @type {import('tailwindcss').Config} */
   module.exports = {
     theme: {


### PR DESCRIPTION
- Adds section to shadcn/ui examples for how to use OTP input
- Updates OTP input codeblocks with latest demo

Preview: https://clerk.com/docs/pr/1029/elements/examples/shadcn-ui#otp-input