### PR TITLE
Change codeblock tab in Clerk Middleware docs

### DIFF
--- a/docs/references/nextjs/clerk-middleware.mdx
+++ b/docs/references/nextjs/clerk-middleware.mdx
@@ -59,7 +59,7 @@ There are two methods that you can use:
 - Use [`auth().protect()`](/docs/references/nextjs/auth#protect) if you want to redirect unauthenticated users to the sign-in route automatically.
 - Use [`auth().userId`](/docs/references/nextjs/auth#retrieving-user-id) if you want more control over what your app does based on user authentication status.
 
-<CodeBlockTabs options={["auth().protect()", "auth().has()"]}>
+<CodeBlockTabs options={["auth().protect()", "auth().userId()"]}>
 ```tsx filename="middleware.ts"
 import {
   clerkMiddleware,


### PR DESCRIPTION
We had the tab named incorrectly