### PR TITLE
Improve info on using sign-in tokens

### DIFF
--- a/docs/custom-flows/embedded-email-links.mdx
+++ b/docs/custom-flows/embedded-email-links.mdx
@@ -68,7 +68,7 @@ export default function AcceptToken() {
 
     const createSignIn = async () => {
       try {
-        // Create a signIn with the token
+        // Create a signIn with the token.
         // Note that you need to use the "ticket" strategy.
         const res = await signIn.create({
           strategy: "ticket",
@@ -125,9 +125,10 @@ const AcceptToken = ({
       return;
     }
 
-    const aFunc = async () => {
+    const createSignIn = async () => {
       try {
-        // Create a signIn with the token, note that you need to use the "ticket" strategy.
+        // Create a signIn with the token.
+        // Note that you need to use the "ticket" strategy.
         const res = await signIn.create({
           strategy: "ticket",
           ticket: signInToken as string,
@@ -141,7 +142,7 @@ const AcceptToken = ({
       }
     };
 
-    aFunc();
+    createSignIn();
   }, [signIn, setActive]);
 
   if (!signInToken) {

--- a/docs/custom-flows/embedded-email-links.mdx
+++ b/docs/custom-flows/embedded-email-links.mdx
@@ -8,10 +8,10 @@ An "email link" is a link that, when visited, will automatically authenticate yo
 
 Common use cases include:
 
-- Welcome emails when users are added off a waitlist.
-- Promotional emails for users.
-- Recovering abandoned carts.
-- Surveys or questionnaires.
+- Welcome emails when users are added off a waitlist
+- Promotional emails for users
+- Recovering abandoned carts
+- Surveys or questionnaires
 
 This guide will teach you how to set this flow up.
 
@@ -40,7 +40,7 @@ This will return a token, which can then be embedded as a query param in any lin
 
 You can embedded this link anywhere, such as an email.
 
-### Detect tokens in email links
+### Build a custom flow for signing in with a sign-in token
 
 To do something with the email links you generate, you must setup a page in your frontend that detects the sign-in token, signs the user in, then performs whatever actions you want.
 
@@ -48,7 +48,7 @@ The following example demonstrates basic code that detects a token and uses it t
 
 <Tabs items={["Next.js"]}>
 <Tab>
-<CodeBlockTabs type="framework" options={["App", "Pages"]}>
+<CodeBlockTabs options={["App Router", "Pages Router"]}>
 ```jsx filename="app/accept-token/page.jsx"
 "use client";
 import { useUser, useSignIn } from "@clerk/nextjs";
@@ -66,9 +66,10 @@ export default function AcceptToken() {
       return;
     }
 
-    const aFunc = async () => {
+    const createSignIn = async () => {
       try {
-        // Create a signIn with the token, note that you need to use the "ticket" strategy.
+        // Create a signIn with the token
+        // Note that you need to use the "ticket" strategy.
         const res = await signIn.create({
           strategy: "ticket",
           ticket: signInToken as string,
@@ -82,7 +83,7 @@ export default function AcceptToken() {
       }
     };
 
-    aFunc();
+    createSignIn();
   }, [signIn, setActive]);
 
   if (!signInToken) {

--- a/docs/custom-flows/embedded-email-links.mdx
+++ b/docs/custom-flows/embedded-email-links.mdx
@@ -1,46 +1,105 @@
 ---
-title: Embeddable email links
-description: Learn how to build custom email link flows to increase user engagement and reduce drop off in transactional emails, SMS's, and anywhere else you can imagine.
+description: Learn how to build custom embeddable email link sign-in flows to increase user engagement and reduce drop off in transactional emails, SMS's, and more.
 ---
 
-# Embeddable email links
+# Embeddable email links with sign-in tokens
 
-An "email link" is a link, that when pressed, will automatically authenticate your user, so that they can quickly perform some action on your site with less friction than if they had to sign in manually.
+An "email link" is a link that, when visited, will automatically authenticate your user so that they can perform some action on your site with less friction than if they had to sign in manually. You can create email links with Clerk by generating a sign-in token, which you can detect and take action on in your frontend.
 
 Common use cases include:
 
-- Welcome emails, when users are added off a waitlist
-- Promotional emails for users
-- Recovering abandoned carts
-- Surveys or questionnaires
+- Welcome emails when users are added off a waitlist.
+- Promotional emails for users.
+- Recovering abandoned carts.
+- Surveys or questionnaires.
 
-## Create an embeddable email link
+This guide will teach you how to set this flow up.
 
-Embeddable email links leverage [sign-in tokens](https://clerk.com/docs/reference/backend-api/tag/Sign-in-Tokens#operation/CreateSignInToken) which can be created from your backend.
+<Steps>
+
+### Generate a sign-in token
+
+Embeddable email links leverage [sign-in tokens](https://clerk.com/docs/reference/backend-api/tag/Sign-in-Tokens#operation/CreateSignInToken), which are JWTs that can be used to sign in to an application without specifying any credentials. A sign-in token can be used at most once, and can be consumed from the Frontend API using the [`ticket`](/docs/references/javascript/sign-in/sign-in#sign-in-create-params) strategy.
+
+> [!NOTE]
+> By default, sign-in tokens expire in 30 days. You can optionally supply a different duration in seconds using the `expires_in_seconds` property.
+
+The following example demonstrates a cURL request that fetches a valid sign-in token: 
 
 ```bash
-curl --request POST \
-  --url 'https://api.clerk.com/v1/sign_in_tokens' \
-  -H 'Authorization: Bearer {{bapi}}' \
+curl 'https://api.clerk.com/v1/sign_in_tokens' \
+  -X POST \
+  -H 'Authorization: Bearer {{secret}}' \
   -H 'Content-Type: application/json' \
-  -d '{
-    "user_id": "user_28dVmJleKwFWrefTJN7skmrbtJi",
-  }'
+  -d '{ "user_id": "user_123" }'
 ```
 
-This will return a token, which can then be embedded as a query param in any link, something like:
+This will return a token, which can then be embedded as a query param in any link, such as the following example:
 
 `https://your-site.com/welcome?token=THE_TOKEN`
 
-Once you have the link, this can be embedded anywhere, such as an email.
+You can embedded this link anywhere, such as an email.
 
-## Accepting email links
+### Detect tokens in email links
 
-Now that you have a way to process a token, you'll need to setup a page on your frontend to get the token from the query string, call the sign in function, then perform whatever action you originally had in mind.
+To do something with the email links you generate, you must setup a page in your frontend that detects the sign-in token, signs the user in, then performs whatever actions you want.
 
-Signing a user in with a token is very similar to all of our other custom flows.
+The following example demonstrates basic code that detects a token and uses it to initiate a sign-in with Clerk:
 
-<CodeBlockTabs type="framework" options={["Next.js", "React"]}>
+<Tabs items={["Next.js"]}>
+<Tab>
+<CodeBlockTabs type="framework" options={["App", "Pages"]}>
+```jsx filename="app/accept-token/page.jsx"
+"use client";
+import { useUser, useSignIn } from "@clerk/nextjs";
+import { useEffect, useState } from "react";
+import { useSearchParams } from "next/navigation";
+
+export default function AcceptToken() {
+  const { signIn, setActive } = useSignIn();
+  const { user } = useUser();
+  const [signInProcessed, setSignInProcessed] = useState<boolean>(false);
+  const signInToken = useSearchParams().get("token");
+
+  useEffect(() => {
+    if (!signIn || !setActive || !signInToken) {
+      return;
+    }
+
+    const aFunc = async () => {
+      try {
+        // Create a signIn with the token, note that you need to use the "ticket" strategy.
+        const res = await signIn.create({
+          strategy: "ticket",
+          ticket: signInToken as string,
+        });
+        setActive({
+          session: res.createdSessionId,
+          beforeEmit: () => setSignInProcessed(true),
+        });
+      } catch (err) {
+        setSignInProcessed(true);
+      }
+    };
+
+    aFunc();
+  }, [signIn, setActive]);
+
+  if (!signInToken) {
+    return <div>no token provided</div>;
+  }
+
+  if (!signInProcessed) {
+    return <div>loading</div>;
+  }
+
+  if (!user) {
+    return <div>error invalid token</div>;
+  }
+
+  return <div>Signed in as {user.id}</div>;
+}
+```
 ```jsx filename="pages/accept-token.jsx"
 import { InferGetServerSidePropsType, GetServerSideProps } from "next";
 import { useUser, useSignIn } from "@clerk/nextjs";
@@ -101,24 +160,8 @@ const AcceptToken = ({
 
 export default AcceptToken;
 ```
-
-```jsx filename="accept-token.js"
-// Grab the sign in token from the query string
-const queryParams = new URLSearchParams(window.location.search);
-const signInToken = queryParams.get('token');
-
-const { signIn, setActive } = useSignIn();
-
-// Create a sign in with the ticket strategy, and the sign-in-token
-const res = await signIn.create({
-  strategy: "ticket",
-  ticket: signInToken,
-});
-
-// Set the session as active, and then do whatever you need to!
-setActive({
-  session: res.createdSessionId,
-  beforeEmit: () => console.log("SignedIn!")
-});
-```
 </CodeBlockTabs>
+</Tab>
+</Tabs>
+
+</Steps>

--- a/docs/custom-flows/embedded-email-links.mdx
+++ b/docs/custom-flows/embedded-email-links.mdx
@@ -14,7 +14,7 @@ Common use cases include:
 - Recovering abandoned carts
 - Surveys or questionnaires
 
-## Creating email links
+## Create an embeddable email link
 
 Embeddable email links leverage [sign-in tokens](https://clerk.com/docs/reference/backend-api/tag/Sign-in-Tokens#operation/CreateSignInToken) which can be created from your backend.
 


### PR DESCRIPTION
This PR:

- Improves our docs on using sign-in tokens for authentication by adding information [from this comment](https://linear.app/clerk/issue/DOCS-6184/create-a-brief-guide-for-using-sign-in-tokens#comment-cbec9e54) to the embeddable links docs.
- Cleans up some of the language in the embeddable links doc
- Adds an app router code snippet
- Does not add an example of embedding a link. I don't think an example would be particularly useful, as it's just a link with a query param. I assume we're leaning so heavily into the "embeddable" aspect because of SEO, but it does feel odd to describe any link as specifically embeddable, since all links are embeddable, but of course I could be missing something here.

[Preview here](https://clerk.com/docs/pr/1139/custom-flows/embedded-email-links#embeddable-email-links)