### PR TITLE
Change "width" param to behave as a min-width

### DIFF
--- a/docs/guides/image-optimization/imageurl-image-optimization.mdx
+++ b/docs/guides/image-optimization/imageurl-image-optimization.mdx
@@ -11,8 +11,8 @@ When displaying your users' profile images, you should use query parameters to s
 
 Some types in Clerk's JavaScript SDK, such as [`User`](/docs/references/javascript/user/user), [`PublicUserData`](/docs/references/javascript/types/public-user-data#properties), and [`Organization`](/docs/references/javascript/organization/organization#properties), have an `imageUrl`. The URL returned from this property can be scaled down with the following image optimization options:
 
-- `"width"`: Sets the max width of the image in pixels.
-- `"height"`: Sets the max height of the image in pixels.
+- `"width"`: Sets the minimum width of the image in pixels.
+- `"height"`: Sets the minimum height of the image in pixels.
 - `"fit"`: Describes how the image should fit its container. It can take the following values:
     - `"scale-down"`: The image will scale down to fit the sizes specified in `"width"` and `"height"` if it's bigger, but will not scale up if it's smaller.
     - `"crop"`: The image will scale down and be cropped to fit within the area specified in `"width"` and `"height"`.


### PR DESCRIPTION
### What's changing?

We are updating the `width` param to return an image larger than the requested width

### What's the current behavior?

Currently, the img.clerk.com is returning the exact width requested. We're updating that API to return a few specific widths, rather than infinitely customizable widths

### Why not respect the api as-written?

The current docs claim that `width` is a maximum width. We don't believe that to be a very useful API. Developers generally care about getting the smallest possible image that will look good at a specific width, not the largest possible (but still a bit blurry) image that will be under a specific size.

### What impact will this change have?

This won't impact any users of clerk's SDK. Users who are consuming the API directly and have an image width defined will sometimes receive larger-than-requested images, but layout will not break. Usage sampling of our API has revealed only these two categories of users thus far.

### Timing considerations

This docs update will be deployed simultaneously with the API change.