### PR TITLE
Update Invitations custom flow guide; update redirectUrl explanation for createInvitation() backend SDK method

### DIFF
--- a/docs/custom-flows/invitations.mdx
+++ b/docs/custom-flows/invitations.mdx
@@ -49,7 +49,7 @@ You can either use a cURL command or Clerk's JavaScript Backend SDK to create an
 
 You can also add metadata to an invitation. Once the invited user signs up using the invitation link, the invitation metadata will end up in the user's `public_metadata`.  You can find more information about user metadata in the [metadata](/docs/users/metadata) docs.
 
-In order to add metadata to an invitation, you can use the `public_metadata` property when the invitation is created. The following example demonstrates how to create an invitation with metadata using cURL:
+To add metadata to an invitation, you can use the `public_metadata` property when the invitation is created. The following example demonstrates how to create an invitation with metadata using cURL:
 
 ```bash
 curl https://api.clerk.com/v1/invitations -X POST -d '{"email_address": "email@example.com", "public_metadata": {"age": "21"}}' -H "Authorization:Bearer {{secret}}" -H 'Content-Type:application/json'

--- a/docs/custom-flows/invitations.mdx
+++ b/docs/custom-flows/invitations.mdx
@@ -7,236 +7,137 @@ description: Learn how to invite users to your Clerk application.
 
 Clerk makes it easy to invite users to your application via the invitations feature. This feature is offered by default to all Clerk applications without any extra configuration. Currently, Clerk supports inviting users via email.
 
-Inviting users to your application begins with creating an invitation for an email address. Once the invitation is created, an email with an invitation link will be sent to the user's email address. By clicking on the invitation link, the user will be redirected to the application's sign up page and their email address will have been automatically verified. At this point, the user will just have to fill in the rest of the details according to the application's settings.
+Inviting users to your application begins with creating an invitation for an email address. Once the invitation is created, an email with an invitation link will be sent to the user's email address. When the user visits the invitation link, they will be redirected to the application's sign up page and **their email address will be automatically verified.** At this point, the user will just have to fill in the rest of the details according to the application's settings.
 
-Invitations expire after a month. If the user clicks on an expired invitation, they will get redirected to the application's sign-up page but they will still have to go via the normal sign-up flow, i.e. their email address will not be auto-verified.
+Invitations expire after a month. If the user clicks on an expired invitation, they will get redirected to the application's sign-up page and will have to go through the normal sign-up flow. Their email address will not be auto-verified.
 
 <Callout type="info">
-  Invitations are only used to invite users to your application. The application will still be available to everyone even without an invitation.If you're looking into creating invitation-only applications, please refer to our [restrictions](/docs/authentication/configuration/restrictions) options.
+  Invitations are only used to invite users to your application. The application will still be available to everyone even without an invitation. If you're looking into creating invitation-only applications, please refer to our [restrictions](/docs/authentication/configuration/restrictions) options.
 </Callout>
-
-## Before you start
-
-- You need to create a Clerk Application in your [Clerk Dashboard](https://dashboard.clerk.com/). For more information, check out our [Set up your application](/docs/quickstarts/setup-clerk) guide.
 
 ## Creating invitations
 
-At the moment, you can only create invitations for email addresses via the [Backend API](/docs/references/backend/overview). 
+At the moment, you can only create invitations for email addresses via the [Backend API](https://clerk.com/docs/reference/backend-api/tag/Invitations#operation/CreateInvitation).
 
-First, you will need to grab your API key which can be found in Clerk Dashboard under API Keys > Backend API Keys.
+You can either use a cURL command or Clerk's JavaScript Backend SDK to create an invitation. Use the tabs to see examples for each method.
 
-{/* TODO: Insert picture of this page */}
+<Tabs items={["cURL", "Backend SDK"]}>
+  <Tab>
+  The following example demonstrates how to create an invitation using cURL.
 
-Once you have that, you can make the following request to the Backend API:
+  <SignedIn>
+  Replace the email address with the email address you want to invite. Your secret key is already injected into the code snippet.
+  </SignedIn>
+
+  <SignedOut>
+  Replace the email address with the email address you want to invite and replace `YOUR_SECRET_KEY` with your Clerk secret key. You can find your secret key in the Clerk Dashboard on the [API Keys](https://dashboard.clerk.com/last-active?path=api-keys) page.
+  </SignedOut>
+
+  ```bash {{ filename: 'terminal' }}
+  curl https://api.clerk.com/v1/invitations -X POST -d '{"email_address": "email@example.com"}' -H "Authorization:Bearer {{secret}}" -H 'Content-Type:application/json'
+  ```
+  </Tab>
+
+  <Tab>
+  Clerk's Backend SDK is a wrapper around the Backend API that makes it easier to interact with the API.
+
+  To use the Backend SDK to create an invitation, see the [`createInvitation()`](/docs/references/backend/invitations/create-invitation) reference documentation.
+  </Tab>
+</Tabs>
+
+### Invitation metadata
+
+You can also add metadata to an invitation. Once the invited user signs up using the invitation link, the invitation metadata will end up in the user's `public_metadata`.  You can find more information about user metadata in the [metadata](/docs/users/metadata) docs.
+
+In order to add metadata to an invitation, you can use the `public_metadata` property when the invitation is created. The following example demonstrates how to create an invitation with metadata using cURL:
 
 ```bash
-curl https://api.clerk.com/v1/invitations -X POST -d '{"email_address": "email@example.com"}' -H "Authorization:Bearer {{bapi}}" -H 'Content-Type:application/json'
+curl https://api.clerk.com/v1/invitations -X POST -d '{"email_address": "email@example.com", "public_metadata": {"age": "21"}}' -H "Authorization:Bearer {{secret}}" -H 'Content-Type:application/json'
 ```
-
-This will create a new invitation and send an invitation email to the given email address.
-
-{/* 
-TODO: Update code example. We can use the createInvitation() method from the backend API.
- 
-<CodeBlockTabs options={["Curl", "Next.js App Router", "Next.js Pages Router", "React", "JavaScript"]}>
-```bash
-
-```
-
-```jsx
-"use client";
-
-import { clerkClient } from "@clerk/nextjs";
-
-async function createInvitation() {
-  try {
-    const invitation = await clerkClient.invitations.createInvitation({
-      emailAddress: "alexmerona@yahoo.com",
-      redirectUrl: "https://optionally-redirect-here",
-    });
-
-    // Handle the response as needed
-    console.log("Invitation created:", invitation);
-  } catch (error) {
-    // Handle any errors that occur during the request
-    console.error("Error creating invitation:", error);
-  }
-}
-```
-
-```jsx
-import { clerkClient } from "@clerk/nextjs";
-
-async function createInvitation() {
-  try {
-    const invitation = await clerkClient.invitations.createInvitation({
-      emailAddress: "alexmerona@yahoo.com",
-      redirectUrl: "https://optionally-redirect-here",
-    });
-
-    // Handle the response as needed
-    console.log("Invitation created:", invitation);
-  } catch (error) {
-    // Handle any errors that occur during the request
-    console.error("Error creating invitation:", error);
-  }
-}
-```
-
-```jsx
-
-```
-
-```js
-
-```
-</CodeBlockTabs> 
-
-For more information on using the `createInvitation` method, check out the [Backend API reference](/docs/references/backend/invitations/create-invitation).
-*/}
 
 ## Revoking invitations
 
-Revoking an invitation prevents the user from using the invitation link that was sent to them. In order to revoke an invitation, you can make the following request to the Backend API:
+Revoking an invitation prevents the user from using the invitation link that was sent to them.
 
-```bash
-curl https://api.clerk.com/v1/invitations/<invitation_id>/revoke -X POST -H "Authorization:Bearer {{bapi}}" -H 'Content-Type:application/json'
-```
+At the moment, you can only revoke invitations via the [Backend API](https://clerk.com/docs/reference/backend-api/tag/Invitations#operation/RevokeInvitation).
 
-The invitation ID can be found in the response of the invitation creation request.
+You can either use a cURL command or Clerk's JavaScript Backend SDK to create an invitation. Use the tabs to see examples for each method.
+
+<Tabs items={["cURL", "Backend SDK"]}>
+  <Tab>
+  The following example demonstrates how to revoke an invitation using cURL.
+
+  <SignedIn>
+  Replace the `<invitation_id>` with the ID of the invitation you want to revoke. Your secret key is already injected into the code snippet.
+  </SignedIn>
+
+  <SignedOut>
+  Replace the `<invitation_id>` with the ID of the invitation you want to revoke and replace `YOUR_SECRET_KEY` with your Clerk secret key. You can find your secret key in the Clerk Dashboard on the [API Keys](https://dashboard.clerk.com/last-active?path=api-keys) page.
+  </SignedOut>
+
+  ```bash {{ filename: 'terminal' }}
+  curl https://api.clerk.com/v1/invitations/<invitation_id>/revoke -X POST -H "Authorization:Bearer {{secret}}" -H 'Content-Type:application/json'
+  ```
+  </Tab>
+
+  <Tab>
+  Clerk's Backend SDK is a wrapper around the Backend API that makes it easier to interact with the API.
+
+  To use the Backend SDK to revoke an invitation, see the [`revokeInvitation()`](/docs/references/backend/invitations/revoke-invitation) reference documentation.
+  </Tab>
+</Tabs>
 
 <Callout type="warning">
-  Revoking an invitation does **not** prevent the user from signing up on their own.If you're looking for invitation-only applications, please refer to our [allowlist feature](/docs/authentication/configuration/restrictions#allowlist).
+  Revoking an invitation does **not** prevent the user from signing up on their own. If you're looking for invitation-only applications, please refer to our [allowlist feature](/docs/authentication/configuration/restrictions#allowlist).
 </Callout>
 
-{/* 
-TODO: Update code example. We can use the revokeInvitation() method from the backend API.
- 
-<CodeBlockTabs options={["Curl", "Next.js App Router", "Next.js Pages Router", "React", "JavaScript"]}>
-```bash
+## Build a custom flow to handle invitations
 
-```
+<Callout type="danger">
+  This section is for users who want to build a *custom* user interface using the Clerk API. To handle invitations using a *prebuilt* UI, you should use Clerk's [Account Portal pages](/docs/account-portal/overview) or [prebuilt components](/docs/components/overview).
+</Callout>
 
-```jsx
-"use client";
+When you create an invitation, you can specify a `redirect_url` parameter. This parameter tells Clerk where to redirect the user when they visit the invitation link.
 
-import { clerkClient } from "@clerk/nextjs";
-
-async function revokeInvitation() {
-  try {
-    const invitationId = 'inv_some-id';
- 
-    const invitation = await clerkClient.invitations.revokeInvitation(invitationId);
-
-    // Handle the response as needed
-    console.log("Invitation revoked:", invitation);
-  } catch (error) {
-    // Handle any errors that occur during the request
-    console.error("Error revoking invitation:", error);
-  }
-}
-```
-
-```jsx
-import { clerkClient } from "@clerk/nextjs";
-
-async function revokeInvitation() {
-  try {
-    const invitationId = 'inv_some-id';
- 
-    const invitation = await clerkClient.invitations.revokeInvitation(invitationId);
-
-    // Handle the response as needed
-    console.log("Invitation revoked:", invitation);
-  } catch (error) {
-    // Handle any errors that occur during the request
-    console.error("Error revoking invitation:", error);
-  }
-}
-```
-
-```jsx
-
-```
-
-```js
-
-```
-</CodeBlockTabs> 
-*/}
-
-## Invitation metadata
-
-Invitations can optionally carry metadata that will eventually end up in the created user once they sign up. The metadata must be a well-formed JSON object.
-
-In order to add metadata to an invitation, you can use the `public_metadata` property when the invitation is created:
-
-```bash
-curl https://api.clerk.com/v1/invitations -X POST -d '{"email_address": "email@example.com", "public_metadata": {"user_type": "loyalty"}}' -H "Authorization:Bearer {{bapi}}" -H 'Content-Type:application/json'
-```
-
-Once an invited user signs up using the invitation link, the invitation metadata will end up in the user's `public_metadata`. You can find more information about user metadata in the [metadata](/docs/users/metadata) docs.
-
-## Custom flow
-
-If you're using [Clerk Components](/docs/components/overview), invitation links are handled out of the box. However, if you have built custom sign-up and sign-in flows using [ClerkJS](/docs/references/javascript/overview) directly, then you'll need to do a little bit of extra work.
-
-The first thing that changes in this case is that during the invitation creation, you will need to specify the url of your sign-up page. You can do that by including an additional `redirect_url` parameter in the invitation creation request.
+The following example demonstrates how to create an invitation with the `redirect_url` set to `https://www.example.com/my-sign-up`:
 
 ```bash
 curl https://api.clerk.com/v1/invitations -X POST -d '{"email_address": "email@example.com", "redirect_url": "https://www.example.com/my-sign-up"}' -H "Authorization:Bearer {{bapi}}" -H 'Content-Type:application/json'
 ```
 
-This `redirect_url` basically tells Clerk where to redirect the user when they click on the invitation link. This redirection will include an invitation token, something like the following:
+Once the user visits the invitation link and is redirected to the specified URL, an invitation token will be appended to the URL.
+
+Using the previous example, the URL with the invitation token would look like this:
 
 `https://www.example.com/my-sign-up?__clerk_ticket=.....`
 
-The second and final thing you'll need to do is to pass this token into the sign up create call, when starting the sign up flow.
+You can then use the invitation token to create a new sign-up. The following example demonstrates how to create a new sign-up using the invitation token:
 
-<CodeBlockTabs type="framework" options={["React", "JavaScript"]}>
-```jsx
-import { useSignUp } from "@clerk/clerk-react";
+<Tabs items={["Next.js"]}>
+  <Tab>
+  ```jsx {{ filename: 'app/my-sign-up/page.tsx' }}
+  import { useSignUp } from "@clerk/nextjs";
 
-const { signUp } = useSignUp();
+  const { signUp } = useSignUp();
 
-// Get the token from the query parameter
-const param = '__clerk_ticket';
-const ticket = new URL(window.location.href).searchParams.get(param);
+  // Get the token from the query parameter
+  const param = '__clerk_ticket';
+  const ticket = new URL(window.location.href).searchParams.get(param);
 
-// Create a new sign-up with the supplied invitation token.
-// Make sure you're also passing the ticket strategy.
-// You can also include any additional information required 
-// based on your application configuration. Or, you can add 
-// them later using the `signUp.update` method.
-// After the below call, the user's email address will be 
-// verified because of the invitation token.
-const response = await signUp.create({
-  strategy: "ticket",
-  ticket,
-  firstName,
-  lastName
-});
-```
+  // Optional: collect additional user information
+  const firstName = "John";
+  const lastName = "Doe";
 
-```js
-const { client } = window.Clerk;
-
-// Get the token from the query parameter
-const param = '__clerk_invitation_token';
-const ticket = new URL(window.location.href).searchParams.get(param);
-
-// Create a new sign-up with the supplied invitation ticket.
-// Make sure you're also passing the ticket strategy.
-// You can also include any additional information required 
-// based on your application configuration. Or, you can add 
-// them later using the `signUp.update` method.
-// After the below call, the user's email address will be 
-// verified because of the invitation token.
-const signUp = await client.signUp.create({
-  strategy: "ticket",
-  ticket,
-  firstName,
-  lastName
-});
-```
-</CodeBlockTabs>
+  // Create a new sign-up with the supplied invitation token.
+  // Make sure you're also passing the ticket strategy.
+  // After the below call, the user's email address will be
+  // automatically verified because of the invitation token.
+  const response = await signUp.create({
+    strategy: "ticket",
+    ticket,
+    firstName,
+    lastName
+  });
+  ```
+  </Tab>
+</Tabs>

--- a/docs/references/backend/invitations/create-invitation.mdx
+++ b/docs/references/backend/invitations/create-invitation.mdx
@@ -18,7 +18,7 @@ function createInvitation: (params: CreateParams) => Promise<Invitation>;
 | Name | Type | Description |
 | --- | --- | --- |
 | `emailAddress` | `string` | The email address of the user to invite. |
-| `redirectUrl?` | `string` | The URL to redirect the user to after they accept the invitation. |
+| `redirectUrl?` | `string` | The URL to redirect the user to when they visit the invitation link. |
 | `publicMetadata?` | `Record<string, unknown>` | Metadata saved on the invitation that is visible to both your Frontend and Backend APIs. |
 | `notify?` | `boolean` | Optional flag to denote whether an email invitation should be sent to the given email address. Defaults to `true`. |
 | `ignoreExisting?` | `boolean` | Optional flag to denote whether an invitation should be created if there is already an existing invitation for this email address, or if the email address already exists in the application. Defaults to `false`. |
@@ -28,7 +28,7 @@ function createInvitation: (params: CreateParams) => Promise<Invitation>;
 ```tsx
 const response = await clerkClient.invitations.createInvitation({
   emailAddress: 'invite@example.com',
-  redirectUrl: 'https://optionally-redirect-here',
+  redirectUrl: 'https://www.example.com/my-sign-up',
   publicMetadata: {
     "example": "metadata",
     "example_nested": {


### PR DESCRIPTION
This PR:
- Addresses updates that the Invitations custom flow guide needed overall.
🔎 Preview: https://clerk.com/docs/pr/1133/custom-flows/invitations

- Addresses the incorrect description of the `redirectUrl` prop for the `createInvitation()` method in the Backend SDK reference docs.
🔎 Preview: https://clerk.com/docs/pr/1133/references/backend/invitations/create-invitation#create-invitation

---

This PR does not address the fact that [Invitations custom flow guide](https://clerk.com/docs/custom-flows/invitations) definitely needs to get separated into two docs:
1. Invitations conceptual doc explaining how to create and revoke invitations
2. Custom flow doc explaining how to handle invitations with a custom flow
These things need to be addressed after the upcoming IA. https://linear.app/clerk/issue/DOCS-8626/post-ia-revisit-breaking-down-the-invitations-guide