### PR TITLE
(/integrations/databases/neon) add instructions for updating react package

### DIFF
--- a/docs/integrations/databases/neon.mdx
+++ b/docs/integrations/databases/neon.mdx
@@ -35,7 +35,11 @@ This tutorial demonstrates how to integrate Neon Postgres with Clerk in a Next.j
     ```sh {{ filename: 'terminal' }}
     npx create-next-app clerk-neon-example --typescript --eslint --tailwind --use-npm --no-src-dir --app --import-alias "@/*"
     ```
-1. Navigate to the project directory and install the required dependencie s:
+1. Update the React package:
+    ```sh {{ filename: 'terminal' }}
+    npm install react react-dom
+    ```
+1. Navigate to the project directory and install the required dependencies:
     ```sh {{ filename: 'terminal' }}
     cd clerk-neon-example
     npm install @neondatabase/serverless drizzle-orm dotenv


### PR DESCRIPTION
The dependencies won't install if the React package isn't 18.3.**