### PR TITLE
docs: minor clean up for remix.mdx

### DIFF
--- a/docs/quickstarts/remix.mdx
+++ b/docs/quickstarts/remix.mdx
@@ -72,8 +72,6 @@ export function Layout({ children }: { children: React.ReactNode }) {
   return (
     <html lang="en">
       <head>
-        <meta charSet="utf-8" />
-        <meta name="viewport" content="width=device-width, initial-scale=1" />
         <Meta />
         <Links />
       </head>
@@ -139,8 +137,6 @@ export function Layout({ children }: { children: React.ReactNode }) {
   return (
     <html lang="en">
       <head>
-        <meta charSet="utf-8" />
-        <meta name="viewport" content="width=device-width, initial-scale=1" />
         <Meta />
         <Links />
       </head>
@@ -215,7 +211,7 @@ These values control the behavior of the components when you sign in or sign up 
 
 Clerk offers [Control Components](/docs/components/overview) that allow you to protect your pages. These components are used to control the visibility of your pages based on the user's authentication state.
 
-```tsx filename="routes/index.tsx"
+```tsx filename="routes/_index.tsx"
 import {
   SignOutButton,
   SignedIn,
@@ -256,7 +252,7 @@ export default function Index() {
 
 To protect your routes, you can use the the loader to check for the `userId` singleton. If it doesn't exist, redirect your user back to the sign-in page.
 
-```tsx filename="routes/index.tsx"
+```tsx filename="routes/_index.tsx"
 import { UserButton } from "@clerk/remix";
 import { getAuth } from "@clerk/remix/ssr.server";
 import { LoaderFunction, redirect } from "@remix-run/node";
@@ -372,8 +368,6 @@ export default function Example() {
 </Tabs>
 
 #### Examples of fetching and mutating user data
-
-
 
 <Tabs type="function" items={["Loader Function", "Action Function"]}>
   <Tab>


### PR DESCRIPTION
- Remove duplicate Meta declarations (Same values set in both function and in html)
  - Chose to keep values in function over HTML since then all meta is the same location
- Rename `routes/_index.html` to `routes/_index.tsx`
  -  Given it is an "index" route, it is likely never intended to show in the url. This means it should be prefixed with underscore. This also more closely matches with structure of default remix application
- Remove extra empty lines