### PR TITLE
Add option to opt-out of telemetry for Astro

### DIFF
--- a/docs/telemetry.mdx
+++ b/docs/telemetry.mdx
@@ -84,7 +84,7 @@ If you are using `@clerk/clerk-react` directly, or using an SDK that doesn't hav
 
 ### Framework specific instructions
 
-<CodeBlockTabs options={["Next.js", "React", "Remix", "Gatsby", "JavaScript", "Chrome Extension", "Expo"]}>
+<CodeBlockTabs options={["Next.js", "React", "Remix", "Gatsby", "JavaScript", "Chrome Extension", "Expo", "Astro"]}>
   ```env {{ prettier: false, filename: '.env.local' }}
   NEXT_PUBLIC_CLERK_TELEMETRY_DISABLED=1
   ```
@@ -112,5 +112,9 @@ If you are using `@clerk/clerk-react` directly, or using an SDK that doesn't hav
 
   ```tsx {{ prettier: false }}
   <ClerkProvider telemetry={false} />
+  ```
+
+  ```env {{ prettier: false, filename: '.env.local' }}
+  PUBLIC_CLERK_TELEMETRY_DISABLED=1
   ```
 </CodeBlockTabs>


### PR DESCRIPTION
<!--- Add the "deploy-preview" label and add your page previews here -->

> [!IMPORTANT]
> 🔎 Previews:
>
> - https://clerk.com/docs/pr/1324/telemetry#framework-specific-instructions

<!--- Describe your changes in detail. Why does this change need to happen? Include any links to Slack discussions, Linear comments, etc. -->

### Explanation:

<!--- How does this PR solve the problem? -->

### This PR:

- Adds new tab in frameworks list for disabling telemetry data collection for Astro
