### PR TITLE
Update SMS template docs about verification code OTP templates

### DIFF
--- a/docs/authentication/configuration/email-sms-templates.mdx
+++ b/docs/authentication/configuration/email-sms-templates.mdx
@@ -133,7 +133,3 @@ The following settings can be changed for an SMS template:
 
 - **Name**: a name for the template on the template listing page. It does not affect the outgoing email in any way.
 - **Message**: a text area where you can author the content of the SMS message. The SMS content should fit within a limit of 160 simple GSM-7 or 140 unicode characters. To insert a [variable](#terminology) at the current cursor position, select the corresponding variable badge. You can interpolate a particular metadata key by using the following syntax: `{{user.metadata.foo.bar}}`.
-
-<Callout type="info">
-  Modifications to Verification OTP SMS templates are very limited due to strict regulations. If changing the Reset password or Verification code SMS template is required, please contact Clerk support.
-</Callout>

--- a/docs/authentication/configuration/email-sms-templates.mdx
+++ b/docs/authentication/configuration/email-sms-templates.mdx
@@ -114,7 +114,7 @@ To access the SMS templates:
 
 ### Delivered by Clerk
 
-Out of the box, Clerk will deliver your SMS messagess using its own SMS Gateway. However, if you wish to handle SMS delivery on your own, then you can toggle **Delivered by Clerk** off.
+Out of the box, Clerk will deliver your SMS messages using its own SMS Gateway. However, if you wish to handle SMS delivery on your own, then you can toggle **Delivered by Clerk** off.
 
 This means that Clerk will no longer be sending this particular SMS and in order to deliver it yourself, you will need to listen to the `sms.created` [webhook](/docs/integrations/webhooks/overview) and extract the necessary info from the event payload.
 
@@ -133,3 +133,7 @@ The following settings can be changed for an SMS template:
 
 - **Name**: a name for the template on the template listing page. It does not affect the outgoing email in any way.
 - **Message**: a text area where you can author the content of the SMS message. The SMS content should fit within a limit of 160 simple GSM-7 or 140 unicode characters. To insert a [variable](#terminology) at the current cursor position, select the corresponding variable badge. You can interpolate a particular metadata key by using the following syntax: `{{user.metadata.foo.bar}}`.
+
+<Callout type="info">
+  Modifications to Verification OTP SMS templates are very limited due to strict regulations. If changing the Reset password or Verification code SMS template is required, please contact Clerk support.
+</Callout>


### PR DESCRIPTION
We are switching over to a new SMS provider (Prelude) very soon, and this makes changes to the SMS message body for verification OTP templates a manual process. In addition, the changes possible are very limited.

As a result, we want to update the docs to call this out and tell customers to contact support if they must change it.