### PR TITLE
Make rate limit impact of current-user clearer

### DIFF
--- a/docs/references/nextjs/current-user.mdx
+++ b/docs/references/nextjs/current-user.mdx
@@ -9,7 +9,8 @@ The `currentUser` helper returns the [`Backend API User`](https://clerk.com/docs
 
 Under the hood, this helper:
 - calls `fetch()`, so it is automatically deduped per request.
-- uses the `GET /v1/users/me` endpoint, so it is subject to [rate limits](/docs/backend-requests/resources/rate-limits).
+- uses the `GET /v1/users/me` endpoint.
+- counts towards the [Backend API Request Rate Limit](/docs/backend-requests/resources/rate-limits#rate-limits)**.
 
 ```tsx filename="app/page.tsx"
 import { currentUser } from '@clerk/nextjs/server';

--- a/docs/references/nextjs/current-user.mdx
+++ b/docs/references/nextjs/current-user.mdx
@@ -10,7 +10,7 @@ The `currentUser` helper returns the [`Backend API User`](https://clerk.com/docs
 Under the hood, this helper:
 - calls `fetch()`, so it is automatically deduped per request.
 - uses the `GET /v1/users/me` endpoint.
-- counts towards the [Backend API Request Rate Limit](/docs/backend-requests/resources/rate-limits#rate-limits)**.
+- counts towards the [Backend API Request Rate Limit](/docs/backend-requests/resources/rate-limits#rate-limits).
 
 ```tsx filename="app/page.tsx"
 import { currentUser } from '@clerk/nextjs/server';

--- a/docs/references/nextjs/read-session-data.mdx
+++ b/docs/references/nextjs/read-session-data.mdx
@@ -17,7 +17,7 @@ The `auth()` helper will return the [`Auth`](/docs/references/nextjs/auth-object
 
 The `currentUser()` helper will return the [`Backend User`](/docs/references/backend/types/backend-user) object of the currently active user. This is helpful if you want to render information, like their first and last name, directly from the server.
 
- Under the hood, `currentUser()` uses the [`clerkClient`](/docs/references/backend/overview) wrapper to make a call to Clerk's Backend API. This does count towards the [Backend API Request Rate Limit](/docs/backend-requests/resources/rate-limits#rate-limits). This also uses `fetch()` so it is automatically deduped per request.
+Under the hood, `currentUser()` uses the [`clerkClient`](/docs/references/backend/overview) wrapper to make a call to Clerk's Backend API. **This does count towards the [Backend API Request Rate Limit](/docs/backend-requests/resources/rate-limits#rate-limits)**. This also uses `fetch()` so it is automatically deduped per request.
 
 <Callout type="info">
   Any requests from a Client Component to a Route Handler will read the session from cookies and will not need the token sent as a Bearer token.


### PR DESCRIPTION
We have [a ticket](https://linear.app/clerk/issue/DOCS-6424/currentuser-doc-missing-rate-limit-callout) saying this isn't clear enough in the `current-user` docs page. We do mention the rate limit in a bullet point, but it isn't its own bullet point. I made it into its own bullet point, so hopefully that will improve clarity.