### PR TITLE
fix(CSP): fix directive syntax, ensure all necessary values are present

### DIFF
--- a/docs/security/clerk-csp.mdx
+++ b/docs/security/clerk-csp.mdx
@@ -6,21 +6,24 @@ description: Learn how to configure your Content Security Policy to work with Cl
 
 [Content-Security-Policy](https://developer.mozilla.org/en-US/docs/Web/HTTP/CSP) (CSP) headers secure your document by preventing resources from being loaded from unexpected sources. This protects your apps from [XSS](/docs/security/xss-leak-protection#xss-leak-protection) attacks and data injections.
 
-You can configure the following CSP headers:
+For Clerk to work correctly in your application, you'll need to configure the following CSP directives:
 
-1. `script-src` – This value should be the host application's FAPI hostname, such as `https://clerk.your-domain.com`.
-2. `connect-src` – This value should also be the host application's FAPI hostname, such as `https://clerk.your-domain.com`.
+1. `script-src` – This value should include the host application's FAPI hostname, such as `https://clerk.your-domain.com`.
+2. `connect-src` – This value should also include the host application's FAPI hostname, such as `https://clerk.your-domain.com`.
 3. `img-src` – This value should be `https://img.clerk.com`.
-4. `worker-src`: This value should be the host application's hostname `https://app.your-domain.com`
+4. `worker-src` - Use the `'self'` value to indicate that workers can be loaded from first-party scripts. The `blob:` schema value also needs to be included.
+5. `style-src` - Due to Clerk's usage of runtime CSS-in-JS for styling, `'unsafe-inline'` needs to be included.
 
-The following example demonstrates a Next.js config file that sets Clerk's CSP headers correctly.
+The following example demonstrates a Next.js config file that sets the necessary directives for your application's assets and Clerk to load and function correctly. The values used apply to your currently selected instance, make sure to handle both your development instance and production instance hosts.
 
-```js filename="next.config.js"
+```js {{ filename: "next.config.js" }}
 const cspHeader = `
-  script-src: https://clerk.your-domain.com
-  connect-src: https://clerk.your-domain.com
-  img-src: https://img.clerk.com
-  worker-src: https://app.your-domain.com
+  default-src: 'self';
+  script-src: 'self' 'unsafe-inline' 'unsafe-eval' https://{{fapi_url}};
+  connect-src: 'self' https://{{fapi_url}};
+  img-src: 'self' https://img.clerk.com;
+  worker-src: 'self' blob:;
+  style-src: 'self' 'unsafe-inline';
 `;
 
 /** @type {import('next').NextConfig} */
@@ -42,3 +45,5 @@ const nextConfig = {
 
 module.exports = nextConfig;
 ```
+
+Note that you will need to make sure any third-party domains where scripts or assets are loaded from are also specified.

--- a/docs/security/clerk-csp.mdx
+++ b/docs/security/clerk-csp.mdx
@@ -16,6 +16,9 @@ For Clerk to work correctly in your application, you'll need to configure the fo
 
 The following example demonstrates a Next.js config file that sets the necessary directives for your application's assets and Clerk to load and function correctly. The values used apply to your currently selected instance, make sure to handle both your development instance and production instance hosts.
 
+> [!WARNING]
+> You will need to make sure any third-party domains where scripts or assets are loaded from are also specified.
+
 ```js {{ filename: "next.config.js" }}
 const cspHeader = `
   default-src: 'self';
@@ -45,5 +48,3 @@ const nextConfig = {
 
 module.exports = nextConfig;
 ```
-
-Note that you will need to make sure any third-party domains where scripts or assets are loaded from are also specified.


### PR DESCRIPTION
Updates the CSP docs to ensure the provided values are formatted correctly. Also uses our `{{fapi_url}}` placeholder to inject the user's instance FAPI host.