### PR TITLE
feat: Add browser + Node.js compat to LTS page

### DIFF
--- a/docs/upgrade-guides/long-term-support.mdx
+++ b/docs/upgrade-guides/long-term-support.mdx
@@ -23,7 +23,7 @@ After the LTS period ends, there will be no further changes to the code for that
 
 ## Library compatibility
 
-Clerk's SDKs run in the browser, in Node.js (+ other compatible runtimes), or in both. Below you can find out which versions of Node.js and which browser versions Clerk's SDKs support.
+Clerk's SDKs run in the browser, in Node.js (+ other compatible runtimes), or in both. Below you can find out which Node.js and browser versions Clerk's SDKs support.
 
 | Version | Node.js     | Browsers          |
 | ------- | ----------- | ----------------- |

--- a/docs/upgrade-guides/long-term-support.mdx
+++ b/docs/upgrade-guides/long-term-support.mdx
@@ -12,14 +12,23 @@ After the LTS period ends, there will be no further changes to the code for that
 ## Schedule
 
 <Callout type="info">
-  Future time ranges are listed when a specific target date is not yet determined. The version number refers to the current version of the [`@clerk/clerk-js`](https://www.npmjs.com/package/@clerk/clerk-js) package.
+  Future time ranges are listed when a specific target date is not yet determined. The version "Core `N`" refers to [how Clerk SDKs are versioned and released](/docs/upgrade-guides/sdk-versioning).
 </Callout>
 
-| Version | Status                        | As Of            | Until            |
-| ------- | ----------------------------- | ---------------- | ---------------- |
-| Core 2       | Active      | April 19, 2024 | TBD          |
-| Core 1       | Long term support | April 19, 2024 | Q1 2025          |
-| Legacy (v3)       | Unsupported                   | - | - |
+| Version     | Status            | As Of          | Until   |
+| ----------- | ----------------- | -------------- | ------- |
+| Core 2      | Active            | April 19, 2024 | TBD     |
+| Core 1      | Long term support | April 19, 2024 | Q1 2025 |
+| Legacy (v3) | Unsupported       | -              | -       |
+
+## Library compatibility
+
+Clerk's SDKs run in the browser, in Node.js (+ other compatible runtimes), or in both. Below you can find out which versions of Node.js and which browser versions Clerk's SDKs support.
+
+| Version | Node.js     | Browsers          |
+| ------- | ----------- | ----------------- |
+| Core 2  | `>=18.17.0` | Evergreen, iOS 16 |
+| Core 1  | `>=14.0.0`  | Evergreen, iOS 16 |
 
 ## Terminology
 
@@ -30,3 +39,5 @@ After the LTS period ends, there will be no further changes to the code for that
 - **Long term support** - Receives critical patches, but does not receive new features.
 
 - **Unsupported** - This version of Clerk no longer receives official support of any kind.
+
+- **Evergreen browser** - Includes these browsers: Google Chrome, Mozilla Firefox, Microsoft Edge (Chromium), Safari, Opera. **No** support for Internet Explorer (IE).

--- a/docs/upgrade-guides/sdk-versioning.mdx
+++ b/docs/upgrade-guides/sdk-versioning.mdx
@@ -7,11 +7,11 @@ description: An overview of Clerk's SDK release cycles, versioning, and release 
 
 Clerk is on roughly a 6 month major release cycle for its SDKs. This means that every ~6 months, there is a release cycle across all SDKs that may include breaking changes that need to be released for any given SDK. All of our SDKs use [semantic versioning](https://semver.org/) independently.
 
-You may see the term "Core `N`" in our docs and release announcements. This refers to a set of core functionality that is included across all SDK libraries, rather than to a specific version of any individual SDK. As an example, in the Core 2 release, the Next.js SDK boosted its major version from v4 to v5. However, not every SDK had a major version increment as part of the Core 2 release.
+You may see the term "Core `N`" in our docs and release announcements. This refers to a set of core functionality that is included across all SDK libraries, rather than to a specific version of any individual SDK. As an example, in the Core 2 release, the Next.js SDK changed its major version from v4 to v5. However, not every SDK had a major version increment as part of the Core 2 release.
 
-When there is a new Core release, you can expect an upgrade guide alongside it for each Clerk SDK, and that guide will mention the SDK's current semver version. However, this is not generally something that anyone needs to be concerned with - if you want the latest version, you can just install the sdk as usual and get the latest version. The "Core `N`" terminology is simply a way for us at Clerk to broadly refer to a set of changes and improvements made to Clerk's functionality that is included in all of our SDKs to different extents. There is no literal SDK or Clerk library called "Core".
+When there is a new Core release, you can expect an upgrade guide alongside it for each Clerk SDK, and that guide will mention the SDK's current semver version. However, this is not generally something that anyone needs to be concerned with - if you want the latest version, you can just install the SDK as usual and get the latest version. The "Core `N`" terminology is simply a way for us at Clerk to broadly refer to a set of changes and improvements made to Clerk's functionality that is included in all of our SDKs to different extents. There is no literal SDK or Clerk library called "Core".
 
 Whenever a new Core release is cut, the latest version of each SDK including the _previous_ Core release will be tagged in npm, to make it simple to roll back if needed. So, for example, if Clerk released Core 2:
 
-- `npm i @clerk/nextjs` would install the latest release, which would be on top of Core 2.
-- `npm i @clerk/nextjs@core-1` would install the latest version of the SDK that was released before Core 2 came out.
+- `npm i @clerk/nextjs` would install v5, which would be on top of Core 2.
+- `npm i @clerk/nextjs@latest-v4` would install v4, which would be on top of Core 1.


### PR DESCRIPTION
This adds the minimum supported Node.js version + browser vendors to the LTS page.

Fixes SDK-1618