### PR TITLE
chore(elements): Use available strategy names vs string in properties

### DIFF
--- a/docs/elements/reference/sign-up.mdx
+++ b/docs/elements/reference/sign-up.mdx
@@ -111,7 +111,7 @@ Conditionally renders its children depending on the authentication strategy that
 
 | Name | Type     | Description                                                       |
 | ---- | -------- | ----------------------------------------------------------------- |
-| `name` | `string` | The name of the strategy for which its children will be rendered. |
+| `name` | <code>'code' \| 'email_code' \| 'email_link' \| 'phone_code'</code>  | The name of the strategy for which its children will be rendered. |
 
 ### Usage {{ toc: false }}
 


### PR DESCRIPTION
https://linear.app/clerk/issue/SDK-1874/provide-the-options-for-signupstrategys-name-prop-within-the-elements

Update SignUp strategy name property with available options vs marking as `string`

<img width="716" alt="Screenshot 2024-07-16 at 5 29 07 PM" src="https://github.com/user-attachments/assets/6bc66640-4b9d-4674-a9ef-da3300b66966">
