### PR TITLE
add reference to errors doc in the custom flow error handling guide

### DIFF
--- a/docs/custom-flows/error-handling.mdx
+++ b/docs/custom-flows/error-handling.mdx
@@ -7,6 +7,11 @@ description: Provide your users with useful information about the errors being r
 
 Clerk-related errors are returned as an array of [`ClerkAPIError`](/docs/references/javascript/types/clerk-api-error) objects. These errors contain a `code`, `message`, `longMessage` and `meta` property. These properties can be used to provide your users with useful information about the errors being returned from sign-up and sign-in requests.
 
+This guide demonstrates how to handle Clerk-related errors when building custom flows.
+
+> [!TIP]
+> To see a list of all possible errors, refer to the [Errors](/docs/errors/overview) documentation.
+
 ## Example
 
 The following example uses the [email & password sign-in custom flow](/docs/custom-flows/email-password) to demonstrate how to handle errors returned during the sign-in process.

--- a/docs/manifest.json
+++ b/docs/manifest.json
@@ -977,7 +977,7 @@
               ]
             },
             {
-              "title": "Error Handling",
+              "title": "Errors",
               "collapse": true,
               "icon": "block",
               "items": [
@@ -1721,7 +1721,7 @@
                   {
                     "title": "Read session and user data",
                     "href": "/docs/references/expo/expo-read-session-user-data"
-                  }                  
+                  }
                 ]
               ]
             },


### PR DESCRIPTION
<!--- Add the "deploy-preview" label and add your page previews here -->

> [!IMPORTANT]
> 🔎 Previews:
>
> -

<!--- Describe your changes in detail. Why does this change need to happen? Include any links to Slack discussions, Linear comments, etc. -->
### Explanation:
[User feedback ticket](https://linear.app/clerk/issue/DOCS-8832/%F0%9F%A4%A9-feedback-for-custom-flowserror-handling) reads:
> This page is helpful, but I would like to see a full list of http errors similar to the JSON seen in the User Locked example.
> If this already exists, I can't find it.  It would be good to have a link to the correct page.

<!--- How does this PR solve the problem? -->
### This PR:

- Adds a callout that references our Clerk-related errors docs, in the custom flow error handling doc.