### PR TITLE
docs(astro): Add nanostores usage

### DIFF
--- a/docs/manifest.json
+++ b/docs/manifest.json
@@ -1801,9 +1801,9 @@
               "items": [
                 [
                   { "title": "Overview", "href": "/docs/references/astro/overview" },
-                  { 
-                    "title": "UI Frameworks", 
-                    "items": [  
+                  {
+                    "title": "UI Frameworks",
+                    "items": [
                       [
                         {
                           "title": "React",
@@ -1846,6 +1846,48 @@
                           "title": "Endpoints",
                           "wrap": false,
                           "href": "/docs/references/astro/endpoints"
+                        }
+                      ]
+                    ]
+                  },
+                  {
+                    "title": "Client-side Helpers",
+                    "items": [
+                      [
+                        {
+                          "title": "`$authStore`",
+                          "wrap": false,
+                          "href": "/docs/references/astro/auth-store"
+                        },
+                        {
+                          "title": "`$userStore`",
+                          "wrap": false,
+                          "href": "/docs/references/astro/user-store"
+                        },
+                        {
+                          "title": "`$signInStore`",
+                          "wrap": false,
+                          "href": "/docs/references/astro/sign-in-store"
+                        },
+                        {
+                          "title": "`$signUpStore`",
+                          "wrap": false,
+                          "href": "/docs/references/astro/sign-up-store"
+                        },
+                        {
+                          "title": "`$sessionStore`",
+                          "wrap": false,
+                          "href": "/docs/references/astro/session-store"
+                        },
+                        {
+                          "title": "`$sessionListStore`",
+                          "wrap": false,
+                          "href": "/docs/references/astro/session-list-store"
+                        },
+                        {
+                          "title": "`$organizationStore`",
+                          "wrap": false,
+                          "href": "/docs/references/astro/organization-store"
                         }
                       ]
                     ]

--- a/docs/manifest.json
+++ b/docs/manifest.json
@@ -1860,6 +1860,11 @@
                           "href": "/docs/references/astro/auth-store"
                         },
                         {
+                          "title": "`$clerkStore`",
+                          "wrap": false,
+                          "href": "/docs/references/astro/clerk-store"
+                        },
+                        {
                           "title": "`$userStore`",
                           "wrap": false,
                           "href": "/docs/references/astro/user-store"

--- a/docs/references/astro/auth-store.mdx
+++ b/docs/references/astro/auth-store.mdx
@@ -1,0 +1,49 @@
+---
+title: $authStore
+description: Clerk's $authStore nanostore is a convenient way to access the current auth state.
+---
+
+# `$authStore`
+
+The `$authStore` store is a convenient way to access the current auth state. This store provides the minimal information needed for data-loading and helper methods to manage the current active session.
+
+## `$authStore.get()` returns
+
+| Name | Type | Description |
+| --- | --- | --- |
+| `userId` | `string` | The current user's ID. |
+| `sessionId` | `string` | The current user's session ID. |
+| `orgId` | `string` | The current user's active organization ID. |
+| `orgRole` | `string` | The current user's active organization role. |
+| `orgSlug` | `string` | The current user's organization slug. |
+
+## How to use the `$authStore` store
+
+The following example demonstrates how to use the `$authStore` store to access the current auth state, like whether the user is signed in or not. It also demonstrates a basic example of how you could use the [`getToken()`](/docs/references/javascript/session#get-token) method to retrieve a session token for fetching data from an external resource.
+
+```tsx filename="components/external-data.tsx"
+import { useStore } from '@nanostores/react';
+import { $authStore } from '@clerk/astro/client';
+
+export default function ExternalData() {
+  const { userId } = useStore($authStore);
+
+  if (userId === undefined) {
+    // Handle loading state however you like
+    return <div>Loading...</div>;
+  }
+
+  if (userId === null) {
+    // Handle signed out state however you like
+    return <div>Sign in to view this page</div>;
+  }
+
+  const fetchDataFromExternalResource = async () => {
+    const token = await window.Clerk.session.getToken();
+    // Add logic to fetch your data
+    return data;
+  }
+
+  return <div>...</div>;
+}
+```

--- a/docs/references/astro/auth-store.mdx
+++ b/docs/references/astro/auth-store.mdx
@@ -5,7 +5,7 @@ description: Clerk's $authStore nanostore is a convenient way to access the curr
 
 # `$authStore`
 
-The `$authStore` store is a convenient way to access the current auth state. This store provides the minimal information needed for data-loading and helper methods to manage the current active session.
+The `$authStore` store is a convenient way to access the current auth state. This store provides the information needed for data-loading and helper methods to manage the current active session.
 
 ## `$authStore.get()` returns
 

--- a/docs/references/astro/auth-store.mdx
+++ b/docs/references/astro/auth-store.mdx
@@ -23,11 +23,11 @@ The following example demonstrates how to use the `$authStore` store to access t
 
 ```tsx filename="components/external-data.tsx"
 import { useStore } from '@nanostores/react';
-import { $authStore, $clerkStore } from '@clerk/astro/client';
+import { $authStore, $sessionStore } from '@clerk/astro/client';
 
 export default function ExternalData() {
   const { userId } = useStore($authStore);
-  const clerk = useStore($clerkStore);
+  const session = useStore($sessionStore);
 
   if (userId === undefined) {
     // Handle loading state however you like
@@ -40,7 +40,7 @@ export default function ExternalData() {
   }
 
   const fetchDataFromExternalResource = async () => {
-    const token = await clerk.session.getToken();
+    const token = await session.getToken();
     // Add logic to fetch your data
     return data;
   }

--- a/docs/references/astro/auth-store.mdx
+++ b/docs/references/astro/auth-store.mdx
@@ -15,11 +15,11 @@ The `$authStore` store is a convenient way to access the current auth state. Thi
 | `sessionId` | `string` | The current user's session ID. |
 | `orgId` | `string` | The current user's active organization ID. |
 | `orgRole` | `string` | The current user's active organization role. |
-| `orgSlug` | `string` | The current user's organization slug. |
+| `orgSlug` | `string` | The current user's active organization slug. |
 
 ## How to use the `$authStore` store
 
-The following example demonstrates how to use the `$authStore` store to access the current auth state, like whether the user is signed in or not. It also demonstrates a basic example of how you could use the [`getToken()`](/docs/references/javascript/session#get-token) method to retrieve a session token for fetching data from an external resource.
+The following example demonstrates how to use the `$authStore` store to access the current auth state. You perform actions like checking whether the user is signed in or not. It also demonstrates a basic example of how you could use the [`getToken()`](/docs/references/javascript/session#get-token) method to retrieve a session token for fetching data from an external resource.
 
 ```tsx filename="components/external-data.tsx"
 import { useStore } from '@nanostores/react';
@@ -27,7 +27,7 @@ import { $authStore, $sessionStore } from '@clerk/astro/client';
 
 export default function ExternalData() {
   const { userId } = useStore($authStore);
-  const session = useStore($sessionStore);
+  const { getToken } = useStore($sessionStore);
 
   if (userId === undefined) {
     // Handle loading state however you like
@@ -40,7 +40,7 @@ export default function ExternalData() {
   }
 
   const fetchDataFromExternalResource = async () => {
-    const token = await session.getToken();
+    const token = await getToken();
     // Add logic to fetch your data
     return data;
   }

--- a/docs/references/astro/auth-store.mdx
+++ b/docs/references/astro/auth-store.mdx
@@ -23,10 +23,11 @@ The following example demonstrates how to use the `$authStore` store to access t
 
 ```tsx filename="components/external-data.tsx"
 import { useStore } from '@nanostores/react';
-import { $authStore } from '@clerk/astro/client';
+import { $authStore, $clerkStore } from '@clerk/astro/client';
 
 export default function ExternalData() {
   const { userId } = useStore($authStore);
+  const clerk = useStore($clerkStore);
 
   if (userId === undefined) {
     // Handle loading state however you like
@@ -39,7 +40,7 @@ export default function ExternalData() {
   }
 
   const fetchDataFromExternalResource = async () => {
-    const token = await window.Clerk.session.getToken();
+    const token = await clerk.session.getToken();
     // Add logic to fetch your data
     return data;
   }

--- a/docs/references/astro/auth-store.mdx
+++ b/docs/references/astro/auth-store.mdx
@@ -27,7 +27,7 @@ import { $authStore, $sessionStore } from '@clerk/astro/client';
 
 export default function ExternalData() {
   const { userId } = useStore($authStore);
-  const { getToken } = useStore($sessionStore);
+  const session = useStore($sessionStore);
 
   if (userId === undefined) {
     // Handle loading state however you like
@@ -40,7 +40,12 @@ export default function ExternalData() {
   }
 
   const fetchDataFromExternalResource = async () => {
-    const token = await getToken();
+    if (!session) {
+      // Handle session loading state
+      return;
+    }
+
+    const token = await session.getToken();
     // Add logic to fetch your data
     return data;
   }

--- a/docs/references/astro/clerk-store.mdx
+++ b/docs/references/astro/clerk-store.mdx
@@ -1,0 +1,25 @@
+---
+title: $clerkStore
+description: Clerk's $clerkStore store is used to access the Clerk object, which can be used to build alternatives to any Clerk Component.
+---
+
+# `$clerkStore`
+
+The `$clerkStore` store provides access to the [`Clerk`](/docs/references/javascript/clerk/clerk) object, giving you the ability to build alternatives to any Clerk Component.
+
+<Callout type="warning">
+  This is intended to be used for advanced use cases, like building a completely custom OAuth flow or as an escape hatch for getting access to the `Clerk` object.
+</Callout>
+
+## How to use the `$clerkStore` store
+
+```tsx filename="components/sign-in.tsx"
+import { useStore } from '@nanostores/react';
+import { $clerkStore } from '@clerk/astro/client';
+
+export default function Home() {
+  const clerk = useStore($clerkStore);
+
+  return <button onClick={() => clerk.openSignIn({})}>Sign in</button>;
+};
+```

--- a/docs/references/astro/clerk-store.mdx
+++ b/docs/references/astro/clerk-store.mdx
@@ -5,7 +5,7 @@ description: Clerk's $clerkStore store is used to access the Clerk object, which
 
 # `$clerkStore`
 
-The `$clerkStore` store provides access to the [`Clerk`](/docs/references/javascript/clerk/clerk) object, giving you the ability to build alternatives to any Clerk Component.
+The `$clerkStore` store provides access to the [`Clerk`](/docs/references/javascript/clerk/clerk) object. This provides access to some methods that are not available in other stores.
 
 <Callout type="warning">
   This is intended to be used for advanced use cases, like building a completely custom OAuth flow or as an escape hatch for getting access to the `Clerk` object.

--- a/docs/references/astro/organization-store.mdx
+++ b/docs/references/astro/organization-store.mdx
@@ -43,6 +43,10 @@ The following example demonstrates how to implement pagination for organization 
 You can implement this pattern to any Clerk function that returns a [`ClerkPaginatedResponse`](/docs/references/javascript/types/clerk-paginated-response#clerk-paginated-response) object.
 
 ```tsx filename="organization-members.tsx"
+import { useState, useEffect } from 'react';
+import { $organizationStore } from '@clerk/astro/client'
+import { useStore } from '@nanostores/react';
+
 export default function OrganizationMembers() {
   const [memberships, setMemberships] = useState([]);
   const [currentPage, setCurrentPage] = useState(1);

--- a/docs/references/astro/organization-store.mdx
+++ b/docs/references/astro/organization-store.mdx
@@ -74,13 +74,13 @@ export default function OrganizationMembers() {
     }
   };
 
-  const handlePrevious = () => {
+  const fetchPrevious = () => {
     if (currentPage > 1) {
       setCurrentPage(currentPage - 1);
     }
   };
 
-  const handleNext = () => {
+  const fetchNext = () => {
     setCurrentPage(currentPage + 1);
   };
 
@@ -101,8 +101,8 @@ export default function OrganizationMembers() {
         ))}
       </ul>
       <div>
-        <button onClick={handlePrevious} disabled={currentPage === 1}>Previous page</button>
-        <button onClick={handleNext}>Next page</button>
+        <button onClick={fetchPrevious} disabled={currentPage === 1}>Previous page</button>
+        <button onClick={fetchNext}>Next page</button>
       </div>
     </div>
   );

--- a/docs/references/astro/organization-store.mdx
+++ b/docs/references/astro/organization-store.mdx
@@ -34,3 +34,73 @@ export default function Home() {
     </div>
   )
 }
+```
+
+## Paginating data
+
+The following example demonstrates how to implement pagination for organization memberships. The `memberships` state will be populated with the first page of the organization's memberships. When the "Previous page" or "Next page" button is clicked, the `fetchMemberships` function will be called to fetch the previous or next page of memberships.
+
+You can implement this pattern to any Clerk function that returns a [`ClerkPaginatedResponse`](/docs/references/javascript/types/clerk-paginated-response#clerk-paginated-response) object.
+
+```tsx filename="organization-members.tsx"
+export default function OrganizationMembers() {
+  const [memberships, setMemberships] = useState([]);
+  const [currentPage, setCurrentPage] = useState(1);
+  const organization = useStore($organizationStore);
+
+  const pageSize = 10;
+
+  useEffect(() => {
+    fetchMemberships();
+  }, [currentPage, organization]);
+
+  const fetchMemberships = async () => {
+    if (!organization) {
+      return;
+    }
+
+    try {
+      const { data } = await organization.getMemberships({
+        initialPage: currentPage,
+        pageSize: pageSize
+      });
+      setMemberships(data);
+    } catch (error) {
+      console.error("Error fetching memberships:", error);
+    }
+  };
+
+  const handlePrevious = () => {
+    if (currentPage > 1) {
+      setCurrentPage(currentPage - 1);
+    }
+  };
+
+  const handleNext = () => {
+    setCurrentPage(currentPage + 1);
+  };
+
+  if (!organization) {
+    // Handle loading state
+    return null;
+  }
+
+  return (
+    <div>
+      <h2>Organization members</h2>
+      <ul>
+        {memberships.map((membership) => (
+          <li key={membership.id}>
+            {membership.publicUserData.firstName} {membership.publicUserData.lastName} &lt;
+            {membership.publicUserData.identifier}&gt; :: {membership.role}
+          </li>
+        ))}
+      </ul>
+      <div>
+        <button onClick={handlePrevious} disabled={currentPage === 1}>Previous page</button>
+        <button onClick={handleNext}>Next page</button>
+      </div>
+    </div>
+  );
+};
+```

--- a/docs/references/astro/organization-store.mdx
+++ b/docs/references/astro/organization-store.mdx
@@ -63,26 +63,15 @@ export default function OrganizationMembers() {
       return;
     }
 
-    try {
-      const { data } = await organization.getMemberships({
-        initialPage: currentPage,
-        pageSize: pageSize
-      });
-      setMemberships(data);
-    } catch (error) {
-      console.error("Error fetching memberships:", error);
-    }
+    const { data } = await organization.getMemberships({
+      initialPage: currentPage,
+      pageSize: 5
+    });
+    setMemberships(data);
   };
 
-  const fetchPrevious = () => {
-    if (currentPage > 1) {
-      setCurrentPage(currentPage - 1);
-    }
-  };
-
-  const fetchNext = () => {
-    setCurrentPage(currentPage + 1);
-  };
+  const handlePrevious = () => setCurrentPage(currentPage - 1);
+  const handleNext = () => setCurrentPage(currentPage + 1);
 
   if (!organization) {
     // Handle loading state
@@ -101,8 +90,8 @@ export default function OrganizationMembers() {
         ))}
       </ul>
       <div>
-        <button onClick={fetchPrevious} disabled={currentPage === 1}>Previous page</button>
-        <button onClick={fetchNext}>Next page</button>
+        <button onClick={handlePrevious} disabled={currentPage === 1}>Previous</button>
+        <button onClick={handleNext}>Next</button>
       </div>
     </div>
   );

--- a/docs/references/astro/organization-store.mdx
+++ b/docs/references/astro/organization-store.mdx
@@ -1,0 +1,36 @@
+---
+title: $organizationStore
+description: Clerk's $organizationStore store retrieves the currently active organization.
+---
+
+# `$organizationStore`
+
+The `$organizationStore` store is used to retrieve attributes of the currently active organization.
+
+## How to use the `$organizationStore` store
+
+The following example demonstrates how to use the `$organizationStore` store to access the [`Organization`](/docs/references/javascript/organization/organization) object, which allows you to access the current active organization.
+
+```tsx filename="session.tsx"
+import { useStore } from '@nanostores/react';
+import { $organizationStore } from '@clerk/astro/client';
+
+export default function Home() {
+  const organization = useStore($organizationStore);
+
+  if (organization === undefined) {
+    // Add logic to handle loading state
+    return null;
+  }
+
+  if(organization === null) {
+    // Add logic to handle no active organization state
+    return null;
+  }
+
+  return (
+    <div>
+      <p>This current organization is {organization.name}</p>
+    </div>
+  )
+}

--- a/docs/references/astro/organization-store.mdx
+++ b/docs/references/astro/organization-store.mdx
@@ -70,8 +70,8 @@ export default function OrganizationMembers() {
     setMemberships(data);
   };
 
-  const handlePrevious = () => setCurrentPage(currentPage - 1);
-  const handleNext = () => setCurrentPage(currentPage + 1);
+  const fetchPrevious = () => setCurrentPage(currentPage - 1);
+  const fetchNext = () => setCurrentPage(currentPage + 1);
 
   if (!organization) {
     // Handle loading state
@@ -90,8 +90,8 @@ export default function OrganizationMembers() {
         ))}
       </ul>
       <div>
-        <button onClick={handlePrevious} disabled={currentPage === 1}>Previous</button>
-        <button onClick={handleNext}>Next</button>
+        <button onClick={fetchPrevious} disabled={currentPage === 1}>Previous</button>
+        <button onClick={fetchNext}>Next</button>
       </div>
     </div>
   );

--- a/docs/references/astro/overview.mdx
+++ b/docs/references/astro/overview.mdx
@@ -6,6 +6,23 @@ description: Learn how to use Clerk to quickly and easily add secure authenticat
 
 Clerk makes it simple to add authentication to your Astro application. This documentation covers the capabilities and methods available from Clerk's Astro SDK.
 
+## Guides
+
+- [Read session and user data](/docs/references/astro/read-session-data)
+
+## Client-side helpers
+
+Clerk Astro provides a set of useful [stores](https://github.com/nanostores/nanostores) that give you access to the [`Clerk`](/docs/references/javascript/clerk/clerk) object, and helper methods for signing in and signing up.
+
+- [`$authStore`](/docs/references/astro/auth-store)
+- [`$clerkStore`](/docs/references/astro/clerk-store)
+- [`$userStore`](/docs/references/astro/user-store)
+- [`$signInStore`](/docs/references/astro/sign-in-store)
+- [`$signUpStore`](/docs/references/astro/sign-up-store)
+- [`$sessionStore`](/docs/references/astro/session-store)
+- [`$sessionListStore`](/docs/references/astro/session-list-store)
+- [`$organizationStore`](/docs/references/astro/organization-store)
+
 ## General Reference
 
 ### `Auth` object

--- a/docs/references/astro/overview.mdx
+++ b/docs/references/astro/overview.mdx
@@ -9,6 +9,7 @@ Clerk makes it simple to add authentication to your Astro application. This docu
 ## Guides
 
 - [Read session and user data](/docs/references/astro/read-session-data)
+- [Migrate from the Astro community SDK to the official Clerk SDK](/docs/references/astro/migrating-from-astro-community-sdk)
 
 ## Client-side helpers
 
@@ -32,7 +33,3 @@ Both `Astro.locals.auth()` returns an Auth object. This JavaScript object contai
 ### `clerkMiddleware()`
 
 The clerkMiddleware() helper integrates Clerk authentication into your Astro application through middleware. It allows you to integrate authorization into both the client and server of your application. You can learn more [here](/docs/references/astro/clerk-middleware).
-
-## Migrating from the Astro community SDK
-
-Learn how to migrate from the Astro community SDK to the official Clerk SDK in the [migration guide](/docs/references/astro/migrating-from-astro-community-sdk)

--- a/docs/references/astro/read-session-data.mdx
+++ b/docs/references/astro/read-session-data.mdx
@@ -28,12 +28,12 @@ const user = await Astro.locals.currentUser()
 ```tsx filename="src/api/me.ts"
 export async function GET({ locals }) {
   if (!locals.auth().userId) {
-    new Response('Unauthorized', { status: 401 })
+    return new Response('Unauthorized', { status: 401 })
   }
 
-  return new Response(JSON.stringify(await locals.currentUser()), {
-    status: 200,
-  });
+  const currentUser = await locals.currentUser();
+
+  return new Response(JSON.stringify(currentUser));
 };
 ```
 </CodeBlockTabs>

--- a/docs/references/astro/read-session-data.mdx
+++ b/docs/references/astro/read-session-data.mdx
@@ -1,11 +1,13 @@
 ---
-title: Read session and user data in your Next.js app with Clerk
+title: Read session and user data in your Astro app with Clerk
 description: Learn how to use Clerk's hooks and helpers to access the active session and user data in your Astro application.
 ---
 
 # Read session and user data
 
 Clerk provides helpers that you can use to access the active session and user data in your Astro application.
+
+## Server side
 
 This example uses the `auth()` local to validate an authenticated user and the  `currentUser()` local to access the `Backend API User` object for the authenticated user.
 
@@ -35,3 +37,48 @@ export async function GET({ locals }) {
 };
 ```
 </CodeBlockTabs>
+
+## Client side
+
+### `$authStore`
+
+The [`$authStore`](/docs/references/astro/auth-store) store is a convenient way to access the current auth state. This store provides the minimal information needed for data-loading and helper methods to manage the current active session.
+
+```tsx filename="components/example.tsx"
+import { useStore } from '@nanostores/react';
+import { $authStore } from '@clerk/astro/client';
+
+export default function Example() {
+  const { userId, sessionId } = useStore($authStore);
+
+  // In case the user signs out while on the page.
+  if (!userId) {
+    return null;
+  }
+
+  return (
+    <div>
+      Hello, {userId} your current active session is {sessionId}
+    </div>
+  );
+}
+```
+
+### `$userStore`
+
+The [`$userStore`](/docs/references/astro/user-store) store is a convenient way to access the current user data where you need it. This store provides the user data and helper methods to manage the current active session.
+
+```tsx filename="components/example.tsx"
+import { useStore } from '@nanostores/react';
+import { $userStore } from '@clerk/astro/client';
+
+export default function Example() {
+  const user = useStore($userStore);
+
+  if (!user) {
+    return null;
+  }
+
+  return <div>Hello, {user.firstName} welcome to Clerk</div>;
+}
+```

--- a/docs/references/astro/session-list-store.mdx
+++ b/docs/references/astro/session-list-store.mdx
@@ -9,7 +9,7 @@ The `$sessionListStore` store returns an array of [`Session`](/docs/references/j
 
 ## How to use the `$sessionListStore` store
 
-The following example demonstrates how to use the `$sessionListStore` store to retrieve a list of sessions that have been registered on the client device. The `isLoaded` property is used to handle the loading state, and the `sessions` property is used to display the number of times the user has visited the page.
+The following example demonstrates how to use the `$sessionListStore` store to display the expiration time of the first session in the list.
 
 ```tsx filename="session-list.tsx"
 import { useStore } from '@nanostores/react';
@@ -25,9 +25,7 @@ export default function Home() {
 
   return (
     <div>
-      <p>Welcome back. You have been here
-      {sessions.length} times before.
-      </p>
+      <p>Your current session expires at {sessions[0].expireAt}.</p>
     </div>
   )
 }

--- a/docs/references/astro/session-list-store.mdx
+++ b/docs/references/astro/session-list-store.mdx
@@ -1,0 +1,34 @@
+---
+title: $sessionListStore
+description: Clerk's $sessionList store retrieves a list of sessions that have been registered on the client device.
+---
+
+# `$sessionListStore`
+
+The `$sessionListStore` store returns an array of [`Session`](/docs/references/javascript/session) objects that have been registered on the client device.
+
+## How to use the `$sessionListStore` store
+
+The following example demonstrates how to use the `$sessionListStore` store to retrieve a list of sessions that have been registered on the client device. The `isLoaded` property is used to handle the loading state, and the `sessions` property is used to display the number of times the user has visited the page.
+
+```tsx filename="session-list.tsx"
+import { useStore } from '@nanostores/react';
+import { $sessionList } from '@clerk/astro/client';
+
+export default function Home() {
+  const sessions = useStore($sessionList);
+
+  if (sessions === undefined) {
+    // handle loading state
+    return null;
+  }
+
+  return (
+    <div>
+      <p>Welcome back. You have been here
+      {sessions.length} times before.
+      </p>
+    </div>
+  )
+}
+```

--- a/docs/references/astro/session-store.mdx
+++ b/docs/references/astro/session-store.mdx
@@ -9,7 +9,7 @@ The `$sessionStore` store provides access to the current user's [`Session`](/doc
 
 ## How to use the `$sessionStore` store
 
-The following example demonstrates how to use the `$sessionStore` store to access the `SignIn` object, which has the `lastActiveAt` property on it. The `lastActiveAt` property is used to display the last active time of the current session to the user.
+The following example demonstrates how to use the `$sessionStore` store to access the `session` object, which has the `lastActiveAt` property on it. The `lastActiveAt` property is used to display the last active time of the current session to the user.
 
 ```tsx filename="session.tsx"
 import { useStore } from '@nanostores/react';

--- a/docs/references/astro/session-store.mdx
+++ b/docs/references/astro/session-store.mdx
@@ -1,0 +1,39 @@
+---
+title: $sessionStore
+description: Clerk's $sessionStore store provides access to the the current user Session object, as well as helpers to set the active session.
+---
+
+# `$sessionStore`
+
+The `$sessionStore` store provides access to the current user's [`Session`](/docs/references/javascript/session) object, as well as helpers for setting the active session.
+
+## How to use the `$sessionStore` store
+
+The following example demonstrates how to use the `$sessionStore` store to access the `SignIn` object, which has the `lastActiveAt` property on it. The `lastActiveAt` property is used to display the last active time of the current session to the user.
+
+```tsx filename="session.tsx"
+import { useStore } from '@nanostores/react';
+import { $sessionStore } from '@clerk/astro/client';
+
+export default function Home() {
+  const session = useStore($sessionStore);
+
+  if (session === undefined) {
+    // Add logic to handle loading state
+    return null;
+  }
+
+  if(session === null) {
+    // Add logic to handle not signed in state
+    return null;
+  }
+
+  return (
+    <div>
+      <p>This session has been active
+      since {session.lastActiveAt.toLocaleString()}
+      </p>
+    </div>
+  )
+}
+```

--- a/docs/references/astro/sign-in-store.mdx
+++ b/docs/references/astro/sign-in-store.mdx
@@ -29,8 +29,8 @@ Use the `$signInStore` store to check the current state of a sign-in.
   }
   ```
 
-The possible values for the `status` property of the `SignIn` resource are listed [here](https://clerk.com/docs/references/javascript/sign-in/sign-in#properties).
+The possible values for the `status` property of the `SignIn` resource are listed [here](/docs/references/javascript/sign-in/sign-in#properties).
 
 ### Create a custom sign-in flow with `$signInStore`
 
-The `$signInStore` store can also be used to build fully custom sign-in flows, if Clerk's pre-built components don't meet your specific needs or if you require more control over the authentication flow. Different sign-in flows include email and password, email and phone codes, email links, and multifactor (MFA). To learn more about using the `$signInStore` store to create custom flows, check out the [custom flow guides](https://clerk.com/docs/custom-flows/overview).
+The `$signInStore` store can also be used to build fully custom sign-in flows, if Clerk's pre-built components don't meet your specific needs or if you require more control over the authentication flow. Different sign-in flows include email and password, email and phone codes, email links, and multifactor (MFA). To learn more about using the `$signInStore` store to create custom flows, check out the [custom flow guides](/docs/custom-flows/overview).

--- a/docs/references/astro/sign-in-store.mdx
+++ b/docs/references/astro/sign-in-store.mdx
@@ -1,0 +1,44 @@
+---
+title: $signInStore
+description: Clerk's $signInStore store provides access to the SignIn object, which allows you to check the current state of a sign-in.
+---
+
+# `$signInStore`
+
+The `$signInStore` store provides access to the [`SignIn`](/docs/references/javascript/sign-in/sign-in) object, which allows you to check the current state of a sign-in. This is also useful for creating a custom sign-in flow.
+
+## How to use the `$signInStore` store
+
+### Check the current state of a sign-in with `$signInStore`
+
+Use the `$signInStore` store to check the current state of a sign-in.
+
+  ```tsx filename="sign-in-step.tsx"
+  import { useStore } from '@nanostores/react';
+  import { $signInStore } from '@clerk/astro/client';
+
+  export default function SignInStep() {
+    const signIn = useStore($signInStore);
+
+    if (signIn === undefined) {
+      // Add logic to handle loading state
+      return null;
+    }
+
+    return <div>The current sign in attempt status is {signIn.status}.</div>;
+  }
+  ```
+
+The `status` property of the `SignIn` object can be one of the following values:
+
+| Values | Descriptiom |
+| --- | --- |
+| `complete` | The user has been signed in and custom flow can proceed to [`setActive()`](https://clerk.com/docs/references/javascript/clerk/session-methods) to create session. |
+| `needs_first_factor` | The First Factor verification is missing. One of `email_link`, `email_code`, `phone_code`, `web3_metamask_signature` or `oauth_provider` is required to verify user. See [First Factor](/docs/references/javascript/sign-in/first-factor) for details. |
+| `needs_second_factor` | The Second Factor verification is missing. The Second Factor is an optional step to provide additional verification and includes `phone_code` and `totp`. See [Second Factor](/docs/references/javascript/sign-in/second-factor) for details. |
+| `needs_identifier` | The user's identifier (email address, phone number, username, etc.) hasn't been provided. |
+| `needs_new_password` | The user needs to set a new password. |
+
+### Create a custom sign-in flow with `$signInStore`
+
+The `$signInStore` store can also be used to build fully custom sign-in flows, if Clerk's pre-built components don't meet your specific needs or if you require more control over the authentication flow. Different sign-in flows include email and password, email and phone codes, email links, and multifactor (MFA). To learn more about using the `$signInStore` store to create custom flows, check out the [custom flow guides](https://clerk.com/docs/custom-flows/overview).

--- a/docs/references/astro/sign-in-store.mdx
+++ b/docs/references/astro/sign-in-store.mdx
@@ -25,6 +25,8 @@ Use the `$signInStore` store to check the current state of a sign-in.
       return null;
     }
 
+  // Logic to handle sign in
+
     return <div>The current sign in attempt status is {signIn.status}.</div>;
   }
   ```

--- a/docs/references/astro/sign-in-store.mdx
+++ b/docs/references/astro/sign-in-store.mdx
@@ -25,7 +25,7 @@ Use the `$signInStore` store to check the current state of a sign-in.
       return null;
     }
 
-  // Logic to handle sign in
+    // Logic to handle sign in
 
     return <div>The current sign in attempt status is {signIn.status}.</div>;
   }

--- a/docs/references/astro/sign-in-store.mdx
+++ b/docs/references/astro/sign-in-store.mdx
@@ -29,15 +29,7 @@ Use the `$signInStore` store to check the current state of a sign-in.
   }
   ```
 
-The `status` property of the `SignIn` object can be one of the following values:
-
-| Values | Descriptiom |
-| --- | --- |
-| `complete` | The user has been signed in and custom flow can proceed to [`setActive()`](https://clerk.com/docs/references/javascript/clerk/session-methods) to create session. |
-| `needs_first_factor` | The First Factor verification is missing. One of `email_link`, `email_code`, `phone_code`, `web3_metamask_signature` or `oauth_provider` is required to verify user. See [First Factor](/docs/references/javascript/sign-in/first-factor) for details. |
-| `needs_second_factor` | The Second Factor verification is missing. The Second Factor is an optional step to provide additional verification and includes `phone_code` and `totp`. See [Second Factor](/docs/references/javascript/sign-in/second-factor) for details. |
-| `needs_identifier` | The user's identifier (email address, phone number, username, etc.) hasn't been provided. |
-| `needs_new_password` | The user needs to set a new password. |
+The possible values for the `status` property of the `SignIn` resource are listed [here](https://clerk.com/docs/references/javascript/sign-in/sign-in#properties).
 
 ### Create a custom sign-in flow with `$signInStore`
 

--- a/docs/references/astro/sign-up-store.mdx
+++ b/docs/references/astro/sign-up-store.mdx
@@ -23,6 +23,9 @@ Use the `$signUpStore` store to access the `SignUp` object and check the current
       // Add logic to handle loading state
       return null;
     }
+```suggestion
+
+  // Logic to handle sign up
 
     return <div>The current sign-up attempt status is {signUp.status}.</div>;
   }

--- a/docs/references/astro/sign-up-store.mdx
+++ b/docs/references/astro/sign-up-store.mdx
@@ -28,8 +28,8 @@ Use the `$signUpStore` store to access the `SignUp` object and check the current
   }
   ```
 
-The possible values for the `status` property of the `SignUp` resource are listed [here](https://clerk.com/docs/references/javascript/sign-up/sign-up#properties).
+The possible values for the `status` property of the `SignUp` resource are listed [here](/docs/references/javascript/sign-up/sign-up#properties).
 
 ### Create a custom sign-up flow with `$signUpStore`
 
-The `$signUpStore` store can also be used to build fully custom sign-up flows, if Clerk's pre-built components don't meet your specific needs or if you require more control over the authentication flow. Different sign-up flows include email and password, email and phone codes, email links, and multifactor (MFA). To learn more about using the `$signUpStore` store to create custom flows, check out the [custom flow guides](https://clerk.com/docs/custom-flows/overview).
+The `$signUpStore` store can also be used to build fully custom sign-up flows, if Clerk's pre-built components don't meet your specific needs or if you require more control over the authentication flow. Different sign-up flows include email and password, email and phone codes, email links, and multifactor (MFA). To learn more about using the `$signUpStore` store to create custom flows, check out the [custom flow guides](/docs/custom-flows/overview).

--- a/docs/references/astro/sign-up-store.mdx
+++ b/docs/references/astro/sign-up-store.mdx
@@ -28,13 +28,7 @@ Use the `$signUpStore` store to access the `SignUp` object and check the current
   }
   ```
 
-The `status` property of the `SignUp` object can be one of the following values:
-
-| Values | Descriptiom |
-| --- | --- |
-| `complete` | The user has been created and custom flow can proceed to [`setActive()`](https://clerk.com/docs/references/javascript/clerk/session-methods) to create session. |
-| `abandoned` | The sign-up attempt will be abandoned if it was started more than 24 hours previously. |
-| `missing_requirements` | A requirement from the [Email, Phone, Username](https://dashboard.clerk.com/last-active?path=user-authentication/email-phone-username) settings is missing. For example, in the Clerk Dashboard, the Password setting is required but a password was not provided in the custom flow. |
+The possible values for the `status` property of the `SignUp` resource are listed [here](https://clerk.com/docs/references/javascript/sign-up/sign-up#properties).
 
 ### Create a custom sign-up flow with `$signUpStore`
 

--- a/docs/references/astro/sign-up-store.mdx
+++ b/docs/references/astro/sign-up-store.mdx
@@ -23,9 +23,8 @@ Use the `$signUpStore` store to access the `SignUp` object and check the current
       // Add logic to handle loading state
       return null;
     }
-```suggestion
 
-  // Logic to handle sign up
+    // Logic to handle sign up
 
     return <div>The current sign-up attempt status is {signUp.status}.</div>;
   }

--- a/docs/references/astro/sign-up-store.mdx
+++ b/docs/references/astro/sign-up-store.mdx
@@ -1,0 +1,41 @@
+---
+title: $signUpStore
+description: Clerk's $signUpStore hook gives you access to the SignUp object, which allows you to check the current state of a sign-up.
+---
+# `$signUpStore`
+
+The `$signUpStore` store gives you access to the [`SignUp`](/docs/references/javascript/sign-up/sign-up) object, which allows you to check the current state of a sign-up. This is also useful for creating a custom sign-up flow.
+
+## How to use the `$signUpStore` store
+
+### Check the current state of a sign-up with `$signUpStore`
+
+Use the `$signUpStore` store to access the `SignUp` object and check the current state of a sign-up.
+
+  ```tsx filename="sign-up-step.tsx"
+  import { useStore } from '@nanostores/react';
+  import { $signUpStore } from '@clerk/astro/client';
+
+  export default function SignUpStep() {
+    const signUp = $signUpStore;
+
+    if (signUp === undefined) {
+      // Add logic to handle loading state
+      return null;
+    }
+
+    return <div>The current sign-up attempt status is {signUp.status}.</div>;
+  }
+  ```
+
+The `status` property of the `SignUp` object can be one of the following values:
+
+| Values | Descriptiom |
+| --- | --- |
+| `complete` | The user has been created and custom flow can proceed to [`setActive()`](https://clerk.com/docs/references/javascript/clerk/session-methods) to create session. |
+| `abandoned` | The sign-up attempt will be abandoned if it was started more than 24 hours previously. |
+| `missing_requirements` | A requirement from the [Email, Phone, Username](https://dashboard.clerk.com/last-active?path=user-authentication/email-phone-username) settings is missing. For example, in the Clerk Dashboard, the Password setting is required but a password was not provided in the custom flow. |
+
+### Create a custom sign-up flow with `$signUpStore`
+
+The `$signUpStore` store can also be used to build fully custom sign-up flows, if Clerk's pre-built components don't meet your specific needs or if you require more control over the authentication flow. Different sign-up flows include email and password, email and phone codes, email links, and multifactor (MFA). To learn more about using the `$signUpStore` store to create custom flows, check out the [custom flow guides](https://clerk.com/docs/custom-flows/overview).

--- a/docs/references/astro/sign-up-store.mdx
+++ b/docs/references/astro/sign-up-store.mdx
@@ -17,7 +17,7 @@ Use the `$signUpStore` store to access the `SignUp` object and check the current
   import { $signUpStore } from '@clerk/astro/client';
 
   export default function SignUpStep() {
-    const signUp = $signUpStore;
+    const signUp = useStore($signUpStore);
 
     if (signUp === undefined) {
       // Add logic to handle loading state

--- a/docs/references/astro/user-store.mdx
+++ b/docs/references/astro/user-store.mdx
@@ -5,7 +5,7 @@ description: The $userStore store is used to get the current user object and to 
 
 # `$userStore`
 
-The `$userStore` store is a convenient way to access the current [`User`](/docs/references/javascript/user/user) data where you need it. This store provides the user data and helper methods to manage the current active session.
+The `$userStore` store is a convenient way to access the current [`User`](/docs/references/javascript/user/user) data where you need it. This store provides the user data and helper methods to manage the current active user.
 
 ## How to use the `$userStore` store
 

--- a/docs/references/astro/user-store.mdx
+++ b/docs/references/astro/user-store.mdx
@@ -11,7 +11,7 @@ The `$userStore` store is a convenient way to access the current [`User`](/docs/
 
 ### Retrieve the current user data with the `$userStore` store
 
-The following example demonstrates how to use the `$userStore` store to access the `user` object, which includes the current user's data, like the user's full name.
+The following example demonstrates how to use the `$userStore` store to access the `user` object. For more information see the [`user` object](/docs/references/javascript/user/user#user-object) reference.
 
 For more information on the `User` object, see the [`reference`](/docs/references/javascript/user/user).
 

--- a/docs/references/astro/user-store.mdx
+++ b/docs/references/astro/user-store.mdx
@@ -74,7 +74,7 @@ export default function User() {
 
 ### Reload user data with the `$userStore` store
 
-To retrieve the latest user data after updating the user in the dashboard or via [Backend API](/docs/references/backend/user/update-user), use the `user.reload()` method.
+To retrieve the latest user data after updating the user in the dashboard or via the [Backend API](/docs/references/backend/user/update-user), use the `user.reload()` method.
 
 For more information on the `reload()` method, see the [`User`](/docs/references/javascript/user/user#reload) reference.
 

--- a/docs/references/astro/user-store.mdx
+++ b/docs/references/astro/user-store.mdx
@@ -1,0 +1,115 @@
+---
+title: $userStore
+description: The $userStore store is used to get the current user object and to update the user's data on the client side.
+---
+
+# `$userStore`
+
+The `$userStore` store is a convenient way to access the current [`User`](/docs/references/javascript/user/user) data where you need it. This store provides the user data and helper methods to manage the current active session.
+
+## How to use the `$userStore` store
+
+### Retrieve the current user data with the `$userStore` store
+
+The following example demonstrates how to use the `$userStore` store to access the `user` object, which includes the current user's data, like the user's full name.
+
+For more information on the `User` object, see the [`reference`](/docs/references/javascript/user/user).
+
+```tsx filename="user.tsx"
+import { useStore } from '@nanostores/react';
+import { $userStore } from '@clerk/astro/client';
+
+export default function User() {
+  const user = useStore($userStore);
+
+  if (user === undefined) {
+    // Handle loading state however you like
+    return null;
+  }
+
+  if (user) {
+    return <div>Hello {user.fullName}!</div>;
+  }
+
+  return <div>Not signed in</div>;
+}
+```
+
+### Update the current user data with the `$userStore` store
+
+The following example demonstrates how to use the `$userStore` Store to access the `user` object, which includes the `update` method for updating the user's data.
+
+For more information on the `update()` method, see the [`User`](/docs/references/javascript/user/user#update) reference.
+
+```tsx filename="user.tsx"
+import { useStore } from '@nanostores/react';
+import { $userStore } from '@clerk/astro/client';
+
+export default function User() {
+  const user = useStore($userStore);
+
+  if (user === undefined) {
+    // Handle loading state however you like
+    return null;
+  }
+
+  if (user === null) return null;
+
+  const updateUser = async () => {
+    await user.update({
+      firstName: "John",
+      lastName: "Doe",
+    });
+  };
+
+  return (
+    <>
+      <button onClick={updateUser}>Click me to update your name</button>
+      <p>user.firstName: {user?.firstName}</p>
+      <p>user.lastName: {user?.lastName}</p>
+    </>
+  );
+}
+```
+
+### Reload user data with the `$userStore` store
+
+To retrieve the latest user data after updating the user elsewhere, use the `user.reload()` method.
+
+For more information on the `reload()` method, see the [`User`](/docs/references/javascript/user/user#reload) reference.
+
+```tsx filename="user.tsx"
+import { useStore } from '@nanostores/react';
+import { $userStore } from '@clerk/astro/client';
+
+export default function User() {
+  const user = useStore($userStore);
+
+  if (user === undefined) {
+    // Handle loading state however you like
+    return null;
+  }
+
+  if (user === null) return null;
+
+  const updateUser = async () => {
+    // Update data via an API endpoint
+    const updateMetadata = await fetch("/api/updateMetadata");
+
+    // Check if the update was successful
+    if (updateMetadata.message !== "success") {
+      throw new Error("Error updating");
+    }
+
+    // If the update was successful, reload the user data
+    await user.reload();
+  };
+
+  return (
+    <>
+      <button onClick={updateUser}>Click me to update your metadata</button>
+      <p>user role: {user?.publicMetadata.role}</p>
+    </>
+  );
+}
+```

--- a/docs/references/astro/user-store.mdx
+++ b/docs/references/astro/user-store.mdx
@@ -11,9 +11,9 @@ The `$userStore` store is a convenient way to access the current [`User`](/docs/
 
 ### Retrieve the current user data with the `$userStore` store
 
-The following example demonstrates how to use the `$userStore` store to access the `user` object. For more information see the [`user` object](/docs/references/javascript/user/user#user-object) reference.
+The following example demonstrates how to use the `$userStore` store to access the `user` object. It returns `undefined` while Clerk is still loading and `null` if the user is not signed in.
 
-For more information on the `User` object, see the [`reference`](/docs/references/javascript/user/user).
+For more information see the [`user` object](/docs/references/javascript/user/user#user-object) reference.
 
 ```tsx filename="user.tsx"
 import { useStore } from '@nanostores/react';

--- a/docs/references/astro/user-store.mdx
+++ b/docs/references/astro/user-store.mdx
@@ -74,7 +74,7 @@ export default function User() {
 
 ### Reload user data with the `$userStore` store
 
-To retrieve the latest user data after updating the user elsewhere, use the `user.reload()` method.
+To retrieve the latest user data after updating the user in the dashboard or via [Backend API](/docs/references/backend/user/update-user), use the `user.reload()` method.
 
 For more information on the `reload()` method, see the [`User`](/docs/references/javascript/user/user#reload) reference.
 


### PR DESCRIPTION
<!--- Add the "deploy-preview" label and add your page previews here -->

> [!IMPORTANT]
> 🔎 Previews:
>
> - https://clerk.com/docs/pr/1259/references/astro/auth-store
> - https://clerk.com/docs/pr/1259/references/astro/clerk-store
> - https://clerk.com/docs/pr/1259/references/astro/user-store
> - https://clerk.com/docs/pr/1259/references/astro/sign-in-store
> - https://clerk.com/docs/pr/1259/references/astro/sign-up-store
> - https://clerk.com/docs/pr/1259/references/astro/session-store
> - https://clerk.com/docs/pr/1259/references/astro/session-list-store
> - https://clerk.com/docs/pr/1259/references/astro/organization-store
> - https://clerk.com/docs/pr/1259/references/astro/overview
> - https://clerk.com/docs/pr/1259/references/astro/read-session-data

<!--- Describe your changes in detail. Why does this change need to happen? Include any links to Slack discussions, Linear comments, etc. -->
### Explanation:

<!--- How does this PR solve the problem? -->
### This PR:

- Adds usage of different stores that acts like the client-side helper hooks of the React SDK
