### PR TITLE
Update expo signInAttempt missing variable

### DIFF
--- a/docs/quickstarts/expo.mdx
+++ b/docs/quickstarts/expo.mdx
@@ -144,7 +144,7 @@ The following example demonstrates an Expo layout that defines a custom token ca
 ```tsx {{ filename: "app/_layout.tsx" }}
 import * as SecureStore from 'expo-secure-store';
 import { ClerkProvider, ClerkLoaded } from "@clerk/clerk-expo"
-import { Slot } from "expo-navigation" 
+import { Slot } from "expo-navigation"
 
 const tokenCache = {
   async getToken(key: string) {
@@ -271,7 +271,7 @@ import { useSignUp } from "@clerk/clerk-expo";
 
 export default function SignUpScreen() {
   const { isLoaded, signUp, setActive } = useSignUp();
-  
+
   const [emailAddress, setEmailAddress] = React.useState("");
   const [password, setPassword] = React.useState("");
   const [pendingVerification, setPendingVerification] = React.useState(false);
@@ -291,9 +291,9 @@ export default function SignUpScreen() {
       await signUp.prepareEmailAddressVerification({ strategy: "email_code" });
 
       setPendingVerification(true);
-    } catch (err: any) {  
-      // See https://clerk.com/docs/custom-flows/error-handling 
-      // for more info on error handling      
+    } catch (err: any) {
+      // See https://clerk.com/docs/custom-flows/error-handling
+      // for more info on error handling
       console.error(JSON.stringify(err, null, 2));
     }
   };
@@ -311,11 +311,11 @@ export default function SignUpScreen() {
       if (completeSignUp.status === 'complete') {
         await setActive({ session: completeSignUp.createdSessionId });
         router.replace('/');
-      } else {        
+      } else {
         console.error(JSON.stringify(completeSignUp, null, 2));
       }
     } catch (err: any) {
-      // See https://clerk.com/docs/custom-flows/error-handling 
+      // See https://clerk.com/docs/custom-flows/error-handling
       // for more info on error handling
       console.error(JSON.stringify(err, null, 2));
     }
@@ -324,7 +324,7 @@ export default function SignUpScreen() {
   return (
     <View>
       {!pendingVerification && (
-        <>          
+        <>
           <TextInput
             autoCapitalize="none"
             value={emailAddress}
@@ -377,7 +377,7 @@ export default function Page() {
     }
 
     try {
-      const completeSignIn = await signIn.create({
+      const signInAttempt = await signIn.create({
         identifier: emailAddress,
         password,
       });
@@ -386,7 +386,7 @@ export default function Page() {
         await setActive({ session: signInAttempt.createdSessionId });
         router.replace('/');
       } else {
-        // See https://clerk.com/docs/custom-flows/error-handling 
+        // See https://clerk.com/docs/custom-flows/error-handling
         // for more info on error handling
         console.error(JSON.stringify(signInAttempt, null, 2));
       }


### PR DESCRIPTION
<!--- Add the "deploy-preview" label and add your page previews here -->

> [!IMPORTANT]
> 🔎 Previews:
>
> -

<!--- Describe your changes in detail. Why does this change need to happen? Include any links to Slack discussions, Linear comments, etc. -->
### Explanation:

The Sign In flow (for Expo) documentation uses an undeclared variable to check Sign In status. 

<!--- How does this PR solve the problem? -->
### This PR:

- replaces `completeSignIn` with `signInAttempt` in the `Sign-in page` section - [section link](https://clerk.com/docs/quickstarts/expo#sign-in-page)
