### PR TITLE
Added warning to top of Clerk as IDP/Oauth Provider that it does not return JWT

### DIFF
--- a/docs/advanced-usage/clerk-idp.mdx
+++ b/docs/advanced-usage/clerk-idp.mdx
@@ -6,7 +6,7 @@ description: Learn how to use Clerk to facilitate Single Sign-On (SSO) with othe
 # Use Clerk as an OAuth 2 Provider
 
 > [!WARNING]
-> This feature will not return a Clerk JWT and does provide authentication. Please see the [FAQ](#how-can-the-access-tokens-obtained-from-the-token-url-be-used) below for more information. 
+> This feature will not return a Clerk JWT and does not provide authentication. Please see the [FAQ](#how-can-the-access-tokens-obtained-from-the-token-url-be-used) below for more information. 
 
 Clerk can be configured as an identity provider to facilitate Single Sign-On (SSO) with other clients that support the OAuth 2.0 protocol. With this feature, your users can sign in with your Clerk application on other websites to authorize sharing of their user info.
 

--- a/docs/advanced-usage/clerk-idp.mdx
+++ b/docs/advanced-usage/clerk-idp.mdx
@@ -5,6 +5,9 @@ description: Learn how to use Clerk to facilitate Single Sign-On (SSO) with othe
 
 # Use Clerk as an OAuth 2 Provider
 
+> [!WARNING]
+> This feature will not return a Clerk JWT and does provide authentication. Please see the [FAQ](#how-can-the-access-tokens-obtained-from-the-token-url-be-used) below for more information. 
+
 Clerk can be configured as an identity provider to facilitate Single Sign-On (SSO) with other clients that support the OAuth 2.0 protocol. With this feature, your users can sign in with your Clerk application on other websites to authorize sharing of their user info.
 
 <Images


### PR DESCRIPTION
> [!IMPORTANT]
> 🔎 Previews:
>
> - https://clerk.com/docs/pr/1300/advanced-usage/clerk-idp#use-clerk-as-an-o-auth-2-provider

### Explanation: 

- Added a `warning` callout to the top of the pag.e

### This PR:

- Customers continue to the think the Clerk as OAuth provider features returns a JWT.