### PR TITLE
Fix incorrect email property name in Clerk webhook documentation

### DIFF
--- a/docs/integrations/webhooks/inngest.mdx
+++ b/docs/integrations/webhooks/inngest.mdx
@@ -128,7 +128,7 @@ const sendWelcomeEmail = inngest.createFunction(
    const { first_name } = user
    const email = user.email_addresses.find(e =>
      e.id === user.primary_email_address_id
-   ).email
+   ).email_address
    // `emails` is a placeholder for the function in your codebase to send email
    await emails.sendWelcomeEmail({ email, first_name })
  }


### PR DESCRIPTION
This pull request fixes the incorrect property name for accessing the user's email address in the Clerk webhook documentation for Inngest integration. The property should be email_address instead of email.

Current code in the documentation:
```
const email = user.email_addresses.find(e =>
  e.id === user.primary_email_address_id
).email;
```

Corrected code:
```
const email = user.email_addresses.find(e =>
  e.id === user.primary_email_address_id
).email_address;
```

The current documentation uses .email, which does not exist in the email_addresses object structure. The correct property is .email_address, which aligns with the actual data structure returned by the Clerk API.

This fix addresses the issue described in Issue #1122 . By making this change, developers following the documentation will be able to correctly access the user's primary email address without encountering errors.