### PR TITLE
Add highlight also for closing provider tag line in the example

### DIFF
--- a/docs/quickstarts/nextjs.mdx
+++ b/docs/quickstarts/nextjs.mdx
@@ -114,7 +114,7 @@ You can control which content signed in and signed out users can see with Clerk'
 Select your preferred router to learn how to make this data available across your entire app:
 
 <CodeBlockTabs type="router" options={["App Router", "Pages Router"]}>
-```tsx filename="app/layout.tsx" {10,13-20}
+```tsx filename="app/layout.tsx" {10,13-20,26}
 import { ClerkProvider, SignInButton, SignedIn, SignedOut, UserButton } from '@clerk/nextjs'
 import './globals.css';
 


### PR DESCRIPTION
Currently, the closing tag `</ClerkProvider>` the example is not highlighted, despite being part of the change set. This change adds the missing highlight.