### PR TITLE
feat(elements): Add docs for strategy-based SafeIdentifier

### DIFF
--- a/docs/elements/reference/sign-in.mdx
+++ b/docs/elements/reference/sign-in.mdx
@@ -270,7 +270,13 @@ Exposes various flow-related actions. It can be used to submit forms, navigate b
 
 ## `<SafeIdentifier />`
 
-Renders an identifier that has been provided by the user during a sign-in attempt. Renders a `string` (or empty string if it can't find an identifier).
+Renders a masked identifier corresponding to the parent `Strategy` or `SupportedStrategy`, falling back to the identifier that has been provided by the user during a sign-in attempt. Renders a `string` (or empty string if it can't find an identifier). Must be a child of either `<Strategy>` or `<SupportedStrategy>`.
+
+### Properties {{ toc: false }}
+
+| Name | Type | Description |
+| ---- | ---- | ----------- |
+| `transform?` | (identifier: string) => string | If provided, modify the supplied `identifier` string before rendering. Useful when interpolating the identifier into localized strings. |
 
 ### Usage {{ toc: false }}
 
@@ -278,6 +284,13 @@ Renders an identifier that has been provided by the user during a sign-in attemp
 <SignIn.Strategy name="email_code">
   <h1>Check your email</h1>
   <p>We sent a code to <SignIn.SafeIdentifier />.</p>
+</SignIn.Strategy>
+```
+
+```tsx filename="page.tsx"
+<SignIn.Strategy name="email_code">
+  <h1>{t('checkEmail')}</h1>
+  <p><SignIn.SafeIdentifier transform={identifier => t('sentCodeTo', { identifier })} /></p>
 </SignIn.Strategy>
 ```
 

--- a/docs/elements/reference/sign-in.mdx
+++ b/docs/elements/reference/sign-in.mdx
@@ -276,7 +276,7 @@ Renders a masked identifier corresponding to the parent `Strategy` or `Supported
 
 | Name | Type | Description |
 | ---- | ---- | ----------- |
-| `transform?` | (identifier: string) => string | If provided, modify the supplied `identifier` string before rendering. Useful when interpolating the identifier into localized strings. |
+| `transform?` | `(identifier: string) => string` | If provided, modify the supplied `identifier` string before rendering. Useful when interpolating the identifier into localized strings. |
 
 ### Usage {{ toc: false }}
 


### PR DESCRIPTION
<!--- Add the "deploy-preview" label and add your page previews here -->

> [!IMPORTANT]
> 🔎 Previews:
>
> - https://clerk.com/docs/pr/1281/elements/reference/sign-in#safe-identifier
>
> 🚫 Waiting For Release:
>
> - https://github.com/clerk/javascript/pull/3749
> - https://github.com/clerk/javascript/pull/3745

<!--- Describe your changes in detail. Why does this change need to happen? Include any links to Slack discussions, Linear comments, etc. -->
### Explanation

Adds docs for the upcoming strategy-aware `SafeIdentifier` component.

<!--- How does this PR solve the problem? -->
### This PR:

- Adds docs for the new strategy-aware `SafeIdentifier`, including the new `transform` prop.
