### PR TITLE
fix: Typo in backend versioning

### DIFF
--- a/docs/backend-requests/versioning/overview.mdx
+++ b/docs/backend-requests/versioning/overview.mdx
@@ -25,7 +25,7 @@ Each Clerk SDK version corresponds to a specific API version, so by updating the
 
 ### Choosing an API version
 
-When making direct API calls to an endpoint, there are three options to specify the version:
+When making direct API calls to an endpoint, there are two options to specify the version:
 
 1. **Query parameter**: Set the `__clerk_api_version` query parameter in your request URL.
 2. **Clerk-API-Version header**: Include a `Clerk-API-Version` header in your requests.


### PR DESCRIPTION
The third option that supposed to go there isn't released yet so in the meantime it needs to be changed to two 👍 