### PR TITLE
Offer alternative to the deprecated verifySessions method

### DIFF
--- a/docs/references/backend/sessions/verify-session.mdx
+++ b/docs/references/backend/sessions/verify-session.mdx
@@ -4,7 +4,7 @@ description: Use Clerk's Backend SDK to to verify whether a session with a given
 ---
 
 <Callout type="danger">
-  This method is now deprecated.
+  This method is now deprecated. Refer to the [Manual JWT Verification](/docs/references/backend/sessions/manual-jwt-verification) guide for the recommended way to verify sessions/tokens.
 </Callout>
 
 # `verifySession()` (deprecated)

--- a/docs/references/backend/sessions/verify-session.mdx
+++ b/docs/references/backend/sessions/verify-session.mdx
@@ -4,7 +4,7 @@ description: Use Clerk's Backend SDK to to verify whether a session with a given
 ---
 
 <Callout type="danger">
-  This method is now deprecated. Refer to the [Manual JWT Verification](/docs/references/backend/sessions/manual-jwt-verification) guide for the recommended way to verify sessions/tokens.
+  This method is now deprecated. Refer to the [Manual JWT Verification](/docs/backend-requests/handling/manual-jwt) guide for the recommended way to verify sessions/tokens.
 </Callout>
 
 # `verifySession()` (deprecated)


### PR DESCRIPTION
<!--- Add the "deploy-preview" label and add your page previews here -->

> [!IMPORTANT]
> 🔎 Previews:
>
> - https://clerk.com/docs/pr/1188/references/backend/sessions/verify-session#verify-session-deprecated

<!--- Describe your changes in detail. Why does this change need to happen? Include any links to Slack discussions, Linear comments, etc. -->
### Explanation:
[User feedback ticket ](https://linear.app/clerk/issue/DOCS-8818/%F0%9F%98%A2-feedback-for-referencesbackendsessionsverify-session) reads:
> what is it depreciated in favor of?

<!--- How does this PR solve the problem? -->
### This PR:

- adds an alternative to the deprecated method in the callout of the doc
