### PR TITLE
fix: update matcher for clerk middleware

### DIFF
--- a/docs/references/nextjs/clerk-middleware.mdx
+++ b/docs/references/nextjs/clerk-middleware.mdx
@@ -21,9 +21,12 @@ import { clerkMiddleware } from '@clerk/nextjs/server';
 export default clerkMiddleware()
 
 export const config = {
-  // The following matcher runs middleware on all routes
-  // except static assets.
-  matcher: [ '/((?!.*\\..*|_next).*)', '/', '/(api|trpc)(.*)'],
+  matcher: [
+    // Skip Next.js internals and all static files, unless found in search params
+    '/((?!_next|[^?]*\\.(?:html?|css|js(?!on)|jpe?g|webp|png|gif|svg|ttf|woff2?|ico|csv|docx?|xlsx?|zip|webmanifest)).*)',
+    // Always run for API routes
+    '/(api|trpc)(.*)',
+  ],
 };
 ```
 


### PR DESCRIPTION
<!--- Add the "deploy-preview" label and add your page previews here -->

> [!IMPORTANT]
> 🔎 Previews: 
>
> - https://clerk.com/docs/pr/1318/references/nextjs/clerk-middleware

<!--- Describe your changes in detail. Why does this change need to happen? Include any links to Slack discussions, Linear comments, etc. -->
### Explanation:
The first example of the default next.js middleware matcher on this page is now outdated. 

<!--- How does this PR solve the problem? -->
### This PR:

- Updates the first reference to the next.js middleware matcher. Other references were updated in #1275 
