### PR TITLE
Review/updates for Astro docs

### DIFF
--- a/docs/components/overview.mdx
+++ b/docs/components/overview.mdx
@@ -1,11 +1,10 @@
 ---
-title: Component Reference
-description: Learn about the available Clerk Components and how easy it is to integrate them into your application.
+description: A list of Clerk's comprehensive suite of components designed to seamlessly integrate authentication and multi-tenancy into your application.
 ---
 
 # Component Reference
 
-Clerk provides a suite of components that let you quickly add authenticaton to your app, customize the look and feel of your auth components and pages, and control what the user sees and customize the auth flow.
+Clerk offers a comprehensive suite of components designed to seamlessly integrate authentication and multi-tenancy into your application. With Clerk components, you can easily customize the appearance of authentication components and pages, manage the entire authentication flow to suit your specific needs, and even build robust SaaS applications.
 
 - Clerk's prebuilt **UI components** give you a beautiful, fully-functional user management experience in minutes.
 - Clerk's **control components** render at `<Loading />` and `<Loaded />` states for assertions on the [Clerk object](/docs/references/javascript/clerk/clerk). Control components allow you to build custom user flows with Clerk.

--- a/docs/manifest.json
+++ b/docs/manifest.json
@@ -1858,7 +1858,7 @@
                           "href": "/docs/references/astro/locals"
                         },
                         {
-                          "title": "Protect your endpoints",
+                          "title": "Endpoints",
                           "wrap": false,
                           "href": "/docs/references/astro/endpoints"
                         }

--- a/docs/manifest.json
+++ b/docs/manifest.json
@@ -1822,7 +1822,7 @@
                       [
                         {
                           "title": "Use Clerk with Astro and React",
-                          "href": "/docs/references/astro/ui-react"
+                          "href": "/docs/references/astro/react"
                         }
                       ]
                     ]
@@ -1836,7 +1836,7 @@
                           "href": "/docs/references/astro/migrating-from-astro-community-sdk"
                         },
                         {
-                          "title": "Read Session and User Data",
+                          "title": "Read session and user data",
                           "wrap": false,
                           "href": "/docs/references/astro/read-session-data"
                         }
@@ -1845,7 +1845,7 @@
                   },
                   {
                     "title": "General Reference",
-                     "items": [
+                      "items": [
                       [
                         {
                           "title": "`clerkMiddleware()`",

--- a/docs/quickstarts/astro.mdx
+++ b/docs/quickstarts/astro.mdx
@@ -36,12 +36,13 @@ description: Add authentication and user management to your Astro app with Clerk
 
 </TutorialHero>
 
+Clerk's [Astro SDK](/docs/references/astro/overview) provides a set of components, hooks, and stores that make it easy to build authentication and user management features in your Astro app.
+
 <Steps>
+
 ### Install `@clerk/astro`
 
-Clerk's [Astro SDK](/docs/references/astro/overview) has prebuilt components and helpers to make user authentication easier.
-
-To get started using Clerk with Astro, add the SDK to your project:
+Add Clerk's Astro SDK to your project:
 
 <CodeBlockTabs type="installer" options={["npm", "yarn", "pnpm"]}>
   ```bash filename="terminal"

--- a/docs/references/astro/auth-store.mdx
+++ b/docs/references/astro/auth-store.mdx
@@ -1,11 +1,11 @@
 ---
 title: $authStore
-description: Clerk's $authStore nanostore is a convenient way to access the current auth state.
+description: Clerk's $authStore nanostore provides a convenient way to access the current auth state and helper methods for managing the active session.
 ---
 
 # `$authStore`
 
-The `$authStore` store is a convenient way to access the current auth state. This store provides the information needed for data-loading and helper methods to manage the current active session.
+The `$authStore` store provides a convenient way to access the current auth state and helper methods for managing the active session.
 
 ## `$authStore.get()` returns
 
@@ -19,7 +19,7 @@ The `$authStore` store is a convenient way to access the current auth state. Thi
 
 ## How to use the `$authStore` store
 
-The following example demonstrates how to use the `$authStore` store to access the current auth state. You perform actions like checking whether the user is signed in or not. It also demonstrates a basic example of how you could use the [`getToken()`](/docs/references/javascript/session#get-token) method to retrieve a session token for fetching data from an external resource.
+The following example demonstrates how to use the `$authStore` store to access the current auth state. It uses `userId` to detect if the user is signed in and the [`getToken()`](/docs/references/javascript/session#get-token) method to retrieve a session token for fetching data from an external resource.
 
 ```tsx filename="components/external-data.tsx"
 import { useStore } from '@nanostores/react';

--- a/docs/references/astro/auth-store.mdx
+++ b/docs/references/astro/auth-store.mdx
@@ -19,7 +19,7 @@ The `$authStore` store provides a convenient way to access the current auth stat
 
 ## How to use the `$authStore` store
 
-The following example demonstrates how to use the `$authStore` store to access the current auth state. It uses `userId` to detect if the user is signed in and the [`getToken()`](/docs/references/javascript/session#get-token) method to retrieve a session token for fetching data from an external resource.
+The following example demonstrates how to use the `$authStore` store to access the current auth state. It uses `userId` to detect if the user is signed in and the [`getToken()`](https://clerk.com/docs/references/javascript/session#get-token) method to retrieve a session token for fetching data from an external resource.
 
 ```tsx filename="components/external-data.tsx"
 import { useStore } from '@nanostores/react';

--- a/docs/references/astro/clerk-middleware.mdx
+++ b/docs/references/astro/clerk-middleware.mdx
@@ -109,4 +109,4 @@ export default clerkMiddleware((auth, context) => {
 
 ## `clerkMiddleware()` options
 
-The `clerkMiddleware()` function accepts an optional object. See the full list of options available [here](/docs/references/nextjs/clerk-middleware#clerk-middleware-options.)
+The `clerkMiddleware()` function accepts an optional object. See the full list of options available [here](https://clerk.com/docs/references/nextjs/clerk-middleware#clerk-middleware-options.)

--- a/docs/references/astro/clerk-middleware.mdx
+++ b/docs/references/astro/clerk-middleware.mdx
@@ -40,7 +40,7 @@ You can protect routes by checking either or both of the following:
 
 ### Protect routes based on user authentication status
 
-To protect routes based on user authentication status, use [`auth().userId`](/docs/references/nextjs/auth#retrieving-user-id) to check if the `userId` is present. If it is not, the user is not authenticated, and you can redirect them to the sign-in page.
+To protect routes based on user authentication status, use [`auth().userId`](https://clerk.com/docs/references/nextjs/auth#retrieving-user-id) to check if the `userId` is present. If it is not, the user is not authenticated, and you can redirect them to the sign-in page.
 
 ```tsx filename="src/middleware.ts"
 import {
@@ -64,7 +64,7 @@ export default clerkMiddleware((auth, context) => {
 
 ### Protect routes based on user authorization status
 
-To protect routes based on user authorization status, use [`auth().has()`](/docs/references/nextjs/auth-object#has) to check if the user has the required roles or permissions.
+To protect routes based on user authorization status, use [`auth().has()`](https://clerk.com/docs/references/nextjs/auth-object#has) to check if the user has the required roles or permissions.
 
 ```tsx filename="src/middleware.ts"
 import {

--- a/docs/references/astro/clerk-middleware.mdx
+++ b/docs/references/astro/clerk-middleware.mdx
@@ -5,11 +5,11 @@ description: The `clerkMiddleware()` function allows you to protect your Astro a
 
 # `clerkMiddleware()`
 
-The `clerkMiddleware()` helper integrates Clerk authentication into your Astro application through Middleware.
+The `clerkMiddleware()` helper integrates Clerk authentication into your Astro application through middleware.
 
 ## Configure `clerkMiddleware()`
 
-Create a `middleware.ts` file inside your `src/` directory.
+Create a `middleware.ts` file inside your `src/` directory.
 
 ```ts filename="src/middleware.ts"
 import { clerkMiddleware } from "@clerk/astro/server";
@@ -40,7 +40,7 @@ You can protect routes by checking either or both of the following:
 
 ### Protect routes based on user authentication status
 
-You can protect routes based on user authentication status by checking if the user is signed in.
+To protect routes based on user authentication status, use [`auth().userId`](/docs/references/nextjs/auth#retrieving-user-id) to check if the `userId` is present. If it is not, the user is not authenticated, and you can redirect them to the sign-in page.
 
 ```tsx filename="src/middleware.ts"
 import {
@@ -64,6 +64,8 @@ export default clerkMiddleware((auth, context) => {
 
 ### Protect routes based on user authorization status
 
+To protect routes based on user authorization status, use [`auth().has()`](/docs/references/nextjs/auth-object#has) to check if the user has the required roles or permissions.
+
 ```tsx filename="src/middleware.ts"
 import {
   clerkMiddleware,
@@ -83,8 +85,7 @@ export default clerkMiddleware((auth, context) => {
     !has({ permission: 'org:sys_domains_manage' })
   ){
 
-    // Add logic to run if the user does not have the required permissions
-
+    // Add logic to run if the user does not have the required permissions; for example, redirecting to the sign-in page
     return redirectToSignIn();
   }
 });

--- a/docs/references/astro/clerk-store.mdx
+++ b/docs/references/astro/clerk-store.mdx
@@ -1,15 +1,14 @@
 ---
 title: $clerkStore
-description: Clerk's $clerkStore store is used to access the Clerk object, which can be used to build alternatives to any Clerk Component.
+description: Clerk's $clerkStore nanostore provides a convenient way to access the `Clerk` object. This provides access to some methods that are not available in other stores.
 ---
 
 # `$clerkStore`
 
-The `$clerkStore` store provides access to the [`Clerk`](/docs/references/javascript/clerk/clerk) object. This provides access to some methods that are not available in other stores.
+The `$clerkStore` store provides a convenient way to access the [`Clerk`](/docs/references/javascript/clerk/clerk) object. This provides access to some methods that are not available in other stores.
 
-<Callout type="warning">
-  This is intended to be used for advanced use cases, like building a completely custom OAuth flow or as an escape hatch for getting access to the `Clerk` object.
-</Callout>
+> [!WARNING]
+> This is intended to be used for advanced use cases, like building a completely custom OAuth flow or as an escape hatch for getting access to the `Clerk` object.
 
 ## How to use the `$clerkStore` store
 

--- a/docs/references/astro/clerk-store.mdx
+++ b/docs/references/astro/clerk-store.mdx
@@ -5,7 +5,7 @@ description: Clerk's $clerkStore nanostore provides a convenient way to access t
 
 # `$clerkStore`
 
-The `$clerkStore` store provides a convenient way to access the [`Clerk`](/docs/references/javascript/clerk/clerk) object. This provides access to some methods that are not available in other stores.
+The `$clerkStore` store provides a convenient way to access the [`Clerk`](https://clerk.com/docs/references/javascript/clerk/clerk) object. This provides access to some methods that are not available in other stores.
 
 > [!WARNING]
 > This is intended to be used for advanced use cases, like building a completely custom OAuth flow or as an escape hatch for getting access to the `Clerk` object.

--- a/docs/references/astro/endpoints.mdx
+++ b/docs/references/astro/endpoints.mdx
@@ -49,7 +49,7 @@ export async function GET({ locals }) {
 
 ## Retrieve the current user
 
-In some cases, you might need the current user in your endpoint. Use the [`currentUser()` local](/docs/references/astro/locals#accessing-the-current-user) to retrieve the current [`Backend User`](https://clerk.com/docs/references/backend/types/backend-user) object, as shown in the following example:
+In some cases, you might need the current user in your endpoint. Use the asynchronous [`currentUser()` local](/docs/references/astro/locals#accessing-the-current-user) to retrieve the current [`Backend User`](https://clerk.com/docs/references/backend/types/backend-user) object, as shown in the following example:
 
 ```ts filename="src/pages/api/route.ts"
 export async function GET({ locals }) {

--- a/docs/references/astro/endpoints.mdx
+++ b/docs/references/astro/endpoints.mdx
@@ -1,16 +1,14 @@
 ---
-title: Protect your Astro endpoints
-description: Learn how to use Clerk in Astro to protect your endpoints.
+description: Learn how to use Clerk's Astro SDK in your Astro endpoints.
 ---
 
 # Endpoints
 
 Clerk provides helpers that allow you to protect your [Astro endpoints](https://docs.astro.build/en/guides/endpoints/#server-endpoints-api-routes), fetch the current user, and interact with the Clerk backend API.
 
-## Protect your Endpoints
+## Protect your endpoints
 
-If you aren't protecting your Endpoints using [`clerkMiddleware()`](/docs/references/astro/clerk-middleware), you can protect your Endpoints by using the `auth()` local and check for the `userId` value:
-
+If you aren't protecting your endpoints using [`clerkMiddleware()`](/docs/references/astro/clerk-middleware), you can use the [`auth()` local](/docs/references/astro/locals) and check for the `userId` value, as shown in the following example:
 
 ```ts filename="src/pages/api/route.ts"
 export async function GET({ locals }) {
@@ -30,7 +28,7 @@ export async function GET({ locals }) {
 
 Clerk provides integrations with a number of popular databases.
 
-The following example demonstrates how to use [`auth().getToken()`](/docs/references/nextjs/auth-object#get-token) to retrieve a token from a JWT template and use it to fetch data from the external source.
+To retrieve a token from a JWT template and fetch data from an external source, use the [`getToken()`](/docs/references/nextjs/auth-object#get-token) method from the [`auth()` local](/docs/references/astro/locals), as shown in the following example:
 
 ```ts filename="src/pages/api/route.ts"
 export async function GET({ locals }) {
@@ -51,11 +49,7 @@ export async function GET({ locals }) {
 
 ## Retrieve the current user
 
-In some cases, you might need the current user in your Endpoint. Clerk provides an asynchronous local called [`currentUser()`](/docs/references/nextjs/current-user) to retrieve the current [`Backend User`](/docs/references/backend/types/backend-user) object.
-
-Under the hood, this local:
-- uses the `GET /v1/users/me` endpoint.
-- counts towards the [Backend API Request Rate Limit](/docs/backend-requests/resources/rate-limits#rate-limits).
+In some cases, you might need the current user in your endpoint. Use the [`currentUser()` local](/docs/references/astro/locals#accessing-the-current-user) to retrieve the current [`Backend User`](/docs/references/backend/types/backend-user) object, as shown in the following example:
 
 ```ts filename="src/pages/api/route.ts"
 export async function GET({ locals }) {
@@ -73,7 +67,7 @@ export async function GET({ locals }) {
 
 The [JavaScript Backend SDK](/docs/references/backend/overview) exposes [Clerk's backend API](https://clerk.com/docs/reference/backend-api) resources and low-level authentication utilities for JavaScript environments.
 
-`clerkClient` exposes an instance of the JavaScript Backend SDK for use in server environments.
+`clerkClient` exposes an instance of the JavaScript Backend SDK for use in server environments. Use this instance to interact with the Clerk backend API, as shown in the following example:
 
 ```ts filename="src/pages/api/route.ts"
 import { clerkClient } from '@clerk/astro/server';

--- a/docs/references/astro/endpoints.mdx
+++ b/docs/references/astro/endpoints.mdx
@@ -28,7 +28,7 @@ export async function GET({ locals }) {
 
 Clerk provides integrations with a number of popular databases.
 
-To retrieve a token from a JWT template and fetch data from an external source, use the [`getToken()`](/docs/references/nextjs/auth-object#get-token) method from the [`auth()` local](/docs/references/astro/locals), as shown in the following example:
+To retrieve a token from a JWT template and fetch data from an external source, use the [`getToken()`](https://clerk.com/docs/references/nextjs/auth-object#get-token) method from the [`auth()` local](/docs/references/astro/locals), as shown in the following example:
 
 ```ts filename="src/pages/api/route.ts"
 export async function GET({ locals }) {
@@ -49,7 +49,7 @@ export async function GET({ locals }) {
 
 ## Retrieve the current user
 
-In some cases, you might need the current user in your endpoint. Use the [`currentUser()` local](/docs/references/astro/locals#accessing-the-current-user) to retrieve the current [`Backend User`](/docs/references/backend/types/backend-user) object, as shown in the following example:
+In some cases, you might need the current user in your endpoint. Use the [`currentUser()` local](/docs/references/astro/locals#accessing-the-current-user) to retrieve the current [`Backend User`](https://clerk.com/docs/references/backend/types/backend-user) object, as shown in the following example:
 
 ```ts filename="src/pages/api/route.ts"
 export async function GET({ locals }) {

--- a/docs/references/astro/locals.mdx
+++ b/docs/references/astro/locals.mdx
@@ -5,14 +5,15 @@ description: Learn how to authenticate your Astro application with Clerk using l
 
 # Locals
 
-Through Astro [`locals`](https://docs.astro.build/en/guides/middleware/#storing-data-in-contextlocals), the [`Auth`](/docs/references/nextjs/auth-object) and current user objects can be accessed between middlewares and pages. These locals are injected when you install the provided [middleware](/docs/references/astro/clerk-middleware).
+Through Astro [`locals`](https://docs.astro.build/en/guides/middleware/#storing-data-in-contextlocals), C;erk's [`Auth`](/docs/references/nextjs/auth-object) and current [`User`](/docs/references/javascript/user/user) objects can be accessed between middlewares and pages. These locals are injected when you install the provided [middleware](/docs/references/astro/clerk-middleware).
 
-The following guide provides examples of using the `auth()` local to validate an authenticated user and the `currentUser()` local to access the `Backend API User` object for the authenticated user.
+The following guide provides examples of using the [`auth()`](/docs/references/nextjs/auth) local to validate an authenticated user and the [`currentUser()`](/docs/references/nextjs/current-user) local to access the [`Backend API User`](/docs/references/backend/types/backend-user) object for the authenticated user.
 
 ## Protect your pages
 
-You can use the `auth()` local to protect your pages. This local will return the current user's ID if they are signed in, or `null` if they are not.
+You can use the `auth()` local to protect your pages and forms. It will return the current user's ID if they are signed in, or `null` if they are not. For more information on `auth()`, see the [reference](/docs/references/nextjs/auth).
 
+<CodeBlockTabs options={["Protect a page", "Protect a form"]}>
 ```astro filename="src/pages/protected.astro"
 ---
 const { userId, redirectToSignIn } = Astro.locals.auth();
@@ -24,8 +25,6 @@ if (!userId) {
 
 <div>Protected page</div>
 ```
-
-## Protect your forms
 
 ```astro filename="src/pages/form.astro"
 ---
@@ -48,14 +47,11 @@ if (Astro.request.method === "POST") {
   <button type="submit">Add to Cart</button>
 </form>
 ```
+</CodeBlockTabs>
 
 ## Accessing the current user
 
-Current user data is important for data enrichment. You can use the `currentUser()` local to fetch the current user's data in your pages.
-
-Under the hood, this local:
-- uses the `GET /v1/users/me` endpoint.
-- counts towards the [Backend API Request Rate Limit](/docs/backend-requests/resources/rate-limits#rate-limits).
+Current user data is important for data enrichment. You can use the `currentUser()` local to fetch the current user's data in your pages. For more information on `currentUser()`, see the [reference](/docs/references/nextjs/current-user).
 
 ```astro filename="src/pages/form.astro"
 ---

--- a/docs/references/astro/locals.mdx
+++ b/docs/references/astro/locals.mdx
@@ -5,7 +5,7 @@ description: Learn how to authenticate your Astro application with Clerk using l
 
 # Locals
 
-Through Astro [`locals`](https://docs.astro.build/en/guides/middleware/#storing-data-in-contextlocals), C;erk's [`Auth`](https://clerk.com/docs/references/nextjs/auth-object) and current [`User`](https://clerk.com/docs/references/javascript/user/user) objects can be accessed between middlewares and pages. These locals are injected when you install the provided [middleware](/docs/references/astro/clerk-middleware).
+Through Astro [`locals`](https://docs.astro.build/en/guides/middleware/#storing-data-in-contextlocals), Clerk's [`Auth`](https://clerk.com/docs/references/nextjs/auth-object) and current [`User`](https://clerk.com/docs/references/javascript/user/user) objects can be accessed between middlewares and pages. These locals are injected when you install the provided [middleware](/docs/references/astro/clerk-middleware).
 
 The following guide provides examples of using the [`auth()`](https://clerk.com/docs/references/nextjs/auth) local to validate an authenticated user and the [`currentUser()`](https://clerk.com/docs/references/nextjs/current-user) local to access the [`Backend API User`](https://clerk.com/docs/references/backend/types/backend-user) object for the authenticated user.
 

--- a/docs/references/astro/locals.mdx
+++ b/docs/references/astro/locals.mdx
@@ -51,7 +51,13 @@ if (Astro.request.method === "POST") {
 
 ## Accessing the current user
 
-Current user data is important for data enrichment. You can use the `currentUser()` local to fetch the current user's data in your pages. For more information on `currentUser()`, see the [reference](https://clerk.com/docs/references/nextjs/current-user).
+Current user data is important for data enrichment. You can use the `currentUser()` local to fetch the current user's data in your pages.
+
+Under the hood, this local:
+- uses the `GET /v1/users/me` endpoint.
+- counts towards the [Backend API Request Rate Limit](/docs/backend-requests/resources/rate-limits#rate-limits).
+
+For more information on `currentUser()`, see the [reference](https://clerk.com/docs/references/nextjs/current-user).
 
 ```astro filename="src/pages/form.astro"
 ---

--- a/docs/references/astro/locals.mdx
+++ b/docs/references/astro/locals.mdx
@@ -5,13 +5,13 @@ description: Learn how to authenticate your Astro application with Clerk using l
 
 # Locals
 
-Through Astro [`locals`](https://docs.astro.build/en/guides/middleware/#storing-data-in-contextlocals), C;erk's [`Auth`](/docs/references/nextjs/auth-object) and current [`User`](/docs/references/javascript/user/user) objects can be accessed between middlewares and pages. These locals are injected when you install the provided [middleware](/docs/references/astro/clerk-middleware).
+Through Astro [`locals`](https://docs.astro.build/en/guides/middleware/#storing-data-in-contextlocals), C;erk's [`Auth`](https://clerk.com/docs/references/nextjs/auth-object) and current [`User`](https://clerk.com/docs/references/javascript/user/user) objects can be accessed between middlewares and pages. These locals are injected when you install the provided [middleware](/docs/references/astro/clerk-middleware).
 
-The following guide provides examples of using the [`auth()`](/docs/references/nextjs/auth) local to validate an authenticated user and the [`currentUser()`](/docs/references/nextjs/current-user) local to access the [`Backend API User`](/docs/references/backend/types/backend-user) object for the authenticated user.
+The following guide provides examples of using the [`auth()`](https://clerk.com/docs/references/nextjs/auth) local to validate an authenticated user and the [`currentUser()`](https://clerk.com/docs/references/nextjs/current-user) local to access the [`Backend API User`](https://clerk.com/docs/references/backend/types/backend-user) object for the authenticated user.
 
 ## Protect your pages
 
-You can use the `auth()` local to protect your pages and forms. It will return the current user's ID if they are signed in, or `null` if they are not. For more information on `auth()`, see the [reference](/docs/references/nextjs/auth).
+You can use the `auth()` local to protect your pages and forms. It will return the current user's ID if they are signed in, or `null` if they are not. For more information on `auth()`, see the [reference](https://clerk.com/docs/references/nextjs/auth).
 
 <CodeBlockTabs options={["Protect a page", "Protect a form"]}>
 ```astro filename="src/pages/protected.astro"
@@ -51,7 +51,7 @@ if (Astro.request.method === "POST") {
 
 ## Accessing the current user
 
-Current user data is important for data enrichment. You can use the `currentUser()` local to fetch the current user's data in your pages. For more information on `currentUser()`, see the [reference](/docs/references/nextjs/current-user).
+Current user data is important for data enrichment. You can use the `currentUser()` local to fetch the current user's data in your pages. For more information on `currentUser()`, see the [reference](https://clerk.com/docs/references/nextjs/current-user).
 
 ```astro filename="src/pages/form.astro"
 ---

--- a/docs/references/astro/migrating-from-astro-community-sdk.mdx
+++ b/docs/references/astro/migrating-from-astro-community-sdk.mdx
@@ -90,7 +90,7 @@ The Astro components have been restructured to provide a more consistent API. Th
 
 ### Stores
 
-Submodule `/stores` was replaced with `/client`. The following changes are required to import the [stores](docs/references/astro/overview#client-side-helpers):
+Submodule `/stores` was replaced with `/client`. The following changes are required to import the [stores](/docs/references/astro/overview#client-side-helpers):
 
 ```diff
 - import { $clerk } from "astro-clerk-auth/stores"

--- a/docs/references/astro/migrating-from-astro-community-sdk.mdx
+++ b/docs/references/astro/migrating-from-astro-community-sdk.mdx
@@ -5,17 +5,11 @@ description: Learn how to migrate from the Astro community SDK to the Clerk Astr
 
 # Migrating from the Astro community SDK
 
-In July 2024, we introduced official support for Astro. This migration guide covers converting from the [`astro-clerk-auth`](https://github.com/panteliselef/astro-with-clerk-auth) community SDK to the official SDK. It covers the breaking changes that were introduced and provides examples on how to resolve them.
-
-
-**Overview:**
-- Install `@clerk/astro`, uninstall `astro-clerk-auth`
-- Update import paths
-- Replace deprecated APIs
+In July 2024, we introduced official support for Astro. This migration guide covers converting from the [`astro-clerk-auth`](https://github.com/panteliselef/astro-with-clerk-auth) community SDK to Clerk's official SDK. It covers the breaking changes that were introduced and provides examples on how to resolve them.
 
 ## Installation
 
-Uninstall the community SDK and install the new offical SDK for Astro.
+Uninstall the community SDK and install Clerk's new offical SDK for Astro.
 
 <CodeBlockTabs type="installer" options={["npm", "yarn", "pnpm"]}>
     ```bash filename="terminal"
@@ -38,32 +32,30 @@ Uninstall the community SDK and install the new offical SDK for Astro.
 
 ### The integration
 
-When using the integration from `@clerk/astro` we are now hotloading clerk-js by default.
-Previously you could choose between two strategies when using the clerk intergration. Now only one is offered:
+With the community SDK, you could choose to either hotload Clerk's `clerk-js` library or bundle it with your application.
 
-**Hotload** 
+With Clerk's official SDK, `clerk-js` is hotloaded by default, and the option to use the bundled `clerk-js` variant has been removed.
+
+The following changes are required in your Astro configuration file:
 
 ```diff
 import { defineConfig } from "astro/config";
 import node from "@astrojs/node";
 - import clerk from "astro-clerk-auth/hotload";
+- import clerk from "astro-clerk-auth/integration/hotload";
 - import clerk from "astro-clerk-auth";
 - import clerk from "astro-clerk-auth/integration";
-- import clerk from "astro-clerk-auth/integration/hotload";
 + import clerk from "@clerk/astro";
 export default defineConfig({
   integrations: [clerk()],
   adapter: node({ mode: "standalone" }),
   output: "server",
 });
+```
 
-**Bundled** \
-We have completely removed the option for an integration that uses the bundled clerk-js variant
+### Prefix for environment variables
 
-### Prefix for environment variable
-
-We changed the expected required prefix for environment variables available in client-side code. This was to align with [best practises](https://docs.astro.build/en/guides/environment-variables/) by Astro.
-This change is applicable to all [environment variables](https://clerk.com/docs/deployments/clerk-environment-variables) Clerk supports.
+The prefix for environment variables used in client-side code has been updated to align with Astro's [best practises](https://docs.astro.build/en/guides/environment-variables/). This change affects all [environment variables](https://clerk.com/docs/deployments/clerk-environment-variables) supported by Clerk.
 
 ```diff
 
@@ -79,7 +71,9 @@ This change is applicable to all [environment variables](https://clerk.com/docs/
 ```
 
 
-### Changes to Astro components
+### Astro component export updates
+
+The Astro components have been restructured to provide a more consistent API. The following changes are required to import your Astro components:
 
 ```diff
 
@@ -94,9 +88,9 @@ This change is applicable to all [environment variables](https://clerk.com/docs/
 
 ```
 
-### Changes related to stores
+### Stores
 
-Submodule `/stores` was replaced with `/client`. For the full list of the stores see [here](docs/references/astro/overview#client-side-helpers)
+Submodule `/stores` was replaced with `/client`. The following changes are required to import the [stores](docs/references/astro/overview#client-side-helpers):
 
 ```diff
 - import { $clerk } from "astro-clerk-auth/stores"
@@ -119,7 +113,7 @@ Submodule `/v0` was dropped completely and the previously exported constants are
 
 ### `clerkClient` changes
 
-`clerkClient` as a variable was already deprecated. Now it should be used as a function and it accepts the Astro context.
+The `clerkClient` variable has been deprecated and should now be used as a function that accepts the Astro context.
 
 ```diff
 import type { APIRoute } from "astro";
@@ -135,7 +129,9 @@ export const GET: APIRoute = async (context) => {
 
 ### React components changes
 
-Previously there was two ways of using a React component inside a `.astro` file. We have decided to drop the submodule `/components/react` in order to avoid confusion.
+With the community SDK, there were to ways to use a React component inside a `.astro` file.
+
+To avoid confusion, the official SDK removes the `/components/react` submodule.
 
 ```diff
 ---
@@ -149,7 +145,7 @@ Previously there was two ways of using a React component inside a `.astro` file.
 </SignedIn>
 ```
 
-In order to use a React component inside a `.jsx` or `.tsx` file, you simply need to update the import path.
+To use a React component inside a `.jsx` or `.tsx` file, update the import path.
 
 ```diff
 import {
@@ -173,4 +169,4 @@ export default function Header() {
     </>
   )
 }
-``` 
+```

--- a/docs/references/astro/migrating-from-astro-community-sdk.mdx
+++ b/docs/references/astro/migrating-from-astro-community-sdk.mdx
@@ -55,7 +55,7 @@ export default defineConfig({
 
 ### Prefix for environment variables
 
-The prefix for environment variables used in client-side code has been updated to align with Astro's [best practises](https://docs.astro.build/en/guides/environment-variables/). This change affects all [environment variables](https://clerk.com/docs/deployments/clerk-environment-variables) supported by Clerk.
+The prefix for environment variables used in client-side code has been updated to align with Astro's [best practices](https://docs.astro.build/en/guides/environment-variables/). This change affects all [environment variables](https://clerk.com/docs/deployments/clerk-environment-variables) supported by Clerk.
 
 ```diff
 

--- a/docs/references/astro/organization-store.mdx
+++ b/docs/references/astro/organization-store.mdx
@@ -9,7 +9,7 @@ The `$organizationStore` store is used to retrieve attributes of the currently a
 
 ## How to use the `$organizationStore` store
 
-The following example demonstrates how to use the `$organizationStore` store to access the [`Organization`](/docs/references/javascript/organization/organization) object, which allows you to access the current active organization.
+The following example demonstrates how to use the `$organizationStore` store to access the [`Organization`](https://clerk.com/docs/references/javascript/organization/organization) object, which allows you to access the current active organization.
 
 ```tsx filename="session.tsx"
 import { useStore } from '@nanostores/react';
@@ -40,7 +40,7 @@ export default function Home() {
 
 The following example demonstrates how to implement pagination for organization memberships. The `memberships` state will be populated with the first page of the organization's memberships. When the "Previous page" or "Next page" button is clicked, the `fetchMemberships` function will be called to fetch the previous or next page of memberships.
 
-You can implement this pattern to any Clerk function that returns a [`ClerkPaginatedResponse`](/docs/references/javascript/types/clerk-paginated-response#clerk-paginated-response) object.
+You can implement this pattern to any Clerk function that returns a [`ClerkPaginatedResponse`](https://clerk.com/docs/references/javascript/types/clerk-paginated-response#clerk-paginated-response) object.
 
 ```tsx filename="organization-members.tsx"
 import { useState, useEffect } from 'react';

--- a/docs/references/astro/overview.mdx
+++ b/docs/references/astro/overview.mdx
@@ -28,7 +28,7 @@ Clerk Astro provides a set of useful [stores](https://github.com/nanostores/nano
 
 ### `Auth` object
 
-`Astro.locals.auth()` returns an Auth object. This JavaScript object contains important information like session data, your user's ID, as well as their active organization ID. Learn more about the Auth object [here](/docs/references/nextjs/auth-object).
+`Astro.locals.auth()` returns an `Auth` object. This JavaScript object contains important information like session data, your user's ID, as well as their active organization ID. Learn more about the `Auth` object [here](https://clerk.com/docs/references/nextjs/auth-object).
 
 ### `clerkMiddleware()`
 

--- a/docs/references/astro/overview.mdx
+++ b/docs/references/astro/overview.mdx
@@ -32,4 +32,4 @@ Clerk Astro provides a set of useful [stores](https://github.com/nanostores/nano
 
 ### `clerkMiddleware()`
 
-The clerkMiddleware() helper integrates Clerk authentication into your Astro application through middleware. It allows you to integrate authorization into both the client and server of your application. You can learn more [here](/docs/references/astro/clerk-middleware).
+The `clerkMiddleware()` helper integrates Clerk authentication and authorization into your Astro application through middleware. You can learn more [here](/docs/references/astro/clerk-middleware).

--- a/docs/references/astro/react.mdx
+++ b/docs/references/astro/react.mdx
@@ -5,13 +5,15 @@ description: Learn how to user Clerk inside an Astro app with React
 
 # Use Clerk with Astro and React
 
-Astro supports intregrations with many UI Frameworks. This guide we teach you how to untilize [`@clerk/astro`](/docs/references/astro/overview) and use [Clerk's components](https://clerk.com/docs/pr/1255/components/overview#ui-components), hooks and the new stores. If you have not set up you Astro applicatoin to work with Clerk, visit the [Astro quickstart.](https://clerk.com/docs/pr/1255/quickstarts/astro)
+Astro provides an [integration](https://docs.astro.build/en/guides/integrations-guide/react/) that enables server-side rendering and client-side hydration for your React components. This guide demonstrates how to use Clerk with Astro and React.
 
+If you have not set up your Astro application to work with Clerk, visit the [Astro quickstart.](/docs/quickstarts/astro)
 
 <Steps>
+
 ### Install `@astrojs/react`
 
-Alternatively can also read the [official Astro documentation](https://docs.astro.build/en/guides/integrations-guide/react/)
+Add the [Astro React integration](https://docs.astro.build/en/guides/integrations-guide/react/) to your project:
 
 <CodeBlockTabs type="installer" options={["npm", "yarn", "pnpm"]}>
   ```bash filename="terminal"
@@ -29,9 +31,9 @@ Alternatively can also read the [official Astro documentation](https://docs.astr
 
 ### Update `astro.config.mjs`
 
-Add the react integration inside your Astro configuration file.
+Add Clerk and React integrations to your Astro configuration:
 
-```ts filename="astro.config.mjs" {3,9}
+```ts filename="astro.config.mjs"
 import { defineConfig } from "astro/config";
 import node from "@astrojs/node";
 import react from "@astrojs/react";
@@ -47,7 +49,13 @@ export default defineConfig({
 });
 ```
 
-### Use Clerk React components in Astro pages
+### Use Clerk components
+
+You can use Clerk's [prebuilt components](/docs/components/overview) in your Astro pages or regular React components.
+
+#### Astro pages
+
+The following example demonstrates how to use Clerk components in Astro pages.
 
 ```astro filename="src/layouts/SiteLayout.astro"
 ---
@@ -70,7 +78,7 @@ import {
     <header>
       <nav>
         <SignedOut client:load>
-         <SignInButton client:load mode="modal" />
+          <SignInButton client:load mode="modal" />
         </SignedOut>
         <SignedIn client:load>
           <UserButton client:load/>
@@ -84,7 +92,9 @@ import {
 </html>
 ```
 
-### Use Clerk React components in your React components
+#### React components
+
+The following example demonstrates how to use Clerk components in React components.
 
 ```tsx filename="src/components/Header.tsx"
 import {
@@ -109,7 +119,11 @@ export default function Header() {
 }
 ```
 
-### Use [stores](/docs/references/astro/overview#client-side-helpers) in your React components
+### Use stores in your React components
+
+Clerk Astro provides a set of useful [stores](/docs/references/astro/overview#client-side-helpers) that give you access to the [`Clerk`](/docs/references/javascript/clerk/clerk) object, and helper methods for signing in and signing up.
+
+The following example demonstrates how to use a Clerk Astro store.
 
 ```tsx filename="src/components/Header.tsx"
 import { $userStore } from '@clerk/astro/client'
@@ -125,3 +139,14 @@ export default function Username() {
 ```
 
 </Steps>
+
+## Next steps
+
+
+<div className="container mx-auto my-4">
+  <div className="grid grid-cols-1 gap-6 md:grid-cols-2">
+    <Cards title="Read user and session data" description="Learn how to use Clerk's hooks and helpers to access the active session and user data in your Astro application." link="/docs/references/astro/read-session-data" cta="Learn More" />
+
+    <Cards title="Client side helpers" description="Learn more about Astro client side helpers and how to use them." link="/docs/references/astro/overview#client-side-helpers" cta="Learn More" />
+  </div>
+</div>

--- a/docs/references/astro/react.mdx
+++ b/docs/references/astro/react.mdx
@@ -121,7 +121,7 @@ export default function Header() {
 
 ### Use stores in your React components
 
-Clerk Astro provides a set of useful [stores](/docs/references/astro/overview#client-side-helpers) that give you access to the [`Clerk`](/docs/references/javascript/clerk/clerk) object, and helper methods for signing in and signing up.
+Clerk Astro provides a set of useful [stores](/docs/references/astro/overview#client-side-helpers) that give you access to the [`Clerk`](https://clerk.com/docs/references/javascript/clerk/clerk) object, and helper methods for signing in and signing up.
 
 The following example demonstrates how to use a Clerk Astro store.
 

--- a/docs/references/astro/read-session-data.mdx
+++ b/docs/references/astro/read-session-data.mdx
@@ -9,7 +9,7 @@ Clerk provides helpers that you can use to access the active session and user da
 
 ## Server side
 
-This example uses the `auth()` local to validate an authenticated user and the  `currentUser()` local to access the `Backend API User` object for the authenticated user.
+The following example uses the [`auth()`](/docs/references/nextjs/auth) local to validate an authenticated user and the [`currentUser()`](/docs/references/nextjs/current-user) local to access the [`Backend API User`](/docs/references/backend/types/backend-user) object for the authenticated user.
 
 <CodeBlockTabs options={[".astro component", "API Route"]}>
 
@@ -40,9 +40,11 @@ export async function GET({ locals }) {
 
 ## Client side
 
+Clerk Astro provides a set of useful [stores](/docs/references/astro/overview#client-side-helpers) that give you access to many important objects, such as the `Clerk`, `User`, and `Session` object.
+
 ### `$authStore`
 
-The [`$authStore`](/docs/references/astro/auth-store) store is a convenient way to access the current auth state. This store provides the minimal information needed for data-loading and helper methods to manage the current active session.
+The following example demonstrates how to use the [`$authStore`](/docs/references/astro/auth-store) to access auth information for the active user, such as the `userId` and `sessionId`.
 
 ```tsx filename="components/example.tsx"
 import { useStore } from '@nanostores/react';
@@ -66,7 +68,7 @@ export default function Example() {
 
 ### `$userStore`
 
-The [`$userStore`](/docs/references/astro/user-store) store is a convenient way to access the current user data where you need it. This store provides the user data and helper methods to manage the current active session.
+The following example demonstrates how to use the [`$userStore`](/docs/references/astro/user-store) store to access information about the active user, such as their `firstName`.
 
 ```tsx filename="components/example.tsx"
 import { useStore } from '@nanostores/react';

--- a/docs/references/astro/read-session-data.mdx
+++ b/docs/references/astro/read-session-data.mdx
@@ -9,7 +9,7 @@ Clerk provides helpers that you can use to access the active session and user da
 
 ## Server side
 
-The following example uses the [`auth()`](/docs/references/nextjs/auth) local to validate an authenticated user and the [`currentUser()`](/docs/references/nextjs/current-user) local to access the [`Backend API User`](/docs/references/backend/types/backend-user) object for the authenticated user.
+The following example uses the [`auth()`](https://clerk.com/docs/references/nextjs/auth) local to validate an authenticated user and the [`currentUser()`](https://clerk.com/docs/references/nextjs/current-user) local to access the [`Backend API User`](https://clerk.com/docs/references/backend/types/backend-user) object for the authenticated user.
 
 <CodeBlockTabs options={[".astro component", "API Route"]}>
 

--- a/docs/references/astro/session-list-store.mdx
+++ b/docs/references/astro/session-list-store.mdx
@@ -5,7 +5,7 @@ description: Clerk's $sessionList store retrieves a list of sessions that have b
 
 # `$sessionListStore`
 
-The `$sessionListStore` store returns an array of [`Session`](/docs/references/javascript/session) objects that have been registered on the client device.
+The `$sessionListStore` store returns an array of [`Session`](https://clerk.com/docs/references/javascript/session) objects that have been registered on the client device.
 
 ## How to use the `$sessionListStore` store
 

--- a/docs/references/astro/session-store.mdx
+++ b/docs/references/astro/session-store.mdx
@@ -5,7 +5,7 @@ description: Clerk's $sessionStore nanostore provides a convenient way to access
 
 # `$sessionStore`
 
-The `$sessionStore` store provides a convenient way to access the current user's [`Session`](/docs/references/javascript/session) object, as well as helpers for setting the active session.
+The `$sessionStore` store provides a convenient way to access the current user's [`Session`](https://clerk.com/docs/references/javascript/session) object, as well as helpers for setting the active session.
 
 ## How to use the `$sessionStore` store
 

--- a/docs/references/astro/session-store.mdx
+++ b/docs/references/astro/session-store.mdx
@@ -1,11 +1,11 @@
 ---
 title: $sessionStore
-description: Clerk's $sessionStore store provides access to the the current user Session object, as well as helpers to set the active session.
+description: Clerk's $sessionStore nanostore provides a convenient way to access the current user Session object, as well as helpers to set the active session.
 ---
 
 # `$sessionStore`
 
-The `$sessionStore` store provides access to the current user's [`Session`](/docs/references/javascript/session) object, as well as helpers for setting the active session.
+The `$sessionStore` store provides a convenient way to access the current user's [`Session`](/docs/references/javascript/session) object, as well as helpers for setting the active session.
 
 ## How to use the `$sessionStore` store
 

--- a/docs/references/astro/sign-in-store.mdx
+++ b/docs/references/astro/sign-in-store.mdx
@@ -1,17 +1,17 @@
 ---
 title: $signInStore
-description: Clerk's $signInStore store provides access to the SignIn object, which allows you to check the current state of a sign-in.
+description: Clerk's $signInStore nanostore provides a convenient way to access the SignIn object, which allows you to check the current state of a sign-in.
 ---
 
 # `$signInStore`
 
-The `$signInStore` store provides access to the [`SignIn`](/docs/references/javascript/sign-in/sign-in) object, which allows you to check the current state of a sign-in. This is also useful for creating a custom sign-in flow.
+The `$signInStore` store provides a convenient way to access the [`SignIn`](/docs/references/javascript/sign-in/sign-in) object, which allows you to check the current state of a sign-in. This is also useful for creating a custom sign-in flow.
 
 ## How to use the `$signInStore` store
 
-### Check the current state of a sign-in with `$signInStore`
+### Check the current state of a sign-in
 
-Use the `$signInStore` store to check the current state of a sign-in.
+The following example demonstrates how to use the `$signInStore` store to check the current state of a sign-in.
 
   ```tsx filename="sign-in-step.tsx"
   import { useStore } from '@nanostores/react';
@@ -33,6 +33,6 @@ Use the `$signInStore` store to check the current state of a sign-in.
 
 The possible values for the `status` property of the `SignIn` resource are listed [here](/docs/references/javascript/sign-in/sign-in#properties).
 
-### Create a custom sign-in flow with `$signInStore`
+### Create a custom sign-in flow
 
 The `$signInStore` store can also be used to build fully custom sign-in flows, if Clerk's pre-built components don't meet your specific needs or if you require more control over the authentication flow. Different sign-in flows include email and password, email and phone codes, email links, and multifactor (MFA). To learn more about using the `$signInStore` store to create custom flows, check out the [custom flow guides](/docs/custom-flows/overview).

--- a/docs/references/astro/sign-in-store.mdx
+++ b/docs/references/astro/sign-in-store.mdx
@@ -5,7 +5,7 @@ description: Clerk's $signInStore nanostore provides a convenient way to access 
 
 # `$signInStore`
 
-The `$signInStore` store provides a convenient way to access the [`SignIn`](/docs/references/javascript/sign-in/sign-in) object, which allows you to check the current state of a sign-in. This is also useful for creating a custom sign-in flow.
+The `$signInStore` store provides a convenient way to access the [`SignIn`](https://clerk.com/docs/references/javascript/sign-in/sign-in) object, which allows you to check the current state of a sign-in. This is also useful for creating a custom sign-in flow.
 
 ## How to use the `$signInStore` store
 

--- a/docs/references/astro/sign-up-store.mdx
+++ b/docs/references/astro/sign-up-store.mdx
@@ -4,7 +4,7 @@ description: Clerk's $signUpStore nanostore provides a convenient way to access 
 ---
 # `$signUpStore`
 
-The `$signUpStore` store provides a convenient way to access the [`SignUp`](/docs/references/javascript/sign-up/sign-up) object, which allows you to check the current state of a sign-up. This is also useful for creating a custom sign-up flow.
+The `$signUpStore` store provides a convenient way to access the [`SignUp`](https://clerk.com/docs/references/javascript/sign-up/sign-up) object, which allows you to check the current state of a sign-up. This is also useful for creating a custom sign-up flow.
 
 ## How to use the `$signUpStore` store
 
@@ -30,7 +30,7 @@ The following example demonstrates how to use the `$signUpStore` store to access
   }
   ```
 
-The possible values for the `status` property of the `SignUp` resource are listed [here](/docs/references/javascript/sign-up/sign-up#properties).
+The possible values for the `status` property of the `SignUp` resource are listed [here](https://clerk.com/docs/references/javascript/sign-up/sign-up#properties).
 
 ### Create a custom sign-up flow
 

--- a/docs/references/astro/sign-up-store.mdx
+++ b/docs/references/astro/sign-up-store.mdx
@@ -1,16 +1,16 @@
 ---
 title: $signUpStore
-description: Clerk's $signUpStore hook gives you access to the SignUp object, which allows you to check the current state of a sign-up.
+description: Clerk's $signUpStore nanostore provides a convenient way to access the `SignUp` object, which allows you to check the current state of a sign-up. This is also useful for creating a custom sign-up flow.
 ---
 # `$signUpStore`
 
-The `$signUpStore` store gives you access to the [`SignUp`](/docs/references/javascript/sign-up/sign-up) object, which allows you to check the current state of a sign-up. This is also useful for creating a custom sign-up flow.
+The `$signUpStore` store provides a convenient way to access the [`SignUp`](/docs/references/javascript/sign-up/sign-up) object, which allows you to check the current state of a sign-up. This is also useful for creating a custom sign-up flow.
 
 ## How to use the `$signUpStore` store
 
-### Check the current state of a sign-up with `$signUpStore`
+### Check the current state of a sign-up
 
-Use the `$signUpStore` store to access the `SignUp` object and check the current state of a sign-up.
+The following example demonstrates how to use the `$signUpStore` store to access the `SignUp` object and check the current state of a sign-up.
 
   ```tsx filename="sign-up-step.tsx"
   import { useStore } from '@nanostores/react';
@@ -32,6 +32,6 @@ Use the `$signUpStore` store to access the `SignUp` object and check the current
 
 The possible values for the `status` property of the `SignUp` resource are listed [here](/docs/references/javascript/sign-up/sign-up#properties).
 
-### Create a custom sign-up flow with `$signUpStore`
+### Create a custom sign-up flow
 
 The `$signUpStore` store can also be used to build fully custom sign-up flows, if Clerk's pre-built components don't meet your specific needs or if you require more control over the authentication flow. Different sign-up flows include email and password, email and phone codes, email links, and multifactor (MFA). To learn more about using the `$signUpStore` store to create custom flows, check out the [custom flow guides](/docs/custom-flows/overview).

--- a/docs/references/astro/user-store.mdx
+++ b/docs/references/astro/user-store.mdx
@@ -5,7 +5,7 @@ description: The $userStore store provides a convenient way to access current us
 
 # `$userStore`
 
-The `$userStore` store provides a convenient way to access current [`User`](/docs/references/javascript/user/user) data and helper methods for managing the active user.
+The `$userStore` store provides a convenient way to access current [`User`](https://clerk.com/docs/references/javascript/user/user) data and helper methods for managing the active user.
 
 ## How to use the `$userStore` store
 
@@ -13,7 +13,7 @@ The `$userStore` store provides a convenient way to access current [`User`](/doc
 
 The following example demonstrates how to use the `$userStore` store to access the `User` object. It returns `undefined` while Clerk is still loading and `null` if the user is not signed in.
 
-For more information, see the [`User` reference.](/docs/references/javascript/user/user#user-object)
+For more information, see the [`User` reference.](https://clerk.com/docs/references/javascript/user/user#user-object)
 
 ```tsx filename="user.tsx"
 import { useStore } from '@nanostores/react';
@@ -39,7 +39,7 @@ export default function User() {
 
 The following example demonstrates how to use the `$userStore` store to update the current user's data on the client side.
 
-For more information on the `update()` method, see the [`User` reference.](/docs/references/javascript/user/user#update)
+For more information on the `update()` method, see the [`User` reference.](https://clerk.com/docs/references/javascript/user/user#update)
 
 ```tsx filename="user.tsx"
 import { useStore } from '@nanostores/react';
@@ -76,7 +76,7 @@ export default function User() {
 
 The following example demonstrates how to use the `$userStore` store to reload the current user's data on the client side.
 
-For more information on the `reload()` method, see the [`User` reference.](/docs/references/javascript/user/user#reload)
+For more information on the `reload()` method, see the [`User` reference.](https://clerk.com/docs/references/javascript/user/user#reload)
 
 ```tsx filename="user.tsx"
 import { useStore } from '@nanostores/react';

--- a/docs/references/astro/user-store.mdx
+++ b/docs/references/astro/user-store.mdx
@@ -1,19 +1,19 @@
 ---
 title: $userStore
-description: The $userStore store is used to get the current user object and to update the user's data on the client side.
+description: The $userStore store provides a convenient way to access current user data and helper methods for managing the active user.
 ---
 
 # `$userStore`
 
-The `$userStore` store is a convenient way to access the current [`User`](/docs/references/javascript/user/user) data where you need it. This store provides the user data and helper methods to manage the current active user.
+The `$userStore` store provides a convenient way to access current [`User`](/docs/references/javascript/user/user) data and helper methods for managing the active user.
 
 ## How to use the `$userStore` store
 
-### Retrieve the current user data with the `$userStore` store
+### Retrieve the current user data
 
-The following example demonstrates how to use the `$userStore` store to access the `user` object. It returns `undefined` while Clerk is still loading and `null` if the user is not signed in.
+The following example demonstrates how to use the `$userStore` store to access the `User` object. It returns `undefined` while Clerk is still loading and `null` if the user is not signed in.
 
-For more information see the [`user` object](/docs/references/javascript/user/user#user-object) reference.
+For more information, see the [`User` reference.](/docs/references/javascript/user/user#user-object)
 
 ```tsx filename="user.tsx"
 import { useStore } from '@nanostores/react';
@@ -35,11 +35,11 @@ export default function User() {
 }
 ```
 
-### Update the current user data with the `$userStore` store
+### Update the current user data
 
-The following example demonstrates how to use the `$userStore` Store to access the `user` object, which includes the `update` method for updating the user's data.
+The following example demonstrates how to use the `$userStore` store to update the current user's data on the client side.
 
-For more information on the `update()` method, see the [`User`](/docs/references/javascript/user/user#update) reference.
+For more information on the `update()` method, see the [`User` reference.](/docs/references/javascript/user/user#update)
 
 ```tsx filename="user.tsx"
 import { useStore } from '@nanostores/react';
@@ -72,11 +72,11 @@ export default function User() {
 }
 ```
 
-### Reload user data with the `$userStore` store
+### Reload user data
 
-To retrieve the latest user data after updating the user in the dashboard or via the [Backend API](/docs/references/backend/user/update-user), use the `user.reload()` method.
+The following example demonstrates how to use the `$userStore` store to reload the current user's data on the client side.
 
-For more information on the `reload()` method, see the [`User`](/docs/references/javascript/user/user#reload) reference.
+For more information on the `reload()` method, see the [`User` reference.](/docs/references/javascript/user/user#reload)
 
 ```tsx filename="user.tsx"
 import { useStore } from '@nanostores/react';


### PR DESCRIPTION
Full editorial of Astro docs that were released today.

We're going to use external links for links that take you from the Astro SDK to another SDK (such as our Nextjs SDK). This is a temporary solution until we figure out how to deal with related/duped docs.