### PR TITLE
Update wording in callout to suggest PBAC over RBAC

### DIFF
--- a/docs/organizations/verify-user-permissions.mdx
+++ b/docs/organizations/verify-user-permissions.mdx
@@ -295,7 +295,7 @@ If you are not using React or any of the meta-frameworks we support, you can use
 ## Authorize with roles
 
 > [!WARNING]
-> Performing role checks is not considered a best-practice and developers should avoid it as much as possible. Usually, complex role checks can be refactored with a single permission check.
+> We suggest permission-based authorization over role-based authorization, as it reduces complexity and increases security. Usually, complex role checks can be refactored with a single permission check.
 
 You can pass a `role` the same way you can pass a `permission` in all the examples above.
 

--- a/docs/organizations/verify-user-permissions.mdx
+++ b/docs/organizations/verify-user-permissions.mdx
@@ -6,7 +6,7 @@ description: A collection of utility functions and components in order to allow 
 # Verify the active user's permissions in an organization
 
 > [!IMPORTANT]
-> The following authorization checks are predicated on a user having an active organization. Without this, they will likely always evaluate to false by default. Clerk's built-in [`<OrganizationSwitcher/>`](/docs/components/organization/organization-switcher) component and[`useOrganizationList().setActive({ organization: <orgId> })`](/docs/references/react/use-organization-list) method are two available options to set an organization as active for a user.
+> The following authorization checks are predicated on a user having an active organization. Without this, they will likely always evaluate to false by default. Learn more about [active organizations](/docs/organizations/overview#active-organization).
 
 In general, you should always verify whether or not a user is authorized to access sensitive information, important content, or exclusive features. The most secure way to implement authorization is by checking the active user's [role or permissions](/docs/organizations/roles-permissions#permissions).
 


### PR DESCRIPTION
<!--- Add the "deploy-preview" label and add your page previews here -->

> [!IMPORTANT]
> 🔎 Previews:
>
> - https://clerk.com/docs/pr/1243/organizations/verify-user-permissions

<!--- Describe your changes in detail. Why does this change need to happen? Include any links to Slack discussions, Linear comments, etc. -->
### Explanation:
[Linear ticket](https://linear.app/clerk/issue/DOCS-8824/clarify-callout-about-pbac-rbac-best-practice)

<!--- How does this PR solve the problem? -->
### This PR:

- Updates wording in callout to suggest PBAC over RBAC
- Also updates wording in callout about active orgs; adds a reference link to active orgs section in org overview
