### PR TITLE
(/backend/user/update-user-metadata) method merges instead of full replace

### DIFF
--- a/docs/references/backend/user/update-user-metadata.mdx
+++ b/docs/references/backend/user/update-user-metadata.mdx
@@ -5,7 +5,7 @@ description: Use Clerk's Backend SDK to update the metadata associated with the 
 
 # `updateUserMetadata()`
 
-Updates the metadata associated with the specified user.
+Updates the metadata associated with the specified user by merging existing values with the provided parameters.
 
 ```tsx
 function updateUserMetadata: (userId: string, params: UpdateUserMetadataParams) => Promise<User>;


### PR DESCRIPTION
[DOCS-8803](https://linear.app/clerk/issue/DOCS-8803/feedback-for-referencesbackenduserupdate-user-metadata) reads:
> User's feedback: Does it override or extend the metadata? It's not clear how this works.

From the [backend API reference docs](https://clerk.com/docs/reference/backend-api/tag/Users#operation/UpdateUserMetadata), it reads:
"Update a user's metadata attributes by merging existing values with the provided parameters."

This PR:
- adds this information to the updateUserMetadata doc