### PR TITLE
remove repetition in Cypress doc

### DIFF
--- a/docs/testing/cypress.mdx
+++ b/docs/testing/cypress.mdx
@@ -175,7 +175,7 @@ The `cy.clerkLoaded` command asserts that Clerk has been loaded.
 
 #### Prerequisites
 
-- Before calling this command, you must call `cy.visit` before calling this command.
+- Before calling this command, you must call `cy.visit`.
 - Before using this command, navigate to a page that loads Clerk.
 
 #### Example


### PR DESCRIPTION
This PR merely removes a repeated phrase from the doc on Cypress.

### Explanation:

It removes the repetition. :)

### This PR:

-
