### PR TITLE
fix: Webhook guides typos

### DIFF
--- a/docs/integrations/webhooks/debug-your-webhooks.mdx
+++ b/docs/integrations/webhooks/debug-your-webhooks.mdx
@@ -36,7 +36,7 @@ export const config = {
 ```
 
 ```tsx filename="middleware.tsx" {4}
-import { authMiddleware } from "@clerk/nextjs";
+import { authMiddleware } from "@clerk/nextjs/server";
 
 export default authMiddleware({
   ignoredRoutes: ["/api/webhooks(.*)"],

--- a/docs/integrations/webhooks/sync-data.mdx
+++ b/docs/integrations/webhooks/sync-data.mdx
@@ -90,7 +90,7 @@ export const config = {
 ```
 
 ```tsx filename="middleware.tsx" {4}
-import { authMiddleware } from "@clerk/nextjs";
+import { authMiddleware } from "@clerk/nextjs/server";
 
 export default authMiddleware({
   ignoredRoutes: ["/api/webhooks(.*)"],
@@ -288,12 +288,12 @@ app.post(
 
     // Get the headers and body
     const headers = req.headers;
-    const payload: unknown = req.body;
+    const payload = req.body;
 
     // Get the Svix headers for verification
-    const svix_id = headers["svix-id"] as string;
-    const svix_timestamp = headers["svix-timestamp"] as string;
-    const svix_signature = headers["svix-signature"] as string;
+    const svix_id = headers["svix-id"];
+    const svix_timestamp = headers["svix-timestamp"];
+    const svix_signature = headers["svix-signature"];
 
     // If there are no Svix headers, error out
     if (!svix_id || !svix_timestamp || !svix_signature) {
@@ -305,7 +305,7 @@ app.post(
     // Create a new Svix instance with your secret.
     const wh = new Webhook(WEBHOOK_SECRET);
 
-    let evt: WebhookEvent;
+    let evt;
 
     // Attempt to verify the incoming webhook
     // If successful, the payload will be available from 'evt'
@@ -315,8 +315,8 @@ app.post(
         "svix-id": svix_id,
         "svix-timestamp": svix_timestamp,
         "svix-signature": svix_signature,
-      }) as WebhookEvent;
-    } catch (err: any) {
+      });
+    } catch (err) {
       console.log("Error verifying webhook:", err.message);
       return res.status(400).json({
         success: false,


### PR DESCRIPTION
The https://clerk.com/docs/integrations/webhooks/sync-data guide had TS in JS codeblocks. It also had incorrect import for `authMiddleware`.

Fixes https://github.com/clerk/clerk-docs/issues/1143
Fixes https://github.com/clerk/clerk-docs/issues/1144