### PR TITLE
Change non-existent Linking method method to correct one

### DIFF
--- a/docs/references/expo/expo-oauth.mdx
+++ b/docs/references/expo/expo-oauth.mdx
@@ -51,7 +51,7 @@ const SignInWithOAuth = () => {
   const onPress = React.useCallback(async () => {
     try {
       const { createdSessionId, signIn, signUp, setActive } =
-        await startOAuthFlow({ redirectUrl: Linking.createUrl("/dashboard", { scheme: "myapp" })});
+        await startOAuthFlow({ redirectUrl: Linking.createURL("/dashboard", { scheme: "myapp" })});
 
       if (createdSessionId) {
         setActive!({ session: createdSessionId });


### PR DESCRIPTION
change createUrl to createURL

https://docs.expo.dev/versions/latest/sdk/linking/#linkingcreateurlpath-namedparameters

<!--- Add the "deploy-preview" label and add your page previews here -->

> [!IMPORTANT]
> 🔎 Previews:
>
> -

<!--- Describe your changes in detail. Why does this change need to happen? Include any links to Slack discussions, Linear comments, etc. -->
### Explanation:
Docs content a wrong method call to Linking

<!--- How does this PR solve the problem? -->
### This PR:
This PR corrects it as per expo-linking docs

-
