### PR TITLE
Fix highlighted code in React Quickstart

### DIFF
--- a/docs/quickstarts/react.mdx
+++ b/docs/quickstarts/react.mdx
@@ -161,7 +161,7 @@ You can control which content signed in and signed out users can see with Clerk'
 - [`<UserButton />`](/docs/components/user/user-button): A prebuilt component that comes styled out of the box to show the avatar from the account the user is signed in with.
 - [`<SignInButton />`](/docs/components/unstyled/sign-in-button): An unstyled component that links to the sign-in page or displays the sign-in modal.
 
-```tsx filename="src/App.tsx" {1, 7-12}
+```tsx filename="src/App.tsx" {1, 6-11}
 import { SignedIn, SignedOut, SignInButton, UserButton } from "@clerk/clerk-react";
 
 export default function App() {


### PR DESCRIPTION
<!--- Add the "deploy-preview" label and add your page previews here -->

> [!IMPORTANT]
> 🔎 Previews:
>
> -

<!--- Describe your changes in detail. Why does this change need to happen? Include any links to Slack discussions, Linear comments, etc. -->
### Explanation:

The "[Create a header with Clerk components](https://clerk.com/docs/quickstarts/react#create-a-header-with-clerk-components)" section of the React Quickstart docs contains a snippet where certain lines are highlighted to indicate a change. The current highlighted lines are from `7-12`, which does not accurately represent the change in the code.

![Screenshot 2024-06-22 at 12 59 22 PM](https://github.com/clerk/clerk-docs/assets/13049130/6d118725-5b1b-4f4e-b8a3-2bae549e6f9e)


<!--- How does this PR solve the problem? -->
### This PR:

- Updates it to highlight the correct lines, changing the range to 6-11
- Ensures that the highlighted section are the added components
