### PR TITLE
feat: Add sections corresponding to new SMS UI functionality in dashboard

### DIFF
--- a/docs/authentication/configuration/email-sms-templates.mdx
+++ b/docs/authentication/configuration/email-sms-templates.mdx
@@ -34,13 +34,9 @@ Revolvapp allows the user to design the template using blocks and under the hood
 
 ### Handlebars templating language
 
-Both the email and SMS editor use the [Handlebars](https://handlebarsjs.com/) templating language for the interpolation of dynamic values into your content via [variables](#terminology). It is a well established language, especially popular in the Javascript ecosystem, which has been adopted by leading Email Service Providers (ESPs) for templating as well.
-
-The most core Handlebars concept you should bear in mind is that variables are wrapped in double curly braces. For example: `{{app.name}}`. When the message is to be sent, the variable will be replaced with the actual value, which in this example would be the name of the application.
+Both the email and SMS editor use the [Handlebars](https://handlebarsjs.com/) templating language for the interpolation of dynamic values into your content via [variables](#terminology). Variables are wrapped in double curly braces. For example: `{{app.name}}`. When the message is to be sent, the variable will be replaced with the actual value, which in this example would be the name of the application.
 
 When editing a template in the Clerk Dashboard, you can insert variables at the desired position, so there is no need to write them by hand. Though, you can still do so if you like.
-
-For further information on Handlebars, we recommend you take a look at the [official guides](https://handlebarsjs.com/guide/).
 
 <Callout type="info">
   In order to unescape special characters, you may need to wrap variables in triple curly braces. For example: `{{{app.name}}}`. This will allow special characters (e.g. `'`, `&`) to appear as displayed and not as escaped HTML entities (e.g. `&apos;`, `&amp;`).
@@ -53,76 +49,26 @@ To access the email templates:
 1. Navigate to the [Clerk Dashboard](https://dashboard.clerk.com/last-active?path=customization/email).
 2. In the navigation sidebar, select **Customization > Emails**.
 3. Select a template to edit.
-4. Once you have selected a template, you will be presented with the [template settings](#email-template-settings) & [the WYSIWYG editor](#email-wysiwyg-editor).
+4. Once you have selected a template, you will be presented with [template operations](#template-operations), the [template settings](#email-template-settings), and [the WYSIWYG editor](#email-wysiwyg-editor).
 
 ### Template operations
 
-Please consult the following sub-sections to see which operations are available in the template editor.
+The following operations are available for an email template:
 
-<Callout type="info">
-  Depending on the state of the template and the current application subscription plan, one or more operations may not not available.
-</Callout>
-
-#### Preview
-
-The **Preview** operation enables you to get an idea of how the template will render when sent to the recipient. This is useful for sampling your changes without actually having to commit them first.
-
-To trigger a preview of a template, select the **Preview** button at the bottom left of the dashboard.
-
-The `app_logo` and `copyright` sections (if present) will be replaced with their actual markup in this view.
-
-#### Copy to another instance of the same application
-
-If your application has more than one instance, you can copy the current state of the editor to another instance.
-
-This is especially useful for promoting changes from your development or staging environment to production after you have tested them.
-
-To copy to another instance, you will need to first select the **Copy** button in the bottom left of the dashboard. Then, from the sub-menu, select the target instance.
-
-> [!WARNING]
-> The copy icon will not appear if there are no other instances available on your application.
-
-Since this change will override the current state of the template on the target instance, you will be asked to confirm your choice.
-
-#### Revert
-
-If you override a Clerk-provided template with your own customizations, you can always roll back to the system default template version by selecting the **Revert** button at the bottom left of the dashboard.
-
-This can be useful if you want to start over from scratch.
-
-Your current changes will be lost, so make sure you mean to discard them prior to reverting. You will be asked to confirm your choice to prevent an unintentional action.
-
-#### Reset
-
-While editing a template, you can undo all changes since the last save by selecting the **Reset** button at the bottom right of the dashboard.
+- **Preview**: enables you to get an idea of how the template will render when sent to the recipient. This is useful for sampling your changes without actually having to commit them first. The `app_logo` and `copyright` sections (if present) will be replaced with their actual markup in this view.
+- **Copy**: copies the current state of the editor to another instance. This is especially useful for promoting changes from your development or staging environment to production after you have tested them. **The copy icon will not appear if there are no other instances available on your application.**
+- **Revert**: reverts to the system default template version. This can be useful if you want to start over from scratch.
+- **Reset**: undo all changes since the last save by selecting the **Reset** button at the bottom right of the dashboard.
 
 ### Email template settings
 
-The following settings can be changed for an email template:
+The following settings can be changed per email template:
 
-#### Delivered by Clerk
-
-Out of the box, Clerk will deliver your emails using its own Email Service Provider (ESP), which is currently [SendGrid](https://sendgrid.com/). However, if you wish to handle delivery of emails on your own, then you can toggle **Delivered by Clerk** off.
-
-This means that Clerk will no longer be sending this particular email and in order to deliver it yourself, you will need to listen to the `emails.created` [webhook](/docs/integrations/webhooks/overview) and extract the necessary info from the event payload.
-
-<Callout type="info">
-  Remember, this is a per-template setting and will not be applied to other templates.
-</Callout>
-
-#### Name
-
-**Name** is the template name and represents a human-friendly name for identifying the template on the template listing page. It does not affect the outgoing email in any way.
-
-#### Send from
-
-Clerk will populate the **From** email address with:
-
-`<local part>@<your-domain>`
-
-The local part depends on the type of email sent ('verification code', 'invitation', etc).
-
-If you wish to override the local part with your own value, such as 'accounting', 'sales', etc., then set that value in the provided input.
+- **Delivered by Clerk**: out of the box, Clerk will deliver your emails using its own Email Service Provider (ESP), which is currently [SendGrid](https://sendgrid.com/). However, if you wish to handle delivery of emails on your own, then you can toggle this setting off. This means that Clerk will no longer be sending this particular email and in order to deliver it yourself, you will need to listen to the `emails.created` [webhook](/docs/integrations/webhooks/overview) and extract the necessary info from the event payload.
+- **Name**: a name for the template on the template listing page. It does not affect the outgoing email in any way.
+- **From**: the email address that will be used as the **From** address in the email header. The format is `<local part>@<your-domain>`. You can change the local part to a custom value. If no value is provided, it defaults `noreply`.
+- **Reply-To**: the email address that will be used as the **Reply-To** address in the email header. This is useful if you want to direct replies to a different email address than the one used in the **From** field. The format is `<local part>@<your-domain>`. You can change the local part to a custom value. If no value is provided, the **Reply-To** header will be omitted.
+- **Subject**: the subject line of the email.
 
 ### Email WYSIWYG editor
 
@@ -165,7 +111,7 @@ To access the SMS templates:
 1. Navigate to the [Clerk Dashboard](https://dashboard.clerk.com/last-active?path=customization/sms).
 2. In the navigation sidebar, select **Customization > SMS**.
 3. Select a template to edit.
-4. A modal will appear that shows you what the template looks like, plus options to toggle the **Delivered by Clerk** setting or to [request a change to the template](#request-change).
+4. A modal will appear that shows you what the template looks like, plus options to toggle the [**Delivered by Clerk**](#delivered-by-clerk) setting or to [request a change to the template](#request-change).
 
 ### Delivered by Clerk
 
@@ -173,9 +119,8 @@ Out of the box, Clerk will deliver your SMS messagess using its own SMS Gateway.
 
 This means that Clerk will no longer be sending this particular SMS and in order to deliver it yourself, you will need to listen to the `sms.created` [webhook](/docs/integrations/webhooks/overview) and extract the necessary info from the event payload.
 
-<Callout type="info">
-  Remember, this is a per-template setting and will not be applied to other templates.
-</Callout>
+> [!NOTE]
+> Remember, this is a per-template setting and will not be applied to other templates.
 
 ### Request change
 
@@ -187,14 +132,5 @@ You can also cancel a draft yourself if you decide you no longer need the change
 
 The following settings can be changed for an SMS template:
 
-#### Name
-
-**Name** is the template name and represents a human-friendly name for identifying the template on the template listing page. It does not affect the outgoing SMS message in any way.
-
-#### Message
-
-The **Message** text area is where you can author the content of the SMS message. The SMS content should fit within a limit of 160 simple GSM-7 or 140 unicode characters.
-
-To insert a [variable](#terminology) at the current cursor position, select the corresponding variable badge. You can interpolate a particular metadata key as follows:
-
-`{{user.public_metadata.foo.bar}}`
+- **Name**: a name for the template on the template listing page. It does not affect the outgoing email in any way.
+- **Message**: a text area where you can author the content of the SMS message. The SMS content should fit within a limit of 160 simple GSM-7 or 140 unicode characters. To insert a [variable](#terminology) at the current cursor position, select the corresponding variable badge. You can interpolate a particular metadata key by using the following syntax: `{{user.metadata.foo.bar}}`.

--- a/docs/authentication/configuration/email-sms-templates.mdx
+++ b/docs/authentication/configuration/email-sms-templates.mdx
@@ -110,7 +110,7 @@ To access the SMS templates:
 
 1. Navigate to the [Clerk Dashboard](https://dashboard.clerk.com/last-active?path=customization/sms).
 2. In the navigation sidebar, select **Customization > SMS**.
-3. Select a template to edit.
+3. Select a template to edit. You can also disable SMS templates to suppress their corresponding notifications.
 4. A modal will appear that shows you what the template looks like, plus options to toggle the [**Delivered by Clerk**](#delivered-by-clerk) setting or to [request a change to the template](#request-change).
 
 ### Delivered by Clerk

--- a/docs/authentication/configuration/email-sms-templates.mdx
+++ b/docs/authentication/configuration/email-sms-templates.mdx
@@ -34,7 +34,7 @@ Revolvapp allows the user to design the template using blocks and under the hood
 
 ### Handlebars templating language
 
-Both the email and SMS editor use the [Handlebars](https://handlebarsjs.com/) templating language for the interpolation of dynamic values into your content via variables. It is a well established language, especially popular in the Javascript ecosystem, which has been adopted by leading Email Service Providers (ESPs) for templating as well.
+Both the email and SMS editor use the [Handlebars](https://handlebarsjs.com/) templating language for the interpolation of dynamic values into your content via [variables](#terminology). It is a well established language, especially popular in the Javascript ecosystem, which has been adopted by leading Email Service Providers (ESPs) for templating as well.
 
 The most core Handlebars concept you should bear in mind is that variables are wrapped in double curly braces. For example: `{{app.name}}`. When the message is to be sent, the variable will be replaced with the actual value, which in this example would be the name of the application.
 
@@ -46,7 +46,16 @@ For further information on Handlebars, we recommend you take a look at the [offi
   In order to unescape special characters, you may need to wrap variables in triple curly braces. For example: `{{{app.name}}}`. This will allow special characters (e.g. `'`, `&`) to appear as displayed and not as escaped HTML entities (e.g. `&apos;`, `&amp;`).
 </Callout>
 
-## Template operations
+## Edit email templates
+
+To access the email templates:
+
+1. Navigate to the [Clerk Dashboard](https://dashboard.clerk.com/last-active?path=customization/email).
+2. In the navigation sidebar, select **Customization > Emails**.
+3. Select a template to edit.
+4. Once you have selected a template, you will be presented with the [template settings](#email-template-settings) & [the WYSIWYG editor](#email-wysiwyg-editor).
+
+### Template operations
 
 Please consult the following sub-sections to see which operations are available in the template editor.
 
@@ -54,48 +63,15 @@ Please consult the following sub-sections to see which operations are available 
   Depending on the state of the template and the current application subscription plan, one or more operations may not not available.
 </Callout>
 
-### Edit
-
-Editing templates allows you to customize existing Clerk-sent emails and SMS messages to make them more inline with your own branding.
-
-Templates are editable:
-
-- On the development instance of applications on any subscription plan (free or paid)
-- On the staging and production instances of paid plans
-
-This allows you freely test the templating feature on your development environment to see if it fits your individual use case before deciding on a plan upgrade.
-
-To learn more about editing email templates, refer to the [Edit email templates](#edit-email-templates) section.
-
-To learn more about editing SMS templates, refer to the [Edit SMS templates](#edit-sms-templates) section.
-
-### Preview
+#### Preview
 
 The **Preview** operation enables you to get an idea of how the template will render when sent to the recipient. This is useful for sampling your changes without actually having to commit them first.
 
 To trigger a preview of a template, select the **Preview** button at the bottom left of the dashboard.
 
-In email templates, the `app_logo` and `copyright` sections (if present) will be replaced with their actual markup in this view. For both emails & SMS, the template variables will be replaced with sample values.
+The `app_logo` and `copyright` sections (if present) will be replaced with their actual markup in this view.
 
-Previewing is available for all templates.
-
-### Reset
-
-While editing a template, you can undo all changes since the last save by selecting the **Reset** button at the bottom right of the dashboard.
-
-Template reset is applicable to editable templates.
-
-### Revert
-
-If you override a Clerk-provided template with your own customizations, you can always roll back to the system default template version by selecting the **Revert** button at the bottom left of the dashboard.
-
-This can be useful if you want to start over from scratch.
-
-<Callout type="info">
-  Your current changes will be lost, so make sure you mean to discard them prior to reverting. You will be asked to confirm your choice to prevent an unintentional action.
-</Callout>
-
-### Copy to another instance of the same application
+#### Copy to another instance of the same application
 
 If your application has more than one instance, you can copy the current state of the editor to another instance.
 
@@ -103,29 +79,22 @@ This is especially useful for promoting changes from your development or staging
 
 To copy to another instance, you will need to first select the **Copy** button in the bottom left of the dashboard. Then, from the sub-menu, select the target instance.
 
-<Callout type="warning">
-  The copy icon will not appear if there are no other instances available on your application.
-</Callout>
+> [!WARNING]
+> The copy icon will not appear if there are no other instances available on your application.
 
 Since this change will override the current state of the template on the target instance, you will be asked to confirm your choice.
 
-## Edit email templates
+#### Revert
 
-To access the email templates:
+If you override a Clerk-provided template with your own customizations, you can always roll back to the system default template version by selecting the **Revert** button at the bottom left of the dashboard.
 
-1. Navigate to the [Clerk Dashboard](https://dashboard.clerk.com/last-active?path=customization/email).
-2. In the navigation sidebar, select **Customization > Emails**.
-3. Select a template to edit. The following templates are available for customization:
-    - [Invitation](https://dashboard.clerk.com/last-active?path=customization/email/invitation/edit) - Email sent to invite a user to join your application
-    - [Magic link - Sign in](https://dashboard.clerk.com/last-active?path=customization/email/magic_link_sign_in/edit) - Email containing magic link to allow the user to sign in without providing a password
-    - [Magic link - Sign up](https://dashboard.clerk.com/last-active?path=customization/email/magic_link_sign_up/edit) - Email containing magic link that invites the user to sign up
-    - [Magic link - Verify email](https://dashboard.clerk.com/last-active?path=customization/email/magic_link_user_profile/edit) - Email containing magic link to verify the ownership of an email address
-    - [Password changed](https://dashboard.clerk.com/last-active?path=customization/email/password_changed/edit) - Email notifying the user that their password has been changed
-    - [Password removed](https://dashboard.clerk.com/last-active?path=customization/email/password_removed/edit) - Email notifying the user that their password has been removed
-    - [Primary email address changed](https://dashboard.clerk.com/last-active?path=customization/email/primary_email_address_changed/edit) - Email notifying the user that their primary email address has been updated
-    - [Reset password code](https://dashboard.clerk.com/last-active?path=customization/email/reset_password_code/edit) - Email containing an OTP (One Time Password) code that allows the user to reset their password
-    - [Verification code](https://dashboard.clerk.com/last-active?path=customization/email/verification_code/edit) - Email containing an OTP (One Time Password) code for verifying account access
-4. Once you have selected a template, you will be presented with the [template settings](#email-template-settings) & [the WYSIWYG editor](#email-wysiwyg-editor).
+This can be useful if you want to start over from scratch.
+
+Your current changes will be lost, so make sure you mean to discard them prior to reverting. You will be asked to confirm your choice to prevent an unintentional action.
+
+#### Reset
+
+While editing a template, you can undo all changes since the last save by selecting the **Reset** button at the bottom right of the dashboard.
 
 ### Email template settings
 
@@ -135,7 +104,7 @@ The following settings can be changed for an email template:
 
 Out of the box, Clerk will deliver your emails using its own Email Service Provider (ESP), which is currently [SendGrid](https://sendgrid.com/). However, if you wish to handle delivery of emails on your own, then you can toggle **Delivered by Clerk** off.
 
-This means that Clerk will no longer be sending this particular email and in order to deliver it yourself, you will need to listen to the `emails.created` webhook and extract the necessary info from the event payload.
+This means that Clerk will no longer be sending this particular email and in order to deliver it yourself, you will need to listen to the `emails.created` [webhook](/docs/integrations/webhooks/overview) and extract the necessary info from the event payload.
 
 <Callout type="info">
   Remember, this is a per-template setting and will not be applied to other templates.
@@ -195,69 +164,37 @@ To access the SMS templates:
 
 1. Navigate to the [Clerk Dashboard](https://dashboard.clerk.com/last-active?path=customization/sms).
 2. In the navigation sidebar, select **Customization > SMS**.
-3. Select a template to edit. The following templates are available for customization:
-    - [Invitation](https://dashboard.clerk.com/last-active?path=customization/sms/invitation/edit) - SMS sent to invite a user to join your application
-    - [Password changed](https://dashboard.clerk.com/last-active?path=customization/sms/password_changed/edit) - SMS notifying the user that their password has been changed
-    - [Password removed](https://dashboard.clerk.com/last-active?path=customization/sms/password_removed/edit) - SMS notifying the user that their password has been removed
-    - [Reset password](https://dashboard.clerk.com/last-active?path=customization/sms/reset_password_code/edit) - SMS containing an OTP (One Time Password) code that allows the user to reset their password
-    - [Verification code](https://dashboard.clerk.com/last-active?path=customization/sms/verification_code/edit) - SMS containing an OTP (One Time Password) code for verifying account access
-4. Once you have click on a template, you will be presented with the [template settings](#sms-template-settings) & [the text area](#sms-text-area) in a popup.
+3. Select a template to edit.
+4. A modal will appear that shows you what the template looks like, plus options to toggle the **Delivered by Clerk** setting or to [request a change to the template](#request-change).
 
-### SMS approval flow
+### Delivered by Clerk
 
-Modifications to an SMS template are subject to approval by Clerk support.
+Out of the box, Clerk will deliver your SMS messagess using its own SMS Gateway. However, if you wish to handle SMS delivery on your own, then you can toggle **Delivered by Clerk** off.
 
-Once you submit the desired copywriting for a particular SMS template, a draft will be created for Clerk support to review.
-
-If the change conforms to Clerk content policy, a support agent will approve your draft, and it will become effective from that point on.
-
-If the change is rejected, then the draft will be canceled.
-
-You can also cancel a draft yourself if you decide you no longer need the changes or if you wish to submit a new draft.
-
-### SMS template settings
-
-The following settings can be changed for an SMS template:
-
-#### Enabled status
-
-SMS templates of the following types can be disabled to suppress the corresponding notification:
-
-* `passkey_added`
-* `passkey_removed`
-* `password_changed`
-* `password_removed`
-
-This can be achieved by navigating to the [Clerk Dashboard](https://dashboard.clerk.com/last-active?path=customization/sms) and toggling the desired SMS notifications on or off.
-
-#### Delivered by Clerk
-
-Out of the box, Clerk will deliver your SMS messagess using its own SMS Gateway. However, if you wish to handle SMS delivery on your own, then you can toggle **Delivery by Clerk** off.
-
-This means that Clerk will no longer be sending this particular SMS and in order to deliver it yourself, you will need to listen to the `sms.created` webhook and extract the necessary info from the event payload.
+This means that Clerk will no longer be sending this particular SMS and in order to deliver it yourself, you will need to listen to the `sms.created` [webhook](/docs/integrations/webhooks/overview) and extract the necessary info from the event payload.
 
 <Callout type="info">
   Remember, this is a per-template setting and will not be applied to other templates.
 </Callout>
 
+### Request change
+
+Modifications to an SMS template are subject to approval by Clerk support. Once you submit the desired copywriting for a particular SMS template, a draft will be created for Clerk support to review.
+
+If the change conforms to Clerk content policy, a support agent will approve your draft, and it will become effective from that point on. If the change is rejected, then the draft will be canceled.
+
+You can also cancel a draft yourself if you decide you no longer need the changes or if you wish to submit a new draft.
+
+The following settings can be changed for an SMS template:
+
 #### Name
 
 **Name** is the template name and represents a human-friendly name for identifying the template on the template listing page. It does not affect the outgoing SMS message in any way.
 
-### SMS text area
+#### Message
 
-The text area is where you can author the content of the SMS message.
+The **Message** text area is where you can author the content of the SMS message. The SMS content should fit within a limit of 160 simple GSM-7 or 140 unicode characters.
 
-The SMS content should fit within a limit of 160 simple GSM-7 or 140 unicode characters.
+To insert a [variable](#terminology) at the current cursor position, select the corresponding variable badge. You can interpolate a particular metadata key as follows:
 
-#### Insert variables
-
-To insert a variable at the current cursor position, select the corresponding variable badge adjacent to the text area.
-
-<Callout type="info">
-  The **Invitation** template supports public invitation metadata, whereas the **Verification code** template supports public user metadata (in the case that a user already exists).
-</Callout>
-
-You can interpolate a particular metadata key as follows:
-
-`{{invitation.public_metadata.foo.bar}}`
+`{{user.public_metadata.foo.bar}}`

--- a/docs/authentication/configuration/email-sms-templates.mdx
+++ b/docs/authentication/configuration/email-sms-templates.mdx
@@ -19,7 +19,6 @@ It will be useful to take a look at the following terms as they will reappear in
 
 | Name | Description |
 | --- | --- |
-| template name | User-friendly name of the template. This will be visible on the template listing page. |
 | variables | Also known as merge tags in the context of email marketing, these are placeholders that are replaced with dynamic data when the actual email or SMS is being sent to the recipient. |
 | WYSIWYG | Stands for 'What You See Is What You Get.' This term is used for editors and design tools that allow you to create content or layouts in a visual manner (without requiring you to edit the underlying markup) so that you can instantly see how the result is going to display to your users. |
 | blocks | Email WYSIWYG editors enable you to use blocks, rows, and columns in order to control the layout of their content. This is then transpiled to table-based HTML. |
@@ -30,7 +29,7 @@ The email editor uses the [Revolvapp](https://imperavi.com/redactor/legacy/revol
 
 As you will see, the template markup is an HTML-like language and each type of node supports its own set of attributes which control its behavior. A lot of the attributes are borrowed from HTML itself.
 
-Revolvapp allows the user to design the template using blocks and under the hood transpiles its markup to table-based HTML so that the resulting email renders consistently across email clients.
+Revolvapp allows the user to design the template using [blocks](#terminology) and under the hood transpiles its markup to table-based HTML so that the resulting email renders consistently across email clients.
 
 ### Handlebars templating language
 
@@ -87,7 +86,7 @@ The toolbar is located at the top of the editor and contains the following contr
 - **Background** button
 - **Settings** button
 
-For the following controls to appear, you will need to select an existing element in the text area. These controls will not be visible otherwise.
+For the following controls to appear, you will need to select an existing [block](#terminology) in the text area. These controls will not be visible otherwise.
 
 - **Add block** button
 - **Alignment** button
@@ -98,7 +97,7 @@ For the following controls to appear, you will need to select an existing elemen
 
 #### Text area controls
 
-The email WYSIWYG editor text area is intended mainly for authoring content. Though, if you select a block, a set of tools will also appear. In order from top to bottom, these are:
+The email WYSIWYG editor text area is intended mainly for authoring content. Though, if you select a [block](#terminology), a set of tools will also appear. In order from top to bottom, these are:
 
 - **Move handle**
 - **Delete**
@@ -110,7 +109,7 @@ To access the SMS templates:
 
 1. Navigate to the [Clerk Dashboard](https://dashboard.clerk.com/last-active?path=customization/sms).
 2. In the navigation sidebar, select **Customization > SMS**.
-3. Select a template to edit. You can also disable SMS templates to suppress their corresponding notifications.
+3. Select a template to edit. You can also disable certain SMS notifications.
 4. A modal will appear that shows you what the template looks like, plus options to toggle the [**Delivered by Clerk**](#delivered-by-clerk) setting or to [request a change to the template](#request-change).
 
 ### Delivered by Clerk

--- a/docs/authentication/configuration/email-sms-templates.mdx
+++ b/docs/authentication/configuration/email-sms-templates.mdx
@@ -201,11 +201,34 @@ To access the SMS templates:
     - [Password removed](https://dashboard.clerk.com/last-active?path=customization/sms/password_removed/edit) - SMS notifying the user that their password has been removed
     - [Reset password](https://dashboard.clerk.com/last-active?path=customization/sms/reset_password_code/edit) - SMS containing an OTP (One Time Password) code that allows the user to reset their password
     - [Verification code](https://dashboard.clerk.com/last-active?path=customization/sms/verification_code/edit) - SMS containing an OTP (One Time Password) code for verifying account access
-4. Once you have selected a template, you will be presented with the [template settings](#sms-template-settings) & [the text area](#sms-text-area).
+4. Once you have click on a template, you will be presented with the [template settings](#sms-template-settings) & [the text area](#sms-text-area) in a popup.
+
+### SMS approval flow
+
+Modifications to an SMS template are subject to approval by Clerk support.
+
+Once you submit the desired copywriting for a particular SMS template, a draft will be created for Clerk support to review.
+
+If the change conforms to Clerk content policy, a support agent will approve your draft, and it will become effective from that point on.
+
+If the change is rejected, then the draft will be canceled.
+
+You can also cancel a draft yourself if you decide you no longer need the changes or if you wish to submit a new draft.
 
 ### SMS template settings
 
 The following settings can be changed for an SMS template:
+
+#### Enabled status
+
+SMS templates of the following types can be disabled to suppress the corresponding notification:
+
+* `passkey_added`
+* `passkey_removed`
+* `password_changed`
+* `password_removed`
+
+This can be achieved by navigating to the [Clerk Dashboard](https://dashboard.clerk.com/last-active?path=customization/sms) and toggling the desired SMS notifications on or off.
 
 #### Delivered by Clerk
 
@@ -224,6 +247,8 @@ This means that Clerk will no longer be sending this particular SMS and in order
 ### SMS text area
 
 The text area is where you can author the content of the SMS message.
+
+The SMS content should fit within a limit of 160 simple GSM-7 or 140 unicode characters.
 
 #### Insert variables
 

--- a/docs/authentication/configuration/sign-up-sign-in-options.mdx
+++ b/docs/authentication/configuration/sign-up-sign-in-options.mdx
@@ -21,7 +21,10 @@ From the application configuration screen, you can select multiple identifiers i
 
 **Email address** is the most common primary identifier. During the sign-up process, a user must supply and verify their email address. They must keep an email address on their account at all times. However, the email address that was used for registration can be later changed from the user's profile page.
 
-When **phone number** is selected as the identifier, a user will sign up with their phone number and receive an SMS text message with a code to verify their phone number. (**Note**: SMS authentication is a premium feature and is not available on the Free plan. [Upgrade your plan](https://clerk.com/pricing) to enable this feature.)
+When **phone number** is selected as the identifier, a user will sign up with their phone number and receive an SMS text message with a code to verify their phone number. SMS functionality is restricted to phone numbers from countries that are enabled on your [SMS allowlist.](#sms-allowlist)
+
+> [!NOTE]
+> SMS authentication is a premium feature and is not available on the Free plan. [Upgrade your plan](https://clerk.com/pricing) to enable this feature.
 
 Choosing **username** as the identifier enables users to sign up without requiring personal contact information. A username should be from 4 to 64 characters in length and can contain alphanumeric characters, underscores (_), and dashes (-).
 
@@ -102,22 +105,26 @@ There are two **one-time password (OTP)**, or one-time code, strategies to choos
 
 When email address is chosen as the identifier, **Email verification code** is set as the *default* authentication option.
 
-(**Note**: SMS authentication is a premium feature and is not available on the Free plan. [Upgrade your plan](https://clerk.com/pricing) to enable this feature.)
+> [!NOTE]
+> SMS authentication is a premium feature and is not available on the Free plan. [Upgrade your plan](https://clerk.com/pricing) to enable this feature.
 
 #### SMS allowlist
 
-Use of OTPs and SMS functionality in general is restricted to phone numbers from countries that are enabled on your SMS allowlist.
+SMS functionality, including SMS OTPs, is restricted to phone numbers from countries that are enabled on your SMS allowlist. This can be useful for avoiding extraneous SMS fees from countries from which your app is not expected to attract traffic.
 
-This can be useful for avoiding extraneous SMS fees from countries from which your app is not expected to attract traffic.
+Every instance starts off with a default set of enabled SMS country tiers. To tailor it to your needs:
 
-Every instance starts off with a default set of enabled SMS country tiers, but you can tailor it to your needs by navigating to the [Clerk Dashboard](https://dashboard.clerk.com/last-active?path=customization/sms) and clicking the Settings tab.
+1. Navigate to the [Clerk Dashboard](https://dashboard.clerk.com/last-active?path=customization/sms).
+1. In the navigation sidebar, select **Customization > SMS**.
+1. Select the **Settings** tab.
+1. Enable or disable countries as needed.
 
 If a country is disabled, then phone numbers starting with the corresponding country calling code:
 
-* Cannot receive OTPs and a request to receive an OTP will be rejected with an error
-* Cannot receive notifications for password or passkey modifications
-* Cannot be used upon sign-up
-* Cannot be added to an existing user profile
+- Cannot receive OTPs and a request to receive an OTP will be rejected with an error
+- Cannot receive notifications for password or passkey modifications
+- Cannot be used upon sign-up
+- Cannot be added to an existing user profile
 
 ### Email link
 

--- a/docs/authentication/configuration/sign-up-sign-in-options.mdx
+++ b/docs/authentication/configuration/sign-up-sign-in-options.mdx
@@ -104,6 +104,21 @@ When email address is chosen as the identifier, **Email verification code** is s
 
 (**Note**: SMS authentication is a premium feature and is not available on the Free plan. [Upgrade your plan](https://clerk.com/pricing) to enable this feature.)
 
+#### SMS allowlist
+
+Use of OTPs and SMS functionality in general is restricted to phone numbers from countries that are enabled on your SMS allowlist.
+
+This can be useful for avoiding extraneous SMS fees from countries from which your app is not expected to attract traffic.
+
+Every instance starts off with a default set of enabled SMS country tiers, but you can tailor it to your needs by navigating to the [Clerk Dashboard](https://dashboard.clerk.com/last-active?path=customization/sms) and clicking the Settings tab.
+
+If a country is disabled, then phone numbers starting with the corresponding country calling code:
+
+* Cannot receive OTPs and a request to receive an OTP will be rejected with an error
+* Cannot receive notifications for password or passkey modifications
+* Cannot be used upon sign-up
+* Cannot be added to an existing user profile
+
 ### Email link
 
 When the **Email verification link** option is selected as an authentication strategy, users will receive an email message with a link that can be visited in order to complete the authentication process. Email links can be used to sign up new users, sign in existing ones, or allow existing users to verify newly entered email addresses to their profile. Email links work on any device. There's no constraint on where the link will be opened. For example, a user might try to sign in from their desktop browser, but open the link from their mobile phone.


### PR DESCRIPTION
> [!IMPORTANT]
> 🔎 Previews:
>
> - https://clerk.com/docs/pr/1244/authentication/configuration/email-sms-templates
> - https://clerk.com/docs/pr/1244/authentication/configuration/sign-up-sign-in-options

This includes:

* SMS allowlist
* SMS template enabled status toggle
* SMS template approval flow

This PR:

https://clerk.com/docs/pr/1244/authentication/configuration/email-sms-templates
- Removes unnecessary info, including lists of templates (as these can become outdated and are hard to maintain)
- Reorganizes the email-sms-templates page. Settings that were available to both Email and SMS templates are now only available to Email templates, so these sections were moved under #edit-email-templates and the sections were abstracted into bullet points. Also, missing UI information was added such as the **From**, **Reply-To**, and **Subject** settings. For #edit-sms-templates, the copy was updated to reflect the new UI. Sections were abstracted into bullet points wherever they could be, and the new **Request change** feature was added.

https://clerk.com/docs/pr/1244/authentication/configuration/sign-up-sign-in-options
- Documents new information about the SMS allowlist