### PR TITLE
Add app router example to redirect-to-x docs

### DIFF
--- a/docs/components/control/redirect-to-signin.mdx
+++ b/docs/components/control/redirect-to-signin.mdx
@@ -13,7 +13,7 @@ The `<RedirectToSignIn />` component will navigate to the sign in URL which has 
 
 <Tabs items={["Next.js", "React", "Remix"]}>
   <Tab>
-  ```tsx filename="pages/_app.tsx"
+  ```tsx filename="app/layout.tsx"
   import {
     ClerkProvider,
     SignedIn,

--- a/docs/components/control/redirect-to-signin.mdx
+++ b/docs/components/control/redirect-to-signin.mdx
@@ -56,7 +56,7 @@ The `<RedirectToSignIn />` component will navigate to the sign in URL which has 
 
     function MyApp({ Component, pageProps } : AppProps) {
       return (
-        <ClerkProvider {...pageProps}>
+        <ClerkProvider>
           <SignedIn>
             <Component {...pageProps} />
           </SignedIn>

--- a/docs/components/control/redirect-to-signin.mdx
+++ b/docs/components/control/redirect-to-signin.mdx
@@ -12,64 +12,65 @@ The `<RedirectToSignIn />` component will navigate to the sign in URL which has 
 <InjectKeys>
 
 <Tabs items={["Next.js", "React", "Remix"]}>
-  <Tab>
-  ```tsx filename="app/layout.tsx"
-  import {
-    ClerkProvider,
-    SignedIn,
-    SignedOut,
-    RedirectToSignIn,
-  } from "@clerk/nextjs";
+  <CodeBlockTabs options={["App Router", "Pages Router"]}>
+    <Tab>
+    ```tsx filename="app/layout.tsx"
+    import {
+      ClerkProvider,
+      SignedIn,
+      SignedOut,
+      RedirectToSignIn,
+    } from "@clerk/nextjs";
 
-  export default function RootLayout({
-    children,
-  }: {
-    children: React.ReactNode;
-  }) {
-    return (
-      <html>
-        <body>
-          <ClerkProvider>
-            <SignedIn>
-              {children}
-            </SignedIn>
-            <SignedOut>
-              <RedirectToSignIn />
-            </SignedOut>
-          </ClerkProvider>
-        </body>
-      </html>
-    );
-  }
-  ```
-  </Tab>
-  <Tab>
-  ```tsx filename="pages/_app.tsx"
-  import {
-    ClerkProvider,
-    SignedIn,
-    SignedOut,
-    RedirectToSignIn,
-  } from "@clerk/nextjs";
-  import { AppProps } from "next/app";
+    export default function RootLayout({
+      children,
+    }: {
+      children: React.ReactNode;
+    }) {
+      return (
+        <html>
+          <body>
+            <ClerkProvider>
+              <SignedIn>
+                {children}
+              </SignedIn>
+              <SignedOut>
+                <RedirectToSignIn />
+              </SignedOut>
+            </ClerkProvider>
+          </body>
+        </html>
+      );
+    }
+    ```
+    </Tab>
+    <Tab>
+    ```tsx filename="pages/_app.tsx"
+    import {
+      ClerkProvider,
+      SignedIn,
+      SignedOut,
+      RedirectToSignIn,
+    } from "@clerk/nextjs";
+    import { AppProps } from "next/app";
 
-  function MyApp({ Component, pageProps } : AppProps) {
-    return (
-      <ClerkProvider {...pageProps}>
-        <SignedIn>
-          <Component {...pageProps} />
-        </SignedIn>
-        <SignedOut>
-          <RedirectToSignIn />
-        </SignedOut>
-      </ClerkProvider>
-    );
-  }
+    function MyApp({ Component, pageProps } : AppProps) {
+      return (
+        <ClerkProvider {...pageProps}>
+          <SignedIn>
+            <Component {...pageProps} />
+          </SignedIn>
+          <SignedOut>
+            <RedirectToSignIn />
+          </SignedOut>
+        </ClerkProvider>
+      );
+    }
 
-  export default MyApp;
-  ```
-  </Tab>
-
+    export default MyApp;
+    ```
+    </Tab>
+  </CodeBlockTabs>
   <Tab>
   ```tsx filename="pages/privatepage.tsx"
   import {

--- a/docs/components/control/redirect-to-signin.mdx
+++ b/docs/components/control/redirect-to-signin.mdx
@@ -11,7 +11,7 @@ The `<RedirectToSignIn />` component will navigate to the sign in URL which has 
 
 <InjectKeys>
 
-<Tabs type="framework" items={["Next.js App", "Next.js Pages", "React", "Remix"]}>
+<Tabs items={["Next.js", "React", "Remix"]}>
   <Tab>
   ```tsx filename="pages/_app.tsx"
   import {

--- a/docs/components/control/redirect-to-signin.mdx
+++ b/docs/components/control/redirect-to-signin.mdx
@@ -11,7 +11,38 @@ The `<RedirectToSignIn />` component will navigate to the sign in URL which has 
 
 <InjectKeys>
 
-<Tabs type="framework" items={["Next.js", "React", "Remix"]}>
+<Tabs type="framework" items={["Next.js App", "Next.js Pages", "React", "Remix"]}>
+  <Tab>
+  ```tsx filename="pages/_app.tsx"
+  import {
+    ClerkProvider,
+    SignedIn,
+    SignedOut,
+    RedirectToSignIn,
+  } from "@clerk/nextjs";
+
+  export default function RootLayout({
+    children,
+  }: {
+    children: React.ReactNode;
+  }) {
+    return (
+      <html>
+        <body>
+          <ClerkProvider>
+            <SignedIn>
+              {children}
+            </SignedIn>
+            <SignedOut>
+              <RedirectToSignIn />
+            </SignedOut>
+          </ClerkProvider>
+        </body>
+      </html>
+    );
+  }
+  ```
+  </Tab>
   <Tab>
   ```tsx filename="pages/_app.tsx"
   import {

--- a/docs/components/control/redirect-to-signup.mdx
+++ b/docs/components/control/redirect-to-signup.mdx
@@ -11,9 +11,10 @@ The `<RedirectToSignUp />` component will navigate to the sign up URL which has 
 
 <InjectKeys>
 
-<Tabs type="framework" items={["Next.js App", "Next.js Pages", "React", "Remix"]}>
+<Tabs type="framework" items={["Next.js", "React", "Remix"]}>
+  <CodeBlockTabs options={["App Router", "Pages Router"]}>
   <Tab>
-  ```tsx filename="pages/_app.tsx"
+  ```tsx filename="app/layout.tsx"
   import {
     ClerkProvider,
     SignedIn,
@@ -69,6 +70,7 @@ The `<RedirectToSignUp />` component will navigate to the sign up URL which has 
   export default MyApp;
   ```
   </Tab>
+  </CodeBlockTabs>
 
   <Tab>
   ```tsx filename="pages/privatepage.tsx"

--- a/docs/components/control/redirect-to-signup.mdx
+++ b/docs/components/control/redirect-to-signup.mdx
@@ -11,7 +11,38 @@ The `<RedirectToSignUp />` component will navigate to the sign up URL which has 
 
 <InjectKeys>
 
-<Tabs type="framework" items={["Next.js", "React", "Remix"]}>
+<Tabs type="framework" items={["Next.js App", "Next.js Pages", "React", "Remix"]}>
+  <Tab>
+  ```tsx filename="pages/_app.tsx"
+  import {
+    ClerkProvider,
+    SignedIn,
+    SignedOut,
+    RedirectToSignUp,
+  } from "@clerk/nextjs";
+
+  export default function RootLayout({
+    children,
+  }: {
+    children: React.ReactNode;
+  }) {
+    return (
+      <html>
+        <body>
+          <ClerkProvider>
+            <SignedIn>
+              {children}
+            </SignedIn>
+            <SignedOut>
+              <RedirectToSignUp />
+            </SignedOut>
+          </ClerkProvider>
+        </body>
+      </html>
+    );
+  }
+  ```
+  </Tab>
   <Tab>
   ```tsx filename="pages/_app.tsx"
   import {

--- a/docs/components/control/redirect-to-signup.mdx
+++ b/docs/components/control/redirect-to-signup.mdx
@@ -56,9 +56,9 @@ The `<RedirectToSignUp />` component will navigate to the sign up URL which has 
 
   function MyApp({ Component, pageProps } : AppProps) {
     return (
-      <ClerkProvider {...pageProps}>
+      <ClerkProvider>
         <SignedIn>
-          <Component {...pageProps} />
+          <Component {...pageProps />
         </SignedIn>
         <SignedOut>
           <RedirectToSignUp />


### PR DESCRIPTION
Got feedback that this was missing.