### PR TITLE
Update Input Fields for Email Validation and Verification Process in `shadcn-ui` Example Forms

### DIFF
--- a/docs/elements/examples/shadcn-ui.mdx
+++ b/docs/elements/examples/shadcn-ui.mdx
@@ -121,7 +121,7 @@ export default function SignUpPage() {
                       <Clerk.Label asChild>
                         <Label>Email address</Label>
                       </Clerk.Label>
-                      <Clerk.Input type="text" required asChild>
+                      <Clerk.Input type="email" required asChild>
                         <Input />
                       </Clerk.Input>
                       <Clerk.FieldError className="block text-sm text-destructive" />
@@ -188,7 +188,7 @@ export default function SignUpPage() {
               </SignUp.Step>
 
               <SignUp.Step name="verifications">
-                <SignUp.Strategy name="code">
+                <SignUp.Strategy name="email_code">
                   <Card className="w-full sm:w-96">
                     <CardHeader>
                       <CardTitle>Verify your email</CardTitle>
@@ -196,7 +196,7 @@ export default function SignUpPage() {
                     </CardHeader>
                     <CardContent className="grid gap-y-4">
                       <div className="grid items-center justify-center gap-y-2">
-                        <Clerk.Field name="email_code" className="space-y-2">
+                        <Clerk.Field name="code" className="space-y-2">
                           <Clerk.Label className="sr-only">Email address</Clerk.Label>
                           <div className="flex justify-center text-center">
                             <Clerk.Input
@@ -463,7 +463,7 @@ export default function SignInPage() {
                       </p>
                     </CardHeader>
                     <CardContent className="grid gap-y-4">
-                      <Clerk.Field name="email_code">
+                      <Clerk.Field name="code">
                         <Clerk.Label className="sr-only">
                           Email verification code
                         </Clerk.Label>


### PR DESCRIPTION
This PR introduces several updates to enhance the handling of email input fields and the email verification process within the sign-up and sign-in forms. These changes aim to improve user experience and data validation.

**Modifications**
   1. Email Input Type:
      - Changed input type to `email` in the sign-up form to ensure proper email validation.

   2. Email Verification:
      - Updated verification strategy fields to accurately reflect the email verification process.
      - Adjusted field names for consistency in email verification steps.

**Benefits**
   - Enhanced user experience through more intuitive and accurate email input handling.
   - Improved data validation for email fields, reducing errors and ensuring proper email formats.
   - Consistency in the email verification process, making it clearer for developers.

**Screenshot Reference**

> [!NOTE]
> In the <Clerk.Field/> component of email verification code, there is no `email_code` option for `name` attribute.

![elements-shadcn-ui-example](https://github.com/clerk/clerk-docs/assets/64539836/8a4179b5-2e56-467a-9965-ddae2500b635)

These improvements streamline the authentication process using Clerk Elements and ensure a better, more consistent experience for the developers who want to build custom UIs on top of Clerk's APIs.