### PR TITLE
Update expo-oauth.mdx

### DIFF
--- a/docs/references/expo/expo-oauth.mdx
+++ b/docs/references/expo/expo-oauth.mdx
@@ -51,7 +51,7 @@ const SignInWithOAuth = () => {
   const onPress = React.useCallback(async () => {
     try {
       const { createdSessionId, signIn, signUp, setActive } =
-        await startOAuthFlow({ redirectUrl: Linking.createUrl("/dashboard", { scheme: "myapp" })});
+        await startOAuthFlow({ redirectUrl: Linking.createURL("/dashboard", { scheme: "myapp" })});
 
       if (createdSessionId) {
         setActive!({ session: createdSessionId });


### PR DESCRIPTION
Linking.createUrl should be createURL

<!--- Add the "deploy-preview" label and add your page previews here -->

> [!IMPORTANT]
> 🔎 Previews:

https://clerk.com/docs/references/expo/expo-oauth#create-an-o-auth-component
>
> -

<!--- Describe your changes in detail. Why does this change need to happen? Include any links to Slack discussions, Linear comments, etc. -->
### Explanation:

Linking does not have any createUrl method on it it should be createURL.
  
   
     await startOAuthFlow({ redirectUrl: Linking.createURL("/dashboard", { scheme: "myapp" })}); 

<!--- How does this PR solve the problem? -->
### This PR:
Now Linking should have correct method on it  :}
-
