### PR TITLE
(/sign-up-sign-in-options) Clarify enabling MFA does not require it for all users

### DIFF
--- a/docs/authentication/configuration/sign-up-sign-in-options.mdx
+++ b/docs/authentication/configuration/sign-up-sign-in-options.mdx
@@ -155,7 +155,7 @@ To enable Web3 authentication:
 
 ## Multi-factor authentication
 
-Clerk supports multi-factor authentication (MFA), often referred to as two-factor authentication or 2FA. By enabling MFA, you can encourage or require your users to perform a second verification check during sign-in. By enforcing two different types of verifications, you can drastically improve your user's security. Most websites make this step optional, empowering their users with their own security.
+Clerk supports multi-factor authentication (MFA), often referred to as two-factor authentication or 2FA. By enabling MFA, you can encourage your users to perform a second verification check during sign-in. By enforcing two different types of verifications, you can drastically improve your user's security. Most websites make this step optional, empowering their users with their own security.
 
 Although not available as an option in the initial new application screen, you can opt to turn on multi-factor authentication (MFA) in the Clerk Dashboard.
 
@@ -169,7 +169,9 @@ Clerk currently offers the following MFA strategies:
 - **Authenticator application (also known as TOTP - Time-based One-time Password)**
 - **Backup codes**
 
-Once MFA is turned on, registered users can turn on MFA for their own account through their [User Profile](/docs/account-portal/user-profile-org-profile#user-profile) page. However, if you are building a custom user interface, you can [build a custom multi-factor sign-in flow](/docs/custom-flows/email-password-mfa) that allows users to sign in with MFA.
+Enabling MFA allows users of your app to turn on MFA for their own account through their [User Profile](/docs/account-portal/user-profile-org-profile#user-profile) page. Enabling MFA does not automatically turn on MFA for all users.
+
+If you are building a custom user interface instead of using Clerk's Account Portal or prebuilt components, you can use [Clerk elements](/docs/elements/examples/sign-in#multi-factor-authentication-mfa) or use [Clerk's API](/docs/custom-flows/email-password-mfa) to build a custom sign-in flow that allows users to sign in with MFA.
 
 ## Sign-up restrictions
 


### PR DESCRIPTION
<!--- Add the "deploy-preview" label and add your page previews here -->
> [!IMPORTANT]
> 🔎 Previews:
>
> - https://clerk.com/docs/pr/1172/authentication/configuration/sign-up-sign-in-options

<!--- Describe your changes in detail. Why does this change need to happen? Include any links to Slack discussions, Linear comments, etc. -->

### Explanation:
[DOCS-6346](https://linear.app/clerk/issue/DOCS-6346/feedback-for-authenticationconfigurationsign-up-sign-in-options) reads:

> User's feedback: It says you can require Multi factor auth, but I can't find where in the Clerk dashboard where I can enforce this for all users in a given app or org

<!--- How does this PR solve the problem? -->

### This PR:

- updates the description for enabling MFA
- adds reference to clerk elements