### PR TITLE
(/guides/add-onboarding-flow) Add code comment that explains user.reload()

### DIFF
--- a/docs/guides/add-onboarding-flow.mdx
+++ b/docs/guides/add-onboarding-flow.mdx
@@ -148,6 +148,9 @@ You can use the user's `publicMetadata` to track the user's onboarding state. To
 - A process in your frontend with logic to collect and submit all the information for onboarding. In this guide, you will create a simple form.
 - A method in your backend to securely update the user's `publicMetadata`
 
+> [!IMPORTANT]
+> After the backend call returns successfully, call `user.reload()` on the frontend to refresh the **signed-in** user's session token. This ensures that all future requests made from the user include the updated `publicMetadata`.
+
 ### Collect user onboarding information
 
 To collect the user's onboarding information, create a form that will be displayed on the `/onboarding` page. This form will collect the user's application name and application type. This is a very loose example — you can use this step to capture information from the user, sync user data to your database, have the user sign up to a course or subscription, or more.
@@ -155,7 +158,7 @@ To collect the user's onboarding information, create a form that will be display
 1. In your `/onboarding` directory, create a `page.tsx` file.
 2. Add the following code to the file.
 
-```tsx
+```tsx {{ mark: [16, 17] }}
 "use client";
 
 import * as React from "react";
@@ -171,7 +174,8 @@ export default function OnboardingComponent() {
   const handleSubmit = async (formData: FormData) => {
     const res = await completeOnboarding(formData);
     if (res?.message) {
-      await user?.reload();
+      // Call reload() to refresh the user's session token 
+      await user?.reload(); 
       router.push("/");
     }
     if (res?.error) {

--- a/docs/guides/add-onboarding-flow.mdx
+++ b/docs/guides/add-onboarding-flow.mdx
@@ -155,7 +155,7 @@ To collect the user's onboarding information, create a form that will be display
 1. In your `/onboarding` directory, create a `page.tsx` file.
 2. Add the following code to the file.
 
-```tsx {{ mark: [16, 17] }}
+```tsx
 "use client";
 
 import * as React from "react";

--- a/docs/guides/add-onboarding-flow.mdx
+++ b/docs/guides/add-onboarding-flow.mdx
@@ -174,7 +174,7 @@ export default function OnboardingComponent() {
   const handleSubmit = async (formData: FormData) => {
     const res = await completeOnboarding(formData);
     if (res?.message) {
-      // Call reload() to refresh the user's session token 
+      // Reload user to get updated User object
       await user?.reload(); 
       router.push("/");
     }

--- a/docs/guides/add-onboarding-flow.mdx
+++ b/docs/guides/add-onboarding-flow.mdx
@@ -171,7 +171,7 @@ export default function OnboardingComponent() {
   const handleSubmit = async (formData: FormData) => {
     const res = await completeOnboarding(formData);
     if (res?.message) {
-      // Reload user to get updated User object
+      // Reloads the user's data from Clerk's API
       await user?.reload(); 
       router.push("/");
     }

--- a/docs/guides/add-onboarding-flow.mdx
+++ b/docs/guides/add-onboarding-flow.mdx
@@ -148,9 +148,6 @@ You can use the user's `publicMetadata` to track the user's onboarding state. To
 - A process in your frontend with logic to collect and submit all the information for onboarding. In this guide, you will create a simple form.
 - A method in your backend to securely update the user's `publicMetadata`
 
-> [!IMPORTANT]
-> After the backend call returns successfully, call `user.reload()` on the frontend to refresh the **signed-in** user's session token. This ensures that all future requests made from the user include the updated `publicMetadata`.
-
 ### Collect user onboarding information
 
 To collect the user's onboarding information, create a form that will be displayed on the `/onboarding` page. This form will collect the user's application name and application type. This is a very loose example — you can use this step to capture information from the user, sync user data to your database, have the user sign up to a course or subscription, or more.


### PR DESCRIPTION
<!--- Add the "deploy-preview" label and add your page previews here -->

> [!IMPORTANT]
> 🔎 Previews:
>
> - add-onboarding-flow.mdx

<!--- Describe your changes in detail. Why does this change need to happen? Include any links to Slack discussions, Linear comments, etc. -->
### Explanation:
It not easy to notice that developers should call `user.reload()` on the frontend after updating the user's `publicMetadata` on the backend when following the guide ***Add custom onboarding to your authentication flow***. Making that call is a necessary part of the logic and has security implication depending on the use-case. 

Discord issue: https://discord.com/channels/856971667393609759/1253768303483162644

<!--- How does this PR solve the problem? -->
### This PR:

- This PR adds a callout to making a `user.reload()` function call. 
- Also calls it out in the provided code-block incase it's not read earlier on the page. 
