### PR TITLE
call clerkClient as a function instead of singleton for @clerk/nextjs

### DIFF
--- a/docs/authentication/social-connections/oauth.mdx
+++ b/docs/authentication/social-connections/oauth.mdx
@@ -78,7 +78,7 @@ export async function GET() {
   // Get the OAuth access token for the user
   const provider = "oauth_notion";
 
-  const clerkResponse = await clerkClient.users.getUserOauthAccessToken(
+  const clerkResponse = await clerkClient().users.getUserOauthAccessToken(
     userId,
     provider
   );

--- a/docs/guides/add-onboarding-flow.mdx
+++ b/docs/guides/add-onboarding-flow.mdx
@@ -221,7 +221,7 @@ export const completeOnboarding = async (formData: FormData) => {
   }
 
   try {
-    const res = await clerkClient.users.updateUser(userId, {
+    const res = await clerkClient().users.updateUser(userId, {
       publicMetadata: {
         onboardingComplete: true,
         applicationName: formData.get("applicationName"),

--- a/docs/guides/basic-rbac.mdx
+++ b/docs/guides/basic-rbac.mdx
@@ -178,7 +178,7 @@ export async function setRole(formData: FormData) {
   }
 
   try {
-    const res = await clerkClient.users.updateUser(
+    const res = await clerkClient().users.updateUser(
       formData.get("id") as string,
       {
         publicMetadata: { role: formData.get("role") },
@@ -240,7 +240,7 @@ export default async function AdminDashboard(params: {
 
   const query = params.searchParams.search;
 
-  const users = query ? (await clerkClient.users.getUserList({ query })).data : [];
+  const users = query ? (await clerkClient().users.getUserList({ query })).data : [];
 
   return (
     <>

--- a/docs/references/backend/organization/update-organization-logo.mdx
+++ b/docs/references/backend/organization/update-organization-logo.mdx
@@ -58,7 +58,7 @@ export async function updateOrgLogo(formData: FormData) {
     uploaderUserId,
   };
 
-  const response = await clerkClient.organizations.updateOrganizationLogo(
+  const response = await clerkClient().organizations.updateOrganizationLogo(
     organizationId,
     params
   );

--- a/docs/references/backend/sessions/authenticate-request.mdx
+++ b/docs/references/backend/sessions/authenticate-request.mdx
@@ -49,7 +49,7 @@ import { clerkClient } from '@clerk/nextjs/server'
 import { NextRequest, NextResponse } from 'next/server'
 
 export async function GET(req: NextRequest) {
-  const { isSignedIn } = await clerkClient.authenticateRequest(req)
+  const { isSignedIn } = await clerkClient().authenticateRequest(req)
 
   if ( !isSignedIn ) {
     return NextResponse.json({ status: 401 })

--- a/docs/references/backend/sessions/get-token.mdx
+++ b/docs/references/backend/sessions/get-token.mdx
@@ -52,7 +52,7 @@ export async function GET() {
 
   const template = 'test';
 
-  const token = await clerkClient.sessions.getToken(sessionId, template)
+  const token = await clerkClient()ß.sessions.getToken(sessionId, template)
 
   console.log(token);
   /*
@@ -78,7 +78,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
 
   const template = 'test';
 
-  const token = await clerkClient.sessions.getToken(sessionId, template);
+  const token = await clerkClient().sessions.getToken(sessionId, template);
 
   console.log(token);
   /*

--- a/docs/references/backend/sessions/get-token.mdx
+++ b/docs/references/backend/sessions/get-token.mdx
@@ -52,7 +52,7 @@ export async function GET() {
 
   const template = 'test';
 
-  const token = await clerkClient()ß.sessions.getToken(sessionId, template)
+  const token = await clerkClient().sessions.getToken(sessionId, template)
 
   console.log(token);
   /*

--- a/docs/references/backend/user/update-user.mdx
+++ b/docs/references/backend/user/update-user.mdx
@@ -109,7 +109,7 @@ _User {
       // The user attributes to update
       const params = { firstName: 'John', lastName: 'Wick' };
 
-      const updatedUser = await clerkClient.users.updateUser(userId, params);
+      const updatedUser = await clerkClient().users.updateUser(userId, params);
 
       return NextResponse.json({ updatedUser });
     }
@@ -131,7 +131,7 @@ _User {
       // The user attributes to update
       const params = { firstName: 'John', lastName: 'Wick' };
 
-      const updatedUser = await clerkClient.users.updateUser(userId, params);
+      const updatedUser = await clerkClient().users.updateUser(userId, params);
 
       return res.status(200).json({ updatedUser });
     }

--- a/docs/references/nextjs/build-clerk-props.mdx
+++ b/docs/references/nextjs/build-clerk-props.mdx
@@ -38,7 +38,7 @@ import { GetServerSideProps } from "next";
 export const getServerSideProps: GetServerSideProps = async (ctx) => {
   const { userId } = getAuth(ctx.req);
 
-  const user = userId ? await clerkClient.users.getUser(userId) : undefined;
+  const user = userId ? await clerkClient().users.getUser(userId) : undefined;
 
   return { props: { ...buildClerkProps(ctx.req, { user }) } };
 };
@@ -55,7 +55,7 @@ import { GetServerSideProps } from "next";
 export const getServerSideProps: GetServerSideProps = async (ctx) => {
   const { userId } = getAuth(ctx.req);
 
-  const user = userId ? await clerkClient.users.getUser(userId) : undefined;
+  const user = userId ? await clerkClient().users.getUser(userId) : undefined;
 
   return { props: { ...buildClerkProps(ctx.req, { user }) } };
 };

--- a/docs/references/nextjs/get-auth.mdx
+++ b/docs/references/nextjs/get-auth.mdx
@@ -105,7 +105,7 @@ export default async function handler(
 ) {
   const { userId } = getAuth(req);
 
-  const user = userId ? await clerkClient.users.getUser(userId) : null;
+  const user = userId ? await clerkClient().users.getUser(userId) : null;
 
   return res.status(200).json({});
 }

--- a/docs/references/nextjs/read-session-data.mdx
+++ b/docs/references/nextjs/read-session-data.mdx
@@ -141,7 +141,7 @@ Under the hood, `currentUser()` uses the [`clerkClient`](/docs/references/backen
         return res.status(401).json({ error: "Unauthorized" });
       }
 
-      const user = await clerkClient.users.getUser(userId);
+      const user = await clerkClient().users.getUser(userId);
 
       // use the user object to decide what data to return
 


### PR DESCRIPTION
<!--- Add the "deploy-preview" label and add your page previews here -->

> [!IMPORTANT]
> 🔎 Previews:
>
> -

<!--- Describe your changes in detail. Why does this change need to happen? Include any links to Slack discussions, Linear comments, etc. -->
### Explanation:
[clerk/javascript#3617](https://github.com/clerk/javascript/pull/3617) introduced a change where `clerkClient` is now called as a function instead of a singleton for the Clerk Next.js SDK

<!--- How does this PR solve the problem? -->
### This PR:

- Updates all instances of `clerkClient` for `@clerk/nextjs` examples
