### PR TITLE
Fix Step headings on Loops page

### DIFF
--- a/docs/integrations/webhooks/loops.mdx
+++ b/docs/integrations/webhooks/loops.mdx
@@ -30,7 +30,7 @@ This tutorial demonstrates how to sync your Clerk users to Loops so you can emai
 
 <Steps>
 
-## Create a Clerk webhook endpoint in Loops
+### Create a Clerk webhook endpoint in Loops
 
 Loops' [Incoming webhooks](https://loops.so/docs/integrations/incoming-webhooks) feature lets Loops accept webhooks directly from external platforms like Clerk.
 
@@ -38,7 +38,7 @@ To create a new webhook endpoint in Loops:
 1. Navigate to the **Clerk** settings page in the [Loops dashboard](https://app.loops.so/settings?page=clerk).
 1. Save the **Endpoint URL** somewhere secure; you're going to need it for Clerk's webhook configuration.
 
-## Create a webhook in the Clerk Dashboard
+### Create a webhook in the Clerk Dashboard
 
 You must create a new Clerk webhook endpoint so that it can send data to Loops. Here is where you will provide the **Endpoint URL** from the last step, and then choose the events you want to listen to.
 
@@ -49,14 +49,14 @@ You must create a new Clerk webhook endpoint so that it can send data to Loops. 
 6. Select the **Create** button.
 7. You will be redirected to your endpoint's settings page. Leave this page open.
 
-## Add your signing secret in Loops
+### Add your signing secret in Loops
 
 To keep communication secure between the two platforms:
 
 1. On the Clerk endpoint's settings page, copy the **Signing Secret**. It should be on the right side of the page with an eye icon next to it. 
 1. Back in the Loops dashboard, add the **Signing Secret**.
 
-## Configure Loops events
+### Configure Loops events
 
 The final step is to configure which events Loops should accept from Clerk and what Loops should do with the data.
 


### PR DESCRIPTION
Makes sure the proper step headings show on the Loops webhooks page (changing `<h2>` to `<h3>`.