### PR TITLE
fix(elements): Remove social connections from `<SupportedStrategy>` name property

### DIFF
--- a/docs/elements/reference/sign-in.mdx
+++ b/docs/elements/reference/sign-in.mdx
@@ -186,15 +186,12 @@ Renders a button that will change the current strategy that needs to be verified
 
 | Name | Type     | Description                                                       |
 | ---- | -------- | ----------------------------------------------------------------- |
-| `name` | `'email_code' \| 'email_link' \| 'password' \| 'passkey' \| 'phone_code' \| 'reset_password_email_code' \| 'reset_password_phone_code' \| 'web3_metamask_signature'` | The name of the strategy to switch to. Also accepts social connection names.                           |
+| `name` | `'email_code' \| 'email_link' \| 'password' \| 'passkey' \| 'phone_code' \| 'reset_password_email_code' \| 'reset_password_phone_code' \| 'web3_metamask_signature'` |
 
 ### Usage {{ toc: false }}
 
 ```tsx filename="page.tsx"
 <SignIn.Step name="choose-strategy">
-  <SignIn.SupportedStrategy name="google">
-    Sign in with Google
-  </SignIn.SupportedStrategy>
   <SignIn.SupportedStrategy name="password">
     Sign in with password
   </SignIn.SupportedStrategy>

--- a/docs/elements/reference/sign-in.mdx
+++ b/docs/elements/reference/sign-in.mdx
@@ -186,7 +186,7 @@ Renders a button that will change the current strategy that needs to be verified
 
 | Name | Type     | Description                                                       |
 | ---- | -------- | ----------------------------------------------------------------- |
-| `name` | `'email_code' \| 'email_link' \| 'password' \| 'passkey' \| 'phone_code' \| 'reset_password_email_code' \| 'reset_password_phone_code' \| 'web3_metamask_signature'` | The name of the strategy to switch to.                          |
+| `name` | `'email_code' \| 'email_link' \| 'password' \| 'passkey' \| 'phone_code' \| 'reset_password_email_code' \| 'reset_password_phone_code' \| 'web3_metamask_signature'` | The name of the strategy to switch to. |
 
 ### Usage {{ toc: false }}
 

--- a/docs/elements/reference/sign-in.mdx
+++ b/docs/elements/reference/sign-in.mdx
@@ -186,7 +186,7 @@ Renders a button that will change the current strategy that needs to be verified
 
 | Name | Type     | Description                                                       |
 | ---- | -------- | ----------------------------------------------------------------- |
-| `name` | `'email_code' \| 'email_link' \| 'password' \| 'passkey' \| 'phone_code' \| 'reset_password_email_code' \| 'reset_password_phone_code' \| 'web3_metamask_signature'` |
+| `name` | `'email_code' \| 'email_link' \| 'password' \| 'passkey' \| 'phone_code' \| 'reset_password_email_code' \| 'reset_password_phone_code' \| 'web3_metamask_signature'` | The name of the strategy to switch to.                          |
 
 ### Usage {{ toc: false }}
 


### PR DESCRIPTION
Social connections are not supported within SupportedStrategy.

<img width="954" alt="Screenshot 2024-07-18 at 12 44 19 PM" src="https://github.com/user-attachments/assets/ac4b8159-e3a3-41f4-b572-dac7d72cc322">

