### PR TITLE
Fix working examples for custom User Profile pages

### DIFF
--- a/docs/components/customization/user-profile.mdx
+++ b/docs/components/customization/user-profile.mdx
@@ -34,216 +34,16 @@ To add a custom page to the `<UserProfile />` component, use the `<UserButton.Us
 | --- | --- | --- |
 | `label` | `string` | The name that will be displayed in the navigation sidebar for the custom page. |
 | `labelIcon` | `React.ReactElement` | An icon displayed next to the label in the navigation sidebar. |
-| `url` | `string` | The path segment that will be used to navigate to the custom page. (e.g. if the `<UserProfile />` component is rendered at `/user`, then the custom page will be accessed at `/user/{url}` when using path routing) |
+| `url` | `string` | The path segment that will be used to navigate to the custom page. For example, if the `<UserProfile />` component is rendered at `/user`, then the custom page will be accessed at `/user/{url}` when using [path routing](/docs/guides/routing). |
 | `children` | `React.ReactElement` | The components to be rendered as content inside the custom page. |
 
 ### Example
 
 The following example demonstrates two ways that you can render content in the `<UserButton.UserProfilePage />` or `<UserProfile.Page />` component: as a component or as a direct child.
 
-<CodeBlockTabs type="usage" options={["<UserButton />", "Dedicated page"]}>
-  ```tsx filename="/app/components/Header.tsx"
-  "use client";
-
-  import { UserButton } from "@clerk/nextjs";
-
-  const DotIcon = () => {
-    return (
-      <svg
-        xmlns="http://www.w3.org/2000/svg"
-        viewBox="0 0 512 512"
-        fill="currentColor"
-      >
-        <path d="M256 512A256 256 0 1 0 256 0a256 256 0 1 0 0 512z" />
-      </svg>
-    )
-  }
-
-  const CustomPage = () => {
-    return (
-      <div>
-        <h1>Custom Profile Page</h1>
-        <p>This is the custom profile page</p>
-      </div>
-    );
-  };
-
-  const Header = () => (
-    <header>
-      <UserButton afterSignOutUrl='/'>
-        {/* You can pass the content as a component */}
-        <UserButton.UserProfilePage
-          label="Custom Page"
-          url="custom"
-          labelIcon={<DotIcon />}
-        >
-          <CustomPage />
-        </UserButton.UserProfilePage>
-
-        {/* You can also pass the content as direct children */}
-        <UserButton.UserProfilePage
-          label="Terms"
-          labelIcon={<DotIcon />}
-          url="terms"
-        >
-          <div>
-            <h1>Custom Terms Page</h1>
-            <p>This is the custom terms page</p>
-          </div>
-        </UserButton.UserProfilePage>
-      </UserButton>
-    </header>
-  );
-
-  export default Header;
-  ```
-
-  ```tsx filename="/app/user-profile/[[...user-profile]]/page.tsx"
-  "use client";
-
-  import { UserProfile } from '@clerk/nextjs';
-
-  const DotIcon = () => {
-    return (
-      <svg
-        xmlns="http://www.w3.org/2000/svg"
-        viewBox="0 0 512 512"
-        fill="currentColor"
-      >
-        <path d="M256 512A256 256 0 1 0 256 0a256 256 0 1 0 0 512z" />
-      </svg>
-    )
-  }
-
-  const CustomPage = () => {
-    return (
-      <div>
-        <h1>Custom Profile Page</h1>
-        <p>This is the custom profile page</p>
-      </div>
-    );
-  };
-
-  const UserProfilePage = () => (
-    <UserProfile path="/user-profile" routing="path">
-      {/* You can pass the content as a component */}
-      <UserProfile.Page
-        label="Custom Page"
-        labelIcon={<DotIcon />}
-        url="custom-page"
-      >
-        <CustomPage />
-      </UserProfile.Page>
-
-      {/* You can also pass the content as direct children */}
-      <UserProfile.Page
-        label="Terms"
-        labelIcon={<DotIcon />}
-        url="terms"
-      >
-        <div>
-          <h1>Custom Terms Page</h1>
-          <p>This is the custom terms page</p>
-        </div>
-      </UserProfile.Page>
-    </UserProfile>
-  );
-
-  export default UserProfilePage;
-  ```
-</CodeBlockTabs>
-
-## Add a custom link to <code>\<UserProfile&nbsp;/></code>
-
-You can add external links to the `<UserProfile />` navigation sidebar using the `<UserButton.UserProfileLink />` component or the `<UserProfile.Link />` component, depending on your use case.
-
-### Props
-
-`<UserButton.UserProfileLink />` and `<UserProfile.Link />` accept the following props, all of which are *required*:
-
-| Name | Type | Description |
-| --- | --- | --- |
-| `label` | `string` | The name that will be displayed in the navigation sidebar for the link.  |
-| `labelIcon` | `React.ReactElement` | An icon displayed next to the label in the navigation sidebar. |
-| `url` | `string` | The absolute or relative url to navigate to |
-
-### Example
-
-The following example adds a link to the homepage in the navigation sidebar of the `<UserProfile />` component.
-
-<CodeBlockTabs type="usage" options={["<UserButton />", "Dedicated page"]}>
-  ```tsx filename="/app/components/Header.tsx"
-  "use client";
-
-  import { UserButton } from "@clerk/nextjs";
-
-  const DotIcon = () => {
-    return (
-      <svg
-        xmlns="http://www.w3.org/2000/svg"
-        viewBox="0 0 512 512"
-        fill="currentColor"
-      >
-        <path d="M256 512A256 256 0 1 0 256 0a256 256 0 1 0 0 512z" />
-      </svg>
-    )
-  }
-
-  const Header = () => (
-    <header>
-      <UserButton afterSignOutUrl='/'>
-        <UserButton.UserProfileLink
-          label="Homepage"
-          url="/"
-          labelIcon={<DotIcon />}
-        />
-      </UserButton>
-    </header>
-  );
-
-  export default Header;
-  ```
-
-  ```tsx filename="/app/user-profile/[[...user-profile]]/page.tsx"
-  "use client";
-
-  import { UserProfile } from "@clerk/nextjs";
-
-  const DotIcon = () => {
-    return (
-      <svg
-        xmlns="http://www.w3.org/2000/svg"
-        viewBox="0 0 512 512"
-        fill="currentColor"
-      >
-        <path d="M256 512A256 256 0 1 0 256 0a256 256 0 1 0 0 512z" />
-      </svg>
-    )
-  }
-
-  const UserProfilePage = () => (
-    <UserProfile path="/user-profile" routing="path">
-      <UserProfile.Link
-        label="Homepage"
-        labelIcon={<DotIcon />}
-        url="/"
-      />
-    </UserProfile>
-  );
-
-  export default UserProfilePage;
-  ```
-</CodeBlockTabs>
-
-## Reorder default routes
-
-If you want to reorder the default routes, `Account` and `Security`, set the `label` prop to `'account'` or `'security'`. This will target the existing default page and allow you to rearrange it.
-
-Note that when reordering default routes, the first item in the navigation sidebar cannot be a `<UserButton.UserProfileLink />` or `<UserProfile.Link />` component.
-
-<Tabs type="usage" items={["<UserButton />", "Dedicated Page"]}>
+<Tabs items={["<UserButton />", "Dedicated page"]}>
   <Tab>
-    ```tsx filename="/app/components/Header.tsx"
+    ```tsx filename="/app/page.tsx"
     "use client";
 
     import { UserButton } from "@clerk/nextjs";
@@ -269,28 +69,236 @@ Note that when reordering default routes, the first item in the navigation sideb
       );
     };
 
-    const Header = () => (
-      <header>
-        <UserButton afterSignOutUrl='/'>
-          <UserButton.UserProfilePage
-            label="Custom Page"
-            url="custom"
-            labelIcon={<DotIcon />}
-          >
-            <CustomPage />
-          </UserButton.UserProfilePage>
-          <UserButton.UserProfileLink
-            label="Homepage"
-            url="/"
-            labelIcon={<DotIcon />}
-          />
-          <UserButton.UserProfilePage label="account" />
-          <UserButton.UserProfilePage label="security" />
-        </UserButton>
-      </header>
+    export default function Home() {
+      return (
+        <header>
+          <UserButton afterSignOutUrl='/'>
+            {/* You can pass the content as a component */}
+            <UserButton.UserProfilePage
+              label="Custom Page"
+              url="custom"
+              labelIcon={<DotIcon />}
+            >
+              <CustomPage />
+            </UserButton.UserProfilePage>
+
+            {/* You can also pass the content as direct children */}
+            <UserButton.UserProfilePage
+              label="Terms"
+              labelIcon={<DotIcon />}
+              url="terms"
+            >
+              <div>
+                <h1>Custom Terms Page</h1>
+                <p>This is the custom terms page</p>
+              </div>
+            </UserButton.UserProfilePage>
+          </UserButton>
+        </header>
+      );
+    }
+    ```
+  </Tab>
+
+  <Tab>
+    ```tsx filename="/app/user-profile/[[...user-profile]]/page.tsx"
+    "use client";
+
+    import { UserProfile } from '@clerk/nextjs';
+
+    const DotIcon = () => {
+      return (
+        <svg
+          xmlns="http://www.w3.org/2000/svg"
+          viewBox="0 0 512 512"
+          fill="currentColor"
+        >
+          <path d="M256 512A256 256 0 1 0 256 0a256 256 0 1 0 0 512z" />
+        </svg>
+      )
+    }
+
+    const CustomPage = () => {
+      return (
+        <div>
+          <h1>Custom Profile Page</h1>
+          <p>This is the custom profile page</p>
+        </div>
+      );
+    };
+
+    const UserProfilePage = () => (
+      <UserProfile path="/user-profile" routing="path">
+        {/* You can pass the content as a component */}
+        <UserProfile.Page
+          label="Custom Page"
+          labelIcon={<DotIcon />}
+          url="custom-page"
+        >
+          <CustomPage />
+        </UserProfile.Page>
+
+        {/* You can also pass the content as direct children */}
+        <UserProfile.Page
+          label="Terms"
+          labelIcon={<DotIcon />}
+          url="terms"
+        >
+          <div>
+            <h1>Custom Terms Page</h1>
+            <p>This is the custom terms page</p>
+          </div>
+        </UserProfile.Page>
+      </UserProfile>
     );
 
-    export default Header;
+    export default UserProfilePage;
+    ```
+  </Tab>
+</Tabs>
+
+## Add a custom link to <code>\<UserProfile&nbsp;/></code>
+
+You can add external links to the `<UserProfile />` navigation sidebar using the `<UserButton.UserProfileLink />` component or the `<UserProfile.Link />` component, depending on your use case.
+
+### Props
+
+`<UserButton.UserProfileLink />` and `<UserProfile.Link />` accept the following props, all of which are *required*:
+
+| Name | Type | Description |
+| --- | --- | --- |
+| `label` | `string` | The name that will be displayed in the navigation sidebar for the link.  |
+| `labelIcon` | `React.ReactElement` | An icon displayed next to the label in the navigation sidebar. |
+| `url` | `string` | The absolute or relative url to navigate to |
+
+### Example
+
+The following example adds a link to the homepage in the navigation sidebar of the `<UserProfile />` component.
+
+<Tabs items={["<UserButton />", "Dedicated page"]}>
+  <Tab>
+    ```tsx filename="/app/page.tsx"
+    "use client";
+
+    import { UserButton } from "@clerk/nextjs";
+
+    const DotIcon = () => {
+      return (
+        <svg
+          xmlns="http://www.w3.org/2000/svg"
+          viewBox="0 0 512 512"
+          fill="currentColor"
+        >
+          <path d="M256 512A256 256 0 1 0 256 0a256 256 0 1 0 0 512z" />
+        </svg>
+      )
+    }
+
+    export default function Home() {
+      return (
+        <header>
+          <UserButton afterSignOutUrl='/'>
+            <UserButton.UserProfileLink
+              label="Homepage"
+              url="/"
+              labelIcon={<DotIcon />}
+            />
+          </UserButton>
+        </header>
+      );
+    }
+    ```
+  </Tab>
+
+  <Tab>
+    ```tsx filename="/app/user-profile/[[...user-profile]]/page.tsx"
+    "use client";
+
+    import { UserProfile } from "@clerk/nextjs";
+
+    const DotIcon = () => {
+      return (
+        <svg
+          xmlns="http://www.w3.org/2000/svg"
+          viewBox="0 0 512 512"
+          fill="currentColor"
+        >
+          <path d="M256 512A256 256 0 1 0 256 0a256 256 0 1 0 0 512z" />
+        </svg>
+      )
+    }
+
+    const UserProfilePage = () => (
+      <UserProfile path="/user-profile" routing="path">
+        <UserProfile.Link
+          label="Homepage"
+          labelIcon={<DotIcon />}
+          url="/"
+        />
+      </UserProfile>
+    );
+
+    export default UserProfilePage;
+    ```
+  </Tab>
+</Tabs>
+
+## Reorder default routes
+
+If you want to reorder the default routes, `Account` and `Security`, set the `label` prop to `'account'` or `'security'`. This will target the existing default page and allow you to rearrange it.
+
+Note that when reordering default routes, the first item in the navigation sidebar cannot be a `<UserButton.UserProfileLink />` or `<UserProfile.Link />` component.
+
+<Tabs items={["<UserButton />", "Dedicated page"]}>
+  <Tab>
+    ```tsx filename="/app/page.tsx"
+    "use client";
+
+    import { UserButton } from "@clerk/nextjs";
+
+    const DotIcon = () => {
+      return (
+        <svg
+          xmlns="http://www.w3.org/2000/svg"
+          viewBox="0 0 512 512"
+          fill="currentColor"
+        >
+          <path d="M256 512A256 256 0 1 0 256 0a256 256 0 1 0 0 512z" />
+        </svg>
+      )
+    }
+
+    const CustomPage = () => {
+      return (
+        <div>
+          <h1>Custom Profile Page</h1>
+          <p>This is the custom profile page</p>
+        </div>
+      );
+    };
+
+    export default function Home() {
+      return (
+        <header>
+          <UserButton afterSignOutUrl='/'>
+            <UserButton.UserProfilePage
+              label="Custom Page"
+              url="custom"
+              labelIcon={<DotIcon />}
+            >
+              <CustomPage />
+            </UserButton.UserProfilePage>
+            <UserButton.UserProfileLink
+              label="Homepage"
+              url="/"
+              labelIcon={<DotIcon />}
+            />
+            <UserButton.UserProfilePage label="account" />
+            <UserButton.UserProfilePage label="security" />
+          </UserButton>
+        </header>
+      );
+    }
     ```
   </Tab>
 

--- a/docs/components/protect.mdx
+++ b/docs/components/protect.mdx
@@ -7,19 +7,31 @@ description: The Protect component is used for authorization. It only renders it
 
 The `<Protect>` component is used for authorization. It only renders its children when the current user has the specified [permission or role](/docs/organizations/roles-permissions) in the organization.
 
+## Properties
+
+| Name | Type | Description |
+| --- | --- | --- |
+| `condition?` | `has => boolean` | Optional conditional logic that renders the children if it returns `true`. |
+| `fallback?` | `JSX` | An optional snippet of JSX to show when a user doesn't have the `role` or `permission` to access the protected content. |
+| `permission?` | `string` | Optional string corresponding to a Role's Permission in the format `org:<resource>:<action>` |
+| `role?` | `string` | Optional string corresponding to an Organization's Role in the format `org:<role>` |
+
+> [!WARNING]
+> `<Protect>` can only accept `permission` *or* `role`, not both. The recommended approach is to use `permission`.
+
 ## Usage
 
 To limit who is able to see the content that `<Protect>` renders, you can pass either the `permission` or `role` prop. The recommended approach is to use `permission` because this lets you modify roles without breaking your application. Permissions can be assigned to different roles with ease.
 
 If you do not pass either prop, `<Protect>` behaves the same as [`<SignedIn>`](/docs/components/control/signed-in) and will render its children if the user is signed in, regardless of their role or its permissions.
 
-For more complex authorization logic, pass conditional logic to the `condition` prop.
+For more complex authorization logic, [pass conditional logic to the `condition` prop](#render-content-conditionally).
 
 ### Render content by permissions
 
 The children of the following component will only be visible to users with roles that have the `org:invoices:create` permission.
 
-<Tabs type="framework" items={["Next.js", "React"]}>
+<Tabs items={["Next.js", "React"]}>
   <Tab>
       ```jsx
       import { Protect } from "@clerk/nextjs";
@@ -59,7 +71,7 @@ The children of the following component will only be visible to users with roles
 
 While authorization by `permission` is recommended, for convenience, `<Protect>` allows a `role` prop to be passed. The children of the following component will only be visible to users with the `org:billing` role.
 
-<Tabs type="framework" items={["Next.js", "React"]}>
+<Tabs items={["Next.js", "React"]}>
   <Tab>
     ```jsx
     import { Protect } from "@clerk/nextjs";
@@ -95,15 +107,26 @@ While authorization by `permission` is recommended, for convenience, `<Protect>`
   </Tab>
 </Tabs>
 
-## Properties
+### Render content conditionally
 
-| Name | Type | Description |
-| --- | --- | --- |
-| `condition?` | `has => boolean` | Optional conditional logic that renders the children if it returns `true`. |
-| `fallback?` | `JSX` | An optional snippet of JSX to show when a user doesn't have the `role` or `permission` to access the protected content. |
-| `permission?` | `string` | Optional string corresponding to a Role's Permission in the format `org:<resource>:<action>` |
-| `role?` | `string` | Optional string corresponding to an Organization's Role in the format `org:<role>` |
+The following example uses `<Protect>`'s `condition` prop to conditionally render its children if the user has the correct role.
 
-<Callout type="warning">
-  `<Protect>` can only accept `permission` *or* `role`, not both. The recommended approach is to use `permission`.
-</Callout>
+<Tabs items={["Next.js"]}>
+  <Tab>
+  ```tsx {{ filename: '/app/dashboard/settings/layout.tsx' }}
+    import type { PropsWithChildren } from "react";
+    import { Protect } from "@clerk/nextjs";
+
+    export default function SettingsLayout(props: PropsWithChildren){
+      return (
+        <Protect
+          condition={has => has({role: "org:admin"}) || has({role: "org:billing_manager"})}
+          fallback={<p>Only an Admin or Billing Manager can access this content.</p>}
+        >
+          {props.children}
+        </Protect>
+      )
+    }
+  ```
+  </Tab>
+</Tabs>


### PR DESCRIPTION
<!--- Add the "deploy-preview" label and add your page previews here -->

> [!IMPORTANT]
> 🔎 Previews:
>
> -

<!--- Describe your changes in detail. Why does this change need to happen? Include any links to Slack discussions, Linear comments, etc. -->
### Explanation:
[User feedback ticket](https://linear.app/clerk/issue/DOCS-8649/deal-with-it-alexis) reads:
> why are you talking about <Header /> with no context as to what that is or why we are putting this into a generic header component. None of these examples work also, you can paste them into a standard Profile or UserProfile and they actually dont do anything

<!--- How does this PR solve the problem? -->
### This PR:

- Fixed the working examples
