### PR TITLE
Fixed PaginatedResourceResponse docs

### DIFF
--- a/docs/references/backend/allowlist/get-allowlist-identifier-list.mdx
+++ b/docs/references/backend/allowlist/get-allowlist-identifier-list.mdx
@@ -5,7 +5,7 @@ description: Use Clerk's Backend SDK to retrieve a list of allowlist identifiers
 
 # `getAllowlistIdentifierList()`
 
-Retrieves the list of allowlist identifiers.
+Retrieves the list of all allowlist identifiers.
 
 ```tsx
 function getAllowlistIdentifierList: () => Promise<PaginatedResourceResponse<AllowlistIdentifier[]>>;
@@ -13,7 +13,7 @@ function getAllowlistIdentifierList: () => Promise<PaginatedResourceResponse<All
 
 ## Example
 
-In this example, you can see that the returned [`PaginatedResourceResponse`](/docs/references/backend/types/paginated-resource-response) includes `data`, which is an array of `AllowlistIdentifier` objects, and `totalCount`, which indicates the total number of allowlist identifiers in the system.
+In this example, you can see that the returned [`PaginatedResourceResponse`](/docs/references/backend/types/paginated-resource-response) includes `data`, which is an array of all `AllowlistIdentifier` objects, and `totalCount`, which indicates the total number of allowlist identifiers in the system.
 
 ```tsx
 const response = await clerkClient.allowlistIdentifiers.getAllowlistIdentifierList();

--- a/docs/references/backend/invitations/get-invitation-list.mdx
+++ b/docs/references/backend/invitations/get-invitation-list.mdx
@@ -1,11 +1,11 @@
 ---
 title: getInvitationList()
-description: Use Clerk's Backend SDK to retrieve a list of all non-revoked invitations for your application.
+description: Use Clerk's Backend SDK to retrieve a list of non-revoked invitations for your application.
 ---
 
 # `getInvitationList()`
 
-Retrieves a list of all non-revoked invitations for your application, sorted by descending creation date.
+Retrieves a list of non-revoked invitations for your application, sorted by descending creation date.
 
 ```tsx
 function getInvitationList: (params: GetInvitationListParams) => Promise<PaginatedResourceResponse<Invitation[]>>;
@@ -16,8 +16,8 @@ function getInvitationList: (params: GetInvitationListParams) => Promise<Paginat
 | Name | Type | Description |
 | --- | --- | --- |
 | `status?` | `accepted \| pending \| revoked` | Filter by invitation status. |
-| `limit?` | `number` | The number of results to return. Must be an integer greater than zero and less than 501. |
-| `offset?` | `number` | The number of results to skip. |
+| `limit?` | `number` | The number of results to return. Must be an integer greater than zero and less than 501. Default: `10` |
+| `offset?` | `number` | The number of results to skip. Default: `0` |
 
 ## Examples
 

--- a/docs/references/backend/organization/get-organization-invitation-list.mdx
+++ b/docs/references/backend/organization/get-organization-invitation-list.mdx
@@ -16,8 +16,8 @@ function getOrganizationInvitationList: (params: GetOrganizationInvitationListPa
 | Name | Type | Description |
 | --- | --- | --- |
 | `organizationId` | `string` | The ID of the organization to retrieve the list of pending invitations from. |
-| `limit?` | `number` | The number of results to return. Must be an integer greater than zero and less than 501. |
-| `offset?` | `number` | The number of results to skip. |
+| `limit?` | `number` | The number of results to return. Must be an integer greater than zero and less than 501. Default: `10` |
+| `offset?` | `number` | The number of results to skip.  Default: `10` |
 
 ## Examples
 

--- a/docs/references/backend/organization/get-organization-invitation-list.mdx
+++ b/docs/references/backend/organization/get-organization-invitation-list.mdx
@@ -17,7 +17,7 @@ function getOrganizationInvitationList: (params: GetOrganizationInvitationListPa
 | --- | --- | --- |
 | `organizationId` | `string` | The ID of the organization to retrieve the list of pending invitations from. |
 | `limit?` | `number` | The number of results to return. Must be an integer greater than zero and less than 501. Default: `10` |
-| `offset?` | `number` | The number of results to skip.  Default: `10` |
+| `offset?` | `number` | The number of results to skip.  Default: `0` |
 
 ## Examples
 

--- a/docs/references/backend/redirect-urls/get-redirect-url-list.mdx
+++ b/docs/references/backend/redirect-urls/get-redirect-url-list.mdx
@@ -5,7 +5,7 @@ description: Use Clerk's Backend SDK to retrieve a list of white-listed redirect
 
 # `getRedirectUrlList()`
 
-Retrieves a list of white-listed redirect URLs.
+Retrieves a list of all white-listed redirect URLs.
 
 ```tsx
 function getRedirectUrlList(): () => Promise<PaginatedResourceResponse<RedirectUrl[]>>;

--- a/docs/references/backend/sessions/get-session-list.mdx
+++ b/docs/references/backend/sessions/get-session-list.mdx
@@ -11,7 +11,7 @@ Retrieves a list of sessions.
 function getSessionList: (queryParams: SessionListParams) => Promise<PaginatedResourceResponse<Session[]>>;
 ```
 
-## `QueryParams`
+## `SessionListParams`
 
 `getSessionList()` requires either `clientId` or `userId` to be provided.
 

--- a/docs/references/backend/sessions/get-session-list.mdx
+++ b/docs/references/backend/sessions/get-session-list.mdx
@@ -21,7 +21,7 @@ function getSessionList: (queryParams: SessionListParams) => Promise<PaginatedRe
 | `userId?` | `string` | The user ID to retrieve the list of sessions for. |
 | `status?` | [`SessionStatus`](#session-status) | The status of the session. |
 | `limit?` | `number` | The number of results to return. Must be an integer greater than zero and less than 501. Default: `10` |
-| `offset?` | `number` | The number of results to skip.  Default: `10` |
+| `offset?` | `number` | The number of results to skip.  Default: `0` |
 
 ### `SessionStatus`
 

--- a/docs/references/backend/sessions/get-session-list.mdx
+++ b/docs/references/backend/sessions/get-session-list.mdx
@@ -8,7 +8,7 @@ description: Use Clerk's Backend SDK to retrieve a list of sessions.
 Retrieves a list of sessions.
 
 ```tsx
-function getSessionList: (queryParams: QueryParams) => Promise<PaginatedResourceResponse<Session[]>>;
+function getSessionList: (queryParams: SessionListParams) => Promise<PaginatedResourceResponse<Session[]>>;
 ```
 
 ## `QueryParams`
@@ -20,8 +20,8 @@ function getSessionList: (queryParams: QueryParams) => Promise<PaginatedResource
 | `clientId?` | `string` | The client ID to retrieve the list of sessions for. |
 | `userId?` | `string` | The user ID to retrieve the list of sessions for. |
 | `status?` | [`SessionStatus`](#session-status) | The status of the session. |
-| `limit?` | `number` | The number of results to return. Must be an integer greater than zero and less than 501. |
-| `offset?` | `number` | The number of results to skip. |
+| `limit?` | `number` | The number of results to return. Must be an integer greater than zero and less than 501. Default: `10` |
+| `offset?` | `number` | The number of results to skip.  Default: `10` |
 
 ### `SessionStatus`
 

--- a/docs/references/backend/types/paginated-resource-response.mdx
+++ b/docs/references/backend/types/paginated-resource-response.mdx
@@ -16,6 +16,8 @@ An interface that describes the response of a method that returns a paginated li
 
 ## Returns
 
-If the promise resolves, you will get back the [properties](#properties) listed above. `data` will be an array of the resource type you requested, but it will only return the first 10 items. You can use the `totalCount` property to determine how many total items exist remotely.
+If the promise resolves, you will get back the [properties](#properties) listed above. `data` will be an array of the resource type you requested. You can use the `totalCount` property to determine how many total items exist remotely.
+
+Some methods that return this type allow pagination with the `limit` and `offset` parameters, in which case the first 10 items will be returned by default. For methods such as [`getAllowlistIdentifierList()`](/docs/references/backend/allowlist/get-allowlist-identifier-list), which do not take a `limit` or `offset`, all items will be returned.
 
 If the promise is rejected, you will receive a `ClerkAPIResponseError` or network error.


### PR DESCRIPTION
We mention that `PaginatedResourceResponse` [only returns the first 10 items by default](https://clerk.com/docs/references/backend/types/paginated-resource-response?utm_source=www.google.com&utm_medium=referral&utm_campaign=none#returns), but in a couple instances this is not the case.

I've updated `PaginatedResourceResponse` page to mention this, and updated the individual backend sdk methods pages to say they return a list of "all" items, or to drop the word "all" where appropriate.

This is based on both the JavaScript SDK and the [Backend API](https://clerk.com/docs/reference/backend-api/).

[Relevant discussion thread here](https://clerkinc.slack.com/archives/C05LHV6AK50/p1716914568312259)