### PR TITLE
Update explanation of "active organizations"

### DIFF
--- a/docs/components/organization/organization-switcher.mdx
+++ b/docs/components/organization/organization-switcher.mdx
@@ -16,6 +16,8 @@ The `<OrganizationSwitcher />` component allows a user to switch between their a
 
 Out of the box, this component will show notifications to the user if they have organization [invitations](/docs/organizations/overview#organization-invitations) or [suggestions](/docs/organizations/overview#suggestions). Admins will be able to see notifications for [requests](/docs/organizations/overview#membership-requests) to join an organization.
 
+If you would like to learn how to hide a user's personal account in order to enforce an organization-centric application, see the [dedicated guide.](/docs/guides/force-organizations)
+
 ## `<OrganizationSwitcher />` properties
 
 All props below are optional.

--- a/docs/organizations/overview.mdx
+++ b/docs/organizations/overview.mdx
@@ -82,7 +82,7 @@ The easiest way to allow users to set an organization as active is to use Clerk'
 
 You can also use the `setActive()` method, which is available on the [`Clerk`](/docs/references/javascript/clerk/session-methods#set-active) object and is returned by the [`useOrganizationList()`](/docs/references/react/use-organization-list) hook.
 
-If you would like to hide personal workspaces and require users to set an organization as active, see the [Force organizations](/docs/guides/force-organizations) guide.
+If you would like to hide personal workspaces and require users to always have an organization set as active, see the [Force organizations](/docs/guides/force-organizations) guide.
 
 ## Create an organization
 

--- a/docs/organizations/overview.mdx
+++ b/docs/organizations/overview.mdx
@@ -74,11 +74,15 @@ Membership requests are requests from users who want to join an organization. A 
 
 ## Active organization
 
-By default, when a user signs in to a Clerk-powered application, there is no active organization set. Even if they are a member of only one organization, they must explicitly set it as active.
+When a user is a member of an organization, they can switch between their personal workspace and an organization workspace. The organization workspace that a user is currently viewing is called the **active organization**. The active organization determines which organization-specific data the user can access and which roles and permissions they have within the organization.
+
+By default, when a user initially signs in to a Clerk-powered application, they are signed in to their personal workspace and no active organization is set. Even if they are a member of only one organization, they must explicitly set it as active.
 
 The easiest way to allow users to set an organization as active is to use Clerk's [`<OrganizationSwitcher />`](/docs/components/organization/organization-switcher) component.
 
 You can also use the `setActive()` method, which is available on the [`Clerk`](/docs/references/javascript/clerk/session-methods#set-active) object and is returned by the [`useOrganizationList()`](/docs/references/react/use-organization-list) hook.
+
+If you would like to hide personal workspaces and require users to set an organization as active, see the [Force organizations](/docs/guides/force-organizations) guide.
 
 ## Create an organization
 

--- a/docs/organizations/overview.mdx
+++ b/docs/organizations/overview.mdx
@@ -74,7 +74,7 @@ Membership requests are requests from users who want to join an organization. A 
 
 ## Active organization
 
-When a user is a member of an organization, they can switch between their personal workspace and an organization workspace. The organization workspace that a user is currently viewing is called the **active organization**. The active organization determines which organization-specific data the user can access and which roles and permissions they have within the organization.
+When a user is a member of an organization, they can switch between their personal workspace and an organization workspace. The organization workspace that a user is currently viewing is called the **active organization**. The active organization determines which organization-specific data the user can access and which role and related permissions they have within the organization.
 
 By default, when a user initially signs in to a Clerk-powered application, they are signed in to their personal workspace and no active organization is set. Even if they are a member of only one organization, they must explicitly set it as active.
 

--- a/docs/organizations/overview.mdx
+++ b/docs/organizations/overview.mdx
@@ -74,19 +74,11 @@ Membership requests are requests from users who want to join an organization. A 
 
 ## Active organization
 
-There are two types of accounts that a single user can have in a Clerk application: a personal account and an organization account. A personal account is the default account type, and it is created when a user signs up for your application. An organization account is created when a user creates or joins an organization within your application.
+By default, when a user signs in to a Clerk-powered application, there is no active organization set. Even if they are a member of only one organization, they must explicitly set it as active.
 
-Users will always have a single personal account. They can have multiple organization accounts if they are members of multiple organizations.
-
-When a user is a member of an organization, they can switch between their personal account and an organization account. The organization account that a user is currently viewing is called the **active organization**. The active organization determines which organization-specific data the user can access and which roles and permissions they have within the organization.
-
-When a user signs in to your application, they are viewing their personal account and no organization is set as active. Even if they are a member of only one organization, they must explicitly switch to that organization to set it as active.
-
-The easiest way to allow users to switch between their personal account and their organization account is to use Clerk's [`<OrganizationSwitcher />`](/docs/components/organization/organization-switcher) component. Once a user selects an organization, that organization is set as the active organization.
+The easiest way to allow users to set an organization as active is to use Clerk's [`<OrganizationSwitcher />`](/docs/components/organization/organization-switcher) component.
 
 You can also use the `setActive()` method, which is available on the [`Clerk`](/docs/references/javascript/clerk/session-methods#set-active) object and is returned by the [`useOrganizationList()`](/docs/references/react/use-organization-list) hook.
-
-If you would like to learn how to hide a user's personal account in order to enforce an organization-centric application, see the [dedicated guide.](/docs/guides/force-organizations)
 
 ## Create an organization
 

--- a/docs/organizations/overview.mdx
+++ b/docs/organizations/overview.mdx
@@ -76,7 +76,7 @@ Membership requests are requests from users who want to join an organization. A 
 
 When a user is a member of an organization, they can switch between their personal workspace and an organization workspace. The organization workspace that a user is currently viewing is called the **active organization**. The active organization determines which organization-specific data the user can access and which role and related permissions they have within the organization.
 
-By default, when a user initially signs in to a Clerk-powered application, they are signed in to their personal workspace and no active organization is set. Even if they are a member of only one organization, they must explicitly set it as active.
+By default, when a user initially signs in to a Clerk-powered application, they are signed in to their personal workspace and no active organization is set. Even if they are a member of only one organization, they must explicitly set it as active or the application can have logic to set this automatically. 
 
 The easiest way to allow users to set an organization as active is to use Clerk's [`<OrganizationSwitcher />`](/docs/components/organization/organization-switcher) component.
 


### PR DESCRIPTION
<!--- Add the "deploy-preview" label and add your page previews here -->

> [!IMPORTANT]
> 🔎 Previews:
>
> - https://clerk.com/docs/pr/1241/organizations/overview#active-organization

<!--- Describe your changes in detail. Why does this change need to happen? Include any links to Slack discussions, Linear comments, etc. -->
### Explanation:
[The linear ticket](https://linear.app/clerk/issue/DOCS-8865/clarify-organization-account-wording) reads:
> On [the organizations overview page](https://clerk.com/docs/organizations/overview#active-organization), there are multiple mentions of "personal accounts" and "organization accounts" - while I get what we're after here, we had a prospective customer get confused by this and think that there were different account types - user accounts and org accounts, and both operated independently. This isn't the case, there are only user accounts, and users belong to organizations. I think we could probably clarify the wording here to make it clear how this works.

<!--- How does this PR solve the problem? -->
### This PR:

- Updates the explanation of active organizations
