### PR TITLE
Replace dotenv with @next/env in neon guide

### DIFF
--- a/docs/integrations/databases/neon.mdx
+++ b/docs/integrations/databases/neon.mdx
@@ -37,7 +37,7 @@ This tutorial demonstrates how to integrate Neon Postgres with Clerk in a Next.j
 1. Navigate to the project directory and install the required dependencies:
     ```sh {{ filename: 'terminal' }}
     cd clerk-neon-example
-    npm install @neondatabase/serverless dotenv
+    npm install @neondatabase/serverless
     npm install drizzle-orm --legacy-peer-deps
     npm install -D drizzle-kit
     ```
@@ -101,10 +101,12 @@ export const UserMessages = pgTable("user_messages", {
 ```
 
 ```typescript {{ filename: 'app/db/index.ts' }}
-import "dotenv/config";
+import { loadEnvConfig } from "@next/env";
 import { neon } from "@neondatabase/serverless";
 import { drizzle } from "drizzle-orm/neon-http";
 import { UserMessages } from "./schema";
+
+loadEnvConfig(process.cwd());
 
 if (!process.env.DATABASE_URL) {
   throw new Error("DATABASE_URL must be a Neon postgres connection string");
@@ -124,14 +126,18 @@ Use the `drizzle-kit` package to generate and run database migrations.
 1. At the root of your project, create a `drizzle.config.ts` and add the following configuration:
     ```typescript {{ filename: 'drizzle.config.ts' }}
     import { defineConfig } from "drizzle-kit";
-    import * as dotenv from "dotenv";
+    import { loadEnvConfig } from "@next/env";
 
-    dotenv.config({ path: ".env.local" });
+    loadEnvConfig(process.cwd());
+
+    if (!process.env.DATABASE_URL) {
+      throw new Error("DATABASE_URL is not defined");
+    }
 
     export default defineConfig({
       dialect: "postgresql",
       dbCredentials: {
-        url: process.env.DATABASE_URL!,
+        url: process.env.DATABASE_URL,
       },
       schema: "./app/db/schema.ts",
       out: "./migrations",

--- a/docs/integrations/databases/neon.mdx
+++ b/docs/integrations/databases/neon.mdx
@@ -131,7 +131,7 @@ Use the `drizzle-kit` package to generate and run database migrations.
     loadEnvConfig(process.cwd());
 
     if (!process.env.DATABASE_URL) {
-      throw new Error("DATABASE_URL is not defined");
+      throw new Error("DATABASE_URL must be a Neon postgres connection string");
     }
 
     export default defineConfig({


### PR DESCRIPTION
<!--- Add the "deploy-preview" label and add your page previews here -->

> [!IMPORTANT]
> 🔎 Previews:
>
> -

<!--- Describe your changes in detail. Why does this change need to happen? Include any links to Slack discussions, Linear comments, etc. -->
### Explanation

This PR removes the usage of `dotenv` from the neon guide. While a small change, it favors the use of framework-specific utility libraries and reduces unnecessary dependencies, thus simplifying the overall setup.

### Changes Made

- Replaced `dotenv` with [`@next/env`](https://www.npmjs.com/package/@next/env) utility for loading environment variables.
- Added a check for `DATABASE_URL` in `drizzle.config.ts`.

