### PR TITLE
Add iOS code examples to Email & Password custom flows

### DIFF
--- a/docs/custom-flows/email-password.mdx
+++ b/docs/custom-flows/email-password.mdx
@@ -598,9 +598,10 @@ To sign up a user using their email and password, you must:
           // Use the code the user provided to attempt verification
           let signUp = try await inProgressSignUp.attemptVerification(.emailCode(code: code))
           
-          if signUp.status == .complete {
+          switch signUp.status {
+          case .complete:
             // If verification was completed, navigate the user as needed.
-          } else {
+          default:
             // If the status is not complete, check why. User may need to
             // complete further steps.
           }
@@ -1024,9 +1025,10 @@ To authenticate a user using their email and password, you must:
           // Start the sign-in process using the email and password provided
           let signIn = try await SignIn.create(strategy: .identifier(email, password: password))
           
-          if signIn.status == .complete {
-            // If sign-in process is complete, navigate the user as needed.
-          } else {
+          switch signIn.status {
+          case .complete:
+            // If sign-in process is complete, navigate the user as needed
+          default:
             // If the status is not complete, check why. User may need to
             // complete further steps.
           }

--- a/docs/custom-flows/email-password.mdx
+++ b/docs/custom-flows/email-password.mdx
@@ -586,7 +586,7 @@ To sign up a user using their email and password, you must:
         } catch {
           // See https://clerk.com/docs/custom-flows/error-handling
           // for more info on error handling
-          print(error)
+          dump(error)
         }
       }
       
@@ -601,14 +601,16 @@ To sign up a user using their email and password, you must:
           switch signUp.status {
           case .complete:
             // If verification was completed, navigate the user as needed.
+            dump(Clerk.shared.session)
           default:
             // If the status is not complete, check why. User may need to
             // complete further steps.
+            dump(signUp.status)
           }
         } catch {
           // See https://clerk.com/docs/custom-flows/error-handling
           // for more info on error handling
-          print(error)
+          dump(error)
         }
       }
         
@@ -1027,15 +1029,17 @@ To authenticate a user using their email and password, you must:
           
           switch signIn.status {
           case .complete:
-            // If sign-in process is complete, navigate the user as needed
+            // If sign-in process is complete, navigate the user as needed.
+            dump(Clerk.shared.session)
           default:
             // If the status is not complete, check why. User may need to
             // complete further steps.
+            dump(signIn.status)
           }
         } catch {
           // See https://clerk.com/docs/custom-flows/error-handling
           // for more info on error handling
-          print(error)
+          dump(error)
         }
       }
         

--- a/docs/custom-flows/email-password.mdx
+++ b/docs/custom-flows/email-password.mdx
@@ -625,7 +625,7 @@ To authenticate a user using their email and password, you must:
 3. Attempt to complete the first factor verification.
 4. If the verification is successful, set the newly created session as the active session.
 
-<Tabs type="framework" items={["Next.js", "JavaScript", "Expo"]}>
+<Tabs type="framework" items={["Next.js", "JavaScript", "Expo", "iOS (Beta)"]}>
   <Tab>
     This example is written for Next.js App Router but it can be adapted for any React meta framework, such as Remix or Gatsby.
 
@@ -995,6 +995,48 @@ To authenticate a user using their email and password, you must:
           </View>
         </View>
       );
+    }
+    ```
+  </Tab>
+
+  <Tab>
+    ```swift filename="EmailPasswordSignInView.swift"
+    import SwiftUI
+    import ClerkSDK
+
+    struct EmailPasswordSignInView: View {
+      @State private var email = ""
+      @State private var password = ""
+      
+      var body: some View {
+        TextField("Enter email address", text: $email)
+        SecureField("Enter password", text: $password)
+        Button("Sign In") {
+          Task { await submit(email: email, password: password) }
+        }
+      }
+    }
+
+    extension EmailPasswordSignInView {
+        
+      func submit(email: String, password: String) async {
+        do {
+          // Start the sign-in process using the email and password provided
+          let signIn = try await SignIn.create(strategy: .identifier(email, password: password))
+          
+          if signIn.status == .complete {
+            // If sign-in process is complete, navigate the user as needed.
+          } else {
+            // If the status is not complete, check why. User may need to
+            // complete further steps.
+          }
+        } catch {
+          // See https://clerk.com/docs/custom-flows/error-handling
+          // for more info on error handling
+          print(error)
+        }
+      }
+        
     }
     ```
   </Tab>

--- a/docs/custom-flows/email-password.mdx
+++ b/docs/custom-flows/email-password.mdx
@@ -34,7 +34,7 @@ To sign up a user using their email and password, you must:
 3. Attempt to complete the email address verification by supplying the one-time code.
 4. If the email address verification is successful, set the newly created session as the active session.
 
-<Tabs type="framework" items={["Next.js", "JavaScript", "Expo"]}>
+<Tabs type="framework" items={["Next.js", "JavaScript", "Expo", "iOS (Beta)"]}>
   <Tab>
     This example is written for Next.js App Router but it can be adapted for any React meta framework, such as Remix or Gatsby.
 
@@ -536,6 +536,81 @@ To sign up a user using their email and password, you must:
           )}
         </View>
       );
+    }
+    ```
+  </Tab>
+  <Tab>
+    ```swift filename="EmailPasswordSignUpView.swift"
+    import SwiftUI
+    import ClerkSDK
+
+    struct EmailPasswordSignUpView: View {
+        
+      @State private var email = ""
+      @State private var password = ""
+      @State private var code = ""
+      @State private var isVerifying = false
+      
+      var body: some View {
+        if isVerifying {
+          // Display the verification form to capture the OTP code
+          TextField("Enter your verification code", text: $code)
+          Button("Verify") {
+            Task { await verify(code: code) }
+          }
+        } else {
+          // Display the initial sign-up form to capture the email and password
+          TextField("Enter email address", text: $email)
+          SecureField("Enter password", text: $password)
+          Button("Next") {
+            Task { await submit(email: email, password: password) }
+          }
+        }
+      }
+        
+    }
+
+    extension EmailPasswordSignUpView {
+        
+      func submit(email: String, password: String) async {
+        do {
+          // Start the sign-up process using the email and password provided
+          let signUp = try await SignUp.create(strategy: .standard(emailAddress: email, password: password))
+          
+          // Send the user an email with the verification code
+          try await signUp.prepareVerification(strategy: .emailCode)
+          
+          // Set 'isVerifying' true to display second form
+          // and capture the OTP code
+          isVerifying = true
+        } catch {
+          // See https://clerk.com/docs/custom-flows/error-handling
+          // for more info on error handling
+          print(error)
+        }
+      }
+      
+      func verify(code: String) async {
+        do {
+          // Access the in progress sign up stored on the client
+          guard let inProgressSignUp = Clerk.shared.client?.signUp else { return }
+          
+          // Use the code the user provided to attempt verification
+          let signUp = try await inProgressSignUp.attemptVerification(.emailCode(code: code))
+          
+          if signUp.status == .complete {
+            // If verification was completed, navigate the user as needed.
+          } else {
+            // If the status is not complete, check why. User may need to
+            // complete further steps.
+          }
+        } catch {
+          // See https://clerk.com/docs/custom-flows/error-handling
+          // for more info on error handling
+          print(error)
+        }
+      }
+        
     }
     ```
   </Tab>


### PR DESCRIPTION
<!--- Add the "deploy-preview" label and add your page previews here -->

> [!IMPORTANT]
> 🔎 Previews:
>
> - https://clerk.com/docs/pr/1282/custom-flows/email-password

<!--- Describe your changes in detail. Why does this change need to happen? Include any links to Slack discussions, Linear comments, etc. -->
### Explanation:
This will be the first in series of PRs adding iOS code examples to most of the custom flows pages.

<!--- How does this PR solve the problem? -->
### This PR:
- Adds iOS code examples to the Email & Password page.
