### PR TITLE
Update email deliverability docs

### DIFF
--- a/docs/troubleshooting/email-deliverability.mdx
+++ b/docs/troubleshooting/email-deliverability.mdx
@@ -9,7 +9,7 @@ A lot goes into making sure verification emails make it to your customers as qui
 
 In development instances, all emails are sent from `@accounts.dev` domain. In production instances, they are sent from your own domain e.g. `@example.com`.
 
-During production instance set up, Clerk will have you set `SPF`, `DKIM`, and mail records. There are a few additional things you should set up to ensure maximum deliverability.
+During production instance set up, Clerk will have you set up the required records to configure `SPF`, `DKIM`, and `DMARC` for security and deliverability.
 
 ## Best practices
 


### PR DESCRIPTION
We should avoid saying we'll have users "set `SPF` records". Instead, mention that we'll have them set up various records, which will configure `SPF` among other things. Based on this slack discussion: https://clerkinc.slack.com/archives/C053FSYKAH1/p1716485775889239?thread_ts=1716216870.321359&cid=C053FSYKAH1