### PR TITLE
Correct the path to JWT-related functions

### DIFF
--- a/docs/upgrade-guides/core-2/backend.mdx
+++ b/docs/upgrade-guides/core-2/backend.mdx
@@ -86,29 +86,29 @@ The `clockSkewInSeconds` option has been renamed to `clockSkewInMs` in order to 
 
 Some top level import paths have been changed in order to improve tree-shaking and more clearly categorize sets of functionality. Some methods have been moved under an `/internal` path, indicating that they are only intended for internal use, are exempt from semver, and should be used with great caution.
 
-<Accordion titles={["<code>verifyJwt</code> import moved to <code>@clerk/backend/tokens</code>", "<code>decodeJwt</code> import moved to <code>@clerk/backend/tokens</code>", "<code>signJwt</code> import moved to <code>@clerk/backend/tokens</code>", "<code>constants</code> import moved to <code>@clerk/backend/internal</code>", "<code>redirect</code> import moved to <code>@clerk/backend/internal</code>", "<code>createAuthenticateRequest</code> import moved to <code>@clerk/backend/internal</code>", "<code>createIsomorphicRequest</code> import moved to <code>@clerk/backend/internal</code>", "<code>createIsomorphicRequest</code> import moved to <code>/internal</code>", "<code>SignJWTError</code> import moved to <code>@clerk/backend/errors</code>", "<code>TokenVerificationError</code> import moved to <code>@clerk/backend/errors</code>", "<code>TokenVerificationErrorAction</code> import moved to <code>@clerk/backend/errors</code>", "<code>TokenVerificationErrorReason</code> import moved to <code>@clerk/backend/errors</code>"]}>
+<Accordion titles={["<code>verifyJwt</code> import moved to <code>@clerk/backend/jwt</code>", "<code>decodeJwt</code> import moved to <code>@clerk/backend/jwt</code>", "<code>signJwt</code> import moved to <code>@clerk/backend/jwt</code>", "<code>constants</code> import moved to <code>@clerk/backend/internal</code>", "<code>redirect</code> import moved to <code>@clerk/backend/internal</code>", "<code>createAuthenticateRequest</code> import moved to <code>@clerk/backend/internal</code>", "<code>createIsomorphicRequest</code> import moved to <code>@clerk/backend/internal</code>", "<code>createIsomorphicRequest</code> import moved to <code>/internal</code>", "<code>SignJWTError</code> import moved to <code>@clerk/backend/errors</code>", "<code>TokenVerificationError</code> import moved to <code>@clerk/backend/errors</code>", "<code>TokenVerificationErrorAction</code> import moved to <code>@clerk/backend/errors</code>", "<code>TokenVerificationErrorReason</code> import moved to <code>@clerk/backend/errors</code>"]}>
   <AccordionPanel>
-    The `verifyJwt` import path has changed from `@clerk/backend` to `@clerk/backend/tokens`. You must update your import path in order for it to work correctly. Example below of the fix that needs to be made
+    The `verifyJwt` import path has changed from `@clerk/backend` to `@clerk/backend/jwt`. You must update your import path in order for it to work correctly. Example below of the fix that needs to be made
 
     ```diff
     - import { verifyJwt } from "@clerk/backend"
-    + import { verifyJwt } from "@clerk/backend/tokens"
+    + import { verifyJwt } from "@clerk/backend/jwt"
     ```
   </AccordionPanel>
   <AccordionPanel>
-    The `decodeJwt` import path has changed from `@clerk/backend` to `@clerk/backend/tokens`. You must update your import path in order for it to work correctly. Example below of the fix that needs to be made
+    The `decodeJwt` import path has changed from `@clerk/backend` to `@clerk/backend/jwt`. You must update your import path in order for it to work correctly. Example below of the fix that needs to be made
 
     ```diff
     - import { decodeJwt } from "@clerk/backend"
-    + import { decodeJwt } from "@clerk/backend/tokens"
+    + import { decodeJwt } from "@clerk/backend/jwt"
     ```
   </AccordionPanel>
   <AccordionPanel>
-    The `signJwt` import path has changed from `@clerk/backend` to `@clerk/backend/tokens`. You must update your import path in order for it to work correctly. Example below of the fix that needs to be made
+    The `signJwt` import path has changed from `@clerk/backend` to `@clerk/backend/jwt`. You must update your import path in order for it to work correctly. Example below of the fix that needs to be made
 
     ```diff
     - import { signJwt } from "@clerk/backend"
-    + import { signJwt } from "@clerk/backend/tokens"
+    + import { signJwt } from "@clerk/backend/jwt"
     ```
   </AccordionPanel>
   <AccordionPanel>


### PR DESCRIPTION
The prior docs stated that functions like decodeJwt were to be imported from @clerk/backend/tokens, though @clerk/backend/jwt is the correct address based on installing @clerk/backend@^1.2.1