### PR TITLE
remove manual authentication section in docs/references/nodejs/overvi…

### DIFF
--- a/docs/references/nodejs/overview.mdx
+++ b/docs/references/nodejs/overview.mdx
@@ -62,46 +62,6 @@ Our middleware will look for a query string parameter named `_clerk_session_id`.
 
 The Clerk Node SDK offers two [middlewares](/docs/backend-requests/handling/nodejs) to authenticate your backend endpoints.
 
-## Manual authentication
-
-### Authenticate a particular session
-
-```js
-import { clerkClient } from '@clerk/clerk-sdk-node';
-import Cookies from 'cookies';
-
-// Retrieve the particular session ID from a
-// query string parameter
-const sessionId = req.query._clerk_session_id;
-
-// Note: Clerk stores the clientToken in a cookie
-// named "__session" for Firebase compatibility
-const cookies = new Cookies(req, res);
-const clientToken = cookies.get('__session');
-
-const session = await clerkClient.sessions.verifySession(sessionId, clientToken);
-```
-
-### Authenticate the last active session
-
-Using the last active session is appropriate when determining the user after a navigation.
-
-```js
-import { clerkClient } from '@clerk/clerk-sdk-node';
-import Cookies from 'cookies';
-
-// Note: Clerk stores the clientToken in a cookie
-// named "__session" for Firebase compatibility
-const cookies = new Cookies(req, res);
-const clientToken = cookies.get('__session');
-
-const client = await clerkClient.clients.verifyClient(clientToken);
-const sessionId = client.lastActiveSessionId;
-
-const session = await clerkClient.sessions.verifySession(sessionId, clientToken);
-```
-
-
 ## Error handling
 
 Node SDK functions throw errors (`ClerkAPIResponseError`) when something goes wrong. You'll need to catch them in a `try/catch` block and handle them gracefully. For example:


### PR DESCRIPTION
…ew.mdx

<!--- Add the "deploy-preview" label and add your page previews here -->

> [!IMPORTANT]
> 🔎 Previews:
>
> -

<!--- Describe your changes in detail. Why does this change need to happen? Include any links to Slack discussions, Linear comments, etc. -->
### Explanation:
The documentation was using the deprecated `verifySession` method for Manual Authentication. The documentation has a dedicated [Manual JWT verification](https://clerk.com/docs/backend-requests/handling/manual-jwt) guide. So removed the Entire `Manual Authentication` section.
As discussed [here](https://github.com/clerk/clerk-docs/pull/1186#issuecomment-2187006852).


<!--- How does this PR solve the problem? -->
### This PR:

- Removed `Manual Authentication` section which contains "Authenticate a particular session" sub-section and "Authenticate the last active session" sub-section.