### PR TITLE
fix: Fix typo on clerk-environment-variables page

### DIFF
--- a/docs/deployments/clerk-environment-variables.mdx
+++ b/docs/deployments/clerk-environment-variables.mdx
@@ -96,9 +96,9 @@ The following environment variables enable you to configure API and SDK behavior
 
 </Tabs>
 
-## Sattelite domains
+## Satellite domains
 
-Clerk supports sharing sessions across different domains by adding one or many satellite domains to an application. See [the sattelite domains guide](/docs/advanced-usage/satellite-domains) for more information.
+Clerk supports sharing sessions across different domains by adding one or many satellite domains to an application. See [the satellite domains guide](/docs/advanced-usage/satellite-domains) for more information.
 
 <Tabs type="framework" items={["General", "Next.js"]}>
 


### PR DESCRIPTION
I found a couple typos on the `/deployments/clerk-environment-variables` page and corrected them.