### PR TITLE
Expo import navigation -> router fix

### DIFF
--- a/docs/quickstarts/expo.mdx
+++ b/docs/quickstarts/expo.mdx
@@ -163,7 +163,7 @@ The following example demonstrates an Expo layout that defines a custom token ca
 ```tsx {{ filename: "app/_layout.tsx" }}
 import * as SecureStore from 'expo-secure-store';
 import { ClerkProvider, ClerkLoaded } from "@clerk/clerk-expo"
-import { Slot } from "expo-navigation"
+import { Slot } from "expo-router"
 
 const tokenCache = {
   async getToken(key: string) {


### PR DESCRIPTION
I checked the quickstart repo, and could not find an example of an import like expo-navigation being used. Both in the quickstart and further up in these docs the expo-router is used for Slot components. This was reported in Support.
