### PR TITLE
Update Client Backend SDK docs to match BAPI docs

### DIFF
--- a/docs/manifest.json
+++ b/docs/manifest.json
@@ -2232,7 +2232,7 @@
                           "href": "/docs/references/backend/types/paginated-resource-response"
                         },
                         {
-                          "title": "Backend Client object",
+                          "title": "Backend `Client` object",
                           "href": "/docs/references/backend/types/backend-client"
                         },
                         {

--- a/docs/manifest.json
+++ b/docs/manifest.json
@@ -2232,6 +2232,10 @@
                           "href": "/docs/references/backend/types/paginated-resource-response"
                         },
                         {
+                          "title": "Backend Client object",
+                          "href": "/docs/references/backend/types/backend-client"
+                        },
+                        {
                           "title": "Backend User object",
                           "href": "/docs/references/backend/types/backend-user"
                         }

--- a/docs/references/backend/client/get-client.mdx
+++ b/docs/references/backend/client/get-client.mdx
@@ -3,9 +3,11 @@ title: getClient()
 description: Use Clerk's Backend SDK to retrieve a single client by its ID.
 ---
 
+{/* clerk/javascript file: https://github.com/clerk/javascript/blob/main/packages/backend/src/api/endpoints/ClientApi.ts#L19 */}
+
 # `getClient()`
 
-Retrieves a single [`Client`](/docs/references/javascript/client) by its ID, if the ID is valid.
+Retrieves a single [`Client`](/docs/references/javascript/client).
 
 ```tsx
 function getClient: (clientId: string) => Promise<Client>;
@@ -20,19 +22,19 @@ function getClient: (clientId: string) => Promise<Client>;
 ## Example
 
 ```tsx
-const clientId = 'client_2b6J9fCrQt0KRCCtFu7WCIQvSfd';
+const clientId = 'client_123';
 
 const response = await clerkClient.clients.getClient(clientId);
 
 console.log(response);
 /*
 _Client {
-  id: 'client_2b6J9fCrQt0KRCCtFu7WCIQvSfd',
-  sessionIds: [ 'sess_2b6M8I4VZ1wMtgXGQeDe3SJD3cG' ],
+  id: 'client_123',
+  sessionIds: [ 'sess_123' ],
   sessions: [ [_Session] ],
   signInId: null,
   signUpId: null,
-  lastActiveSessionId: 'sess_2b6M8I4VZ1wMtgXGQeDe3SJD3cG',
+  lastActiveSessionId: 'sess_123',
   createdAt: 1705529444202,
   updatedAt: 1705530913279
 }

--- a/docs/references/backend/client/verify-client.mdx
+++ b/docs/references/backend/client/verify-client.mdx
@@ -3,9 +3,11 @@ title: verifyClient()
 description: Use Clerk's Backend SDK to retrieve a client for a given session token, if the session is active.
 ---
 
+{/* clerk/javascript file: https://github.com/clerk/javascript/blob/main/packages/backend/src/api/endpoints/ClientApi.ts#L27 */}
+
 # `verifyClient()`
 
-Retrieves a [`Client`](/docs/references/javascript/client) for a given session token, if the session is active.
+Verifies the [`Client`](/docs/references/javascript/client) in the provided token.
 
 ```tsx
 function verifyClient: (token: string) => Promise<Client>;

--- a/docs/references/backend/types/backend-client.mdx
+++ b/docs/references/backend/types/backend-client.mdx
@@ -1,0 +1,22 @@
+---
+title: The Backend Client object
+description: The Backend Client object holds information about the authenticated sessions in the current device. However, the Backend Client object is different from the Client object in that it is used in the Backend API.
+---
+
+# The Backend `Client` object
+
+The Backend `Client` object is similar to the [`Client`](/docs/references/javascript/client) object as it holds information about the authenticated sessions in the current device. However, the Backend `Client` object is different from the `Client` object in that it is used in the [Backend API](/docs/reference/backend-api/tag/Clients#operation/GetClient) and is not directly accessible from the Frontend API.
+
+
+## Properties
+
+| Name | Type | Description |
+| --- | --- | --- |
+| `id` | `string` | A unique identifier for the client. |
+| `sessionIds` | `string[]` | An array of [Session](https://clerk.com/docs/references/javascript/session) IDs associated with the `Client`. |
+| `sessions` | <code>[Session](https://clerk.com/docs/references/javascript/session)[]</code> | An array of [Session](https://clerk.com/docs/references/javascript/session) objects associated with the `Client`. |
+| `signInId` | `string` | The ID of the [`SignIn`](https://clerk.com/docs/references/javascript/sign-in/sign-in). |
+| `signUpId` | `string` | The ID of the [`SignUp`](https://clerk.com/docs/references/javascript/sign-up/sign-up) |
+| `lastActiveSessionId` | `string` | The ID of the last active [Session](https://clerk.com/docs/references/javascript/session). |
+| `createdAt` | `number` | Date when the `Client` was first created. |
+| `updatedAt` | `number` | Date of the last time the `Client` was updated. |

--- a/docs/references/backend/types/backend-client.mdx
+++ b/docs/references/backend/types/backend-client.mdx
@@ -7,7 +7,6 @@ description: The Backend Client object holds information about the authenticated
 
 The Backend `Client` object is similar to the [`Client`](/docs/references/javascript/client) object as it holds information about the authenticated sessions in the current device. However, the Backend `Client` object is different from the `Client` object in that it is used in the [Backend API](/docs/reference/backend-api/tag/Clients#operation/GetClient) and is not directly accessible from the Frontend API.
 
-
 ## Properties
 
 | Name | Type | Description |


### PR DESCRIPTION
<!--- Add the "deploy-preview" label and add your page previews here -->

> [!IMPORTANT]
> 🔎 Previews:
>
> -

<!--- Describe your changes in detail. Why does this change need to happen? Include any links to Slack discussions, Linear comments, etc. -->
### Explanation:

Part of the work for checking that our /backend/* reference docs were up to date ([due to this linear ticket](https://linear.app/clerk/issue/DOCS-6039/check-that-our-docsreferencesbackend-pages-match-our-backend-api))

I added each pages' corresponding `clerk/javascript` file in a comment on at the top of the page. Adding these links will make it easy to find where these methods exist in the `clerk/javascript` repo when updating their respective pages.

I updated pages accordingly to reflect the BAPI docs.