### PR TITLE
Reorganize Nextjs sdk ref section

### DIFF
--- a/docs/manifest.json
+++ b/docs/manifest.json
@@ -1201,6 +1201,19 @@
                     ]
                   },
                   {
+                    "title": "General References",
+                    "items": [
+                      [
+                        {
+                          "title": "`clerkMiddleware()`",
+                          "wrap": false,
+                          "href": "/docs/references/nextjs/clerk-middleware"
+                        },
+                        { "title": "Auth Object", "href": "/docs/references/nextjs/auth-object" }
+                      ]
+                    ]
+                  },
+                  {
                     "title": "App Router References",
                     "items": [
                       [
@@ -1239,19 +1252,6 @@
                           "wrap": false,
                           "href": "/docs/references/nextjs/build-clerk-props"
                         }
-                      ]
-                    ]
-                  },
-                  {
-                    "title": "Other References",
-                    "items": [
-                      [
-                        {
-                          "title": "`clerkMiddleware()`",
-                          "wrap": false,
-                          "href": "/docs/references/nextjs/clerk-middleware"
-                        },
-                        { "title": "Auth Object", "href": "/docs/references/nextjs/auth-object" }
                       ]
                     ]
                   },


### PR DESCRIPTION
@royanger [mentioned](https://clerkinc.slack.com/archives/C01QFRQNHSN/p1714601287288829) moving the "Other References" section of the Next.js sdk docs up above App and Pages router. This PR renames the section and moves it up