### PR TITLE
Clean up /verify-user-permissions page

### DIFF
--- a/docs/organizations/verify-user-permissions.mdx
+++ b/docs/organizations/verify-user-permissions.mdx
@@ -5,9 +5,8 @@ description: A collection of utility functions and components in order to allow 
 
 # Verify the active user's permissions in an organization
 
-<Callout type="info">
-  The following authorization checks are predicated on a user having an active organization. Without this, they will likely always evaluate to false by default. Clerk's built-in [`<OrganizationSwitcher/>`](/docs/components/organization/organization-switcher) component and[`useOrganizationList().setActive({ organization: <orgId> })`](/docs/references/react/use-organization-list) method are two available options to set an organization as active for a user.
-</Callout>
+> [!IMPORTANT]
+> The following authorization checks are predicated on a user having an active organization. Without this, they will likely always evaluate to false by default. Clerk's built-in [`<OrganizationSwitcher/>`](/docs/components/organization/organization-switcher) component and[`useOrganizationList().setActive({ organization: <orgId> })`](/docs/references/react/use-organization-list) method are two available options to set an organization as active for a user.
 
 In general, you should always verify whether or not a user is authorized to access sensitive information, important content, or exclusive features. The most secure way to implement authorization is by checking the active user's [role or permissions](/docs/organizations/roles-permissions#permissions).
 
@@ -25,7 +24,7 @@ The examples below work for both SSR and CSR. Examples are written for Next.js A
 
 <Tabs items={["<Protect>", "has()"]}>
   <Tab>
-    The following example uses Clerk's `<Protect>` component to only render the form for users with the `org:team_settings:manage` permission. The example uses the `fallback` prop to render a different UI if the user is not authorized.
+    The following example uses Clerk's `<Protect>` component to only render the form for users with the correct permission. The example uses the `fallback` prop to render a different UI if the user is not authorized.
 
     ```tsx {{ filename: '/app/dashboard/settings/form.tsx' }}
       'use client';
@@ -50,7 +49,7 @@ The examples below work for both SSR and CSR. Examples are written for Next.js A
   <Tab>
     Use the [`useAuth()`](/docs/references/react/use-auth) hook to access the `has()` helper in Client Components.
 
-    The following example uses `has()` to inspect a user's permissions granularly. If the user doesn't have the `org:team_settings:manage` permission, `has()` returns `false`, causing the component to return `null` instead of rendering its children.
+    The following example uses `has()` to inspect a user's permissions granularly. If the user doesn't have the permission, `has()` returns `false`, causing the component to return `null` instead of rendering its children.
 
     ```tsx {{ filename: '/app/dashboard/settings/form.tsx' }}
       'use client';
@@ -78,7 +77,7 @@ The examples below work for both SSR and CSR. Examples are written for Next.js A
 
 <Tabs items={["<Protect>", "has()", "auth().protect()"]}>
   <Tab>
-      The following example uses Clerk's `<Protect>` component to only render the form for users with the `org:team_settings:read` permission. If the user is not authorized, the component will not render its children.
+      The following example uses Clerk's `<Protect>` component to only render the form for users with the correct permission. If the user is not authorized, the component will not render its children.
 
       ```tsx {{ filename: '/app/dashboard/settings/layout.tsx' }}
         import type { PropsWithChildren } from "react";
@@ -97,7 +96,7 @@ The examples below work for both SSR and CSR. Examples are written for Next.js A
   </Tab>
 
   <Tab>
-    The following example uses `has()` to inspect a user's permissions granularly. If the user doesn't have the `org:team_settings:read` permission, `has()` returns `false`, causing the component to return `null` instead of rendering its children.
+    The following example uses `has()` to inspect a user's permissions granularly. If the user doesn't have the correct permission, `has()` returns `false`, causing the component to return `null` instead of rendering its children.
 
     ```tsx {{ filename: '/app/dashboard/settings/layout.tsx' }}
       import type { PropsWithChildren } from "react";
@@ -117,17 +116,13 @@ The examples below work for both SSR and CSR. Examples are written for Next.js A
   </Tab>
 
   <Tab>
-      <Callout type="warning">
-        `auth().protect()` only works for App Router and is considered experimental.
-      </Callout>
+      > [!WARNING]
+      > `auth().protect()` only works for App Router and is considered experimental.
 
       The following example uses [`auth().protect()`](/docs/references/nextjs/auth#protect) to protect a RSC from unauthenticated and unauthorized access.
-
-      If the user is not authenticated, `auth().protect()` will redirect the user to the sign-in route.
-
-      If the user is authenticated but is not authorized (as in, does not have the `org:team_settings:read` permission), `auth().protect()` will throw a `404` error.
-
-      If the user is both authenticated and authorized, `auth().protect()` will return the user's `userId`.
+      - If the user is not authenticated, `auth().protect()` will redirect the user to the sign-in route.
+      - If the user is authenticated but is not authorized (as in, does not have the `org:team_settings:read` permission), `auth().protect()` will throw a `404` error.
+      - If the user is both authenticated and authorized, `auth().protect()` will return the user's `userId`.
 
       ```tsx {{ filename: '/app/dashboard/settings/layout.tsx' }}
       import type { PropsWithChildren } from "react";
@@ -146,7 +141,7 @@ The examples below work for both SSR and CSR. Examples are written for Next.js A
 
 <Tabs items={["Next.js Server Actions", "Next.js Route Handlers", "Next.js Pages Router"]}>
   <Tab>
-    The following example uses `has()` to inspect a user's permissions granularly in a Next.js Server Action. If the user doesn't have the `org:team_settings:manage` permission, `has()` returns `false`, causing the Server Action to return a `403` error.
+    The following example uses `has()` to inspect a user's permissions granularly in a Next.js Server Action. If the user doesn't have the correct permission, `has()` returns `false`, causing the Server Action to return a `403` error.
 
     ```tsx {{ filename: 'app/components/ExampleServerComponent.tsx'}}
       import { auth } from "@clerk/nextjs/server";
@@ -182,7 +177,7 @@ The examples below work for both SSR and CSR. Examples are written for Next.js A
 
         The example:
         - uses the `userId` returned from [`auth()`](/docs/references/nextjs/auth) to check if the user is signed in. If the user is not authenticated, the Route Handler will return a `401` error.
-        - uses `has()` to check if the user has the `org:team_settings:read` permission. If the user is not authorized, `has()` will return false, causing the Route Handler to return a `403` error.
+        - uses `has()` to check if the user has the correct permission. If the user is not authorized, `has()` will return false, causing the Route Handler to return a `403` error.
 
         ```tsx {{ filename: 'app/api/get-teams/route.tsx' }}
           import { useAuth } from "@clerk/nextjs";
@@ -204,9 +199,8 @@ The examples below work for both SSR and CSR. Examples are written for Next.js A
       </Tab>
 
       <Tab>
-        <Callout type="warning">
-          `auth().protect()` only works for App Router and is considered experimental.
-        </Callout>
+        > [!WARNING]
+        > `auth().protect()` only works for App Router and is considered experimental.
 
         The following example uses [`auth().protect()`](/docs/references/nextjs/auth#protect) to protect a Next.js Route Handler from unauthenticated and unauthorized access.
         - If the user is not authenticated nor authorized (as in, does not have the `org:team_settings:manage` permission), `auth().protect()` will throw a `404` error.
@@ -230,9 +224,9 @@ The examples below work for both SSR and CSR. Examples are written for Next.js A
   <Tab>
     Use the [`getAuth()`](/docs/references/nextjs/get-auth) helper to access the `has()` helper in a Next.js Pages Router application.
 
-    The example uses the `userId` returned from `getAuth()` to check if the user is signed in. If the user is not authenticated, the route will return a `401` error.
-
-    Then, the example uses `has()` to check if the user has the `org:team_settings:read` permission. If the user is not authorized, `has()` will return false, causing the route to return a `403` error.
+    The following example:
+    - uses the `userId` returned from `getAuth()` to check if the user is signed in. If the user is not authenticated, the route will return a `401` error.
+    - uses `has()` to check if the user has the correct permission. If the user is not authorized, `has()` will return false, causing the route to return a `403` error.
 
     ```tsx {{ filename: 'src/pages/api/get-teams.ts' }}
       import { getAuth } from "@clerk/nextjs/server";
@@ -300,15 +294,14 @@ If you are not using React or any of the meta-frameworks we support, you can use
 
 ## Authorize with roles
 
-<Callout type="warning">
-Performing role checks is not considered a best-practice and developers should avoid it as much as possible. Usually, complex role checks can be refactored with a single permission check.
-</Callout>
+> [!WARNING]
+> Performing role checks is not considered a best-practice and developers should avoid it as much as possible. Usually, complex role checks can be refactored with a single permission check.
 
 You can pass a `role` the same way you can pass a `permission` in all the examples above.
 
 <Tabs items={[ "RSC with <Protect>", "RSC with auth().protect()", "Client Component with has()", ]}>
   <Tab>
-    The following example uses `<Protect>`'s `condition` prop to conditionally render its children if the user is either an `org:admin` *or* an `org:billing_manager`.
+    The following example uses `<Protect>`'s `condition` prop to conditionally render its children if the user has the correct role.
 
     ```tsx {{ filename: '/app/dashboard/settings/layout.tsx' }}
       import type { PropsWithChildren } from "react";
@@ -327,17 +320,13 @@ You can pass a `role` the same way you can pass a `permission` in all the exampl
   </Tab>
 
   <Tab>
-    <Callout type="warning">
-      `auth().protect()` only works for App Router and is considered experimental.
-    </Callout>
+    > [!WARNING]
+    > `auth().protect()` only works for App Router and is considered experimental.
 
     The following example uses [`auth().protect()`](/docs/references/nextjs/auth#protect) to protect a RSC from unauthenticated and unauthorized access.
-
-    If the user is not authenticated, `auth().protect()` will redirect the user to the sign-in route.
-
-    If the user is authenticated but is not authorized (as in, does not have the `org:admin` or `org:billing_manager` role), `auth().protect()` will throw a `404` error.
-
-    If the user is both authenticated and authorized, `auth().protect()` will return the user's `userId`.
+    - If the user is not authenticated, `auth().protect()` will redirect the user to the sign-in route.
+    - If the user is authenticated but is not authorized (as in, does not have the `org:admin` or `org:billing_manager` role), `auth().protect()` will throw a `404` error.
+    - If the user is both authenticated and authorized, `auth().protect()` will return the user's `userId`.
 
     ```tsx {{ filename: '/app/dashboard/settings/layout.tsx' }}
       import type { PropsWithChildren } from "react";
@@ -354,7 +343,7 @@ You can pass a `role` the same way you can pass a `permission` in all the exampl
   <Tab>
     Use the [`useAuth()`](/docs/references/react/use-auth) hook to access the `has()` helper in Client Components.
 
-    The following example uses `has()` to inspect a user's roles granularly. If the user doesn't have the `org:admin` or `org:billing_manager` role, `has()` returns `false`, causing the component to return `null` instead of rendering its children.
+    The following example uses `has()` to inspect a user's roles granularly. If the user doesn't have the correct role, `has()` returns `false`, causing the component to return `null` instead of rendering its children.
 
     ```tsx filename="/app/dashboard/settings/form.tsx"
       'use client';
@@ -381,9 +370,8 @@ You can pass a `role` the same way you can pass a `permission` in all the exampl
 
 In order to enhance typesafety in your project, you can define a global `ClerkAuthorization` interface, which defines the acceptable values for roles and permissions.
 
-<Callout type="info">
-  By default, types related to roles and permissions, such as `OrganizationCustomRoleKey` and `OrganizationCustomPermissionKey`, will be assigned to `string` if `ClerkAuthorization` is not defined. If you define `ClerkAuthorization` in your project, `OrganizationCustomRoleKey` and `OrganizationCustomPermissionKey` will be assigned to the keys of the `ClerkAuthorization` interface.
-</Callout>
+> [!INFO]
+> By default, types related to roles and permissions, such as `OrganizationCustomRoleKey` and `OrganizationCustomPermissionKey`, will be assigned to `string` if `ClerkAuthorization` is not defined. If you define `ClerkAuthorization` in your project, `OrganizationCustomRoleKey` and `OrganizationCustomPermissionKey` will be assigned to the keys of the `ClerkAuthorization` interface.
 
 In the example below, `ClerkAuthorization` is defined with the default roles that Clerk provides.
 

--- a/docs/organizations/verify-user-permissions.mdx
+++ b/docs/organizations/verify-user-permissions.mdx
@@ -13,21 +13,21 @@ In general, you should always verify whether or not a user is authorized to acce
 
 Clerk enables two broad approaches to role and permissions-based authorization:
 
-1. **Immediately blocking unauthorized users**.
+1. If you would like to immediately prevent unauthorized users from accessing content, you can:
   - Use the [`<Protect>`](/docs/components/protect) component to prevent content from rendering if the active user is unauthorized.
-  - Call [`auth().protect()`](/docs/references/nextjs/auth#protect) to throw an error if the active user is unauthorized.
-2. **Configuring custom behavior for unauthorized users*.
-  - The [`has()`](/docs/references/nextjs/auth-object#has) helper returns `false` if the active user lacks the role or permissions you're checking for. You can choose how your app responds without immediately throwing an error or preventing content from rendering.
+  - Call [`auth().protect()`](/docs/references/nextjs/auth#protect) to throw a `404` error if the active user is unauthorized.
+2. If you would like more control over the response when a user is unauthorized, you can:
+  - Call the [`has()`](/docs/references/nextjs/auth-object#has) helper, which returns `false` if the active user lacks the role or permissions you're checking for. You can *choose* how your app responds instead of immediately preventing content from rendering or throwing an error.
 
 ## Authorization in Client Components
 
 The examples below work for both SSR and CSR. Examples are written for Next.js App Router but they are supported by any React meta framework, such as Remix or Gatsby.
 
-<Tabs type="framework" items={["Next.js with <Protect>", "Next.js with has()"]}>
+<Tabs items={["<Protect>", "has()"]}>
   <Tab>
-    The following snippet uses Clerk's `<Protect>` component to only render the form for users with the `org:team_settings:manage` permission.
+    The following example uses Clerk's `<Protect>` component to only render the form for users with the `org:team_settings:manage` permission. The example uses the `fallback` prop to render a different UI if the user is not authorized.
 
-    ```tsx filename="/app/dashboard/settings/form.tsx"
+    ```tsx {{ filename: '/app/dashboard/settings/form.tsx' }}
       'use client';
       import { Protect } from "@clerk/nextjs";
 
@@ -38,7 +38,7 @@ The examples below work for both SSR and CSR. Examples are written for Next.js A
             fallback={<p>You are not allowed to see this section.</p>}
           >
             <form>
-              ....
+              {/* Add UI for managing team settings */}
             </form>
           </Protect>
         )
@@ -48,9 +48,11 @@ The examples below work for both SSR and CSR. Examples are written for Next.js A
   </Tab>
 
   <Tab>
-    The `useAuth()` hook can help you access what permissions a user has by using `has()`. In the example below, `has({ permission: "org:team_settings:manage" })` returns `false` if the user does not have the `org:team_settings:manage` permission.
+    Use the [`useAuth()`](/docs/references/react/use-auth) hook to access the `has()` helper in Client Components.
 
-    ```tsx filename="/app/dashboard/settings/form.tsx"
+    The following example uses `has()` to inspect a user's permissions granularly. If the user doesn't have the `org:team_settings:manage` permission, `has()` returns `false`, causing the component to return `null` instead of rendering its children.
+
+    ```tsx {{ filename: '/app/dashboard/settings/form.tsx' }}
       'use client';
       import { useAuth } from "@clerk/nextjs";
 
@@ -63,7 +65,7 @@ The examples below work for both SSR and CSR. Examples are written for Next.js A
 
         return (
           <form>
-            //...
+            {/* Add UI for managing team settings */}
           </form>
         )
       }
@@ -74,49 +76,11 @@ The examples below work for both SSR and CSR. Examples are written for Next.js A
 
 ## Authorization in React Server Components
 
-<Tabs type="framework" items={[ "RSC with has()", "RSC with auth().protect()", "RSC with <Protect>"]}>
+<Tabs items={["<Protect>", "has()", "auth().protect()"]}>
   <Tab>
-    The following example uses `has()` to inspect a user's permissions granularly. If the user doesn't have the `org:team_settings:read` permission, the component returns `null` instead of rendering its children.
+      The following example uses Clerk's `<Protect>` component to only render the form for users with the `org:team_settings:read` permission. If the user is not authorized, the component will not render its children.
 
-    ```tsx filename="/app/dashboard/settings/layout.tsx"
-      import type { PropsWithChildren } from "react";
-      import { auth } from "@clerk/nextjs/server";
-
-      export default function SettingsLayout(props: PropsWithChildren){
-        const { has } = auth()
-
-        const canAccessSettings = has({permission: "org:team_settings:read"});
-
-        if(!canAccessSettings) return null;
-
-        return props.children
-      }
-      ```
-
-  </Tab>
-
-  <Tab>
-    <Callout>
-      `auth().protect()` will throw a `notFound` Next.js error if authorization checks fail.
-    </Callout>
-
-    ```tsx filename="/app/dashboard/settings/layout.tsx"
-      import type { PropsWithChildren } from "react";
-      import { auth } from "@clerk/nextjs/server";
-
-      export default function SettingsLayout(props: PropsWithChildren){
-        const { userId } = auth().protect({permission: "org:team_settings:read"})
-
-        return props.children
-      }
-      ```
-
-  </Tab>
-
-  <Tab>
-    The following snippet uses `<Protect>`'s `condition` prop to conditionally render its children if the user has the `org:team_settings:read` permission.
-
-      ```tsx filename="/app/dashboard/settings/layout.tsx"
+      ```tsx {{ filename: '/app/dashboard/settings/layout.tsx' }}
         import type { PropsWithChildren } from "react";
         import { Protect } from "@clerk/nextjs";
 
@@ -130,73 +94,148 @@ The examples below work for both SSR and CSR. Examples are written for Next.js A
           )
         }
       ```
+  </Tab>
 
+  <Tab>
+    The following example uses `has()` to inspect a user's permissions granularly. If the user doesn't have the `org:team_settings:read` permission, `has()` returns `false`, causing the component to return `null` instead of rendering its children.
+
+    ```tsx {{ filename: '/app/dashboard/settings/layout.tsx' }}
+      import type { PropsWithChildren } from "react";
+      import { auth } from "@clerk/nextjs/server";
+
+      export default function SettingsLayout(props: PropsWithChildren){
+        const { has } = auth();
+
+        const canAccessSettings = has({ permission: "org:team_settings:read" });
+
+        if(!canAccessSettings) return null;
+
+        return props.children;
+      }
+      ```
+
+  </Tab>
+
+  <Tab>
+      <Callout type="warning">
+        `auth().protect()` only works for App Router and is considered experimental.
+      </Callout>
+
+      The following example uses [`auth().protect()`](/docs/references/nextjs/auth#protect) to protect a RSC from unauthenticated and unauthorized access.
+
+      If the user is not authenticated, `auth().protect()` will redirect the user to the sign-in route.
+
+      If the user is authenticated but is not authorized (as in, does not have the `org:team_settings:read` permission), `auth().protect()` will throw a `404` error.
+
+      If the user is both authenticated and authorized, `auth().protect()` will return the user's `userId`.
+
+      ```tsx {{ filename: '/app/dashboard/settings/layout.tsx' }}
+      import type { PropsWithChildren } from "react";
+      import { auth } from "@clerk/nextjs/server";
+
+      export default function SettingsLayout(props: PropsWithChildren){
+        const { userId } = auth().protect({ permission: "org:team_settings:read" })
+
+        return props.children
+      }
+      ```
   </Tab>
 </Tabs>
 
 ## Authorization in endpoints
 
-<Tabs type="framework" items={["Next.js Server Actions", "Nexjts Route Handlers", "Next.js API Routes"]}>
+<Tabs items={["Next.js Server Actions", "Next.js Route Handlers", "Next.js Pages Router"]}>
   <Tab>
-    ```tsx
+    The following example uses `has()` to inspect a user's permissions granularly in a Next.js Server Action. If the user doesn't have the `org:team_settings:manage` permission, `has()` returns `false`, causing the Server Action to return a `403` error.
+
+    ```tsx {{ filename: 'app/components/ExampleServerComponent.tsx'}}
       import { auth } from "@clerk/nextjs/server";
 
-      export default function ServerComponent() {
-        async function myAction() {
+      export default function ExampleServerComponent() {
+        async function myAction(formData: FormData) {
           'use server'
           const { has } = auth();
 
-          const canManage = has({permission:"org:team_settings:manage"});
-          ...
-          // Perform a DB operation ...
+          const canManage = has({ permission:"org:team_settings:manage" });
+
+          // If has() returns false, the user does not have the correct permissions
+          if(!canManage) return Response.json({ error: "User does not have the correct permissions" }, { status: 403 });
+
+          // Add logic for managing team settings
         }
+
+        return (
+          <form action={myAction}>
+            {/* Add UI for managing team settings */}
+            <button type="submit">Submit</button>
+          </form>
+        );
       }
     ```
 
   </Tab>
 
   <Tab>
-    <Callout>
-      `auth().protect()` will throw a `notFound` Next.js error if authorization checks fail.
-    </Callout>
+    <Tabs items={["has()", "auth().protect()"]}>
+      <Tab>
+        The following example demonstrates how to use `has()` in a Next.js Route Handler.
 
-    ### Using `auth().protect()`
+        The example:
+        - uses the `userId` returned from [`auth()`](/docs/references/nextjs/auth) to check if the user is signed in. If the user is not authenticated, the Route Handler will return a `401` error.
+        - uses `has()` to check if the user has the `org:team_settings:read` permission. If the user is not authorized, `has()` will return false, causing the Route Handler to return a `403` error.
 
-    ```tsx
-      import { useAuth } from "@clerk/nextjs";
+        ```tsx {{ filename: 'app/api/get-teams/route.tsx' }}
+          import { useAuth } from "@clerk/nextjs";
 
-      export const POST = () => {
-        const { userId } = auth().protect({
-          permission: "org:team_settings:manage"
-        })
-        return users.createTeam(userId);
-      }
-    ```
+          export const GET = () => {
+            const { userId, has } = auth();
 
-    ### Using `has()`
+            if(!userId){
+              return Response.json({ error: "User is not signed in" }, { status: 401 })
+            }
 
-    ```tsx
-      import { useAuth } from "@clerk/nextjs";
+            const canRead = has({ permission: "org:team_settings:read" });
 
-      export const GET = () => {
-        const { userId, has } = auth();
+            if(!canRead) return Response.json({ error: "User does not have the correct permissions" }, { status: 403 });
 
-        if(!userId){
-          return Response.json({error: "Unathorized"}, {status: 401})
-        }
+            return users.getTeams(userId)
+          }
+        ```
+      </Tab>
 
-        if(!has({permission: "org:team_settings:read"})){
-          return Response.json({error: "Forbidden"}, {status: 403})
-        }
+      <Tab>
+        <Callout type="warning">
+          `auth().protect()` only works for App Router and is considered experimental.
+        </Callout>
 
-        return users.getTeams(userId)
-      }
-    ```
+        The following example uses [`auth().protect()`](/docs/references/nextjs/auth#protect) to protect a Next.js Route Handler from unauthenticated and unauthorized access.
+        - If the user is not authenticated, `auth().protect()` will redirect the user to the sign-in route.
+        - If the user is authenticated but is not authorized (as in, does not have the `org:team_settings:manage` permission), `auth().protect()` will throw a `404` error.
+        - If the user is both authenticated and authorized, `auth().protect()` will return the user's `userId`.
 
+        ```tsx {{ filename: 'app/api/create-team/route.tsx' }}
+          import { useAuth } from "@clerk/nextjs";
+
+          export const POST = () => {
+            const { userId } = auth().protect({
+              permission: "org:team_settings:manage"
+            })
+
+            return users.createTeam(userId);
+          }
+        ```
+      </Tab>
+    </Tabs>
   </Tab>
 
   <Tab>
-    ```tsx
+    Use the [`getAuth()`](/docs/references/nextjs/get-auth) helper to access the `has()` helper in a Next.js Pages Router application.
+
+    The example uses the `userId` returned from `getAuth()` to check if the user is signed in. If the user is not authenticated, the route will return a `401` error.
+
+    Then, the example uses `has()` to check if the user has the `org:team_settings:read` permission. If the user is not authorized, `has()` will return false, causing the route to return a `403` error.
+
+    ```tsx {{ filename: 'src/pages/api/get-teams.ts' }}
       import { getAuth } from "@clerk/nextjs/server";
 
       export default async function handler(req: NextApiRequest) {
@@ -204,9 +243,11 @@ The examples below work for both SSR and CSR. Examples are written for Next.js A
 
         if (!userId) return res.status(401);
 
-        if(!has({permission: "org:team_settings:read"})) return res.status(403)
+        const canRead = has({ permission: "org:team_settings:read" });
 
-        return users.getTeams(userId)
+        if(!canRead) return res.status(403);
+
+        return users.getTeams(userId);
       }
     ```
 
@@ -236,22 +277,27 @@ export default function Settings() {
 ```
 </CodeBlockTabs>
 
-## Authorization in JS SDK
+## Authorization in JavaScript
 
-If you are not using React or any of the meta-frameworks we support, there's a good chance that you are using Clerk.js directly. In that case, the following example can help.
+If you are not using React or any of the meta-frameworks we support, you can use the Clerk JavaScript SDK. The following example demonstrates how to use the [`checkAuthorization()`](/docs/references/javascript/session#check-authorization) method to check if a user is authorized.
 
-<CodeBlockTabs type="framework" options={["JavaScript"]}>
-  ```tsx
-    import { Clerk } from '@clerk/clerk-js'
+<Tabs items={["JavaScript"]}>
+  ```tsx {{ filename: 'main.js' }}
+    import { Clerk } from '@clerk/clerk-js';
 
-    const clerk = new Clerk(...)
-    await clerk.load(...)
+    // Initialize Clerk with your Clerk publishable key
+    const clerk = new Clerk('{{pub_key}}');
+    await clerk.load();
 
-    const canManageSettings = clerk.session.checkAuthorization({
-      permission: "org:team_settings:manage"
-    })
+    // Check if the user is authenticated
+    if (clerk.user) {
+      // Check if the user is authorized
+      const canManageSettings = clerk.session.checkAuthorization({
+        permission: "org:team_settings:manage"
+      })
+    }
 ```
-</CodeBlockTabs>
+</Tabs>
 
 ## Authorize with roles
 
@@ -261,64 +307,75 @@ Performing role checks is not considered a best-practice and developers should a
 
 You can pass a `role` the same way you can pass a `permission` in all the examples above.
 
-<Tabs type="framework" items={[ "RSC with <Protect>","RSC with auth().protect()", "Client Component with has()", ]}>
-<Tab>
-  The following example uses `<Protect>`'s `condition` prop to conditionally render its children if the user is either an `org:admin` or an `org:billing_manager`.
+<Tabs items={[ "RSC with <Protect>", "RSC with auth().protect()", "Client Component with has()", ]}>
+  <Tab>
+    The following example uses `<Protect>`'s `condition` prop to conditionally render its children if the user is either an `org:admin` *or* an `org:billing_manager`.
 
-  ```tsx filename="/app/dashboard/settings/layout.tsx"
-    import type { PropsWithChildren } from "react";
-    import { Protect } from "@clerk/nextjs";
+    ```tsx {{ filename: '/app/dashboard/settings/layout.tsx' }}
+      import type { PropsWithChildren } from "react";
+      import { Protect } from "@clerk/nextjs";
 
-    export default function SettingsLayout(props: PropsWithChildren){
-      return (
-        <Protect
-          condition={has => has({role: "org:admin"}) || has({role: "org:billing_manager"})}
-        >
-          {props.children}
-        </Protect>
-      )
-    }
-  ```
-</Tab>
+      export default function SettingsLayout(props: PropsWithChildren){
+        return (
+          <Protect
+            condition={has => has({role: "org:admin"}) || has({role: "org:billing_manager"})}
+          >
+            {props.children}
+          </Protect>
+        )
+      }
+    ```
+  </Tab>
 
-<Tab>
-  <Callout>
-    `auth().protect()` will throw a `notFound` Next.js error if authorization checks fail.
-  </Callout>
+  <Tab>
+    <Callout type="warning">
+      `auth().protect()` only works for App Router and is considered experimental.
+    </Callout>
 
-  ```tsx filename="/app/dashboard/settings/layout.tsx"
-    import type { PropsWithChildren } from "react";
-    import { auth } from "@clerk/nextjs/server";
+    The following example uses [`auth().protect()`](/docs/references/nextjs/auth#protect) to protect a RSC from unauthenticated and unauthorized access.
 
-    export default function SettingsLayout(props: PropsWithChildren){
-      const { userId } = auth().protect(has => has({role: "org:admin"}) || has({role: "org:billing_manager"}))
+    If the user is not authenticated, `auth().protect()` will redirect the user to the sign-in route.
 
-      return props.children
-    }
-  ```
-</Tab>
+    If the user is authenticated but is not authorized (as in, does not have the `org:admin` or `org:billing_manager` role), `auth().protect()` will throw a `404` error.
 
-<Tab>
-  The following snippet uses `useAuth()` to inspect a user's roles granularly. If the user doesn't have either an `org:admin` or an `org:billing_manager` role, the component returns `null` instead of rendering its children.
+    If the user is both authenticated and authorized, `auth().protect()` will return the user's `userId`.
 
-  ```tsx filename="/app/dashboard/settings/form.tsx"
-    'use client';
-    import { useAuth } from "@clerk/nextjs";
+    ```tsx {{ filename: '/app/dashboard/settings/layout.tsx' }}
+      import type { PropsWithChildren } from "react";
+      import { auth } from "@clerk/nextjs/server";
 
-    export function SettingsForm(){
-      const { has } = useAuth();
-      const canAccessSettings = has({role: "org:admin"}) || has({role: "org:billing_manager"})
+      export default function SettingsLayout(props: PropsWithChildren){
+        const { userId } = auth().protect(has => has({ role: "org:admin" }) || has({ role: "org:billing_manager" }))
 
-      if(!canManageSettings) return null;
+        return props.children
+      }
+    ```
+  </Tab>
 
-      return (
-        <form>
-          //...
-        </form>
-      )
-    }
-   ```
-</Tab>
+  <Tab>
+    Use the [`useAuth()`](/docs/references/react/use-auth) hook to access the `has()` helper in Client Components.
+
+    The following example uses `has()` to inspect a user's roles granularly. If the user doesn't have the `org:admin` or `org:billing_manager` role, `has()` returns `false`, causing the component to return `null` instead of rendering its children.
+
+    ```tsx filename="/app/dashboard/settings/form.tsx"
+      'use client';
+      import { useAuth } from "@clerk/nextjs";
+
+      export function SettingsForm(){
+        const { has } = useAuth();
+
+        const canAccessSettings = has({ role: "org:admin" }) || has({ role: "org:billing_manager" })
+
+        if(!canAccessSettings) return null;
+
+        return (
+          <form>
+            {/* Add UI for team settings */}
+          </form>
+        )
+      }
+    ```
+  </Tab>
 </Tabs>
 
 ## How to add types for roles and permissions

--- a/docs/organizations/verify-user-permissions.mdx
+++ b/docs/organizations/verify-user-permissions.mdx
@@ -209,8 +209,7 @@ The examples below work for both SSR and CSR. Examples are written for Next.js A
         </Callout>
 
         The following example uses [`auth().protect()`](/docs/references/nextjs/auth#protect) to protect a Next.js Route Handler from unauthenticated and unauthorized access.
-        - If the user is not authenticated, `auth().protect()` will redirect the user to the sign-in route.
-        - If the user is authenticated but is not authorized (as in, does not have the `org:team_settings:manage` permission), `auth().protect()` will throw a `404` error.
+        - If the user is not authenticated nor authorized (as in, does not have the `org:team_settings:manage` permission), `auth().protect()` will throw a `404` error.
         - If the user is both authenticated and authorized, `auth().protect()` will return the user's `userId`.
 
         ```tsx {{ filename: 'app/api/create-team/route.tsx' }}


### PR DESCRIPTION
> [!IMPORTANT]
> 🔎 [Preview](https://clerk.com/docs/pr/1141/organizations/verify-user-permissions#verify-the-active-user-s-permissions-in-an-organization)

While [updating the `auth()` documentation to better explain the `protect()` helper](https://github.com/clerk/clerk-docs/pull/1140), I noticed that this page needed a lot of cleaning up - and we actually had a ticket for it!

This PR:
- cleans up copy that explains the code examples
- adds missing filenames to codeblocks
- updates the props for codeblocks to our new syntax 
  - `{{ filename: '' }}`
- updates the names of tabs in code blocks to be consistent throughout the doc 
  - `has()` `<Protect>` and `auth().protect()`