### PR TITLE
update title for org switcher custom flow guide; remove unnecessary h2s from all org custom flows

### DIFF
--- a/docs/manifest.json
+++ b/docs/manifest.json
@@ -338,7 +338,7 @@
                           "href": "/docs/organizations/manage-membership-requests"
                         },
                         {
-                          "title": "Create a custom organization switcher",
+                          "title": "Switch between organizations",
                           "href": "/docs/organizations/custom-organization-switcher"
                         }
                       ]

--- a/docs/organizations/custom-organization-switcher.mdx
+++ b/docs/organizations/custom-organization-switcher.mdx
@@ -1,15 +1,14 @@
 ---
-title: Build a custom organization switcher
-description: Learn how to use Clerk's API to build a custom organization switcher.
+description: Learn how to use Clerk's API to build a custom flow for switching between organizations.
 ---
 
-# Build a custom organization switcher
+# Build a custom flow for switching organizations
 
 <Callout type="danger">
   This guide is for users who want to build a *custom* user interface using the Clerk API. To switch organizations using a *prebuilt* UI, you should use Clerk's [`<OrganizationSwitcher />`](/docs/components/organization/organization-switcher) component.
 </Callout>
 
-This guide will demonstrate how to use Clerk's API to build a custom flow for switching organizations.
+This guide will demonstrate how to use Clerk's API to build a custom flow for switching between organizations.
 
 <Tabs items={["Next.js", "JavaScript"]}>
   <Tab>

--- a/docs/organizations/inviting-users.mdx
+++ b/docs/organizations/inviting-users.mdx
@@ -14,8 +14,6 @@ Users with the appropriate permissions can also revoke organization invitations 
 
 This guide will demonstrate how to use Clerk's API to build a custom flow for inviting users to an organization and listing an organization's pending invitations.
 
-## Create the invite user flow
-
 <Tabs items={["Next.js", "JavaScript"]}>
   <Tab>
   To invite a user:
@@ -393,7 +391,7 @@ This guide will demonstrate how to use Clerk's API to build a custom flow for in
   </Tab>
 </Tabs>
 
-### Custom redirect URL
+## Custom redirect URL
 
 When creating an organization invitation and using Clerk's Next.js, Remix, or Backend SDKs, you can specify a custom redirect URL. After users click on organization invitation link and the ticket is verified, they will get redirected to that URL. The URL will contain two important query parameters added by Clerk: `__clerk_ticket` and `__clerk_status`.
 

--- a/docs/organizations/manage-membership-requests.mdx
+++ b/docs/organizations/manage-membership-requests.mdx
@@ -10,8 +10,6 @@ description: Learn how to use Clerk's API to build a custom flow for managing or
 
 This guide will demonstrate how to use Clerk's API to build a custom flow for managing [organization membership requests](/docs/organizations/overview#membership-requests).
 
-## Create a list of a user's organization memberships
-
 <Tabs items={["Next.js", "JavaScript"]}>
   <Tab>
   The following example uses the [`useOrganization()`](/docs/references/react/use-organization) hook to get `membershipRequests`, which is a list of the active organization's membership requests.

--- a/docs/organizations/viewing-memberships.mdx
+++ b/docs/organizations/viewing-memberships.mdx
@@ -10,8 +10,6 @@ description: Learn how to use Clerk's API to build a custom flow for viewing a u
 
 This guide will demonstrate how to use Clerk's API to build a custom flow for viewing the list of a user's organization memberships.
 
-## Create a list of a user's organization memberships
-
 <Tabs items={["Next.js", "JavaScript"]}>
   <Tab>
   The following example:

--- a/docs/organizations/viewing-memberships.mdx
+++ b/docs/organizations/viewing-memberships.mdx
@@ -5,10 +5,10 @@ description: Learn how to use Clerk's API to build a custom flow for viewing a u
 # Build a custom flow for viewing a user's organization memberships
 
 <Callout type="danger">
-  This guide is for users who want to build a *custom* user interface using the Clerk API. To view a user's organization memberships using a *prebuilt* UI, you should use Clerk's [prebuilt components](/docs/components/overview).
+  This guide is for users who want to build a *custom* user interface using the Clerk API. To view the list of a user's organization memberships using a *prebuilt* UI, you should use Clerk's [`<OrganizationList/>`](/docs/components/organization/organization-list) component.
 </Callout>
 
-This guide will demonstrate how to use Clerk's API to build a custom flow for viewing a list of a user's organization memberships.
+This guide will demonstrate how to use Clerk's API to build a custom flow for viewing the list of a user's organization memberships.
 
 ## Create a list of a user's organization memberships
 


### PR DESCRIPTION
Technically, the "Build a custom organization switcher" guide isn't recreating the `<OrganizationSwitcher />`. That component is fully-featured and complex, including handling membership suggestions and requests and organization creation... This guide is simply for building a flow for switching between organizations.
So this PR updates the title of that page to more accurately reflect its content.

This PR also removes all unnecessary h2's from all of the organization custom flow guides.