### PR TITLE
Update clerk-middleware.mdx

### DIFF
--- a/docs/references/astro/clerk-middleware.mdx
+++ b/docs/references/astro/clerk-middleware.mdx
@@ -83,7 +83,7 @@ export default clerkMiddleware((auth, context) => {
   const { has, redirectToSignIn } = auth();
 
   // Restrict admin routes to users with specific permissions
-  if (isProtectedRoute(context.request) &&
+  if (isProtectedRoute(request) &&
     !has({ permission: 'org:sys_memberships:manage' }) ||
     !has({ permission: 'org:sys_domains_manage' })
   ) {
@@ -103,10 +103,10 @@ import { clerkMiddleware, createRouteMatcher } from '@clerk/astro/server'
 
 const isPublicRoute = createRouteMatcher(['/sign-in(.*)', '/sign-up(.*)']);
 
-export default clerkMiddleware((auth, context) => {
+export default clerkMiddleware((auth, request) => {
   const { redirectToSignIn, userId } = auth();
 
-  if (!isPublicRoute(context.request) && !userId) {
+  if (!isPublicRoute(request) && !userId) {
     return redirectToSignIn();
   }
 });


### PR DESCRIPTION
### Explanation:
The `ClerkMiddleware` accepts `ClerkMiddlewareHandler`, which is a function that accepts `auth` and `request`, not `auth` and `context`. The `ClerkMiddleware.d.ts` definition file is documented right, while the Clerk documentation webpage is not.

### This PR:
- Updates the documentation webpage where there is an error.
- Reflects the true usage of the `ClerkMiddlewareHandler` as explained in the TypeScript definition file.