### PR TITLE
Change all default Clerk imports to named imports

### DIFF
--- a/docs/components/authentication/sign-in.mdx
+++ b/docs/components/authentication/sign-in.mdx
@@ -134,7 +134,7 @@ function mountSignIn(node: HTMLDivElement, props?: SignInProps): void;
 
 <CodeBlockTabs type="npm-script" options={['NPM module', '<script>']}>
   ```js filename="index.js" {14}
-  import Clerk from '@clerk/clerk-js';
+  import { Clerk } from '@clerk/clerk-js';
 
   // Initialize Clerk with your Clerk publishable key
   const clerk = new Clerk('{{pub_key}}');
@@ -199,7 +199,7 @@ function unmountSignIn(node: HTMLDivElement): void;
 
 <CodeBlockTabs type="npm-script" options={['NPM module', '<script>']}>
   ```js filename="index.js" {18}
-  import Clerk from '@clerk/clerk-js';
+  import { Clerk } from '@clerk/clerk-js';
 
   // Initialize Clerk with your Clerk publishable key
   const clerk = new Clerk('{{pub_key}}');
@@ -272,7 +272,7 @@ function openSignIn(props?: SignInProps): void;
 
 <CodeBlockTabs type="npm-script" options={['NPM module', '<script>']}>
   ```js filename="index.js" {7}
-  import Clerk from '@clerk/clerk-js';
+  import { Clerk } from '@clerk/clerk-js';
 
   // Initialize Clerk with your Clerk publishable key
   const clerk = new Clerk('{{pub_key}}');
@@ -318,7 +318,7 @@ function closeSignIn(): void;
 
 <CodeBlockTabs type="npm-script" options={['NPM module', '<script>']}>
   ```js filename="index.js" {11}
-  import Clerk from '@clerk/clerk-js';
+  import { Clerk } from '@clerk/clerk-js';
 
   // Initialize Clerk with your Clerk publishable key
   const clerk = new Clerk('{{pub_key}}');

--- a/docs/components/authentication/sign-up.mdx
+++ b/docs/components/authentication/sign-up.mdx
@@ -134,7 +134,7 @@ function mountSignUp(node: HTMLDivElement, props?: SignUpProps): void;
 
 <CodeBlockTabs type="npm-script" options={['NPM module', '<script>']}>
   ```typescript filename="index.ts" {14}
-  import Clerk from '@clerk/clerk-js';
+  import { Clerk } from '@clerk/clerk-js';
 
   // Initialize Clerk with your Clerk publishable key
   const clerk = new Clerk('{{pub_key}}');
@@ -199,7 +199,7 @@ function unmountSignUp(node: HTMLDivElement): void;
 
 <CodeBlockTabs type="npm-script" options={['NPM module', '<script>']}>
   ```typescript filename="index.ts" {18}
-  import Clerk from '@clerk/clerk-js';
+  import { Clerk } from '@clerk/clerk-js';
 
   // Initialize Clerk with your Clerk publishable key
   const clerk = new Clerk('{{pub_key}}');
@@ -272,7 +272,7 @@ function openSignUp(props?: SignUpProps): void;
 
 <CodeBlockTabs type="npm-script" options={['NPM module', '<script>']}>
   ```js filename="index.ts" {7}
-  import Clerk from '@clerk/clerk-js';
+  import { Clerk } from '@clerk/clerk-js';
 
   // Initialize Clerk with your Clerk publishable key
   const clerk = new Clerk('{{pub_key}}');
@@ -318,7 +318,7 @@ function closeSignUp(): void;
 
 <CodeBlockTabs type="npm-script" options={['NPM module', '<script>']}>
   ```js filename="index.ts" {11}
-  import Clerk from '@clerk/clerk-js';
+  import { Clerk } from '@clerk/clerk-js';
 
   // Initialize Clerk with your Clerk publishable key
   const clerk = new Clerk('{{pub_key}}');

--- a/docs/components/organization/create-organization.mdx
+++ b/docs/components/organization/create-organization.mdx
@@ -106,7 +106,7 @@ function mountCreateOrganization(node: HTMLDivElement, props?: CreateOrganizatio
 
 <CodeBlockTabs type="npm-script" options={['NPM module', '<script>']}>
   ```js filename="main.js" {14}
-  import Clerk from '@clerk/clerk-js';
+  import { Clerk } from '@clerk/clerk-js';
 
   // Initialize Clerk with your Clerk publishable key
   const clerk = new Clerk('{{pub_key}}');
@@ -171,7 +171,7 @@ function unmountCreateOrganization(node: HTMLDivElement): void;
 
 <CodeBlockTabs type="npm-script" options={['NPM module', '<script>']}>
   ```js filename="main.js" {18}
-  import Clerk from '@clerk/clerk-js';
+  import { Clerk } from '@clerk/clerk-js';
 
   // Initialize Clerk with your Clerk publishable key
   const clerk = new Clerk('{{pub_key}}');
@@ -244,7 +244,7 @@ function openCreateOrganization(props?: CreateOrganizationProps): void;
 
 <CodeBlockTabs type="npm-script" options={['NPM module', '<script>']}>
   ```js filename="main.js" {18}
-  import Clerk from '@clerk/clerk-js';
+  import { Clerk } from '@clerk/clerk-js';
 
   // Initialize Clerk with your Clerk publishable key
   const clerk = new Clerk('{{pub_key}}');
@@ -303,7 +303,7 @@ function closeCreateOrganization(): void;
 
 <CodeBlockTabs type="npm-script" options={['NPM module', '<script>']}>
   ```js filename="main.js" {18}
-  import Clerk from '@clerk/clerk-js';
+  import { Clerk } from '@clerk/clerk-js';
 
   // Initialize Clerk with your Clerk publishable key
   const clerk = new Clerk('{{pub_key}}');

--- a/docs/components/organization/organization-list.mdx
+++ b/docs/components/organization/organization-list.mdx
@@ -125,7 +125,7 @@ function mountOrganizationList(node: HTMLDivElement, props?: OrganizationListPro
 
 <CodeBlockTabs type="npm-script" options={['NPM module', '<script>']}>
   ```js filename="main.js" {14}
-  import Clerk from '@clerk/clerk-js';
+  import { Clerk } from '@clerk/clerk-js';
 
   // Initialize Clerk with your Clerk publishable key
   const clerk = new Clerk('{{pub_key}}');
@@ -190,7 +190,7 @@ function unmountOrganizationList(node: HTMLDivElement): void;
 
 <CodeBlockTabs type="npm-script" options={['NPM module', '<script>']}>
   ```js filename="main.js" {18}
-  import Clerk from '@clerk/clerk-js';
+  import { Clerk } from '@clerk/clerk-js';
 
   // Initialize Clerk with your Clerk publishable key
   const clerk = new Clerk('{{pub_key}}');

--- a/docs/components/organization/organization-profile.mdx
+++ b/docs/components/organization/organization-profile.mdx
@@ -111,7 +111,7 @@ function mountOrganizationProfile(node: HTMLDivElement, props?: OrganizationProf
 
 <CodeBlockTabs type="npm-script" options={['NPM module', '<script>']}>
   ```js filename="main.js" {14}
-  import Clerk from '@clerk/clerk-js';
+  import { Clerk } from '@clerk/clerk-js';
 
   // Initialize Clerk with your Clerk publishable key
   const clerk = new Clerk('{{pub_key}}');
@@ -176,7 +176,7 @@ function unmountOrganizationProfile(node: HTMLDivElement): void;
 
 <CodeBlockTabs type="npm-script" options={['NPM module', '<script>']}>
   ```js filename="main.js" {18}
-  import Clerk from '@clerk/clerk-js';
+  import { Clerk } from '@clerk/clerk-js';
 
   // Initialize Clerk with your Clerk publishable key
   const clerk = new Clerk('{{pub_key}}');
@@ -249,7 +249,7 @@ function openOrganizationProfile(props?: OrganizationProfileProps): void;
 
 <CodeBlockTabs type="npm-script" options={['NPM module', '<script>']}>
   ```js filename="main.js" {14}
-  import Clerk from '@clerk/clerk-js';
+  import { Clerk } from '@clerk/clerk-js';
 
   // Initialize Clerk with your Clerk publishable key
   const clerk = new Clerk('{{pub_key}}');
@@ -308,7 +308,7 @@ function closeOrganizationProfile(): void;
 
 <CodeBlockTabs type="npm-script" options={['NPM module', '<script>']}>
   ```js filename="main.js" {14}
-  import Clerk from '@clerk/clerk-js';
+  import { Clerk } from '@clerk/clerk-js';
 
   // Initialize Clerk with your Clerk publishable key
   const clerk = new Clerk('{{pub_key}}');

--- a/docs/components/organization/organization-switcher.mdx
+++ b/docs/components/organization/organization-switcher.mdx
@@ -124,7 +124,7 @@ function mountOrganizationSwitcher(node: HTMLDivElement, props?: OrganizationSwi
 
 <CodeBlockTabs type="npm-script" options={['NPM module', '<script>']}>
   ```js filename="main.js" {14}
-  import Clerk from '@clerk/clerk-js';
+  import { Clerk } from '@clerk/clerk-js';
 
   // Initialize Clerk with your Clerk publishable key
   const clerk = new Clerk('{{pub_key}}');
@@ -189,7 +189,7 @@ function unmountOrganizationSwitcher(node: HTMLDivElement): void;
 
 <CodeBlockTabs type="npm-script" options={['NPM module', '<script>']}>
   ```js filename="main.js" {18}
-  import Clerk from '@clerk/clerk-js';
+  import { Clerk } from '@clerk/clerk-js';
 
   // Initialize Clerk with your Clerk publishable key
   const clerk = new Clerk('{{pub_key}}');

--- a/docs/components/user/user-button.mdx
+++ b/docs/components/user/user-button.mdx
@@ -245,7 +245,7 @@ function mountUserButton(node: HTMLDivElement, props?: UserButtonProps): void;
 
 <CodeBlockTabs type="npm-script" options={['NPM module', '<script>']}>
   ```js filename="main.js" {14}
-  import Clerk from '@clerk/clerk-js';
+  import { Clerk } from '@clerk/clerk-js';
 
   // Initialize Clerk with your Clerk publishable key
   const clerk = new Clerk('{{pub_key}}');
@@ -310,7 +310,7 @@ function unmountUserButton(node: HTMLDivElement): void;
 
 <CodeBlockTabs type="npm-script" options={['NPM module', '<script>']}>
   ```js filename="main.js" {18}
-  import Clerk from '@clerk/clerk-js';
+  import { Clerk } from '@clerk/clerk-js';
 
   // Initialize Clerk with your Clerk publishable key
   const clerk = new Clerk('{{pub_key}}');

--- a/docs/components/user/user-profile.mdx
+++ b/docs/components/user/user-profile.mdx
@@ -109,7 +109,7 @@ function mountUserProfile(node: HTMLDivElement, props?: UserProfileProps): void;
 
 <CodeBlockTabs type="npm-script" options={['NPM module', '<script>']}>
   ```js filename="main.js" {14}
-  import Clerk from '@clerk/clerk-js';
+  import { Clerk } from '@clerk/clerk-js';
 
   // Initialize Clerk with your Clerk publishable key
   const clerk = new Clerk('{{pub_key}}');
@@ -174,7 +174,7 @@ function unmountUserProfile(node: HTMLDivElement): void;
 
 <CodeBlockTabs type="npm-script" options={['NPM module', '<script>']}>
   ```js filename="main.js" {18}
-  import Clerk from '@clerk/clerk-js';
+  import { Clerk } from '@clerk/clerk-js';
 
   // Initialize Clerk with your Clerk publishable key
   const clerk = new Clerk('{{pub_key}}');
@@ -247,7 +247,7 @@ function openUserProfile(props?: UserProfileProps): void;
 
 <CodeBlockTabs type="npm-script" options={['NPM module', '<script>']}>
   ```js filename="main.js" {14}
-  import Clerk from '@clerk/clerk-js';
+  import { Clerk } from '@clerk/clerk-js';
 
   // Initialize Clerk with your Clerk publishable key
   const clerk = new Clerk('{{pub_key}}');
@@ -306,7 +306,7 @@ function closeUserProfile(): void;
 
 <CodeBlockTabs type="npm-script" options={['NPM module', '<script>']}>
   ```js filename="main.js" {14}
-  import Clerk from '@clerk/clerk-js';
+  import { Clerk } from '@clerk/clerk-js';
 
   // Initialize Clerk with your Clerk publishable key
   const clerk = new Clerk('{{pub_key}}');

--- a/docs/custom-flows/email-password-mfa.mdx
+++ b/docs/custom-flows/email-password-mfa.mdx
@@ -228,7 +228,7 @@ To authenticate a user using their email and password, you need to:
 
       ```js filename="main.js"
       import './style.css';
-      import Clerk from '@clerk/clerk-js';
+      import { Clerk } from '@clerk/clerk-js';
 
       const pubKey = import.meta.env.VITE_CLERK_PUBLISHABLE_KEY;
 

--- a/docs/custom-flows/email-password.mdx
+++ b/docs/custom-flows/email-password.mdx
@@ -166,7 +166,7 @@ To sign up a user using their email and password, you must:
       And your JavaScript file should look like this:
 
       ```js filename="main.js"
-      import Clerk from '@clerk/clerk-js';
+      import { Clerk } from '@clerk/clerk-js';
 
       // Initialize Clerk with your Clerk publishable key
       const clerk = new Clerk('{{pub_key}}');
@@ -477,7 +477,7 @@ To authenticate a user using their email and password, you must:
 
       ```js filename="main.js"
       import './style.css';
-      import Clerk from '@clerk/clerk-js';
+      import { Clerk } from '@clerk/clerk-js';
 
       const pubKey = import.meta.env.VITE_CLERK_PUBLISHABLE_KEY;
 

--- a/docs/custom-flows/email-sms-otp.mdx
+++ b/docs/custom-flows/email-sms-otp.mdx
@@ -193,7 +193,7 @@ To sign up a user using an OTP, you must:
       And your JavaScript file should look like this:
 
       ```js filename="main.js"
-      import Clerk from '@clerk/clerk-js';
+      import { Clerk } from '@clerk/clerk-js';
 
       // Initialize Clerk with your Clerk publishable key
       const clerk = new Clerk('{{pub_key}}');
@@ -550,7 +550,7 @@ To authenticate a user with an OTP, you must:
       And your JavaScript file should look like this:
 
       ```js filename="main.js"
-      import Clerk from '@clerk/clerk-js';
+      import { Clerk } from '@clerk/clerk-js';
 
       // Initialize Clerk with your Clerk publishable key
       const clerk = new Clerk('{{pub_key}}');

--- a/docs/custom-flows/user-impersonation.mdx
+++ b/docs/custom-flows/user-impersonation.mdx
@@ -176,7 +176,7 @@ When working with client-side code, you can detect impersonated sessions and gai
 
     <CodeBlockTabs type="npm-script" options={["NPM module", "<script>"]}>
     ```js filename="main.js"
-    import Clerk from '@clerk/clerk-js';
+    import { Clerk } from '@clerk/clerk-js';
 
     // Initialize Clerk with your Clerk publishable key
     const clerk = new Clerk("{{pub_key}}");

--- a/docs/organizations/verify-user-permissions.mdx
+++ b/docs/organizations/verify-user-permissions.mdx
@@ -242,7 +242,7 @@ If you are not using React or any of the meta-frameworks we support, there's a g
 
 <CodeBlockTabs type="framework" options={["JavaScript"]}>
   ```tsx
-    import Clerk from '@clerk/clerk-js'
+    import { Clerk } from '@clerk/clerk-js'
 
     const clerk = new Clerk(...)
     await clerk.load(...)

--- a/docs/quickstarts/javascript.mdx
+++ b/docs/quickstarts/javascript.mdx
@@ -109,7 +109,7 @@ Select your preferred method below to get started.
       To initialize the ClerkJS SDK, import the `Clerk` class and instantiate it with your **Publishable Key**. Then, call the `load()` method to initialize ClerkJS.
 
       ```js filename="main.js"
-      import Clerk from "@clerk/clerk-js";
+      import { Clerk } from "@clerk/clerk-js";
 
       const clerkPubKey = import.meta.env.VITE_CLERK_PUBLISHABLE_KEY;
 
@@ -135,7 +135,7 @@ Select your preferred method below to get started.
       Your `main.js` file should look something like this:
 
       ```js filename="main.js"
-      import Clerk from "@clerk/clerk-js";
+      import { Clerk } from "@clerk/clerk-js";
 
       const clerkPubKey = import.meta.env.VITE_CLERK_PUBLISHABLE_KEY;
 

--- a/docs/references/javascript/clerk/organization-methods.mdx
+++ b/docs/references/javascript/clerk/organization-methods.mdx
@@ -35,7 +35,7 @@ The following example demonstrates how to retrieve information about the current
   <Tab>
     <CodeBlockTabs options={["main.js", "index.html"]}>
     ```js filename="main.js" {9}
-    import Clerk from '@clerk/clerk-js';
+    import { Clerk } from '@clerk/clerk-js';
 
     // Initialize Clerk with your Clerk publishable key
     const clerk = new Clerk('{{pub_key}}');
@@ -165,7 +165,7 @@ function createOrganization({name, slug}: CreateOrganizationParams): Promise<Org
   <Tab>
     <CodeBlockTabs options={["main.js", "index.html"]}>
     ```js filename="main.js" {11-13}
-    import Clerk from '@clerk/clerk-js';
+    import { Clerk } from '@clerk/clerk-js';
 
     // Initialize Clerk with your Clerk publishable key
     const clerk = new Clerk('{{pub_key}}');

--- a/docs/references/javascript/organization-invitation.mdx
+++ b/docs/references/javascript/organization-invitation.mdx
@@ -47,7 +47,7 @@ It assumes:
 
 <CodeBlockTabs type="npm-script" options={['NPM module', '<script>']}>
 ```js filename="main.js" {21}
-import Clerk from '@clerk/clerk-js';
+import { Clerk } from '@clerk/clerk-js';
 
 // Initialize Clerk with your Clerk publishable key
 const clerk = new Clerk('{{pub_key}}');

--- a/docs/references/javascript/organization/domains.mdx
+++ b/docs/references/javascript/organization/domains.mdx
@@ -39,7 +39,7 @@ function createDomain: (domainName: string) => Promise<OrganizationDomainResourc
 
 <CodeBlockTabs type="npm-script" options={['NPM module', '<script>']}>
 ```js filename="main.js" {10}
-import Clerk from '@clerk/clerk-js';
+import { Clerk } from '@clerk/clerk-js';
 
 // Initialize Clerk with your Clerk publishable key
 const clerk = new Clerk('{{pub_key}}');
@@ -153,7 +153,7 @@ function getDomains(params?: GetDomainsParams): Promise<ClerkPaginatedResponse<O
 
 <CodeBlockTabs type="npm-script" options={['NPM module', '<script>']}>
 ```js filename="main.js" {10}
-import Clerk from '@clerk/clerk-js';
+import { Clerk } from '@clerk/clerk-js';
 
 // Initialize Clerk with your Clerk publishable key
 const clerk = new Clerk('{{pub_key}}');
@@ -265,7 +265,7 @@ function getDomain(params: GetDomainParams): Promise<OrganizationDomain>;
 
 <CodeBlockTabs type="npm-script" options={['NPM module', '<script>']}>
 ```js filename="main.js" {12}
-import Clerk from '@clerk/clerk-js';
+import { Clerk } from '@clerk/clerk-js';
 
 // Initialize Clerk with your Clerk publishable key
 const clerk = new Clerk('{{pub_key}}');

--- a/docs/references/javascript/organization/invitations.mdx
+++ b/docs/references/javascript/organization/invitations.mdx
@@ -40,7 +40,7 @@ function getInvitations(params?: GetInvitationsParams): Promise<ClerkPaginatedRe
 
 <CodeBlockTabs type="npm-script" options={['NPM module', '<script>']}>
 ```js filename="main.js" {10}
-import Clerk from '@clerk/clerk-js';
+import { Clerk } from '@clerk/clerk-js';
 
 // Initialize Clerk with your Clerk publishable key
 const clerk = new Clerk('{{pub_key}}');
@@ -155,7 +155,7 @@ function inviteMember(params: InviteMemberParams): Promise<OrganizationInvitatio
 
 <CodeBlockTabs type="npm-script" options={['NPM module', '<script>']}>
 ```js filename="main.js" {13}
-import Clerk from '@clerk/clerk-js';
+import { Clerk } from '@clerk/clerk-js';
 
 // Initialize Clerk with your Clerk publishable key
 const clerk = new Clerk('{{pub_key}}');
@@ -276,7 +276,7 @@ function inviteMembers(params: InviteMembersParams): Promise<OrganizationInvitat
 
 <CodeBlockTabs type="npm-script" options={['NPM module', '<script>']}>
 ```js filename="main.js" {13}
-import Clerk from '@clerk/clerk-js';
+import { Clerk } from '@clerk/clerk-js';
 
 // Initialize Clerk with your Clerk publishable key
 const clerk = new Clerk('{{pub_key}}');

--- a/docs/references/javascript/organization/members.mdx
+++ b/docs/references/javascript/organization/members.mdx
@@ -175,7 +175,7 @@ The following example demonstrates how to use the organization membership method
   And your JavaScript file should look like this:
 
   ```js filename="main.js" {13,41,60,79}
-  import Clerk from '@clerk/clerk-js';
+  import { Clerk } from '@clerk/clerk-js';
 
   // Initialize Clerk with your Clerk publishable key
   const clerk = new Clerk('{{pub_key}}');

--- a/docs/references/javascript/organization/membership-request.mdx
+++ b/docs/references/javascript/organization/membership-request.mdx
@@ -99,7 +99,7 @@ The following example demonstrates how to use the `getMembershipRequests()` meth
   And your JavaScript file should look like this:
 
   ```js filename="main.js" {13}
-  import Clerk from '@clerk/clerk-js';
+  import { Clerk } from '@clerk/clerk-js';
 
   // Initialize Clerk with your Clerk publishable key
   const clerk = new Clerk('{{pub_key}}');

--- a/docs/references/javascript/organization/organization.mdx
+++ b/docs/references/javascript/organization/organization.mdx
@@ -58,7 +58,7 @@ function update(params: UpdateOrganizationParams): Promise<Organization>;
 
 <CodeBlockTabs type="npm-script" options={['NPM module', '<script>']}>
 ```js filename="main.js" {10}
-import Clerk from '@clerk/clerk-js';
+import { Clerk } from '@clerk/clerk-js';
 
 // Initialize Clerk with your Clerk publishable key
 const clerk = new Clerk('{{pub_key}}');
@@ -167,7 +167,7 @@ function destroy(): Promise<void>;
 
 <CodeBlockTabs type="npm-script" options={['NPM module', '<script>']}>
 ```js filename="main.js" {10}
-import Clerk from '@clerk/clerk-js';
+import { Clerk } from '@clerk/clerk-js';
 
 // Initialize Clerk with your Clerk publishable key
 const clerk = new Clerk('{{pub_key}}');
@@ -305,7 +305,7 @@ function setLogo(params: SetOrganizationLogoParams): Promise<Organization>;
     And your JavaScript file should look like this:
 
     ```js filename="main.js" {14}
-    import Clerk from '@clerk/clerk-js';
+    import { Clerk } from '@clerk/clerk-js';
 
     // Initialize Clerk with your Clerk publishable key
     const clerk = new Clerk('{{pub_key}}');
@@ -463,7 +463,7 @@ An *experimental* interface that includes information about a user's permission.
 
 <CodeBlockTabs type="npm-script" options={['NPM module', '<script>']}>
 ```js filename="main.js" {10}
-import Clerk from '@clerk/clerk-js';
+import { Clerk } from '@clerk/clerk-js';
 
 // Initialize Clerk with your Clerk publishable key
 const clerk = new Clerk('{{pub_key}}');

--- a/docs/references/javascript/session.mdx
+++ b/docs/references/javascript/session.mdx
@@ -87,7 +87,7 @@ function getToken(options?: GetTokenOptions): Promise<string | null>;
 
 <CodeBlockTabs type="npm-script" options={['NPM module', '<script>']}>
   ```js filename="main.js" {8}
-  import Clerk from '@clerk/clerk-js';
+  import { Clerk } from '@clerk/clerk-js';
 
   // Initialize Clerk with your Clerk publishable key
   const clerk = new Clerk('{{pub_key}}');

--- a/docs/references/javascript/user/create-metadata.mdx
+++ b/docs/references/javascript/user/create-metadata.mdx
@@ -35,7 +35,7 @@ The following example adds `test@test.com` as an email address for the user. If 
 
 <CodeBlockTabs type="npm-script" options={['NPM module', '<script>']}>
 ```js filename="main.js"
-import Clerk from '@clerk/clerk-js';
+import { Clerk } from '@clerk/clerk-js';
 
 // Initialize Clerk with your Clerk publishable key
 const clerk = new Clerk('{{pub_key}}');
@@ -123,7 +123,7 @@ The following example adds `15551234567` as a phone number for the user. If the 
 
 <CodeBlockTabs type="npm-script" options={['NPM module', '<script>']}>
 ```js filename="main.js"
-import Clerk from '@clerk/clerk-js';
+import { Clerk } from '@clerk/clerk-js';
 
 // Initialize Clerk with your Clerk publishable key
 const clerk = new Clerk('{{pub_key}}');
@@ -211,7 +211,7 @@ The following example adds `0x0123456789ABCDEF0123456789ABCDEF01234567` as a web
 
 <CodeBlockTabs type="npm-script" options={['NPM module', '<script>']}>
 ```js filename="main.js"
-import Clerk from '@clerk/clerk-js';
+import { Clerk } from '@clerk/clerk-js';
 
 // Initialize Clerk with your Clerk publishable key
 const clerk = new Clerk('{{pub_key}}');
@@ -336,7 +336,7 @@ The following example demonstrates how to add a Notion account as an external ac
     And your JavaScript file should look like this:
 
     ```js filename="main.js"
-    import Clerk from '@clerk/clerk-js';
+    import { Clerk } from '@clerk/clerk-js';
 
     // Initialize Clerk with your Clerk publishable key
     const clerk = new Clerk('{{pub_key}}');

--- a/docs/references/javascript/user/password-management.mdx
+++ b/docs/references/javascript/user/password-management.mdx
@@ -67,7 +67,7 @@ function updatePassword: (params: UpdateUserPasswordParams) => Promise<User>;
     And your JavaScript file should look like this:
 
     ```js filename="main.js"
-    import Clerk from '@clerk/clerk-js';
+    import { Clerk } from '@clerk/clerk-js';
 
     // Initialize Clerk with your Clerk publishable key
     const clerk = new Clerk('{{pub_key}}');
@@ -186,7 +186,7 @@ function removePassword: (params: RemoveUserPasswordParams) => Promise<User>;
     For the following example, your HTML file should look like this:
 
     ```js filename="main.js"
-    import Clerk from '@clerk/clerk-js';
+    import { Clerk } from '@clerk/clerk-js';
 
     // Initialize Clerk with your Clerk publishable key
     const clerk = new Clerk('{{pub_key}}');

--- a/docs/references/javascript/user/totp.mdx
+++ b/docs/references/javascript/user/totp.mdx
@@ -140,7 +140,7 @@ The following example assumes:
     And your JavaScript file should look like this:
 
     ```js filename="main.js"
-    import Clerk from '@clerk/clerk-js';
+    import { Clerk } from '@clerk/clerk-js';
 
     // Initialize Clerk with your Clerk publishable key
     const clerk = new Clerk('{{pub_key}}');

--- a/docs/references/javascript/user/user.mdx
+++ b/docs/references/javascript/user/user.mdx
@@ -88,7 +88,7 @@ In the following example, the user's first name is updated to "Test".
 
 <CodeBlockTabs type="npm-script" options={['NPM module', '<script>']}>
   ```js filename="main.js" {8}
-  import Clerk from '@clerk/clerk-js';
+  import { Clerk } from '@clerk/clerk-js';
 
   // Initialize Clerk with your Clerk publishable key
   const clerk = new Clerk('{{pub_key}}');
@@ -160,7 +160,7 @@ function delete: () => Promise<void>;
 
 <CodeBlockTabs type="npm-script" options={['NPM module', '<script>']}>
   ```js filename="main.js" {8}
-  import Clerk from '@clerk/clerk-js';
+  import { Clerk } from '@clerk/clerk-js';
 
   // Initialize Clerk with your Clerk publishable key
   const clerk = new Clerk('{{pub_key}}');
@@ -271,7 +271,7 @@ function setProfileImage: (params: SetProfileImageParams) => Promise<ImageResour
     And your JavaScript file should look like this:
 
     ```js filename="main.js"
-    import Clerk from '@clerk/clerk-js';
+    import { Clerk } from '@clerk/clerk-js';
 
     // Initialize Clerk with your Clerk publishable key
     const clerk = new Clerk('{{pub_key}}');
@@ -369,7 +369,7 @@ function reload: (p?: ClerkResourceReloadParams) => Promise<this>;
 
 <CodeBlockTabs type="npm-script" options={['NPM module', '<script>']}>
   ```js filename="main.js" {7}
-  import Clerk from '@clerk/clerk-js';
+  import { Clerk } from '@clerk/clerk-js';
 
   // Initialize Clerk with your Clerk publishable key
   const clerk = new Clerk('{{pub_key}}');
@@ -421,7 +421,7 @@ function getSessions: () => Promise<SessionWithActivities[]>;
 
 <CodeBlockTabs type="npm-script" options={['NPM module', '<script>']}>
   ```js filename="main.js" {8}
-  import Clerk from '@clerk/clerk-js';
+  import { Clerk } from '@clerk/clerk-js';
 
   // Initialize Clerk with your Clerk publishable key
   const clerk = new Clerk('{{pub_key}}');
@@ -538,7 +538,7 @@ function getOrganizationInvitations: (params?: GetUserOrganizationInvitationsPar
 
 <CodeBlockTabs type="npm-script" options={['NPM module', '<script>']}>
   ```js filename="main.js" {8}
-  import Clerk from '@clerk/clerk-js';
+  import { Clerk } from '@clerk/clerk-js';
 
   // Initialize Clerk with your Clerk publishable key
   const clerk = new Clerk('{{pub_key}}');
@@ -624,7 +624,7 @@ function getOrganizationSuggestions: (params?: GetUserOrganizationSuggestionsPar
 
 <CodeBlockTabs type="npm-script" options={['NPM module', '<script>']}>
   ```js filename="main.js" {8}
-  import Clerk from '@clerk/clerk-js';
+  import { Clerk } from '@clerk/clerk-js';
 
   // Initialize Clerk with your Clerk publishable key
   const clerk = new Clerk('{{pub_key}}');
@@ -709,7 +709,7 @@ function getOrganizationMemberships: (params?: GetUserOrganizationMembershipPara
 
 <CodeBlockTabs type="npm-script" options={['NPM module', '<script>']}>
   ```js filename="main.js" {8}
-  import Clerk from '@clerk/clerk-js';
+  import { Clerk } from '@clerk/clerk-js';
 
   // Initialize Clerk with your Clerk publishable key
   const clerk = new Clerk('{{pub_key}}');

--- a/docs/users/metadata.mdx
+++ b/docs/users/metadata.mdx
@@ -570,7 +570,7 @@ Updating this value overrides the previous value; it does not merge. To perform 
   <Tab>
     <CodeBlockTabs type="npm-script" options={["NPM module", "<script>"]}>
     ```js filename="main.js"
-    import Clerk from '@clerk/clerk-js';
+    import { Clerk } from '@clerk/clerk-js';
 
     // Initialize Clerk with your Clerk publishable key
     const clerk = new Clerk('{{pub_key}}');


### PR DESCRIPTION
The top level Clerk import was changed to a named export, like { Clerk }. Per [the upgrade guides](https://clerk.com/docs/upgrade-guides/core-2/javascript).

This PR changes the default Clerk imports in our code snippets to named imports.