### PR TITLE
Highlight closing tag

### DIFF
--- a/docs/quickstarts/nextjs.mdx
+++ b/docs/quickstarts/nextjs.mdx
@@ -114,7 +114,7 @@ You can control which content signed in and signed out users can see with Clerk'
 Select your preferred router to learn how to make this data available across your entire app:
 
 <CodeBlockTabs type="router" options={["App Router", "Pages Router"]}>
-```tsx filename="app/layout.tsx" {10,13-20}
+```tsx filename="app/layout.tsx" {10,13-20,26}
 import { ClerkProvider, SignInButton, SignedIn, SignedOut, UserButton } from '@clerk/nextjs'
 import './globals.css';
 


### PR DESCRIPTION
Highlights closing `</ClerkProvider>` line in https://clerk.com/docs/quickstarts/nextjs