### PR TITLE
Move 'expo app' step to main guide to draw attention to the needs for…

### DIFF
--- a/docs/quickstarts/expo.mdx
+++ b/docs/quickstarts/expo.mdx
@@ -58,7 +58,7 @@ To get started using Clerk with Expo, create a new Expo project and install the 
 
 ### Install `@clerk/clerk-expo`
 
-Add the Expo SDK to your project:
+Add Clerk's [Expo SDK] (/docs/expo/overview) to your project:
 
 <CodeBlockTabs type="installer" options={["npm", "yarn", "pnpm"]}>
   ```bash filename="terminal"

--- a/docs/quickstarts/expo.mdx
+++ b/docs/quickstarts/expo.mdx
@@ -18,15 +18,11 @@ description: Add authentication and user management to your Expo app with Clerk.
       title: "Set up a Clerk application",
       link: "https://clerk.com/docs/quickstarts/setup-clerk",
       icon: "clerk",
-    },
-    {
-      title: "Create an Expo application",
-      link: "https://docs.expo.dev/tutorial/create-your-first-app/",
-      icon: "link",
-    },
+    }
   ]}
 >
 
+- Create an Expo application
 - Install `@clerk/expo`
 - Set up your environment keys to test your app locally
 - Add `<ClerkProvider />` to your application
@@ -37,9 +33,32 @@ description: Add authentication and user management to your Expo app with Clerk.
 
 <Steps>
 
+### Create an Expo application
+
+To get started using Clerk with Expo, create a new Expo project and install the nessecary dependencies. See the [Expo documentation](https://docs.expo.dev/tutorial/create-your-first-app/) for more information.
+
+<CodeBlockTabs type="installer" options={["npm", "yarn", "pnpm"]}>
+  ```bash filename="terminal"
+  npx create-expo-app application-name --template blank && cd application-name
+  npx expo install react-dom react-native-web @expo/metro-runtime
+
+  ```
+
+  ```bash filename="terminal"
+  npx create-expo-app application-name --template blank && cd application-name
+  npx expo install react-dom react-native-web @expo/metro-runtime
+  ```
+
+  ```bash filename="terminal"
+  pnpm dlx create-expo-app application-name --template blank && cd application-name
+  pnpm dlx expo install react-dom react-native-web @expo/metro-runtime
+  ```
+</CodeBlockTabs>
+
+
 ### Install `@clerk/clerk-expo`
 
-To get started using Clerk with Expo, add the SDK to your project:
+Add the Expo SDK to your project:
 
 <CodeBlockTabs type="installer" options={["npm", "yarn", "pnpm"]}>
   ```bash filename="terminal"


### PR DESCRIPTION
> [!IMPORTANT]
> 🔎 Previews:
>
> - https://clerk.com/docs/pr/1278/quickstarts/expo

### Explanation: 

Customers are not following the Expo docs and installing the required deps, leading to support contacts. This moves the 'create an Expo app' to a step in the main guide and includes the deps to draw attention to them.


