### PR TITLE
Refactor: Update order of lib managers in the CodeBlockTabs on the add-react-router reference page

### DIFF
--- a/docs/references/react/add-react-router.mdx
+++ b/docs/references/react/add-react-router.mdx
@@ -41,7 +41,7 @@ Learn how to add React Router to your application using React Router's new Data 
 
 React Router's `react-router-dom` is a mature, battle tested routing package for React that gives you many options. As it is the most popular routing option, it will be used for this guide.
 
-<CodeBlockTabs type="installer" options={["npm", "pnpm", "yarn" ]}>
+<CodeBlockTabs type="installer" options={["npm", "yarn",  "pnpm" ]}>
   ```bash filename="terminal"
   npm install react-router-dom
   ```

--- a/docs/references/react/add-react-router.mdx
+++ b/docs/references/react/add-react-router.mdx
@@ -47,11 +47,11 @@ React Router's `react-router-dom` is a mature, battle tested routing package for
   ```
 
   ```bash filename="terminal"
-  pnpm add react-router-dom
+  yarn add react-router-dom
   ```
 
   ```bash filename="terminal"
-  yarn add react-router-dom
+  pnpm add react-router-dom
   ```
 </CodeBlockTabs>
 


### PR DESCRIPTION
<!--- Add the "deploy-preview" label and add your page previews here -->

> [!IMPORTANT]
> 🔎 Previews:
>
> - https://clerk.com/docs/pr/1298/references/react/add-react-router

<!--- Describe your changes in detail. Why does this change need to happen? Include any links to Slack discussions, Linear comments, etc. -->
### Explanation:
In order to improve DX within our docs, the lib managers order should be consistent from page to page, to reduce confusion and maintain patterns across the docs.

<!--- How does this PR solve the problem? -->
### This PR:

- Update the add-react-router page codeblock options prop to have an array of `['npm', 'yarn', 'pnpm']` to match the same order as the previous React quick start guide's codeblock order
