### PR TITLE
Add instructions for linking OAuth accounts with different emails

### DIFF
--- a/docs/authentication/social-connections/account-linking.mdx
+++ b/docs/authentication/social-connections/account-linking.mdx
@@ -47,7 +47,7 @@ Clerk initiates the email verification process at the outset. Upon successful em
 
 If a user has a different email from the one associated with the OAuth account, they can manually associate the two. To do so, they must:
 
-1. Sign into your Clerk application with the account that uses their main email address.
+1. Sign into their Clerk application with the account that uses their main email address.
 1. In the **Manage Profile** section of their profile page, add the different email.
 
 After following these steps, the user's OAuth accounts associated with both their primary and added email addresses will be linked to their main account.

--- a/docs/authentication/social-connections/account-linking.mdx
+++ b/docs/authentication/social-connections/account-linking.mdx
@@ -48,6 +48,6 @@ Clerk initiates the email verification process at the outset. Upon successful em
 If a user has a different email from the one associated with the OAuth account, they can manually associate the two. To do so, they must:
 
 1. Sign into their Clerk application with the account that uses their main email address.
-1. In the **Manage Profile** section of their profile page, add the different email.
+1. In the **Manage Profile** section of the [`<UserProfile />`](/docs/components/user/user-profile) page, add the different email.
 
 After following these steps, the user's OAuth accounts associated with both their primary and added email addresses will be linked to their main account.

--- a/docs/authentication/social-connections/account-linking.mdx
+++ b/docs/authentication/social-connections/account-linking.mdx
@@ -42,3 +42,12 @@ To allow unverified email addresses for your instance, navigate to the [Email, P
 />
 
 Clerk initiates the email verification process at the outset. Upon successful email verification, regardless of the method, additional steps may be taken to validate existing connections or passwords. This is done to ensure the user's account remains secure.
+
+## Users with different email addresses
+
+If a user has a different email from the one associated with the OAuth account, they can manually associate the two. To do so they must:
+
+1. Sign into your Clerk application with the account that uses their main email address.
+1. In the **Manage Profile** section of their profile page, add the different email.
+
+After following these steps, the user's OAuth accounts associated with both their primary and added email addresses will be linked to their main account.

--- a/docs/authentication/social-connections/account-linking.mdx
+++ b/docs/authentication/social-connections/account-linking.mdx
@@ -45,7 +45,7 @@ Clerk initiates the email verification process at the outset. Upon successful em
 
 ## Users with different email addresses
 
-If a user has a different email from the one associated with the OAuth account, they can manually associate the two. To do so they must:
+If a user has a different email from the one associated with the OAuth account, they can manually associate the two. To do so, they must:
 
 1. Sign into your Clerk application with the account that uses their main email address.
 1. In the **Manage Profile** section of their profile page, add the different email.


### PR DESCRIPTION
Sometimes a user may want to link an OAuth account that has a different email address from the one associated with their Clerk account. These instructions teach them how to do so, based on notes from [this linear issue](https://linear.app/clerk/issue/DOCS-246/how-clerk-handles-multiple-oauth-connectionslogin-methods).