### PR TITLE
Update setActive occurrences to state that org slug is accepted

### DIFF
--- a/docs/organizations/overview.mdx
+++ b/docs/organizations/overview.mdx
@@ -116,8 +116,8 @@ If you need more organizations or custom pricing, please contact [our sales team
 By default, users can create organizations within your application. To disable this permission for all users:
 
 1. Navigate to the [Clerk Dashboard](https://dashboard.clerk.com/last-active?path=organizations-settings).
-2. In the navigation sidebar, select **Organization Settings**.
-3. At the bottom of the page, in the **Limit creation** section, toggle **Allow new users to create organizations** off.
+1. In the navigation sidebar, select **Organization Settings**.
+1. At the bottom of the page, in the **Limit creation** section, toggle **Allow new users to create organizations** off.
 
 If you want to only disable this permission for certain users, you can override it on a per-user basis on the user's profile page in the Clerk Dashboard:
 

--- a/docs/references/javascript/clerk/session-methods.mdx
+++ b/docs/references/javascript/clerk/session-methods.mdx
@@ -24,7 +24,7 @@ function setActive({
 | Name | Type | Description |
 | - | - | - |
 | `session?` | [`Session`](/docs/references/javascript/session) \| `string` \| `null` | The session resource or session ID (string version) to be set as active. If `null`, the current session is deleted. |
-| `organization?` | [`Organization`](/docs/references/javascript/organization/organization) \| `string` \| `null` | The organization resource or organization ID (string version) to be set as active in the current session. If `null`, the currently active organization is removed as active. |
+| `organization?` | [`Organization`](/docs/references/javascript/organization/organization) \| `string` \| `null` | The organization resource or organization ID/slug (string version) to be set as active in the current session. If `null`, the currently active organization is removed as active. |
 | `beforeEmit?` | `(session?: Session \| null) => void \| Promise<any>` | Callback run just before the active session and/or organization is set to the passed object. Can be used to hook up for pre-navigation actions. |
 
 ### Example

--- a/docs/references/react/use-organization-list.mdx
+++ b/docs/references/react/use-organization-list.mdx
@@ -75,7 +75,7 @@ type OrganizationSuggestionStatus = "pending" | "accepted";
 | Name | Type | Description |
 | - | - | - |
 | `session` | <code>[Session](/docs/references/javascript/session) \| string \| null</code> | The session resource or session ID (string version) to be set as active. If `null`, the current session is deleted. |
-| `organization` | <code>[Organization](/docs/references/javascript/organization/organization) \| string \| null</code> | The organization resource or organization ID (string version) to be set as active in the current session. If `null`, the currently active organization is removed as active. |
+| `organization` | <code>[Organization](/docs/references/javascript/organization/organization) \| string \| null</code> | The organization resource or organization ID/slug (string version) to be set as active in the current session. If `null`, the currently active organization is removed as active. |
 | `beforeEmit?` | `(session?: Session \| null) => void \| Promise<any>` | Callback run just before the active session and/or organization is set to the passed object. Can be used to hook up for pre-navigation actions. |
 
 ### `PaginatedResources`

--- a/docs/references/react/use-session-list.mdx
+++ b/docs/references/react/use-session-list.mdx
@@ -20,7 +20,7 @@ The `useSessionList()` hook returns an array of [`Session`](/docs/references/jav
 | Name | Type | Description |
 | - | - | - |
 | `session` | <code>[Session](/docs/references/javascript/session) \| string \| null</code> | The session resource or session ID (string version) to be set as active. If `null`, the current session is deleted. |
-| `organization` | <code>[Organization](/docs/references/javascript/organization/organization) \| string \| null</code> | The organization resource or organization ID (string version) to be set as active in the current session. If `null`, the currently active organization is removed as active. |
+| `organization` | <code>[Organization](/docs/references/javascript/organization/organization) \| string \| null</code> | The organization resource or organization ID/slug (string version) to be set as active in the current session. If `null`, the currently active organization is removed as active. |
 | `beforeEmit?` | `(session?: Session \| null) => void \| Promise<any>` | Callback run just before the active session and/or organization is set to the passed object. Can be used to hook up for pre-navigation actions. |
 
 ## How to use the `useSessionList()` hook

--- a/docs/references/react/use-sign-in.mdx
+++ b/docs/references/react/use-sign-in.mdx
@@ -20,7 +20,7 @@ The `useSignIn()` hook provides access to the [`SignIn`](/docs/references/javasc
 | Name | Type | Description |
 | - | - | - |
 | `session` | <code>[Session](/docs/references/javascript/session) \| string \| null</code> | The session resource or session ID (string version) to be set as active. If `null`, the current session is deleted. |
-| `organization` | <code>[Organization](/docs/references/javascript/organization/organization) \| string \| null</code> | The organization resource or organization ID (string version) to be set as active in the current session. If `null`, the currently active organization is removed as active. |
+| `organization` | <code>[Organization](/docs/references/javascript/organization/organization) \| string \| null</code> | The organization resource or organization ID/slug (string version) to be set as active in the current session. If `null`, the currently active organization is removed as active. |
 | `beforeEmit?` | `(session?: Session \| null) => void \| Promise<any>` | Callback run just before the active session and/or organization is set to the passed object. Can be used to hook up for pre-navigation actions. |
 
 ## How to use the `useSignIn()` hook

--- a/docs/references/react/use-sign-up.mdx
+++ b/docs/references/react/use-sign-up.mdx
@@ -20,7 +20,7 @@ The `useSignUp()` hook gives you access to the [`SignUp`](/docs/references/javas
 | Name | Type | Description |
 | - | - | - |
 | `session` | <code>[Session](/docs/references/javascript/session) \| string \| null</code> | The session resource or session ID (string version) to be set as active. If `null`, the current session is deleted. |
-| `organization` | <code>[Organization](/docs/references/javascript/organization/organization) \| string \| null</code> | The organization resource or organization ID (string version) to be set as active in the current session. If `null`, the currently active organization is removed as active. |
+| `organization` | <code>[Organization](/docs/references/javascript/organization/organization) \| string \| null</code> | The organization resource or organization ID/slug (string version) to be set as active in the current session. If `null`, the currently active organization is removed as active. |
 | `beforeEmit?` | `(session?: Session \| null) => void \| Promise<any>` | Callback run just before the active session and/or organization is set to the passed object. Can be used to hook up for pre-navigation actions. |
 
 ## How to use the `useSignUp()` hook


### PR DESCRIPTION
<!--- Add the "deploy-preview" label and add your page previews here -->

> [!IMPORTANT]
> 🔎 Previews:
>
> - https://clerk.com/docs/pr/1328/references/javascript/clerk/session-methods#set-active-params
> - https://clerk.com/docs/pr/1328/references/react/use-sign-in#set-active-params
> - https://clerk.com/docs/pr/1328/references/react/use-sign-up#set-active-params
> - https://clerk.com/docs/pr/1328/references/react/use-session-list#set-active-params
> - https://clerk.com/docs/pr/1328/references/react/use-organization-list#set-active-params

<!--- Describe your changes in detail. Why does this change need to happen? Include any links to Slack discussions, Linear comments, etc. -->

### Explanation:

<!--- How does this PR solve the problem? -->

### This PR:

- Updates all occurrences of `setActive` params to state that an organization slug can be used besides the ID.
- https://github.com/clerk/javascript/pull/3825
