### PR TITLE
[Edit] - remove firebase mention from Neon-Clerk tutorial

### DIFF
--- a/docs/integrations/databases/neon.mdx
+++ b/docs/integrations/databases/neon.mdx
@@ -20,8 +20,7 @@ description: Learn how to integrate Clerk into your Neon application.
   ]}
 >
 
-- Use Clerk to authenticate access to your Firebase data.
-- Configure your Firebase Clerk integration.
+- Use Clerk to authenticate access to your application backed by Neon.
 
 </TutorialHero>
 
@@ -38,7 +37,8 @@ This tutorial demonstrates how to integrate Neon Postgres with Clerk in a Next.j
 1. Navigate to the project directory and install the required dependencie s:
     ```sh {{ filename: 'terminal' }}
     cd clerk-neon-example
-    npm install @neondatabase/serverless drizzle-orm dotenv
+    npm install @neondatabase/serverless dotenv
+    npm install drizzle-orm --legacy-peer-deps
     npm install -D drizzle-kit
     ```
 


### PR DESCRIPTION
There was a leftover firebase mention in the Neon post, this PR removes it. Also, resolves an npm package install. 