### PR TITLE
Add pricing info on satellite domains page

### DIFF
--- a/docs/advanced-usage/satellite-domains.mdx
+++ b/docs/advanced-usage/satellite-domains.mdx
@@ -18,7 +18,7 @@ To access authentication state from a satellite domain, users will be transparen
 ## How to add satellite domains
 
 > [!WARNING]
-> This feature is not available for free plans. See the [pricing](https://clerk.com/pricing) page for more information.
+> This feature is not available in production for free plans, though you can try it out free in development to see if it works for you. See the [pricing](https://clerk.com/pricing) page for more information.
 
 <Steps>
 

--- a/docs/advanced-usage/satellite-domains.mdx
+++ b/docs/advanced-usage/satellite-domains.mdx
@@ -17,6 +17,9 @@ To access authentication state from a satellite domain, users will be transparen
 
 ## How to add satellite domains
 
+> [!WARNING]
+> This feature is not available for free plans. See the [pricing](https://clerk.com/pricing) page for more information.
+
 <Steps>
 
 ### Create your application and install Clerk


### PR DESCRIPTION
<!--- Add the "deploy-preview" label and add your page previews here -->

> [!IMPORTANT]
> 🔎 Previews:
>
> -

<!--- Describe your changes in detail. Why does this change need to happen? Include any links to Slack discussions, Linear comments, etc. -->
### Explanation:
[User feedback ticket](https://linear.app/clerk/issue/DOCS-8822/add-pricing-info-on-satellite-domains-page) reads:
> Include the plan name needed to use this feature as this cannot be achieved on free tier, and i don't think its possible to make it work on multiple domains unless paying for enterprise.

<!--- How does this PR solve the problem? -->
### This PR:

- Adds a WARNING callout about pricing
