### PR TITLE
Convert the Remix SPA mode page into a guide for apps without Clerk

### DIFF
--- a/docs/manifest.json
+++ b/docs/manifest.json
@@ -1760,7 +1760,18 @@
                     "title": "SPA Mode",
                     "wrap": false,
                     "href": "/docs/references/remix/spa-mode"
+                  },
+                  {
+                    "title": "Add custom sign up and sign in pages",
+                    "wrap": true,
+                    "href": "/docs/references/remix/custom-signup-signin-pages"
+                  },
+                  {
+                    "title": "Read session and user data",
+                    "wrap": true,
+                    "href": "/docs/references/remix/read-session-data"
                   }
+
                 ]
               ]
             },

--- a/docs/quickstarts/remix.mdx
+++ b/docs/quickstarts/remix.mdx
@@ -9,7 +9,7 @@ description: Learn how to use Clerk to quickly and easily add secure authenticat
   framework="remix"
   exampleRepo={[
     {
-      title: "Remixt Quickstart Repo",
+      title: "Remix Quickstart Repo",
       link: "https://github.com/clerk/clerk-remix-quickstart"
 
     }

--- a/docs/quickstarts/remix.mdx
+++ b/docs/quickstarts/remix.mdx
@@ -7,6 +7,10 @@ description: Learn how to use Clerk to quickly and easily add secure authenticat
 
 Learn how to use Clerk to quickly and easily add secure authentication and user management to your Remix application. This guide assumes that you are using Remix v2 or later.
 
+<Callout type="info">
+If you are using Remix SPA mode, follow the [Remix SPA mode guide](/docs/references/remix/spa-mode).
+</Callout>
+
 <Steps>
 
 ### Install `@clerk/remix`

--- a/docs/quickstarts/remix.mdx
+++ b/docs/quickstarts/remix.mdx
@@ -5,6 +5,32 @@ description: Learn how to use Clerk to quickly and easily add secure authenticat
 
 # Use Clerk with Remix
 
+<TutorialHero
+  framework="remix"
+  exampleRepo={[
+    {
+      title: "Remixt Quickstart Repo",
+      link: "https://github.com/clerk/clerk-remix-quickstart"
+
+    }
+  ]}
+  beforeYouStart={[
+    {
+      title: "Set up a Clerk application",
+      link: "https://clerk.com/docs/quickstarts/setup-clerk",
+      icon: "clerk",
+    }
+  ]}
+>
+- Install `@clerk/remix`
+- Set up your environment variables
+- Configure rootAuthLoader
+- Configure ClerkApp
+- Protecting your pages
+</TutorialHero>
+
+
+
 Learn how to use Clerk to quickly and easily add secure authentication and user management to your Remix application. This guide assumes that you are using Remix v2 or later.
 
 <Callout type="info">
@@ -160,55 +186,6 @@ function App() {
 export default ClerkApp(App);
 ```
 
-### Build your own sign-in and sign-up pages
-
-In addition to the [Account Portal pages](/docs/account-portal/overview), Clerk also offers a set of [prebuilt components](/docs/components/overview) that you can use instead to embed sign-in, sign-up, and other user management functions into your Remix application. We are going to use the `<SignIn /> `and `<SignUp />` components by utilizing the Remix optional catch-all route.
-
-The functionality of the components are controlled by the instance settings you specify in your [Clerk Dashboard](https://dashboard.clerk.com).
-
-#### Build your sign-up page
-
-```tsx filename="app/routes/sign-up.$.tsx"
-import { SignUp } from "@clerk/remix";
-
-export default function SignUpPage() {
-  return (
-    <div>
-      <h1>Sign Up route</h1>
-      <SignUp />
-    </div>
-  );
-}
-```
-
-#### Build your sign-in page
-
-```tsx filename="app/routes/sign-in.$.tsx"
-import { SignIn } from "@clerk/remix";
-
-export default function SignInPage() {
-  return (
-    <div>
-      <h1>Sign In route</h1>
-      <SignIn />
-    </div>
-  );
-}
-```
-
-### Update your environment variables
-
-Next, add environment variables for the `signIn`, `signUp`, `afterSignUp`, and `afterSignIn` paths:
-
-```sh filename=".env"
-CLERK_SIGN_IN_URL=/sign-in
-CLERK_SIGN_UP_URL=/sign-up
-CLERK_SIGN_IN_FALLBACK_URL=/
-CLERK_SIGN_UP_FALLBACK_URL=/
-```
-
-These values control the behavior of the components when you sign in or sign up and when you click on the respective links at the bottom of each component.
-
 ### Protecting your pages
 
 #### Client side
@@ -217,12 +194,13 @@ Clerk offers [Control Components](/docs/components/overview) that allow you to p
 
 ```tsx filename="routes/_index.tsx"
 import {
+  SignInButton,
   SignOutButton,
+  SignUpButton,
   SignedIn,
   SignedOut,
   UserButton,
 } from "@clerk/remix";
-import { Link } from "@remix-run/react";
 
 export default function Index() {
   return (
@@ -231,7 +209,7 @@ export default function Index() {
       <SignedIn>
         <p>You are signed in!</p>
         <div>
-          <p>View your profile here 👇</p>
+          <p>View your profile here</p>
           <UserButton />
         </div>
         <div>
@@ -241,10 +219,10 @@ export default function Index() {
       <SignedOut>
         <p>You are signed out</p>
         <div>
-          <Link to="/sign-in">Go to Sign in</Link>
+          <SignInButton />
         </div>
         <div>
-          <Link to="/sign-up">Go to Sign up</Link>
+          <SignUpButton />
         </div>
       </SignedOut>
     </div>
@@ -280,145 +258,8 @@ export default function Index() {
 }
 ```
 
-### Read session and user data
 
-Clerk provides a set of [hooks and helpers](/docs/references/react/use-user) that you can use to access the active session and user data in your Remix application. Here are examples of how to use these helpers.
 
-#### Client side
-
-#### `useAuth()`
-
-The `useAuth` hook is a convenient way to access the current auth state. This hook provides the minimal information needed for data-loading and helper methods to manage the current active session.
-
-```tsx filename="routes/example.tsx"
-import { useAuth } from "@clerk/remix";
-
-export default function Example() {
-  const { isLoaded, userId, sessionId, getToken } = useAuth();
-
-  // In case the user signs out while on the page.
-  if (!isLoaded || !userId) {
-    return null;
-  }
-
-  return (
-    <div>
-      Hello, {userId} your current active session is {sessionId}
-    </div>
-  );
-}
-```
-
-#### `useUser()`
-
-The `useUser` hook is a convenient way to access the current user data where you need it. This hook provides the user data and helper methods to manage the current active session.
-
-```tsx filename="routes/example.tsx"
-import { useUser } from "@clerk/remix";
-
-export default function Example() {
-  const { isLoaded, isSignedIn, user } = useUser();
-
-  if (!isLoaded || !isSignedIn) {
-    return null;
-  }
-
-  return <div>Hello, {user.firstName} welcome to Clerk</div>;
-}
-```
-
-#### Server side
-
-#### `getAuth()`
-
-<Tabs type="function" items={["Loader Function", "Action Function"]}>
-  <Tab>
-  The [`getAuth()`][get-auth] helper allows you to access the [`Auth` object](/docs/references/nextjs/auth-object), including the current `userId`. You can use this helper to protect your loader function or get data for the initial render of the route.
-
-  ```tsx filename="routes/example.tsx"
-  export const loader: LoaderFunction = async (args) => {
-    // Use getAuth to retrieve user data
-    const { userId, sessionId, getToken } = await getAuth(args);
-
-    // If there is no userId, then redirect to sign-in route
-    if (!userId) {
-      return redirect("/sign-in?redirect_url=" + args.request.url);
-    }
-
-    // Use the userId to fetch data from your database
-    const posts = await mockGetPosts(userId);
-
-    return { posts };
-  };
-  ```
-  </Tab>
-
-  <Tab>
-  The [`getAuth()`][get-auth] helper allows you to access the [`Auth` object](/docs/references/nextjs/auth-object). You can use the returns from `getAuth()` to protect the action function, update the user or perform mutations on data in your database.
-
-  ```tsx filename="routes/example.tsx"
-  export const action: ActionFunction = async (args) => {
-
-    // Use getAuth to retrieve user data
-    const { userId, getToken } = await getAuth(args)
-
-    // Use the userId to perform a mutation on data in your database
-    const updatedPost = await mockUpdatePost(userId, postId, body)
-
-    return { updatedPost };
-  }
-  ```
-  </Tab>
-</Tabs>
-
-#### Examples of fetching and mutating user data
-
-<Tabs type="function" items={["Loader Function", "Action Function"]}>
-  <Tab>
-  ```tsx filename="routes/profile.tsx"
-  import { LoaderFunction, redirect } from "@remix-run/node";
-  import { getAuth } from "@clerk/remix/ssr.server";
-  import { createClerkClient } from '@clerk/remix/api.server';
-
-  export const loader: LoaderFunction = async (args) => {
-    const { userId } = await getAuth(args);
-
-    if (!userId) {
-      return redirect("/sign-in?redirect_url=" + args.request.url);
-    }
-
-    const user = await createClerkClient({secretKey: process.env.CLERK_SECRET_KEY}).users.getUser(userId);
-    return { serialisedUser: JSON.stringify(user) };
-  };
-  ```
-  </Tab>
-
-  <Tab>
-  ```tsx filename="routes/profile.tsx"
-  import { ActionFunction, redirect } from "@remix-run/node";
-  import { getAuth } from "@clerk/remix/ssr.server";
-  import { createClerkClient } from '@clerk/remix/api.server';
-
-  export const action: ActionFunction = async (args) => {
-    // Use getAuth to retrieve user data
-    const { userId } = await getAuth(args)
-
-    // If there is no userId, then redirect to sign-in route
-    if (!userId) {
-      return redirect("/sign-in?redirect_url=" + args.request.url);
-    }
-    // Prepare the data for the mutation
-    const params = { firstName: 'John', lastName: 'Wicker' };
-
-    // Initialize clerkClient and perform the mutations
-    const updatedUser = await createClerkClient({ secretKey: process.env.CLERK_SECRET_KEY }).users.updateUser(userId, params);
-
-    // Return the updated user
-    return { serialisedUser: JSON.stringify(updatedUser) };
-  };
-  ```
-  </Tab>
-</Tabs>
 
 </Steps>
 

--- a/docs/quickstarts/remix.mdx
+++ b/docs/quickstarts/remix.mdx
@@ -269,12 +269,13 @@ Now that you have an application integrated with Clerk, you will want to read th
 
 <div className="container mx-auto my-4">
   <div className="grid grid-cols-1 gap-6 md:grid-cols-2">
+    <Cards title="Create custom sign-up and sign-in pages" description="Learn how add custom sign-up and sign-in pages with Clerk components." link="/docs/references/remix/custom-signup-signin-pages" cta="Learn More" />
+
+    <Cards title="Read user and session data" description="Learn how to use Clerk's hooks and helpers to access the active session and user data in your Remix application." link="/docs/references/remix/read-session-data" cta="Learn More" />
+
     <Cards title="Customization & Localization" description="Learn how to customize and localize the Clerk components." link="/docs/components/customization/overview" cta="Learn More" />
 
     <Cards title="Authentication Components" description="Learn more about all our authentication components." link="/docs/components/authentication/sign-in" cta="Learn More" />
 
-    <Cards title="Client Side Helpers" description="Learn more about our client side helpers and how to use them." link="/docs/references/react/use-user" cta="Learn More" />
   </div>
 </div>
-
-[get-auth]: /docs/references/nextjs/get-auth

--- a/docs/references/remix/custom-signup-signin-pages.mdx
+++ b/docs/references/remix/custom-signup-signin-pages.mdx
@@ -1,0 +1,117 @@
+---
+title: Build your own sign-in and sign-up pages for your Remix app with Clerk
+description: Learn how to add custom sign-in and sign-up pages to your Remix app with Clerk's prebuilt components.
+---
+
+This guide shows you how to use the [`<SignIn />`](/docs/components/authentication/sign-in) and [`<SignUp />`](/docs/components/authentication/sign-up) components with the [Remix optional route](https://reactrouter.com/en/main/route/route#optional-segments) in order to build custom sign-in and sign-up pages for your Remix app.
+
+If Clerk's prebuilt components don't meet your specific needs or if you require more control over the logic, you can rebuild the existing Clerk flows using the Clerk API. For more information, check out the [custom flows](/docs/custom-flows/overview) guides.
+
+The functionality of the components are controlled by the instance settings you specify in your [Clerk Dashboard](https://dashboard.clerk.com).
+
+<Callout>
+  Just getting started with Clerk and Remix? Check out the [quickstart tutorial](/docs/quickstarts/remix)!
+</Callout>
+
+<Steps>
+
+## Build your sign-up page
+
+Create a new file that will be used to render the sign-up page. In the file, import the `<SignUp />` component from @clerk/remix and render it.
+
+```tsx {{ filename: 'app/routes/sign-up.$.tsx' }}
+import { SignUp } from "@clerk/remix";
+
+export default function SignUpPage() {
+  return (
+    <div>
+      <h1>Sign Up route</h1>
+      <SignUp />
+    </div>
+  );
+}
+```
+
+## Build your sign-in page
+
+Create a new file that will be used to render the sign-in page. In the file, import the `<SignIn />` component from @clerk/remix and render it.
+
+```tsx {{ filename: 'app/routes/sign-in.$.tsx' }}
+import { SignIn } from "@clerk/remix";
+
+export default function SignInPage() {
+  return (
+    <div>
+      <h1>Sign In route</h1>
+      <SignIn />
+    </div>
+  );
+}
+```
+
+## Configure your sign-up and sign-in pages
+
+<Tabs items={["SSR Mode", "SPA Mode"]}>
+<Tab>
+
+For SSR Mode, add environment variables for the `signIn`, `signUp`, `afterSignUp`, and `afterSignIn` paths:
+
+```sh filename=".env"
+CLERK_SIGN_IN_URL=/sign-in
+CLERK_SIGN_UP_URL=/sign-up
+CLERK_SIGN_IN_FALLBACK_URL=/
+CLERK_SIGN_UP_FALLBACK_URL=/
+```
+</Tab>
+
+<Tab>
+
+For SPA Mode, add paths to your `ClerkApp` options to control the behavior of the components when you sign in or sign up and when you click on the respective links at the bottom of each component.
+
+```ts {{ filename: 'app/root.tsx', mark: [[3,6]] }}
+export default ClerkApp(App, {
+  publishableKey: 'pk_test_XYZ',
+  signInUrl: '/sign-in',
+  signUpUrl: '/sign-up',
+  signInFallbackRedirectUrl: '/',
+  signUpFallbackRedirectUrl: '/',
+});
+```
+
+</Tab>
+</Tabs>
+
+
+These values control the behavior of the components when you sign in or sign up and when you click on the respective links at the bottom of each component.
+
+## Visit your new pages
+
+Run your project with the following terminal command from the root directory of your project:
+
+  <CodeBlockTabs type="installer" options={["npm", "yarn", "pnpm"]}>
+    ```bash filename="terminal"
+    npm run dev
+    ```
+
+    ```bash filename="terminal"
+    yarn dev
+    ```
+
+    ```bash filename="terminal"
+    pnpm dev
+    ```
+
+  </CodeBlockTabs>
+
+Visit your new custom pages locally at [localhost:3000/sign-in](http://localhost:3000/sign-in) and [localhost:3000/sign-up](http://localhost:3000/sign-up).
+
+</Steps>
+
+## Next steps
+
+<div className="container mx-auto my-4">
+  <div className="grid grid-cols-1 gap-6 md:grid-cols-2">
+    <Cards title="Read user and session data" description="Learn how to use Clerk's hooks and helpers to access the active session and user data in your Remix application." link="/docs/references/remix/read-session-data" cta="Learn More" />
+
+  </div>
+</div>

--- a/docs/references/remix/custom-signup-signin-pages.mdx
+++ b/docs/references/remix/custom-signup-signin-pages.mdx
@@ -70,7 +70,7 @@ For SPA Mode, add paths to your `ClerkApp` options to control the behavior of th
 
 ```ts {{ filename: 'app/root.tsx', mark: [[3,6]] }}
 export default ClerkApp(App, {
-  publishableKey: 'pk_test_XYZ',
+  publishableKey: PUBLISHABLE_KEY,
   signInUrl: '/sign-in',
   signUpUrl: '/sign-up',
   signInFallbackRedirectUrl: '/',

--- a/docs/references/remix/read-session-data.mdx
+++ b/docs/references/remix/read-session-data.mdx
@@ -1,0 +1,144 @@
+---
+title: Read session and user data in your Remix app with Clerk
+description: Learn how to use Clerk's hooks and helpers to access the active session and user data in your Remix application.
+---
+
+# Read session and user data in your Remix app with Clerk
+
+Clerk provides a set of [hooks and helpers](/docs/references/nextjs/overview#client-side-helpers) that you can use to access the active session and user data in your Remix application. Here are examples of how to use these helpers in both the client and server side to get you started.
+
+## Server side
+
+### `getAuth()`
+
+<Tabs type="function" items={["Loader Function", "Action Function"]}>
+  <Tab>
+  The [`getAuth()`][get-auth] helper allows you to access the [`Auth` object](/docs/references/nextjs/auth-object), including the current `userId`. You can use this helper to protect your loader function or get data for the initial render of the route.
+
+  ```tsx filename="routes/example.tsx"
+  export const loader: LoaderFunction = async (args) => {
+    // Use getAuth to retrieve user data
+    const { userId, sessionId, getToken } = await getAuth(args);
+
+    // If there is no userId, then redirect to sign-in route
+    if (!userId) {
+      return redirect("/sign-in?redirect_url=" + args.request.url);
+    }
+
+    // Use the userId to fetch data from your database
+    const posts = await mockGetPosts(userId);
+
+    return { posts };
+  };
+  ```
+  </Tab>
+
+  <Tab>
+  The [`getAuth()`][get-auth] helper allows you to access the [`Auth` object](/docs/references/nextjs/auth-object). You can use the returns from `getAuth()` to protect the action function, update the user or perform mutations on data in your database.
+
+  ```tsx filename="routes/example.tsx"
+  export const action: ActionFunction = async (args) => {
+
+    // Use getAuth to retrieve user data
+    const { userId, getToken } = await getAuth(args)
+
+    // Use the userId to perform a mutation on data in your database
+    const updatedPost = await mockUpdatePost(userId, postId, body)
+
+    return { updatedPost };
+  }
+  ```
+  </Tab>
+</Tabs>
+
+### Examples of fetching and mutating user data
+
+<Tabs type="function" items={["Loader Function", "Action Function"]}>
+  <Tab>
+  ```tsx filename="routes/profile.tsx"
+  import { LoaderFunction, redirect } from "@remix-run/node";
+  import { getAuth } from "@clerk/remix/ssr.server";
+  import { createClerkClient } from '@clerk/remix/api.server';
+
+  export const loader: LoaderFunction = async (args) => {
+    const { userId } = await getAuth(args);
+
+    if (!userId) {
+      return redirect("/sign-in?redirect_url=" + args.request.url);
+    }
+
+    const user = await createClerkClient({secretKey: process.env.CLERK_SECRET_KEY}).users.getUser(userId);
+    return { serialisedUser: JSON.stringify(user) };
+  };
+  ```
+  </Tab>
+
+  <Tab>
+  ```tsx filename="routes/profile.tsx"
+  import { ActionFunction, redirect } from "@remix-run/node";
+  import { getAuth } from "@clerk/remix/ssr.server";
+  import { createClerkClient } from '@clerk/remix/api.server';
+
+  export const action: ActionFunction = async (args) => {
+    // Use getAuth to retrieve user data
+    const { userId } = await getAuth(args)
+
+    // If there is no userId, then redirect to sign-in route
+    if (!userId) {
+      return redirect("/sign-in?redirect_url=" + args.request.url);
+    }
+    // Prepare the data for the mutation
+    const params = { firstName: 'John', lastName: 'Wicker' };
+
+    // Initialize clerkClient and perform the mutations
+    const updatedUser = await createClerkClient({ secretKey: process.env.CLERK_SECRET_KEY }).users.updateUser(userId, params);
+
+    // Return the updated user
+    return { serialisedUser: JSON.stringify(updatedUser) };
+  };
+  ```
+  </Tab>
+</Tabs>
+
+## Client Side
+
+### `useAuth()`
+
+The `useAuth` hook is a convenient way to access the current auth state. This hook provides the minimal information needed for data-loading and helper methods to manage the current active session.
+
+```tsx filename="routes/example.tsx"
+import { useAuth } from "@clerk/remix";
+
+export default function Example() {
+  const { isLoaded, userId, sessionId, getToken } = useAuth();
+
+  // In case the user signs out while on the page.
+  if (!isLoaded || !userId) {
+    return null;
+  }
+
+  return (
+    <div>
+      Hello, {userId} your current active session is {sessionId}
+    </div>
+  );
+}
+```
+
+### `useUser()`
+
+The `useUser` hook is a convenient way to access the current user data where you need it. This hook provides the user data and helper methods to manage the current active session.
+
+```tsx filename="routes/example.tsx"
+import { useUser } from "@clerk/remix";
+
+export default function Example() {
+  const { isLoaded, isSignedIn, user } = useUser();
+
+  if (!isLoaded || !isSignedIn) {
+    return null;
+  }
+
+  return <div>Hello, {user.firstName} welcome to Clerk</div>;
+}
+```

--- a/docs/references/remix/read-session-data.mdx
+++ b/docs/references/remix/read-session-data.mdx
@@ -142,3 +142,5 @@ export default function Example() {
   return <div>Hello, {user.firstName} welcome to Clerk</div>;
 }
 ```
+
+[get-auth]: /docs/references/nextjs/get-auth

--- a/docs/references/remix/spa-mode.mdx
+++ b/docs/references/remix/spa-mode.mdx
@@ -5,8 +5,24 @@ description: Clerk supports Remix SPA mode out-of-the-box.
 
 # Remix SPA Mode
 
+<TutorialHero
+  framework="remix"
+  beforeYouStart={[
+    {
+      title: "Set up a Clerk application",
+      link: "https://clerk.com/docs/quickstarts/setup-clerk",
+      icon: "clerk",
+    }
+  ]}
+>
+- Install `@clerk/remix`
+- Configure ClerkApp with your Publishable key
+- Update your paths through ClerkApp options
+- Protecting your pages
+</TutorialHero>
+
 <Callout type="info">
-This guide explains how to use Clerk with [Remix in SPA mode](https://remix.run/docs/en/main/guides/spa-mode). 
+This guide explains how to use Clerk with [Remix in SPA mode](https://remix.run/docs/en/main/guides/spa-mode).
 If you are using Remix with SSR, follow the [Remix quickstart](/docs/quickstarts/remix).
 </Callout>
 
@@ -71,51 +87,13 @@ export default ClerkApp(App, {
 });
 ```
 
-### Build your own sign-in and sign-up pages
-
-In addition to the [Account Portal pages](/docs/account-portal/overview), Clerk also offers a set of [prebuilt components](/docs/components/overview) that you can use instead to embed sign-in, sign-up, and other user management functions into your Remix application. We are going to use the `<SignIn /> `and `<SignUp />` components by utilizing the Remix optional catch-all route.
-
-The functionality of the components are controlled by the instance settings you specify in your [Clerk Dashboard](https://dashboard.clerk.com).
-
-#### Build your sign-up page
-
-```tsx filename="app/routes/sign-up.$.tsx"
-import { SignUp } from "@clerk/remix";
-
-export default function SignUpPage() {
-  return (
-    <div>
-      <h1>Sign Up route</h1>
-      <SignUp />
-    </div>
-  );
-}
-```
-
-#### Build your sign-in page
-
-```tsx filename="app/routes/sign-in.$.tsx"
-import { SignIn } from "@clerk/remix";
-
-export default function SignInPage() {
-  return (
-    <div>
-      <h1>Sign In route</h1>
-      <SignIn />
-    </div>
-  );
-}
-```
-
 ### Update your paths through ClerkApp options
 
 Next, add paths to your `ClerkApp` options to control the behavior of the components when you sign in or sign up and when you click on the respective links at the bottom of each component.
 
-```ts {{ filename: 'app/root.tsx' }}
+```ts {{ filename: 'app/root.tsx', mark: [[3,4]] }}
 export default ClerkApp(App, {
   publishableKey: 'pk_test_XYZ',
-  signInUrl: '/sign-in',
-  signUpUrl: '/sign-up',
   signInFallbackRedirectUrl: '/',
   signUpFallbackRedirectUrl: '/',
 });
@@ -127,12 +105,13 @@ Clerk offers [Control Components](/docs/components/overview) that allow you to p
 
 ```tsx filename="routes/_index.tsx"
 import {
+  SignInButton,
   SignOutButton,
+  SignUpButton,
   SignedIn,
   SignedOut,
   UserButton,
 } from "@clerk/remix";
-import { Link } from "@remix-run/react";
 
 export default function Index() {
   return (
@@ -151,10 +130,10 @@ export default function Index() {
       <SignedOut>
         <p>You are signed out</p>
         <div>
-          <Link to="/sign-in">Go to Sign in</Link>
+          <SignInButton />
         </div>
         <div>
-          <Link to="/sign-up">Go to Sign up</Link>
+          <SignUpButton />
         </div>
       </SignedOut>
     </div>
@@ -162,49 +141,5 @@ export default function Index() {
 }
 ```
 
-### Read session and user data
-
-Clerk provides a set of [hooks and helpers](/docs/references/react/use-user) that you can use to access the active session and user data in your Remix application. Here are examples of how to use these helpers.
-
-#### `useAuth()`
-
-The `useAuth` hook is a convenient way to access the current auth state. This hook provides the minimal information needed for data-loading and helper methods to manage the current active session.
-
-```tsx filename="routes/example.tsx"
-import { useAuth } from "@clerk/remix";
-
-export default function Example() {
-  const { isLoaded, userId, sessionId, getToken } = useAuth();
-
-  // In case the user signs out while on the page.
-  if (!isLoaded || !userId) {
-    return null;
-  }
-
-  return (
-    <div>
-      Hello, {userId} your current active session is {sessionId}
-    </div>
-  );
-}
-```
-
-#### `useUser()`
-
-The `useUser` hook is a convenient way to access the current user data where you need it. This hook provides the user data and helper methods to manage the current active session.
-
-```tsx filename="routes/example.tsx"
-import { useUser } from "@clerk/remix";
-
-export default function Example() {
-  const { isLoaded, isSignedIn, user } = useUser();
-
-  if (!isLoaded || !isSignedIn) {
-    return null;
-  }
-
-  return <div>Hello, {user.firstName} welcome to Clerk</div>;
-}
-```
 
 </Steps>

--- a/docs/references/remix/spa-mode.mdx
+++ b/docs/references/remix/spa-mode.mdx
@@ -16,8 +16,9 @@ description: Clerk supports Remix SPA mode out-of-the-box.
   ]}
 >
 - Install `@clerk/remix`
-- Configure ClerkApp with your Publishable key
-- Update your paths through ClerkApp options
+- Set your environment variables
+- Configure `ClerkApp`
+- Update your paths through `ClerkApp` options
 - Protecting your pages
 </TutorialHero>
 
@@ -46,13 +47,32 @@ Once you have a Remix application ready, you need to install Clerk's Remix SDK. 
   ```
 </CodeBlockTabs>
 
-### Configure `ClerkApp` with your Publishable key
+### Set your environment variables
 
-Clerk provides a `ClerkApp` wrapper to provide the authentication state to your React tree. Also, you will need your Publishable key which can be found in the Clerk Dashboard on the [API Keys](https://dashboard.clerk.com/last-active?path=api-keys) page.
+1. If you don't have an `.env` file in the root directory of your React project, create one now.
+2. Find your Clerk publishable key. If you're signed into Clerk, the `.env` snippet below will contain your key. Otherwise:
+  - Navigate to the [Clerk Dashboard](https://dashboard.clerk.com/last-active?path=api-keys) and select your application.
+  - In the navigation sidebar, select **API Keys**.
+  - You can copy your key from the **Quick Copy** section.
+3. Add your key to your `.env` file.
 
 <Callout type="warning">
 You will not need the Clerk Secret Key in Remix SPA mode, as it should never be used on the client side.
 </Callout>
+
+The final result should look as follows:
+
+<InjectKeys>
+
+```sh filename=".env"
+VITE_CLERK_PUBLISHABLE_KEY={{pub_key}}
+```
+
+</InjectKeys>
+
+### Configure `ClerkApp`
+
+Clerk provides a `ClerkApp` wrapper to provide the authentication state to your React tree.
 
 ```tsx {{ filename: 'app/root.tsx' }}
 import { ClerkApp } from "@clerk/remix";
@@ -82,8 +102,11 @@ function App() {
   );
 }
 
+// Import your publishable key
+const PUBLISHABLE_KEY = import.meta.env.VITE_CLERK_PUBLISHABLE_KEY
+
 export default ClerkApp(App, {
-  publishableKey: 'pk_test_XYZ',
+  publishableKey: PUBLISHABLE_KEY,
 });
 ```
 
@@ -93,7 +116,7 @@ Next, add paths to your `ClerkApp` options to control the behavior of the compon
 
 ```ts {{ filename: 'app/root.tsx', mark: [[3,4]] }}
 export default ClerkApp(App, {
-  publishableKey: 'pk_test_XYZ',
+  publishableKey: PUBLISHABLE_KEY,
   signInFallbackRedirectUrl: '/',
   signUpFallbackRedirectUrl: '/',
 });
@@ -120,7 +143,7 @@ export default function Index() {
       <SignedIn>
         <p>You are signed in!</p>
         <div>
-          <p>View your profile here 👇</p>
+          <p>View your profile here</p>
           <UserButton />
         </div>
         <div>
@@ -141,5 +164,18 @@ export default function Index() {
 }
 ```
 
-
 </Steps>
+
+### Next steps
+
+Now that you have an application integrated with Clerk, you will want to read the following documentation:
+
+<div className="container mx-auto my-4">
+  <div className="grid grid-cols-1 gap-6 md:grid-cols-2">
+    <Cards title="Customization & Localization" description="Learn how to customize and localize the Clerk components." link="/docs/components/customization/overview" cta="Learn More" />
+
+    <Cards title="Authentication Components" description="Learn more about all our authentication components." link="/docs/components/authentication/sign-in" cta="Learn More" />
+
+    <Cards title="Client Side Helpers" description="Learn more about our client side helpers and how to use them." link="/docs/references/remix/read-session-data#client-side" cta="Learn More" />
+  </div>
+</div>

--- a/docs/references/remix/spa-mode.mdx
+++ b/docs/references/remix/spa-mode.mdx
@@ -1,19 +1,44 @@
 ---
-title: SPA Mode
+title: Remix SPA Mode
 description: Clerk supports Remix SPA mode out-of-the-box.
 ---
 
-# SPA Mode
+# Remix SPA Mode
 
-After implementing the [Remix SPA Mode changes](https://remix.run/docs/en/main/guides/spa-mode), you need to make the following changes to your Remix app to use Clerk in SPA mode:
+<Callout type="info">
+This guide explains how to use Clerk with [Remix in SPA mode](https://remix.run/docs/en/main/guides/spa-mode). 
+If you are using Remix with SSR, follow the [Remix quickstart](/docs/quickstarts/remix).
+</Callout>
 
-1. Remove the `rootAuthLoader()` from your `app/root.tsx` file.
-2. Pass the publishable key and any other environment variables to the [`ClerkApp`](/docs/references/remix/clerk-app) component (except the secret key, which should never be used on the client side).
-3. Remove all usages of server-side Clerk functions (for example, all the imported functions coming from `@clerk/remix/ssr.server`)
+<Steps>
 
-## Example `root.tsx` page
+### Install `@clerk/remix`
 
-The following example demonstrates an `app/root.tsx` file that uses SPA mode. Notice the absence of the `rootAuthLoader()`.
+Once you have a Remix application ready, you need to install Clerk's Remix SDK. This gives you access to our prebuilt components and hooks for Remix applications.
+
+<CodeBlockTabs type="installer" options={["npm", "yarn", "pnpm"]}>
+  ```bash filename="terminal"
+  npm install @clerk/remix
+  ```
+
+  ```bash filename="terminal"
+  yarn add @clerk/remix
+  ```
+
+  ```bash filename="terminal"
+  pnpm add @clerk/remix
+  ```
+</CodeBlockTabs>
+
+### Configure `ClerkApp` with your publishable key and options
+
+Clerk provides a `ClerkApp` wrapper to provide the authentication state to your React tree.
+
+Also, you will need your publishable key which can be found in the Clerk Dashboard on the [API Keys](https://dashboard.clerk.com/last-active?path=api-keys) page.
+
+<Callout type="warning">
+You will not need the secret key in Remix SPA mode, as it should never be used on the client side.
+</Callout>
 
 ```tsx {{ filename: 'app/root.tsx' }}
 import { ClerkApp } from "@clerk/remix";
@@ -45,6 +70,46 @@ function App() {
 
 export default ClerkApp(App, {
   publishableKey: 'pk_test_XYZ',
+});
+```
+
+#### Build your sign-up page
+
+```tsx filename="app/routes/sign-up.$.tsx"
+import { SignUp } from "@clerk/remix";
+
+export default function SignUpPage() {
+  return (
+    <div>
+      <h1>Sign Up route</h1>
+      <SignUp />
+    </div>
+  );
+}
+```
+
+#### Build your sign-in page
+
+```tsx filename="app/routes/sign-in.$.tsx"
+import { SignIn } from "@clerk/remix";
+
+export default function SignInPage() {
+  return (
+    <div>
+      <h1>Sign In route</h1>
+      <SignIn />
+    </div>
+  );
+}
+```
+
+### Update your paths through ClerkApp options
+
+Next, add paths to your `ClerkApp` options to control the behavior of the components when you sign in or sign up and when you click on the respective links at the bottom of each component.
+
+```ts {{ filename: 'app/root.tsx' }}
+export default ClerkApp(App, {
+  publishableKey: 'pk_test_XYZ',
   signInUrl: '/sign-in',
   signUpUrl: '/sign-up',
   signInFallbackRedirectUrl: '/',
@@ -52,28 +117,90 @@ export default ClerkApp(App, {
 });
 ```
 
+### Protecting your pages
 
-## Example protected route
+Clerk offers [Control Components](/docs/components/overview) that allow you to protect your pages. These components are used to control the visibility of your pages based on the user's authentication state.
 
-The following example demonstrates how to use Clerk's [control components](/docs/components/overview) in order to protect a route that uses SPA mode. 
+```tsx filename="routes/_index.tsx"
+import {
+  SignOutButton,
+  SignedIn,
+  SignedOut,
+  UserButton,
+} from "@clerk/remix";
+import { Link } from "@remix-run/react";
 
-```tsx
-import { SignedIn, RedirectToSignIn, useUser, SignedOut } from "@clerk/remix";
-
-export default function ProtectedRoute() {
-  const { user } = useUser();
+export default function Index() {
   return (
-    <>
+    <div>
+      <h1>Index Route</h1>
       <SignedIn>
+        <p>You are signed in!</p>
         <div>
-          <h1>Protected Page</h1>
-          <div>Hello, {user?.id}</div>
+          <p>View your profile here 👇</p>
+          <UserButton />
+        </div>
+        <div>
+          <SignOutButton />
         </div>
       </SignedIn>
       <SignedOut>
-        <RedirectToSignIn />
+        <p>You are signed out</p>
+        <div>
+          <Link to="/sign-in">Go to Sign in</Link>
+        </div>
+        <div>
+          <Link to="/sign-up">Go to Sign up</Link>
+        </div>
       </SignedOut>
-    </>
+    </div>
   );
 }
 ```
+
+### Read session and user data
+
+Clerk provides a set of [hooks and helpers](/docs/references/react/use-user) that you can use to access the active session and user data in your Remix application. Here are examples of how to use these helpers.
+
+#### `useAuth()`
+
+The `useAuth` hook is a convenient way to access the current auth state. This hook provides the minimal information needed for data-loading and helper methods to manage the current active session.
+
+```tsx filename="routes/example.tsx"
+import { useAuth } from "@clerk/remix";
+
+export default function Example() {
+  const { isLoaded, userId, sessionId, getToken } = useAuth();
+
+  // In case the user signs out while on the page.
+  if (!isLoaded || !userId) {
+    return null;
+  }
+
+  return (
+    <div>
+      Hello, {userId} your current active session is {sessionId}
+    </div>
+  );
+}
+```
+
+#### `useUser()`
+
+The `useUser` hook is a convenient way to access the current user data where you need it. This hook provides the user data and helper methods to manage the current active session.
+
+```tsx filename="routes/example.tsx"
+import { useUser } from "@clerk/remix";
+
+export default function Example() {
+  const { isLoaded, isSignedIn, user } = useUser();
+
+  if (!isLoaded || !isSignedIn) {
+    return null;
+  }
+
+  return <div>Hello, {user.firstName} welcome to Clerk</div>;
+}
+```
+
+</Steps>

--- a/docs/references/remix/spa-mode.mdx
+++ b/docs/references/remix/spa-mode.mdx
@@ -30,14 +30,12 @@ Once you have a Remix application ready, you need to install Clerk's Remix SDK. 
   ```
 </CodeBlockTabs>
 
-### Configure `ClerkApp` with your publishable key and options
+### Configure `ClerkApp` with your Publishable key
 
-Clerk provides a `ClerkApp` wrapper to provide the authentication state to your React tree.
-
-Also, you will need your publishable key which can be found in the Clerk Dashboard on the [API Keys](https://dashboard.clerk.com/last-active?path=api-keys) page.
+Clerk provides a `ClerkApp` wrapper to provide the authentication state to your React tree. Also, you will need your Publishable key which can be found in the Clerk Dashboard on the [API Keys](https://dashboard.clerk.com/last-active?path=api-keys) page.
 
 <Callout type="warning">
-You will not need the secret key in Remix SPA mode, as it should never be used on the client side.
+You will not need the Clerk Secret Key in Remix SPA mode, as it should never be used on the client side.
 </Callout>
 
 ```tsx {{ filename: 'app/root.tsx' }}
@@ -72,6 +70,12 @@ export default ClerkApp(App, {
   publishableKey: 'pk_test_XYZ',
 });
 ```
+
+### Build your own sign-in and sign-up pages
+
+In addition to the [Account Portal pages](/docs/account-portal/overview), Clerk also offers a set of [prebuilt components](/docs/components/overview) that you can use instead to embed sign-in, sign-up, and other user management functions into your Remix application. We are going to use the `<SignIn /> `and `<SignUp />` components by utilizing the Remix optional catch-all route.
+
+The functionality of the components are controlled by the instance settings you specify in your [Clerk Dashboard](https://dashboard.clerk.com).
 
 #### Build your sign-up page
 


### PR DESCRIPTION
<!--- Add the "deploy-preview" label and add your page previews here -->

> [!IMPORTANT]
> 🔎 Previews:
>
> - https://clerk.com/docs/pr/1266/references/remix/spa-mode
> - https://clerk.com/docs/pr/1266/quickstarts/remix

<!--- Describe your changes in detail. Why does this change need to happen? Include any links to Slack discussions, Linear comments, etc. -->
### Explanation:
The Remix SPA mode docs page was showcasing how to convert an existing Clerk-Remix project into a SPA mode. Probably, this won't be the case for most people.

<!--- How does this PR solve the problem? -->
### This PR: 

- Creates a guide similar to the Remix quickstart, that will help devs install Clerk into a Remix that uses the SPA mode.
