### PR TITLE
Add SignInTokens API to Backend SDK

### DIFF
--- a/docs/manifest.json
+++ b/docs/manifest.json
@@ -2164,6 +2164,24 @@
                     ]
                   },
                   {
+                    "title": "Sign-in tokens",
+                    "collapse": true,
+                    "items": [
+                      [
+                        {
+                          "title": "`createSignInToken()`",
+                          "wrap": false,
+                          "href": "/docs/references/backend/sign-in-tokens/create-sign-in-token"
+                        },
+                        {
+                          "title": "`revokeSignInToken()`",
+                          "wrap": false,
+                          "href": "/docs/references/backend/sign-in-tokens/revoke-sign-in-token"
+                        }
+                      ]
+                    ]
+                  },
+                  {
                     "title": "Testing Tokens",
                     "collapse": true,
                     "items": [

--- a/docs/references/backend/sign-in-tokens/create-sign-in-token.mdx
+++ b/docs/references/backend/sign-in-tokens/create-sign-in-token.mdx
@@ -1,0 +1,49 @@
+---
+title: createSignInToken()
+description: Use Clerk's Backend SDK to create a new sign-in token for a given user.
+---
+
+# `createSignInToken()`
+
+Creates a new sign-in token and associates it with the given user. By default, sign-in tokens expire in 30 days. You can optionally supply a different duration in seconds using the `expires_in_seconds` property.
+
+```tsx
+function createSignInToken: (params: CreateSignInTokensParams) => Promise<SignInToken>;
+```
+
+## `CreateSignInTokenParams`
+
+| Name | Type | Description |
+| --- | --- | --- |
+| `userId` | `string` | The ID of the user that can use the newly created sign in token |
+| `expiresInSeconds` | `string` | Specifies the life duration of the sign in token in seconds. Defaults to `2592000` (30 days) |
+
+## Example
+
+```tsx
+const userId = 'user_2f9RVdIOe8JzGlfc3HWwXDg1AaX';
+
+const expiresInSeconds = 60 * 60 * 24 * 7; // 1 week
+
+const response = await clerkClient.signInTokens.createSignInToken({
+  userId,
+  expiresInSeconds,
+});
+
+console.log(response);
+/*
+_SignInToken {
+  id: 'sit_123',
+  userId: 'user_123',
+  token: 'eyJ...',
+  status: 'pending',
+  url: 'https://prepared-phoenix-00.accounts.dev/sign-in?__clerk_ticket=eyJ...',
+  createdAt: 1719952616214,
+  updatedAt: 1719952616214
+}
+*/
+```
+
+## Backend API (BAPI) endpoint
+
+This method in the SDK is a wrapper around the BAPI endpoint `POST/sign_in_tokens`. See the [BAPI reference](https://clerk.com/docs/reference/backend-api/tag/Sign-in-Tokens#operation/CreateSignInToken) for more details.

--- a/docs/references/backend/sign-in-tokens/revoke-sign-in-token.mdx
+++ b/docs/references/backend/sign-in-tokens/revoke-sign-in-token.mdx
@@ -1,0 +1,45 @@
+---
+title: revokeSignInToken()
+description: Use Clerk's Backend SDK to revoke a pending sign-in token.
+---
+
+# `revokeSignInToken()`
+
+Revokes a pending sign-in token.
+
+```tsx
+function revokeSignInToken: (signInTokenId: string) => Promise<SignInToken>;
+```
+
+## Parameters
+
+| Name | Type | Description |
+| --- | --- | --- |
+| `signInTokenId` | `string` | The ID of the sign-in token to revoke. |
+
+## Example
+
+```tsx
+const signInTokenId = 'sit_123';
+
+const response = await clerkClient.signInTokens.revokeSignInToken(
+  signInTokenId
+);
+
+console.log(response);
+/*
+_SignInToken {
+  id: 'sit_123',
+  userId: 'user_123',
+  token: undefined,
+  status: 'revoked',
+  url: undefined,
+  createdAt: 1719952616214,
+  updatedAt: 1719953040703
+}
+*/
+```
+
+## Backend API (BAPI) endpoint
+
+This method in the SDK is a wrapper around the BAPI endpoint `POST/sign_in_tokens/{sign_in_token_id}/revoke`. See the [BAPI reference](https://clerk.com/docs/reference/backend-api/tag/Sign-in-Tokens#operation/RevokeSignInToken) for more details.


### PR DESCRIPTION
<!--- Add the "deploy-preview" label and add your page previews here -->

> [!IMPORTANT]
> 🔎 Previews:
>
> - https://clerk.com/docs/pr/1221/references/backend/sign-in-tokens/create-sign-in-token
> - https://clerk.com/docs/pr/1221/references/backend/sign-in-tokens/revoke-sign-in-token

<!--- Describe your changes in detail. Why does this change need to happen? Include any links to Slack discussions, Linear comments, etc. -->
### Explanation:
Missing docs

<!--- How does this PR solve the problem? -->
### This PR:

- Adds doc for the [SignInTokens API](https://github.com/clerk/javascript/blob/main/packages/backend/src/api/endpoints/SignInTokenApi.ts)
