### PR TITLE
Adapt demo placeholder background colour to active theme

### DIFF
--- a/docs/elements/examples/shadcn-ui.mdx
+++ b/docs/elements/examples/shadcn-ui.mdx
@@ -49,7 +49,7 @@ You must also configure the appropriate settings in Clerk:
     demo: '/demo/shadcn/elements/sign-up',
     style: {
       height: `${616 / 16}rem`,
-      backgroundColor: 'rgb(10, 10, 10)'
+      backgroundColor: 'var(--light, hsl(0 0% 100%)) var(--dark, hsl(0 0% 3.9%))'
     },
     bordered: true
   },
@@ -284,7 +284,7 @@ export default function SignUpPage() {
     demo: '/demo/shadcn/elements/sign-in',
     style: {
       height: `${528 / 16}rem`,
-      backgroundColor: 'rgb(10, 10, 10)'
+      backgroundColor: 'var(--light, hsl(0 0% 100%)) var(--dark, hsl(0 0% 3.9%))'
     },
     bordered: true
   },
@@ -561,7 +561,7 @@ The following example demonstrates how to make a one-time password (OTP) input w
     demo: '/demo/shadcn/elements/otp-input',
     style: {
       height: `${528 / 16}rem`,
-      backgroundColor: 'rgb(10, 10, 10)'
+      backgroundColor: 'var(--light, hsl(0 0% 100%)) var(--dark, hsl(0 0% 3.9%))'
     },
     bordered: true
   },


### PR DESCRIPTION
This PR uses the `var(--light, lightValue) var(--dark, darkValue)` [trick](https://lightningcss.dev/transpilation.html#light-dark()-color-function) to set the background colour for the Elements shadcn/ui demos. This prevents the background colour from initialising with the incorrect colour.

**Before**

https://github.com/clerk/clerk-docs/assets/2615508/68c4ca75-ad37-4fc8-899d-a4268b336673

**After**

https://github.com/clerk/clerk-docs/assets/2615508/7a95b775-5497-47a9-be41-8ebeb2cae210