### PR TITLE
Added Tutorial Hero, added some changes, broke read session into its …

### DIFF
--- a/docs/manifest.json
+++ b/docs/manifest.json
@@ -1791,7 +1791,13 @@
                     "title": "`clerkMiddleware()`",
                     "wrap": false,
                     "href": "/docs/references/astro/clerk-middleware"
+                  },
+{
+                    "title": "Read Session and User Data",
+                    "wrap": false,
+                    "href": "/docs/references/astro/read-session-data"
                   }
+
                 ]
               ]
             },

--- a/docs/quickstarts/astro.mdx
+++ b/docs/quickstarts/astro.mdx
@@ -3,9 +3,34 @@ title: Use Clerk with Astro
 description: Learn how to use Clerk to quickly and easily add secure authentication and user management to your Astro application.
 ---
 
-# Use Clerk with Astro
+# Astro Quickstart
 
-Learn how to use Clerk to quickly and easily add secure authentication and user management to your Astro application.
+<TutorialHero
+  framework="astro"
+  exampleRepo={[
+    {
+      title: "Astro Quickstart Repo",
+      link: "https://github.com/clerk/clerk-astro-quickstart"
+
+    }
+  ]}
+  beforeYouStart={[
+    {
+      title: "Set up a Clerk application",
+      link: "https://clerk.com/docs/quickstarts/setup-clerk",
+      icon: "clerk",
+    }
+  ]}
+>
+
+- Install @clerk/astro
+- Set up your environment variables
+- Add TypeScript declarations
+- Update your Astro configuration
+- Add middleware
+- Create a header with Clerk
+</TutorialHero>
+
 
 <Steps>
 ### Install `@clerk/astro`
@@ -53,19 +78,43 @@ Inside your `src/` directory, update the `.env.d.ts` file to ensure that the loc
 /// <reference types="@clerk/astro/env" />
 ```
 
+### Install `@astrojs/node` and optionally `@astrojs/react`
+
+Install the [`@astrojs/node`](https://docs.astro.build/en/guides/integrations-guide/node/) adapter. This is required for the middleware to work.
+
+If you wish to use the React version of the components and features from `@clerk/astro`, including the React examples below, also install `@astrojs/react`.
+
+<CodeBlockTabs type="installer" options={["npm", "yarn", "pnpm"]}>
+  ```bash filename="terminal"
+  npx astro add node
+  npx astro add react
+  ```
+
+  ```bash filename="terminal"
+  yarn astro add node
+  yarn astro add react
+  ```
+
+  ```bash filename="terminal"
+  pnpm astro add node
+ pnpm astro add react
+  ```
+</CodeBlockTabs>
+
+
 ### Update `astro.config.mjs`
 
 To configure Clerk in your astro application, you will need to update your `astro.config.mjs`.
 
 - Add the Clerk integration to the `integrations` list.
-- Install the [`@astrojs/node`](https://docs.astro.build/en/guides/integrations-guide/node/) adapter. This is required for the middleware to work.
 - Set `output` to `server`. This is required when deploying to a host supporting SSR.
 
-```ts filename="astro.config.mjs" {2,3,6-8}
+```ts filename="astro.config.mjs" {3,7}
 import { defineConfig } from "astro/config";
 import node from "@astrojs/node";
 import clerk from "@clerk/astro";
 
+ // https://astro.build/config
 export default defineConfig({
   integrations: [clerk()],
   output: "server",
@@ -92,20 +141,58 @@ export const onRequest = clerkMiddleware();
 
 Clerk offers components that allow you to protect your pages. These components are used to control the visibility of your pages based on the user's authentication state.
 
+
+<CodeBlockTabs options={["Astro", "React"]}>
+  ```astro filename="src/layouts/SiteLayout.astro"
+---
+import { SignedIn, SignedOut } from "@clerk/astro/components/control";
+import { UserButton } from "@clerk/astro/components/interactive";
+import { SignInButton } from '@clerk/astro/components/unstyled'
+
+const { title } = Astro.props;
+---
+
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
+    <meta name="generator" content={Astro.generator} />
+  </head>
+  <body>
+    <header>
+      <h1>{title}</h1>
+      <nav>
+        <SignedOut>
+         <SignInButton mode="modal" />
+        </SignedOut>
+        <SignedIn>
+          <UserButton />
+        </SignedIn>
+      </nav>
+    </header>
+    <article>
+      <slot />
+    </article>
+  </body>
+  <style>
+    h1 {
+      font-size: 2rem;
+    }
+  </style>
+</html>
+```
+</CodeBlockTabs>
+
+
 <CodeBlockTabs options={["Astro", "React"]}>
   ```astro filename="src/pages/index.astro"
   ---
-  import { SignedIn, SignedOut } from '@clerk/astro/components/control'
-  import { UserButton } from '@clerk/astro/components/interactive'
-  import { SignInButton } from '@clerk/astro/components/unstyled'
+  import SiteLayout from "../layouts/SiteLayout.astro"
   ---
-
-  <SignedOut>
-    <SignInButton />
-  </SignedOut>
-  <SignedIn>
-    <UserButton />
-  </SignedIn>
+  <SiteLayout title="Clerk + Astro">
+	  <p>Sign in to try Clerk out!</p>
+  </SiteLayout>
   ```
 
   ```tsx filename="src/pages/index.tsx"
@@ -131,38 +218,6 @@ Clerk offers components that allow you to protect your pages. These components a
   ```
 </CodeBlockTabs>
 
-### Read session and user data
-
-Clerk provides helpers that you can use to access the active session and user data in your Astro application.
-
-This example uses the `auth()` local to validate an authenticated user and the  `currentUser()` local to access the `Backend API User` object for the authenticated user.
-
-<CodeBlockTabs options={["Page component", "API Route"]}>
-
-```astro filename="src/pages/me.astro"
----
-if (!Astro.locals.auth().userId) {
-  return Astro.redirect('/login');
-}
-
-const user = await Astro.locals.currentUser()
----
-
-<div>{JSON.stringify(user)}</div>
-```
-
-```tsx filename="src/api/me.ts"
-export async function GET({ locals }) {
-  if (!locals.auth().userId) {
-    new Response('Unauthorized', { status: 401 })
-  }
-
-  return new Response(JSON.stringify(await locals.currentUser()), {
-    status: 200,
-  });
-};
-```
-</CodeBlockTabs>
 </Steps>
 
 ## Next steps

--- a/docs/references/astro/read-session-data.mdx
+++ b/docs/references/astro/read-session-data.mdx
@@ -9,7 +9,7 @@ Clerk provides helpers that you can use to access the active session and user da
 
 This example uses the `auth()` local to validate an authenticated user and the  `currentUser()` local to access the `Backend API User` object for the authenticated user.
 
-<CodeBlockTabs options={["Page component", "API Route"]}>
+<CodeBlockTabs options={[".astro component", "API Route"]}>
 
 ```astro filename="src/pages/me.astro"
 ---

--- a/docs/references/astro/read-session-data.mdx
+++ b/docs/references/astro/read-session-data.mdx
@@ -1,0 +1,37 @@
+---
+title: Read session and user data in your Next.js app with Clerk
+description: Learn how to use Clerk's hooks and helpers to access the active session and user data in your Astro application.
+---
+
+# Read session and user data
+
+Clerk provides helpers that you can use to access the active session and user data in your Astro application.
+
+This example uses the `auth()` local to validate an authenticated user and the  `currentUser()` local to access the `Backend API User` object for the authenticated user.
+
+<CodeBlockTabs options={["Page component", "API Route"]}>
+
+```astro filename="src/pages/me.astro"
+---
+if (!Astro.locals.auth().userId) {
+  return Astro.redirect('/login');
+}
+
+const user = await Astro.locals.currentUser()
+---
+
+<div>{JSON.stringify(user)}</div>
+```
+
+```tsx filename="src/api/me.ts"
+export async function GET({ locals }) {
+  if (!locals.auth().userId) {
+    new Response('Unauthorized', { status: 401 })
+  }
+
+  return new Response(JSON.stringify(await locals.currentUser()), {
+    status: 200,
+  });
+};
+```
+</CodeBlockTabs>


### PR DESCRIPTION
<!--- Add the "deploy-preview" label and add your page previews here -->

> [!IMPORTANT]
> 🔎 Previews:
>
> - https://clerk.com/docs/pr/1228/quickstarts/astro
> - https://clerk.com/docs/pr/1228/references/astro/read-session-data
> 
> TODO: Move 'Read session and user data' to Guides once https://github.com/clerk/clerk-docs/pull/1227 is merged.

<!--- Describe your changes in detail. Why does this change need to happen? Include any links to Slack discussions, Linear comments, etc. -->
### Explanation:

Updated Quickstart with Tutorial Hero component, broke `@astrojs/node` info into its own section, modified initial code to use a Layout. Move the 'read session data' to its own page to expand later.

<!--- How does this PR solve the problem? -->
### This PR:

- Adding documentation for upcoming Astro SDK
