### PR TITLE
Reintroduce JS SDK examples for adding custom pages to components

### DIFF
--- a/docs/components/customization/organization-profile.mdx
+++ b/docs/components/customization/organization-profile.mdx
@@ -26,7 +26,7 @@ Custom pages can be rendered inside the `<OrganizationProfile />` component and 
 
 To add a custom page to the `<OrganizationProfile />` component, use the `<OrganizationSwitcher.OrganizationProfilePage />` component or the `<OrganizationProfile.Page />` component, depending on your use case.
 
-### `<OrganizationProfile.Page />` Props
+### Props
 
 `<OrganizationSwitcher.OrganizationProfilePage />` and `<OrganizationProfile.Page />` accept the following props, all of which are *required*:
 

--- a/docs/components/customization/organization-profile.mdx
+++ b/docs/components/customization/organization-profile.mdx
@@ -158,7 +158,7 @@ The following example demonstrates two ways that you can render content in the `
 To add custom pages to the `<OrganizationProfile />` component using the [JavaScript SDK](/docs/references/javascript/overview), you can pass the  `customPages` property to the `mountOrganizationProfile()` or `openOrganizationProfile()` method, as shown in the following example:
 
 <CodeBlockTabs type="npm-script" options={['NPM module', '<script>']}>
-  ```js filename="main.js" {14}
+  ```js filename="main.js"
   import { Clerk } from '@clerk/clerk-js';
 
   // Initialize Clerk with your Clerk publishable key
@@ -206,7 +206,7 @@ To add custom pages to the `<OrganizationProfile />` component using the [JavaSc
   });
   ```
 
-  ```html filename="index.html" {21}
+  ```html filename="index.html"
   <!-- Add a <div id="organization-profile"> element to your HTML -->
   <div id="organization-profile"></div>
 

--- a/docs/components/customization/organization-profile.mdx
+++ b/docs/components/customization/organization-profile.mdx
@@ -153,6 +153,117 @@ The following example demonstrates two ways that you can render content in the `
   ```
 </CodeBlockTabs>
 
+### JavaScript example
+
+To add custom pages to the `<OrganizationProfile />` component using the [JavaScript SDK](/docs/references/javascript/overview), you can pass the  `customPages` property to the `mountOrganizationProfile()` or `openOrganizationProfile()` method, as shown in the following example:
+
+<CodeBlockTabs type="npm-script" options={['NPM module', '<script>']}>
+  ```js filename="main.js" {14}
+  import { Clerk } from '@clerk/clerk-js';
+
+  // Initialize Clerk with your Clerk publishable key
+  const clerk = new Clerk('{{pub_key}}');
+  await clerk.load();
+
+  document.getElementById('app').innerHTML = `
+    <div id="organization-profile"></div>
+  `
+
+  const orgProfileDiv = document.getElementById('organization-profile');
+
+  clerk.openOrganizationProfile(orgProfileDiv, {
+    customPages: [
+      {
+        url: "custom-page",
+        label: "Custom Page",
+        mountIcon: (el) => {
+          el.innerHTML = "👋";
+        },
+        unmountIcon: (el) => {
+          el.innerHTML = "";
+        },
+        mount: (el) => {
+          el.innerHTML = `
+            <h1><b>Custom Page</b></h1>
+            <p>This is the content of the custom page.</p>
+            `;
+        },
+        unmount: (el) => {
+          el.innerHTML = "";
+        },
+      },
+      {
+        url: "/other-page",
+        label: "Other Page",
+        mountIcon: (el) => {
+          el.innerHTML = "🌐";
+        },
+        unmountIcon: (el) => {
+          el.innerHTML = "";
+        },
+      }
+    ]
+  });
+  ```
+
+  ```html filename="index.html" {21}
+  <!-- Add a <div id="organization-profile"> element to your HTML -->
+  <div id="organization-profile"></div>
+
+  <!-- Initialize Clerk with your
+  Clerk Publishable key and Frontend API URL -->
+  <script
+    async
+    crossorigin="anonymous"
+    data-clerk-publishable-key="{{pub_key}}"
+    src="https://{{fapi_url}}/npm/@clerk/clerk-js@latest/dist/clerk.browser.js"
+    type="text/javascript"
+  ></script>
+
+  <script>
+    window.addEventListener("load", async function () {
+      await Clerk.load();
+
+      const orgProfileDiv =
+        document.getElementById('organization-profile');
+
+      Clerk.openOrganizationProfile(orgProfileDiv, {
+        customPages: [
+          {
+            url: "custom-page",
+            label: "Custom Page",
+            mountIcon: (el) => {
+              el.innerHTML = "👋";
+            },
+            unmountIcon: (el) => {
+                el.innerHTML = "";
+            },
+            mount: (el) => {
+              el.innerHTML = `
+                <h1><b>Custom Page</b></h1>
+                <p>This is the content of the custom page.</p>
+                `;
+            },
+            unmount: (el) => {
+              el.innerHTML = "";
+            },
+          },
+          {
+            url: "/other-page",
+            label: "Other Page",
+            mountIcon: (el) => {
+              el.innerHTML = "🌐";
+            },
+            unmountIcon: (el) => {
+              el.innerHTML = "";
+            },
+          }
+        ]
+      });
+    });
+  </script>
+  ```
+</CodeBlockTabs>
 
 ## Add a custom link to `<OrganizationProfile />`
 
@@ -357,115 +468,3 @@ With the above example, the `<OrganizationProfile />` navigation sidebar will be
 2. Homepage
 3. Members
 4. Settings
-
-## JavaScript examples
-
-To add custom pages to the `<OrganizationProfile />` component using JavaScript, you can pass `customPages` property to the `mountOrganizationProfile()` or `openOrganizationProfile()` method, as shown in the following example:
-
-<CodeBlockTabs type="npm-script" options={['NPM module', '<script>']}>
-  ```js filename="main.js" {14}
-  import { Clerk } from '@clerk/clerk-js';
-
-  // Initialize Clerk with your Clerk publishable key
-  const clerk = new Clerk('{{pub_key}}');
-  await clerk.load();
-
-  document.getElementById('app').innerHTML = `
-    <div id="organization-profile"></div>
-  `
-
-  const orgProfileDiv = document.getElementById('organization-profile');
-
-  clerk.openOrganizationProfile(orgProfileDiv, {
-    customPages: [
-      {
-        url: "custom-page",
-        label: "Custom Page",
-        mountIcon: (el) => {
-          el.innerHTML = "👋";
-        },
-        unmountIcon: (el) => {
-          el.innerHTML = "";
-        },
-        mount: (el) => {
-          el.innerHTML = `
-            <h1><b>Custom Page</b></h1>
-            <p>This is the content of the custom page.</p>
-            `;
-        },
-        unmount: (el) => {
-          el.innerHTML = "";
-        },
-      },
-      {
-        url: "/other-page",
-        label: "Other Page",
-        mountIcon: (el) => {
-          el.innerHTML = "🌐";
-        },
-        unmountIcon: (el) => {
-          el.innerHTML = "";
-        },
-      }
-    ]
-  });
-  ```
-
-  ```html filename="index.html" {21}
-  <!-- Add a <div id="organization-profile"> element to your HTML -->
-  <div id="organization-profile"></div>
-
-  <!-- Initialize Clerk with your
-  Clerk Publishable key and Frontend API URL -->
-  <script
-    async
-    crossorigin="anonymous"
-    data-clerk-publishable-key="{{pub_key}}"
-    src="https://{{fapi_url}}/npm/@clerk/clerk-js@latest/dist/clerk.browser.js"
-    type="text/javascript"
-  ></script>
-
-  <script>
-    window.addEventListener("load", async function () {
-      await Clerk.load();
-
-      const orgProfileDiv =
-        document.getElementById('organization-profile');
-
-      Clerk.openOrganizationProfile(orgProfileDiv, {
-        customPages: [
-          {
-            url: "custom-page",
-            label: "Custom Page",
-            mountIcon: (el) => {
-              el.innerHTML = "👋";
-            },
-            unmountIcon: (el) => {
-                el.innerHTML = "";
-            },
-            mount: (el) => {
-              el.innerHTML = `
-                <h1><b>Custom Page</b></h1>
-                <p>This is the content of the custom page.</p>
-                `;
-            },
-            unmount: (el) => {
-              el.innerHTML = "";
-            },
-          },
-          {
-            url: "/other-page",
-            label: "Other Page",
-            mountIcon: (el) => {
-              el.innerHTML = "🌐";
-            },
-            unmountIcon: (el) => {
-              el.innerHTML = "";
-            },
-          }
-        ]
-      });
-    });
-  </script>
-  ```
-</CodeBlockTabs>

--- a/docs/components/customization/organization-profile.mdx
+++ b/docs/components/customization/organization-profile.mdx
@@ -357,3 +357,115 @@ With the above example, the `<OrganizationProfile />` navigation sidebar will be
 2. Homepage
 3. Members
 4. Settings
+
+## JavaScript examples
+
+To add custom pages to the `<OrganizationProfile />` component using JavaScript, you can pass `customPages` property to the `mountOrganizationProfile()` or `openOrganizationProfile()` method, as shown in the following example:
+
+<CodeBlockTabs type="npm-script" options={['NPM module', '<script>']}>
+  ```js filename="main.js" {14}
+  import { Clerk } from '@clerk/clerk-js';
+
+  // Initialize Clerk with your Clerk publishable key
+  const clerk = new Clerk('{{pub_key}}');
+  await clerk.load();
+
+  document.getElementById('app').innerHTML = `
+    <div id="organization-profile"></div>
+  `
+
+  const orgProfileDiv = document.getElementById('organization-profile');
+
+  clerk.openOrganizationProfile(orgProfileDiv, {
+    customPages: [
+      {
+        url: "custom-page",
+        label: "Custom Page",
+        mountIcon: (el) => {
+          el.innerHTML = "👋";
+        },
+        unmountIcon: (el) => {
+          el.innerHTML = "";
+        },
+        mount: (el) => {
+          el.innerHTML = `
+            <h1><b>Custom Page</b></h1>
+            <p>This is the content of the custom page.</p>
+            `;
+        },
+        unmount: (el) => {
+          el.innerHTML = "";
+        },
+      },
+      {
+        url: "/other-page",
+        label: "Other Page",
+        mountIcon: (el) => {
+          el.innerHTML = "🌐";
+        },
+        unmountIcon: (el) => {
+          el.innerHTML = "";
+        },
+      }
+    ]
+  });
+  ```
+
+  ```html filename="index.html" {21}
+  <!-- Add a <div id="organization-profile"> element to your HTML -->
+  <div id="organization-profile"></div>
+
+  <!-- Initialize Clerk with your
+  Clerk Publishable key and Frontend API URL -->
+  <script
+    async
+    crossorigin="anonymous"
+    data-clerk-publishable-key="{{pub_key}}"
+    src="https://{{fapi_url}}/npm/@clerk/clerk-js@latest/dist/clerk.browser.js"
+    type="text/javascript"
+  ></script>
+
+  <script>
+    window.addEventListener("load", async function () {
+      await Clerk.load();
+
+      const orgProfileDiv =
+        document.getElementById('organization-profile');
+
+      Clerk.openOrganizationProfile(orgProfileDiv, {
+        customPages: [
+          {
+            url: "custom-page",
+            label: "Custom Page",
+            mountIcon: (el) => {
+              el.innerHTML = "👋";
+            },
+            unmountIcon: (el) => {
+                el.innerHTML = "";
+            },
+            mount: (el) => {
+              el.innerHTML = `
+                <h1><b>Custom Page</b></h1>
+                <p>This is the content of the custom page.</p>
+                `;
+            },
+            unmount: (el) => {
+              el.innerHTML = "";
+            },
+          },
+          {
+            url: "/other-page",
+            label: "Other Page",
+            mountIcon: (el) => {
+              el.innerHTML = "🌐";
+            },
+            unmountIcon: (el) => {
+              el.innerHTML = "";
+            },
+          }
+        ]
+      });
+    });
+  </script>
+  ```
+</CodeBlockTabs>

--- a/docs/components/customization/user-profile.mdx
+++ b/docs/components/customization/user-profile.mdx
@@ -363,3 +363,115 @@ With the above example, the `<UserProfile />` navigation sidebar will be in the 
 2. Homepage
 3. Account
 4. Security
+
+## JavaScript examples
+
+To add custom pages to the `<UserProfile />` component using JavaScript, you can pass `customPages` property to the `mountUserProfile()` or `openUserProfile()` method, as shown in the following example:
+
+<CodeBlockTabs type="npm-script" options={['NPM module', '<script>']}>
+  ```js filename="main.js" {14}
+  import { Clerk } from '@clerk/clerk-js';
+
+  // Initialize Clerk with your Clerk publishable key
+  const clerk = new Clerk('{{pub_key}}');
+  await clerk.load();
+
+  document.getElementById('app').innerHTML = `
+    <div id="user-profile"></div>
+  `
+
+  const userProfileDiv = document.getElementById('user-profile');
+
+  clerk.openUserProfile(userProfileDiv, {
+    customPages: [
+      {
+        url: "custom-page",
+        label: "Custom Page",
+        mountIcon: (el) => {
+          el.innerHTML = "👋";
+        },
+        unmountIcon: (el) => {
+          el.innerHTML = "";
+        },
+        mount: (el) => {
+          el.innerHTML = `
+            <h1><b>Custom Page</b></h1>
+            <p>This is the content of the custom page.</p>
+            `;
+        },
+        unmount: (el) => {
+          el.innerHTML = "";
+        },
+      },
+      {
+        url: "/other-page",
+        label: "Other Page",
+        mountIcon: (el) => {
+          el.innerHTML = "🌐";
+        },
+        unmountIcon: (el) => {
+          el.innerHTML = "";
+        },
+      }
+    ]
+  });
+  ```
+
+  ```html filename="index.html" {21}
+  <!-- Add a <div id="user-profile"> element to your HTML -->
+  <div id="user-profile"></div>
+
+  <!-- Initialize Clerk with your
+  Clerk Publishable key and Frontend API URL -->
+  <script
+    async
+    crossorigin="anonymous"
+    data-clerk-publishable-key="{{pub_key}}"
+    src="https://{{fapi_url}}/npm/@clerk/clerk-js@latest/dist/clerk.browser.js"
+    type="text/javascript"
+  ></script>
+
+  <script>
+    window.addEventListener("load", async function () {
+      await Clerk.load();
+
+      const userProfileDiv =
+        document.getElementById('user-profile');
+
+      Clerk.openUserProfile(userProfileDiv, {
+        customPages: [
+          {
+            url: "custom-page",
+            label: "Custom Page",
+            mountIcon: (el) => {
+              el.innerHTML = "👋";
+            },
+            unmountIcon: (el) => {
+                el.innerHTML = "";
+            },
+            mount: (el) => {
+              el.innerHTML = `
+                <h1><b>Custom Page</b></h1>
+                <p>This is the content of the custom page.</p>
+                `;
+            },
+            unmount: (el) => {
+              el.innerHTML = "";
+            },
+          },
+          {
+            url: "/other-page",
+            label: "Other Page",
+            mountIcon: (el) => {
+              el.innerHTML = "🌐";
+            },
+            unmountIcon: (el) => {
+              el.innerHTML = "";
+            },
+          }
+        ]
+      });
+    });
+  </script>
+  ```
+</CodeBlockTabs>

--- a/docs/components/customization/user-profile.mdx
+++ b/docs/components/customization/user-profile.mdx
@@ -162,7 +162,7 @@ The following example demonstrates two ways that you can render content in the `
 To add custom pages to the `<UserProfile />` component using the [JavaScript SDK](/docs/references/javascript/overview), you can pass the `customPages` property to the `mountUserProfile()` or `openUserProfile()` method, as shown in the following example:
 
 <CodeBlockTabs type="npm-script" options={['NPM module', '<script>']}>
-  ```js filename="main.js" {14}
+  ```js filename="main.js"
   import { Clerk } from '@clerk/clerk-js';
 
   // Initialize Clerk with your Clerk publishable key
@@ -210,7 +210,7 @@ To add custom pages to the `<UserProfile />` component using the [JavaScript SDK
   });
   ```
 
-  ```html filename="index.html" {21}
+  ```html filename="index.html"
   <!-- Add a <div id="user-profile"> element to your HTML -->
   <div id="user-profile"></div>
 

--- a/docs/components/customization/user-profile.mdx
+++ b/docs/components/customization/user-profile.mdx
@@ -157,6 +157,118 @@ The following example demonstrates two ways that you can render content in the `
   </Tab>
 </Tabs>
 
+### JavaScript example
+
+To add custom pages to the `<UserProfile />` component using the [JavaScript SDK](/docs/references/javascript/overview), you can pass the `customPages` property to the `mountUserProfile()` or `openUserProfile()` method, as shown in the following example:
+
+<CodeBlockTabs type="npm-script" options={['NPM module', '<script>']}>
+  ```js filename="main.js" {14}
+  import { Clerk } from '@clerk/clerk-js';
+
+  // Initialize Clerk with your Clerk publishable key
+  const clerk = new Clerk('{{pub_key}}');
+  await clerk.load();
+
+  document.getElementById('app').innerHTML = `
+    <div id="user-profile"></div>
+  `
+
+  const userProfileDiv = document.getElementById('user-profile');
+
+  clerk.openUserProfile(userProfileDiv, {
+    customPages: [
+      {
+        url: "custom-page",
+        label: "Custom Page",
+        mountIcon: (el) => {
+          el.innerHTML = "👋";
+        },
+        unmountIcon: (el) => {
+          el.innerHTML = "";
+        },
+        mount: (el) => {
+          el.innerHTML = `
+            <h1><b>Custom Page</b></h1>
+            <p>This is the content of the custom page.</p>
+            `;
+        },
+        unmount: (el) => {
+          el.innerHTML = "";
+        },
+      },
+      {
+        url: "/other-page",
+        label: "Other Page",
+        mountIcon: (el) => {
+          el.innerHTML = "🌐";
+        },
+        unmountIcon: (el) => {
+          el.innerHTML = "";
+        },
+      }
+    ]
+  });
+  ```
+
+  ```html filename="index.html" {21}
+  <!-- Add a <div id="user-profile"> element to your HTML -->
+  <div id="user-profile"></div>
+
+  <!-- Initialize Clerk with your
+  Clerk Publishable key and Frontend API URL -->
+  <script
+    async
+    crossorigin="anonymous"
+    data-clerk-publishable-key="{{pub_key}}"
+    src="https://{{fapi_url}}/npm/@clerk/clerk-js@latest/dist/clerk.browser.js"
+    type="text/javascript"
+  ></script>
+
+  <script>
+    window.addEventListener("load", async function () {
+      await Clerk.load();
+
+      const userProfileDiv =
+        document.getElementById('user-profile');
+
+      Clerk.openUserProfile(userProfileDiv, {
+        customPages: [
+          {
+            url: "custom-page",
+            label: "Custom Page",
+            mountIcon: (el) => {
+              el.innerHTML = "👋";
+            },
+            unmountIcon: (el) => {
+                el.innerHTML = "";
+            },
+            mount: (el) => {
+              el.innerHTML = `
+                <h1><b>Custom Page</b></h1>
+                <p>This is the content of the custom page.</p>
+                `;
+            },
+            unmount: (el) => {
+              el.innerHTML = "";
+            },
+          },
+          {
+            url: "/other-page",
+            label: "Other Page",
+            mountIcon: (el) => {
+              el.innerHTML = "🌐";
+            },
+            unmountIcon: (el) => {
+              el.innerHTML = "";
+            },
+          }
+        ]
+      });
+    });
+  </script>
+  ```
+</CodeBlockTabs>
+
 ## Add a custom link to <code>\<UserProfile&nbsp;/></code>
 
 You can add external links to the `<UserProfile />` navigation sidebar using the `<UserButton.UserProfileLink />` component or the `<UserProfile.Link />` component, depending on your use case.
@@ -363,115 +475,3 @@ With the above example, the `<UserProfile />` navigation sidebar will be in the 
 2. Homepage
 3. Account
 4. Security
-
-## JavaScript examples
-
-To add custom pages to the `<UserProfile />` component using JavaScript, you can pass `customPages` property to the `mountUserProfile()` or `openUserProfile()` method, as shown in the following example:
-
-<CodeBlockTabs type="npm-script" options={['NPM module', '<script>']}>
-  ```js filename="main.js" {14}
-  import { Clerk } from '@clerk/clerk-js';
-
-  // Initialize Clerk with your Clerk publishable key
-  const clerk = new Clerk('{{pub_key}}');
-  await clerk.load();
-
-  document.getElementById('app').innerHTML = `
-    <div id="user-profile"></div>
-  `
-
-  const userProfileDiv = document.getElementById('user-profile');
-
-  clerk.openUserProfile(userProfileDiv, {
-    customPages: [
-      {
-        url: "custom-page",
-        label: "Custom Page",
-        mountIcon: (el) => {
-          el.innerHTML = "👋";
-        },
-        unmountIcon: (el) => {
-          el.innerHTML = "";
-        },
-        mount: (el) => {
-          el.innerHTML = `
-            <h1><b>Custom Page</b></h1>
-            <p>This is the content of the custom page.</p>
-            `;
-        },
-        unmount: (el) => {
-          el.innerHTML = "";
-        },
-      },
-      {
-        url: "/other-page",
-        label: "Other Page",
-        mountIcon: (el) => {
-          el.innerHTML = "🌐";
-        },
-        unmountIcon: (el) => {
-          el.innerHTML = "";
-        },
-      }
-    ]
-  });
-  ```
-
-  ```html filename="index.html" {21}
-  <!-- Add a <div id="user-profile"> element to your HTML -->
-  <div id="user-profile"></div>
-
-  <!-- Initialize Clerk with your
-  Clerk Publishable key and Frontend API URL -->
-  <script
-    async
-    crossorigin="anonymous"
-    data-clerk-publishable-key="{{pub_key}}"
-    src="https://{{fapi_url}}/npm/@clerk/clerk-js@latest/dist/clerk.browser.js"
-    type="text/javascript"
-  ></script>
-
-  <script>
-    window.addEventListener("load", async function () {
-      await Clerk.load();
-
-      const userProfileDiv =
-        document.getElementById('user-profile');
-
-      Clerk.openUserProfile(userProfileDiv, {
-        customPages: [
-          {
-            url: "custom-page",
-            label: "Custom Page",
-            mountIcon: (el) => {
-              el.innerHTML = "👋";
-            },
-            unmountIcon: (el) => {
-                el.innerHTML = "";
-            },
-            mount: (el) => {
-              el.innerHTML = `
-                <h1><b>Custom Page</b></h1>
-                <p>This is the content of the custom page.</p>
-                `;
-            },
-            unmount: (el) => {
-              el.innerHTML = "";
-            },
-          },
-          {
-            url: "/other-page",
-            label: "Other Page",
-            mountIcon: (el) => {
-              el.innerHTML = "🌐";
-            },
-            unmountIcon: (el) => {
-              el.innerHTML = "";
-            },
-          }
-        ]
-      });
-    });
-  </script>
-  ```
-</CodeBlockTabs>

--- a/docs/components/organization/organization-profile.mdx
+++ b/docs/components/organization/organization-profile.mdx
@@ -28,6 +28,7 @@ All props are optional.
 | `afterLeaveOrganizationUrl` | `string` | Full URL or path to navigate to after leaving an organization. |
 | `routing` | `'hash' \| 'path' \| 'virtual'` | The routing strategy for your pages. <br />Defaults to `'path'` in Next.js and Remix applications. Defaults to `hash` for all other SDK's. |
 | `path` | `string` | The path where the component is mounted on when `routing` is set to `path`. It is ignored in hash- and virtual-based routing.<br />For example: `/organization-profile`. |
+| `customPages` | `CustomPages[]` | An array of custom pages to add to the organization profile. Only available for the [JavaScript SDK](/docs/references/javascript/overview). To add custom pages with React-based SDK's, see the [dedicated guide](/docs/components/customization/organization-profile). |
 
 ## Usage with frameworks
 

--- a/docs/components/user/user-profile.mdx
+++ b/docs/components/user/user-profile.mdx
@@ -24,6 +24,7 @@ All props are optional.
 | `routing` | `'hash' \| 'path' \| 'virtual'` | The routing strategy for your pages. <br />Defaults to `'path'` in Next.js and Remix applications. Defaults to `hash` for all other SDK's. |
 | `path` | `string` | The path where the component is mounted on when `routing` is set to `path`. It is ignored in hash- and virtual-based routing.<br />For example: `/user-profile`. |
 | `additionalOAuthScopes` | `object` | Specify additional scopes per OAuth provider that your users would like to provide if not already approved. <br />For example: `{google: ['foo', 'bar'], github: ['qux']}`. |
+| `customPages` | <code>[CustomPage](/docs/references/javascript/types/custom-page)[]</code> | An array of custom pages to add to the user profile. Only available for the [JavaScript SDK](/docs/references/javascript/overview). To add custom pages with React-based SDK's, see the [dedicated guide](/docs/components/customization/user-profile). |
 
 ## Usage with frameworks
 


### PR DESCRIPTION
<!--- Add the "deploy-preview" label and add your page previews here -->

> [!IMPORTANT]
> 🔎 Previews:
>
> - https://clerk.com/docs/pr/1258/components/customization/user-profile#java-script-example
> - https://clerk.com/docs/pr/1258/components/customization/organization-profile#java-script-example

<!--- Describe your changes in detail. Why does this change need to happen? Include any links to Slack discussions, Linear comments, etc. -->
### Explanation:
[Linear ticket](https://linear.app/clerk/issue/DOCS-8899/bring-back-the-custom-pages-javascript-guides) reads:
Hello, I think 2 pages have gone missing:

https://github.com/clerk/clerk-docs/pull/404/files#diff-f23176b48e0e8683714aa153471f80873011acb8791a295ede6c9c4d272d7316

https://github.com/clerk/clerk-docs/pull/404/files#diff-857e57c057659631021e10bbf03cd7e34c8edc25306790483838ce149d5f1740

These two pages showcase how to use the Custom Pages if you are using vanilla JS.

I have also seen people in Discord looking for relevant information: https://discord.com/channels/856971667393609759/1021521740800733244/threads/1257975014200705065

<!--- How does this PR solve the problem? -->
### This PR:

- adds this information back to the docs. It seems they were accidentally removed when the /javascript/clerk/user-profile and /javascript/clerk/organization-profile pages were removed
