### PR TITLE
(/quickstarts/nextjs) remove create homepage step; add clerk middleware to next steps

### DIFF
--- a/docs/quickstarts/nextjs.mdx
+++ b/docs/quickstarts/nextjs.mdx
@@ -152,14 +152,12 @@ import type { AppProps } from 'next/app'
 function MyApp({ Component, pageProps }: AppProps) {
   return (
     <ClerkProvider {...pageProps}>
-      <header>
         <SignedOut>
           <SignInButton />
         </SignedOut>
         <SignedIn>
           <UserButton />
         </SignedIn>
-      </header>
       <Component {...pageProps} />
     </ClerkProvider>
   )

--- a/docs/quickstarts/nextjs.mdx
+++ b/docs/quickstarts/nextjs.mdx
@@ -169,38 +169,14 @@ export default MyApp;
 ```
 </CodeBlockTabs>
 
-### Create a home page
-
-To render the header you just created, create a simple homepage.
-
-<CodeBlockTabs type="router" options={["App Router", "Pages Router"]}>
-```tsx filename="app/page.tsx"
-
-export default function Home() {
-  return (
-    <h1>Home Page</h1>
-  )
-}
-```
-
-```tsx filename="pages/index.tsx"
-
-export default function Home() {
-  return (
-    <h1>Home Page</h1>
-  )
-}
-```
-</CodeBlockTabs>
-
-Then, visit your app's homepage at [`localhost:3000`](http://localhost:3000) while signed out to see the sign-in button. Once signed in, your app will render the user button.
-
 </Steps>
 
 ## Next steps
 
 <div className="container mx-auto my-4">
   <div className="grid grid-cols-1 gap-6 md:grid-cols-2">
+
+    <Cards title="Protect routes using Clerk Middleware" description="Learn how to protect specific routes from unauthenticated users." link="/docs/references/nextjs/clerk-middleware" cta="Learn More" />
 
     <Cards title="Create custom sign-up and sign-in pages" description="Learn how add custom sign-up and sign-in pages with Clerk components." link="/docs/references/nextjs/custom-signup-signin-pages" cta="Learn More" />
 


### PR DESCRIPTION
https://clerk.com/docs/pr/1061/quickstarts/nextjs

Remove create homepage step:
Per this discussion: https://clerkinc.slack.com/archives/C01QFRQNHSN/p1716128555906809
Many users will already have a Next.js application running, and won't really need the create a homepage step.

Add clerk-middleware to next steps:
Per this discussion: https://clerkinc.slack.com/archives/C01QFRQNHSN/p1716128688058099
Clerk middleware should be called out so that users can be directed on how to protect routes.