### PR TITLE
Fix missing imports from Node SDK usage

### DIFF
--- a/docs/references/nodejs/available-methods.mdx
+++ b/docs/references/nodejs/available-methods.mdx
@@ -18,14 +18,6 @@ If you would like to use the default instance of `clerkClient` provided by the S
 
   const userList = await clerkClient.users.getUserList();
   ```
-
-  If you are interested in a certain resource, you can destructure `clerkClient` to access just that resource.:
-
-  ```js
-  import { sessions } from '@clerk/clerk-sdk-node';
-
-  const sessionList = await sessions.getSessionList();
-  ```
   </Tab>
 
   <Tab>
@@ -36,18 +28,6 @@ If you would like to use the default instance of `clerkClient` provided by the S
   clerkClient.sessions
     .getSessionList()
     .then((sessions) => console.log(sessions))
-    .catch((error) => console.error(error));
-  ```
-
-  Or if you prefer a resource sub-api directly:
-
-  ```js
-  const pkg = require('@clerk/clerk-sdk-node');
-  const { clients } = pkg;
-
-  clients
-    .getClient(clientId)
-    .then((client) => console.log(client))
     .catch((error) => console.error(error));
   ```
   </Tab>

--- a/docs/references/nodejs/overview.mdx
+++ b/docs/references/nodejs/overview.mdx
@@ -67,7 +67,7 @@ The Clerk Node SDK offers two [middlewares](/docs/backend-requests/handling/node
 ### Authenticate a particular session
 
 ```js
-import { sessions } from '@clerk/clerk-sdk-node';
+import { clerkClient } from '@clerk/clerk-sdk-node';
 import Cookies from 'cookies';
 
 // Retrieve the particular session ID from a
@@ -79,7 +79,7 @@ const sessionId = req.query._clerk_session_id;
 const cookies = new Cookies(req, res);
 const clientToken = cookies.get('__session');
 
-const session = await sessions.verifySession(sessionId, clientToken);
+const session = await clerkClient.sessions.verifySession(sessionId, clientToken);
 ```
 
 ### Authenticate the last active session
@@ -87,7 +87,7 @@ const session = await sessions.verifySession(sessionId, clientToken);
 Using the last active session is appropriate when determining the user after a navigation.
 
 ```js
-import { clients, sessions } from '@clerk/clerk-sdk-node';
+import { clerkClient } from '@clerk/clerk-sdk-node';
 import Cookies from 'cookies';
 
 // Note: Clerk stores the clientToken in a cookie
@@ -95,13 +95,13 @@ import Cookies from 'cookies';
 const cookies = new Cookies(req, res);
 const clientToken = cookies.get('__session');
 
-const client = await clients.verifyClient(clientToken);
+const client = await clerkClient.clients.verifyClient(clientToken);
 const sessionId = client.lastActiveSessionId;
 
-const session = await sessions.verifySession(sessionId, clientToken);
+const session = await clerkClient.sessions.verifySession(sessionId, clientToken);
 ```
 
- 
+
 ## Error handling
 
 Node SDK functions do not throw errors when something goes wrong. Instead, they return a [`ClerkBackendApiResponse`](/docs/references/javascript/types/clerk-backend-api-response) object, just as they would if there were no errors. You can check for errors on the `.errors` property of the response. For example:


### PR DESCRIPTION
In the Node SDK example on the Clerk docs site, there are sections where resources are destructured from the `clerkClient` function and imported directly. These methods are not exported, resulting in an error.

- https://clerk.com/docs/references/nodejs/overview#manual-authentication
- https://clerk.com/docs/references/nodejs/available-methods#instantiate-a-default-clerk-client-instance

This change updates those sections to just import `clerkClient` and access the resource from it.

Before:

```ts
import { sessions } from '@clerk/clerk-sdk-node';

// more code

const session = await sessions.verifySession(sessionId, clientToken);
```

After:

```ts
import { clerkClient } from '@clerk/clerk-sdk-node';

// more code

const session = await clerkClient.sessions.verifySession(sessionId, clientToken);
```