### PR TITLE
docs(astro): Multi-framework example for nanostores usage

### DIFF
--- a/docs/backend-requests/resources/session-tokens.mdx
+++ b/docs/backend-requests/resources/session-tokens.mdx
@@ -19,9 +19,9 @@ Every generated token has default claims that cannot be overridden by templates.
 - `sid`: session ID - the ID of the current session For example: `sess_123`.
 - `sub`: subject - the ID of the current user of the session. For example: `user_123`. See [RFC 7519](https://datatracker.ietf.org/doc/html/rfc7519#section-4.1.2) for more information.
 - `act`: actor - will only be included if the user is [impersonating](/docs/users/user-impersonation) another user. It's an object that contains the following properties:
-    - `iss`: issuer - the referrer of the token. For example: `https://dashboard.clerk.com`.
-    - `sid`: session ID - the session ID of the impersonated session. For example: `sess_456`.
-    - `sub`: subject - the ID of the impersonator. For example: `user_456`.
+  - `iss`: issuer - the referrer of the token. For example: `https://dashboard.clerk.com`.
+  - `sid`: session ID - the session ID of the impersonated session. For example: `sess_456`.
+  - `sub`: subject - the ID of the impersonator. For example: `user_456`.
 
 The following claims are only included if the user is part of an organization:
 

--- a/docs/references/astro/auth-store.mdx
+++ b/docs/references/astro/auth-store.mdx
@@ -85,7 +85,7 @@ The following example demonstrates how to use the `$authStore` store to access t
   ```svelte {{ prettier: false, filename: 'components/external-data.svelte' }}
   <script>
   // The $ prefix is reserved in Svelte for its own reactivity system.
-  // We're aliasing the imports to avoid conflicts.
+  // Alias the imports to avoid conflicts.
   import {
     $authStore as auth,
     $sessionStore as session

--- a/docs/references/astro/auth-store.mdx
+++ b/docs/references/astro/auth-store.mdx
@@ -21,35 +21,94 @@ The `$authStore` store provides a convenient way to access the current auth stat
 
 The following example demonstrates how to use the `$authStore` store to access the current auth state. It uses `userId` to detect if the user is signed in and the [`getToken()`](https://clerk.com/docs/references/javascript/session#get-token) method to retrieve a session token for fetching data from an external resource.
 
-```tsx {{ prettier: false, filename: 'components/external-data.tsx' }}
-import { useStore } from '@nanostores/react';
-import { $authStore, $sessionStore } from '@clerk/astro/client';
+<CodeBlockTabs options={['React', 'Vue', 'Svelte']}>
+  ```tsx {{ prettier: false, filename: 'components/external-data.tsx' }}
+  import { useStore } from '@nanostores/react';
+  import { $authStore, $sessionStore } from '@clerk/astro/client';
 
-export default function ExternalData() {
-  const { userId } = useStore($authStore);
+  export default function ExternalData() {
+    const { userId } = useStore($authStore);
+    const session = useStore($sessionStore);
+
+    if (userId === undefined) {
+      // Handle loading state however you like
+      return <div>Loading...</div>;
+    }
+
+    if (userId === null) {
+      // Handle signed out state however you like
+      return <div>Sign in to view this page</div>;
+    }
+
+    const fetchDataFromExternalResource = async () => {
+      if (!session) {
+        // Handle session loading state
+        return;
+      }
+
+      const token = await session.getToken();
+      // Add logic to fetch your data
+      return data;
+    }
+
+    return <div>...</div>;
+  }
+  ```
+
+  ```vue {{ prettier: false, filename: 'components/external-data.vue' }}
+  <script setup>
+  import { useStore } from '@nanostores/vue';
+  import { $authStore, $sessionStore } from '@clerk/astro/client';
+
+  const auth = useStore($authStore);
   const session = useStore($sessionStore);
 
-  if (userId === undefined) {
-    // Handle loading state however you like
-    return <div>Loading...</div>;
-  }
-
-  if (userId === null) {
-    // Handle signed out state however you like
-    return <div>Sign in to view this page</div>;
-  }
-
   const fetchDataFromExternalResource = async () => {
-    if (!session) {
+    if (!session.value) {
       // Handle session loading state
       return;
     }
 
-    const token = await session.getToken();
+    const token = await session.value.getToken();
     // Add logic to fetch your data
-    return data;
-  }
+    // return data;
+  };
+  </script>
 
-  return <div>...</div>;
-}
-```
+  <template>
+    <div v-if="auth.userId === undefined">Loading...</div>
+    <div v-else-if="auth.userId === null">Sign in to view this page</div>
+    <div v-else>...</div>
+  </template>
+  ```
+
+  ```svelte {{ prettier: false, filename: 'components/external-data.svelte' }}
+  <script>
+  // The $ prefix is reserved in Svelte for its own reactivity system.
+  // We're aliasing the imports to avoid conflicts.
+  import {
+    $authStore as auth,
+    $sessionStore as session
+  } from '@clerk/astro/client';
+
+  const fetchDataFromExternalResource = async () => {
+    if (!$session) {
+      // Handle session loading state
+      return;
+    }
+
+    const token = await $session.getToken();
+    // Add logic to fetch your data
+    // return data;
+  };
+  </script>
+
+  {#if $auth.userId === undefined}
+    <div>Loading...</div>
+  {:else if $auth.userId === null}
+    <div>Sign in to view this page</div>
+  {:else}
+    <div>...</div>
+  {/if}
+  ```
+</CodeBlockTabs>

--- a/docs/references/astro/clerk-store.mdx
+++ b/docs/references/astro/clerk-store.mdx
@@ -12,13 +12,40 @@ The `$clerkStore` store provides a convenient way to access the [`Clerk`](https:
 
 ## How to use the `$clerkStore` store
 
-```tsx {{ prettier: false, filename: 'components/sign-in.tsx' }}
-import { useStore } from '@nanostores/react';
-import { $clerkStore } from '@clerk/astro/client';
+<CodeBlockTabs options={['React', 'Vue', 'Svelte']}>
+  ```tsx {{ prettier: false, filename: 'components/sign-in.tsx' }}
+  import { useStore } from '@nanostores/react';
+  import { $clerkStore } from '@clerk/astro/client';
 
-export default function Home() {
+  export default function Home() {
+    const clerk = useStore($clerkStore);
+
+    return <button onClick={() => clerk.openSignIn({})}>Sign in</button>;
+  };
+  ```
+
+  ```vue {{ prettier: false, filename: 'components/sign-in.vue' }}
+  <script setup>
+  import { useStore } from '@nanostores/vue';
+  import { $clerkStore } from '@clerk/astro/client';
+
   const clerk = useStore($clerkStore);
 
-  return <button onClick={() => clerk.openSignIn({})}>Sign in</button>;
-};
-```
+  const openSignIn = () => clerk.value.openSignIn({});
+  </script>
+
+  <template>
+    <button @click="openSignIn">Sign in</button>
+  </template>
+  ```
+
+  ```svelte {{ prettier: false, filename: 'components/sign-in.svelte' }}
+  <script>
+  // The $ prefix is reserved in Svelte for its own reactivity system.
+  // We're aliasing the imports to avoid conflicts.
+  import { $clerkStore as clerk } from '@clerk/astro/client';
+  </script>
+
+  <button on:click={() => $clerk.openSignIn({})}>Sign in</button>
+  ```
+</CodeBlockTabs>

--- a/docs/references/astro/clerk-store.mdx
+++ b/docs/references/astro/clerk-store.mdx
@@ -42,7 +42,7 @@ The `$clerkStore` store provides a convenient way to access the [`Clerk`](https:
   ```svelte {{ prettier: false, filename: 'components/sign-in.svelte' }}
   <script>
   // The $ prefix is reserved in Svelte for its own reactivity system.
-  // We're aliasing the imports to avoid conflicts.
+  // Alias the imports to avoid conflicts.
   import { $clerkStore as clerk } from '@clerk/astro/client';
   </script>
 

--- a/docs/references/astro/clerk-store.mdx
+++ b/docs/references/astro/clerk-store.mdx
@@ -20,7 +20,7 @@ The `$clerkStore` store provides a convenient way to access the [`Clerk`](https:
   export default function Home() {
     const clerk = useStore($clerkStore);
 
-    return <button onClick={() => clerk.openSignIn({})}>Sign in</button>;
+    return <button onClick={() => clerk.openSignIn()}>Sign in</button>;
   };
   ```
 

--- a/docs/references/astro/organization-store.mdx
+++ b/docs/references/astro/organization-store.mdx
@@ -63,7 +63,7 @@ The following example demonstrates how to use the `$organizationStore` store to 
   ```svelte {{ prettier: false, filename: 'session.svelte' }}
   <script>
   // The $ prefix is reserved in Svelte for its own reactivity system.
-  // We're aliasing the imports to avoid conflicts.
+  // Alias the imports to avoid conflicts.
   import { $organizationStore as organization } from '@clerk/astro/client';
   </script>
 
@@ -209,7 +209,7 @@ You can implement this pattern to any Clerk function that returns a [`ClerkPagin
   ```svelte {{ prettier: false, filename: 'organization-members.svelte' }}
   <script>
   // The $ prefix is reserved in Svelte for its own reactivity system.
-  // We're aliasing the imports to avoid conflicts.
+  // Alias the imports to avoid conflicts.
   import { $organizationStore as organization } from '@clerk/astro/client';
 
   let memberships = [];

--- a/docs/references/astro/organization-store.mdx
+++ b/docs/references/astro/organization-store.mdx
@@ -11,30 +11,73 @@ The `$organizationStore` store is used to retrieve attributes of the currently a
 
 The following example demonstrates how to use the `$organizationStore` store to access the [`Organization`](https://clerk.com/docs/references/javascript/organization/organization) object, which allows you to access the current active organization.
 
-```tsx {{ prettier: false, filename: 'session.tsx' }}
-import { useStore } from '@nanostores/react';
-import { $organizationStore } from '@clerk/astro/client';
+<CodeBlockTabs options={['React', 'Vue', 'Svelte']}>
+  ```tsx {{ prettier: false, filename: 'session.tsx' }}
+  import { useStore } from '@nanostores/react';
+  import { $organizationStore } from '@clerk/astro/client';
 
-export default function Home() {
+  export default function Home() {
+    const organization = useStore($organizationStore);
+
+    if (organization === undefined) {
+      // Add logic to handle loading state
+      return null;
+    }
+
+    if(organization === null) {
+      // Add logic to handle no active organization state
+      return null;
+    }
+
+    return (
+      <div>
+        <p>This current organization is {organization.name}</p>
+      </div>
+    )
+  }
+  ```
+
+  ```vue {{ prettier: false, filename: 'session.vue' }}
+  <script setup>
+  import { useStore } from '@nanostores/vue';
+  import { $organizationStore } from '@clerk/astro/client';
+
   const organization = useStore($organizationStore);
+  </script>
 
-  if (organization === undefined) {
-    // Add logic to handle loading state
-    return null;
-  }
-
-  if(organization === null) {
-    // Add logic to handle no active organization state
-    return null;
-  }
-
-  return (
-    <div>
-      <p>This current organization is {organization.name}</p>
+  <template>
+    <div v-if="organization === undefined">
+      <!-- Add logic to handle loading state -->
     </div>
-  )
-}
-```
+
+    <div v-else-if="organization === null">
+      <!-- Add logic to handle no active organization state -->
+    </div>
+
+    <div v-else>
+      <p>This current organization is {{ organization.name }}</p>
+    </div>
+  </template>
+  ```
+
+  ```svelte {{ prettier: false, filename: 'session.svelte' }}
+  <script>
+  // The $ prefix is reserved in Svelte for its own reactivity system.
+  // We're aliasing the imports to avoid conflicts.
+  import { $organizationStore as organization } from '@clerk/astro/client';
+  </script>
+
+  {#if $organization === undefined}
+    <!-- Add logic to handle loading state -->
+  {:else if $organization === null}
+    <!-- Add logic to handle no active organization state -->
+  {:else}
+    <div>
+      <p>This current organization is {$organization.name}</p>
+    </div>
+  {/if}
+  ```
+</CodeBlockTabs>
 
 ## Paginating data
 
@@ -42,58 +85,174 @@ The following example demonstrates how to implement pagination for organization 
 
 You can implement this pattern to any Clerk function that returns a [`ClerkPaginatedResponse`](https://clerk.com/docs/references/javascript/types/clerk-paginated-response#clerk-paginated-response) object.
 
-```tsx {{ prettier: false, filename: 'organization-members.tsx' }}
-import { useState, useEffect } from 'react';
-import { $organizationStore } from '@clerk/astro/client'
-import { useStore } from '@nanostores/react';
+<CodeBlockTabs options={['React', 'Vue', 'Svelte']}>
+  ```tsx {{ prettier: false, filename: 'organization-members.tsx' }}
+  import { useState, useEffect } from 'react';
+  import { $organizationStore } from '@clerk/astro/client'
+  import { useStore } from '@nanostores/react';
 
-export default function OrganizationMembers() {
-  const [memberships, setMemberships] = useState([]);
-  const [currentPage, setCurrentPage] = useState(1);
+  export default function OrganizationMembers() {
+    const [memberships, setMemberships] = useState([]);
+    const [currentPage, setCurrentPage] = useState(1);
+    const organization = useStore($organizationStore);
+
+    const pageSize = 10;
+
+    useEffect(() => {
+      fetchMemberships();
+    }, [currentPage, organization]);
+
+    const fetchMemberships = async () => {
+      if (!organization) {
+        return;
+      }
+
+      const { data } = await organization.getMemberships({
+        initialPage: currentPage,
+        pageSize: 5
+      });
+      setMemberships(data);
+    };
+
+    const fetchPrevious = () => setCurrentPage(currentPage - 1);
+    const fetchNext = () => setCurrentPage(currentPage + 1);
+
+    if (organization === undefined) {
+      // Handle loading state
+      return null;
+    }
+
+    if (organization === null) {
+      // Handle no organization state
+      return null;
+    }
+
+    return (
+      <div>
+        <h2>Organization members</h2>
+        <ul>
+          {memberships.map((membership) => (
+            <li key={membership.id}>
+              {membership.publicUserData.firstName} {membership.publicUserData.lastName} &lt;
+              {membership.publicUserData.identifier}&gt; :: {membership.role}
+            </li>
+          ))}
+        </ul>
+        <div>
+          <button onClick={fetchPrevious} disabled={currentPage === 1}>Previous</button>
+          <button onClick={fetchNext}>Next</button>
+        </div>
+      </div>
+    );
+  };
+  ```
+
+  ```vue {{ prettier: false, filename: 'organization-members.vue' }}
+  <script setup>
+  import { useStore } from '@nanostores/vue';
+  import { $organization } from '@clerk/astro/client';
+  import { ref, watchEffect } from 'vue';
+
+  const memberships = ref([]);
+  const currentPage = ref(1);
   const organization = useStore($organizationStore);
 
   const pageSize = 10;
 
-  useEffect(() => {
-    fetchMemberships();
-  }, [currentPage, organization]);
-
   const fetchMemberships = async () => {
-    if (!organization) {
+    if (!organization.value) {
       return;
     }
 
-    const { data } = await organization.getMemberships({
-      initialPage: currentPage,
+    const { data } = await organization.value.getMemberships({
+      initialPage: currentPage.value,
       pageSize: 5
     });
-    setMemberships(data);
-  };
-
-  const fetchPrevious = () => setCurrentPage(currentPage - 1);
-  const fetchNext = () => setCurrentPage(currentPage + 1);
-
-  if (!organization) {
-    // Handle loading state
-    return null;
+    memberships.value = data;
   }
 
-  return (
-    <div>
+  watchEffect(() => {
+    if (!organization.value) {
+      return;
+    }
+
+    fetchMemberships();
+  });
+
+  const fetchPrevious = () => currentPage.value--;
+  const fetchNext = () => currentPage.value++;
+  </script>
+
+  <template>
+    <div v-if="organization === undefined">
+      <!-- Handle loading state -->
+    </div>
+    <div v-else-if="organization === null">
+      <!-- Handle no organization state -->
+    </div>
+    <div v-else>
       <h2>Organization members</h2>
       <ul>
-        {memberships.map((membership) => (
-          <li key={membership.id}>
-            {membership.publicUserData.firstName} {membership.publicUserData.lastName} &lt;
-            {membership.publicUserData.identifier}&gt; :: {membership.role}
-          </li>
-        ))}
+        <li v-for="membership in memberships" :key="membership.id">
+          {{ membership.publicUserData.firstName }} {{ membership.publicUserData.lastName }}
+          &lt;{{ membership.publicUserData.identifier }}&gt; :: {{ membership.role }}
+        </li>
       </ul>
       <div>
-        <button onClick={fetchPrevious} disabled={currentPage === 1}>Previous</button>
-        <button onClick={fetchNext}>Next</button>
+        <button @click="fetchPrevious" :disabled="currentPage === 1">Previous</button>
+        <button @click="fetchNext">Next</button>
       </div>
     </div>
-  );
-};
-```
+  </template>
+  ```
+
+  ```svelte {{ prettier: false, filename: 'organization-members.svelte' }}
+  <script>
+  // The $ prefix is reserved in Svelte for its own reactivity system.
+  // We're aliasing the imports to avoid conflicts.
+  import { $organizationStore as organization } from '@clerk/astro/client';
+
+  let memberships = [];
+  let currentPage = 1;
+
+  async function fetchMemberships() {
+      if (!$organization) {
+          return;
+      }
+
+      const { data } = await $organization.getMemberships({
+          initialPage: currentPage,
+          pageSize: 5
+      });
+      memberships = data;
+  }
+
+  $: fetchMemberships();
+
+  const fetchPrevious = () => currentPage.value--;
+  const fetchNext = () => currentPage.value++;
+  </script>
+
+  {#if organization === undefined}
+      <!-- Handle loading state -->
+  {:else if organization === null}
+      <!-- Handle no organization state -->
+  {:else}
+      <div>
+          <h2>Organization members</h2>
+          <ul>
+              {#each memberships as membership (membership.id)}
+                  <li>
+                      {membership.publicUserData.firstName} {membership.publicUserData.lastName} &lt;
+                      {membership.publicUserData.identifier}&gt; :: {membership.role}
+                  </li>
+              {/each}
+          </ul>
+          <div>
+              <button on:click={fetchPrevious} disabled={currentPage === 1}>Previous</button>
+              <button on:click={fetchNext}>Next</button>
+          </div>
+      </div>
+  {/if}
+  ```
+</CodeBlockTabs>

--- a/docs/references/astro/session-list-store.mdx
+++ b/docs/references/astro/session-list-store.mdx
@@ -54,7 +54,7 @@ The following example demonstrates how to use the `$sessionListStore` store to d
   ```svelte {{ prettier: false, filename: 'session-list.svelte' }}
   <script>
   // The $ prefix is reserved in Svelte for its own reactivity system.
-  // We're aliasing the imports to avoid conflicts.
+  // Alias the imports to avoid conflicts.
   import { $sessionList as sessions } from '@clerk/astro/client';
   </script>
 

--- a/docs/references/astro/session-list-store.mdx
+++ b/docs/references/astro/session-list-store.mdx
@@ -11,22 +11,59 @@ The `$sessionListStore` store returns an array of [`Session`](https://clerk.com/
 
 The following example demonstrates how to use the `$sessionListStore` store to display the expiration time of the first session in the list.
 
-```tsx {{ prettier: false, filename: 'session-list.tsx' }}
-import { useStore } from '@nanostores/react';
-import { $sessionList } from '@clerk/astro/client';
+<CodeBlockTabs options={['React', 'Vue', 'Svelte']}>
+  ```tsx {{ prettier: false, filename: 'session-list.tsx' }}
+  import { useStore } from '@nanostores/react';
+  import { $sessionList } from '@clerk/astro/client';
 
-export default function Home() {
-  const sessions = useStore($sessionList);
+  export default function Home() {
+    const sessions = useStore($sessionList);
 
-  if (sessions === undefined) {
-    // handle loading state
-    return null;
+    if (sessions === undefined) {
+      // Handle loading state
+      return null;
+    }
+
+    return (
+      <div>
+        <p>Your current session expires at {sessions[0].expireAt}.</p>
+      </div>
+    )
   }
+  ```
 
-  return (
-    <div>
-      <p>Your current session expires at {sessions[0].expireAt}.</p>
+  ```vue {{ prettier: false, filename: 'session-list.vue' }}
+  <script setup>
+  import { useStore } from '@nanostores/vue';
+  import { $sessionList } from '@clerk/astro/client';
+
+  const sessions = useStore($sessionList);
+  </script>
+
+  <template>
+    <div v-if="sessions === undefined">
+      <!-- Handle loading state -->
     </div>
-  )
-}
-```
+
+    <div v-else>
+      <p>Your current session expires at {{ sessions[0].expireAt }}.</p>
+    </div>
+  </template>
+  ```
+
+  ```svelte {{ prettier: false, filename: 'session-list.svelte' }}
+  <script>
+  // The $ prefix is reserved in Svelte for its own reactivity system.
+  // We're aliasing the imports to avoid conflicts.
+  import { $sessionList as sessions } from '@clerk/astro/client';
+  </script>
+
+  {#if $sessions === undefined}
+    <!-- Handle loading state -->
+  {:else}
+    <div>
+      <p>Your current session expires at {$sessions[0].expireAt}.</p>
+    </div>
+  {/if}
+  ```
+</CodeBlockTabs>

--- a/docs/references/astro/session-store.mdx
+++ b/docs/references/astro/session-store.mdx
@@ -11,29 +11,72 @@ The `$sessionStore` store provides a convenient way to access the current user's
 
 The following example demonstrates how to use the `$sessionStore` store to access the `session` object, which has the `lastActiveAt` property on it. The `lastActiveAt` property is used to display the last active time of the current session to the user.
 
-```tsx {{ prettier: false, filename: 'session.tsx' }}
-import { useStore } from '@nanostores/react';
-import { $sessionStore } from '@clerk/astro/client';
+<CodeBlockTabs options={['React', 'Vue', 'Svelte']}>
+  ```tsx {{ prettier: false, filename: 'session.tsx' }}
+  import { useStore } from '@nanostores/react';
+  import { $sessionStore } from '@clerk/astro/client';
 
-export default function Home() {
+  export default function Session() {
+    const session = useStore($sessionStore);
+
+    if (session === undefined) {
+      // Add logic to handle loading state
+      return null;
+    }
+
+    if(session === null) {
+      // Add logic to handle not signed in state
+      return null;
+    }
+
+    return (
+      <div>
+        <p>This session has been active
+        since {session.lastActiveAt.toLocaleString()}
+        </p>
+      </div>
+    )
+  }
+  ```
+
+  ```vue {{ prettier: false, filename: 'session.vue' }}
+  <script setup>
+  import { useStore } from '@nanostores/vue';
+  import { $sessionStore } from '@clerk/astro/client';
+
   const session = useStore($sessionStore);
+  </script>
 
-  if (session === undefined) {
-    // Add logic to handle loading state
-    return null;
-  }
-
-  if(session === null) {
-    // Add logic to handle not signed in state
-    return null;
-  }
-
-  return (
-    <div>
-      <p>This session has been active
-      since {session.lastActiveAt.toLocaleString()}
-      </p>
+  <template>
+    <div v-if="session === undefined">
+      <!-- Add logic to handle loading state -->
     </div>
-  )
-}
-```
+
+    <div v-else-if="session === null">
+      <!-- Add logic to handle not signed in state -->
+    </div>
+
+    <div v-else>
+      <p>This session has been active since {{ session.lastActiveAt.toLocaleString() }}</p>
+    </div>
+  </template>
+  ```
+
+  ```svelte {{ prettier: false, filename: 'session.svelte' }}
+  <script>
+  // The $ prefix is reserved in Svelte for its own reactivity system.
+  // We're aliasing the imports to avoid conflicts.
+  import { $sessionStore as session } from '@clerk/astro/client';
+  </script>
+
+  {#if $session === undefined}
+    <!-- Add logic to handle loading state -->
+  {:else if $session === null}
+    <!-- Add logic to handle not signed in state -->
+  {:else}
+    <div>
+      <p>This session has been active since {$session.lastActiveAt.toLocaleString()}</p>
+    </div>
+  {/if}
+  ```
+</CodeBlockTabs>

--- a/docs/references/astro/session-store.mdx
+++ b/docs/references/astro/session-store.mdx
@@ -65,7 +65,7 @@ The following example demonstrates how to use the `$sessionStore` store to acces
   ```svelte {{ prettier: false, filename: 'session.svelte' }}
   <script>
   // The $ prefix is reserved in Svelte for its own reactivity system.
-  // We're aliasing the imports to avoid conflicts.
+  // Alias the imports to avoid conflicts.
   import { $sessionStore as session } from '@clerk/astro/client';
   </script>
 

--- a/docs/references/astro/sign-in-store.mdx
+++ b/docs/references/astro/sign-in-store.mdx
@@ -51,7 +51,7 @@ The following example demonstrates how to use the `$signInStore` store to check 
   ```svelte {{ prettier: false, filename: 'sign-in-step.svelte' }}
   <script>
   // The $ prefix is reserved in Svelte for its own reactivity system.
-  // We're aliasing the imports to avoid conflicts.
+  // Alias the imports to avoid conflicts.
   import { $signInStore as signIn } from '@clerk/astro/client';
   </script>
 

--- a/docs/references/astro/sign-in-store.mdx
+++ b/docs/references/astro/sign-in-store.mdx
@@ -13,23 +13,55 @@ The `$signInStore` store provides a convenient way to access the [`SignIn`](http
 
 The following example demonstrates how to use the `$signInStore` store to check the current state of a sign-in.
 
-```tsx {{ prettier: false, filename: 'sign-in-step.tsx' }}
-import { useStore } from '@nanostores/react';
-import { $signInStore } from '@clerk/astro/client';
+<CodeBlockTabs options={['React', 'Vue', 'Svelte']}>
+  ```tsx {{ prettier: false, filename: 'sign-in-step.tsx' }}
+  import { useStore } from '@nanostores/react';
+  import { $signInStore } from '@clerk/astro/client';
 
-export default function SignInStep() {
-  const signIn = useStore($signInStore);
+  export default function SignInStep() {
+    const signIn = useStore($signInStore);
 
-  if (signIn === undefined) {
-    // Add logic to handle loading state
-    return null;
+    if (signIn === undefined) {
+      // Add logic to handle loading state
+      return null;
+    }
+
+    return <div>The current sign in attempt status is {signIn.status}.</div>;
   }
+  ```
 
-  // Logic to handle sign in
+  ```vue {{ prettier: false, filename: 'sign-in-step.vue' }}
+  <script setup>
+  import { useStore } from '@nanostores/vue';
+  import { $signInStore } from '@clerk/astro/client';
 
-  return <div>The current sign in attempt status is {signIn.status}.</div>;
-}
-```
+  const signIn = useStore($signInStore);
+  </script>
+
+  <template>
+    <div v-if="signIn === undefined">
+      <!-- Add logic to handle loading state -->
+    </div>
+    <div v-else>
+      <div>The current sign in attempt status is {{ signIn.status }}.</div>
+    </div>
+  </template>
+  ```
+
+  ```svelte {{ prettier: false, filename: 'sign-in-step.svelte' }}
+  <script>
+  // The $ prefix is reserved in Svelte for its own reactivity system.
+  // We're aliasing the imports to avoid conflicts.
+  import { $signInStore as signIn } from '@clerk/astro/client';
+  </script>
+
+  {#if $signIn === undefined}
+      <!-- Add logic to handle loading state -->
+  {:else}
+      <div>The current sign in attempt status is {$signIn.status}.</div>
+  {/if}
+  ```
+</CodeBlockTabs>
 
 The possible values for the `status` property of the `SignIn` resource are listed [here](/docs/references/javascript/sign-in/sign-in#properties).
 

--- a/docs/references/astro/sign-up-store.mdx
+++ b/docs/references/astro/sign-up-store.mdx
@@ -13,23 +13,55 @@ The `$signUpStore` store provides a convenient way to access the [`SignUp`](http
 
 The following example demonstrates how to use the `$signUpStore` store to access the `SignUp` object and check the current state of a sign-up.
 
-```tsx {{ prettier: false, filename: 'sign-up-step.tsx' }}
-import { useStore } from '@nanostores/react';
-import { $signUpStore } from '@clerk/astro/client';
+<CodeBlockTabs options={['React', 'Vue', 'Svelte']}>
+  ```tsx {{ prettier: false, filename: 'sign-up-step.tsx' }}
+  import { useStore } from '@nanostores/react';
+  import { $signUpStore } from '@clerk/astro/client';
 
-export default function SignUpStep() {
-  const signUp = useStore($signUpStore);
+  export default function SignUpStep() {
+    const signUp = useStore($signUpStore);
 
-  if (signUp === undefined) {
-    // Add logic to handle loading state
-    return null;
+    if (signUp === undefined) {
+      // Add logic to handle loading state
+      return null;
+    }
+
+    return <div>The current sign-up attempt status is {signUp.status}.</div>;
   }
+  ```
 
-  // Logic to handle sign up
+  ```vue {{ prettier: false, filename: 'sign-up-step.vue' }}
+  <script setup>
+  import { useStore } from '@nanostores/vue';
+  import { $signUpStore } from '@clerk/astro/client';
 
-  return <div>The current sign-up attempt status is {signUp.status}.</div>;
-}
-```
+  const signUp = useStore($signUpStore);
+  </script>
+
+  <template>
+    <div v-if="signUp === undefined">
+      <!-- Add logic to handle loading state -->
+    </div>
+    <div v-else>
+      <div>The current sign-up attempt status is {{ signUp.status }}.</div>
+    </div>
+  </template>
+  ```
+
+  ```svelte {{ prettier: false, filename: 'sign-up-step.svelte' }}
+  <script>
+  // The $ prefix is reserved in Svelte for its own reactivity system.
+  // We're aliasing the imports to avoid conflicts.
+  import { $signUpStore as signUp } from '@clerk/astro/client';
+  </script>
+
+  {#if $signUp === undefined}
+      <!-- Add logic to handle loading state -->
+  {:else}
+      <div>The current sign-up attempt status is {$signUp.status}.</div>
+  {/if}
+  ```
+</CodeBlockTabs>
 
 The possible values for the `status` property of the `SignUp` resource are listed [here](https://clerk.com/docs/references/javascript/sign-up/sign-up#properties).
 

--- a/docs/references/astro/sign-up-store.mdx
+++ b/docs/references/astro/sign-up-store.mdx
@@ -51,7 +51,7 @@ The following example demonstrates how to use the `$signUpStore` store to access
   ```svelte {{ prettier: false, filename: 'sign-up-step.svelte' }}
   <script>
   // The $ prefix is reserved in Svelte for its own reactivity system.
-  // We're aliasing the imports to avoid conflicts.
+  // Alias the imports to avoid conflicts.
   import { $signUpStore as signUp } from '@clerk/astro/client';
   </script>
 

--- a/docs/references/astro/user-store.mdx
+++ b/docs/references/astro/user-store.mdx
@@ -16,60 +16,60 @@ The following example demonstrates how to use the `$userStore` store to access t
 For more information, see the [`User` reference.](https://clerk.com/docs/references/javascript/user/user#user-object)
 
 <CodeBlockTabs options={['React', 'Vue', 'Svelte']}>
-```tsx {{ prettier: false, filename: 'user.tsx' }}
-import { useStore } from '@nanostores/react';
-import { $userStore } from '@clerk/astro/client';
+  ```tsx {{ prettier: false, filename: 'user.tsx' }}
+  import { useStore } from '@nanostores/react';
+  import { $userStore } from '@clerk/astro/client';
 
-export default function User() {
+  export default function User() {
+    const user = useStore($userStore);
+
+    if (user === undefined) {
+      // Handle loading state however you like
+      return null;
+    }
+
+    if (user) {
+      return <div>Hello {user.fullName}!</div>;
+    }
+
+    return <div>Not signed in</div>;
+  }
+  ```
+
+  ```vue {{ prettier: false, filename: 'user.vue' }}
+  <script setup>
+  import { useStore } from '@nanostores/vue';
+  import { $userStore } from '@clerk/astro/client';
+
   const user = useStore($userStore);
+  </script>
 
-  if (user === undefined) {
-    // Handle loading state however you like
-    return null;
-  }
+  <template>
+    <div v-if="user === undefined">
+      <!-- Handle loading state however you like -->
+    </div>
 
-  if (user) {
-    return <div>Hello {user.fullName}!</div>;
-  }
+    <div v-else-if="user">Hello {{ user.fullName }}!</div>
 
-  return <div>Not signed in</div>;
-}
-```
+    <div v-else>Not signed in</div>
+  </template>
+  ```
 
-```vue {{ prettier: false, filename: 'user.vue' }}
-<script setup>
-import { useStore } from '@nanostores/vue';
-import { $userStore } from '@clerk/astro/client';
+  ```svelte {{ prettier: false, filename: 'user.svelte' }}
+  <script>
+  // The $ prefix is reserved in Svelte for its own reactivity system.
+  // Alias the imports to avoid conflicts.
+  import { $userStore as user } from '@clerk/astro/client';
+  </script>
 
-const user = useStore($userStore);
-</script>
-
-<template>
-  <div v-if="user === undefined">
+  {#if $user === undefined}
     <!-- Handle loading state however you like -->
-  </div>
-
-  <div v-else-if="user">Hello {{ user.fullName }}!</div>
-
-  <div v-else>Not signed in</div>
-</template>
-```
-
-```svelte {{ prettier: false, filename: 'user.svelte' }}
-<script>
-// The $ prefix is reserved in Svelte for its own reactivity system.
-// Alias the imports to avoid conflicts.
-import { $userStore as user } from '@clerk/astro/client';
-</script>
-
-{#if $user === undefined}
-  <!-- Handle loading state however you like -->
-{:else if $user}
-  <div>Hello {$user.fullName}!</div>
-{:else}
-  <div>Not signed in</div>
-{/if}
-```
+  {:else if $user}
+    <div>Hello {$user.fullName}!</div>
+  {:else}
+    <div>Not signed in</div>
+  {/if}
+  ```
 </CodeBlockTabs>
 
 ### Update the current user data
@@ -79,91 +79,87 @@ The following example demonstrates how to use the `$userStore` store to update t
 For more information on the `update()` method, see the [`User` reference.](https://clerk.com/docs/references/javascript/user/user#update)
 
 <CodeBlockTabs options={['React', 'Vue', 'Svelte']}>
-```tsx {{ prettier: false, filename: 'user.tsx' }}
-import { useStore } from '@nanostores/react';
-import { $userStore } from '@clerk/astro/client';
+  ```tsx {{ prettier: false, filename: 'user.tsx' }}
+  import { useStore } from '@nanostores/react';
+  import { $userStore } from '@clerk/astro/client';
 
-export default function User() {
+  export default function User() {
+    const user = useStore($userStore);
+
+    if (user === undefined) {
+      // Handle loading state however you like
+      return null;
+    }
+
+    if (user === null) return null;
+
+    const updateUser = async () => {
+      await user.update({
+        firstName: "John",
+        lastName: "Doe",
+      });
+    };
+
+    return (
+      <>
+        <button onClick={updateUser}>Click me to update your name</button>
+        <p>user.firstName: {user?.firstName}</p>
+        <p>user.lastName: {user?.lastName}</p>
+      </>
+    );
+  }
+  ```
+
+  ```vue {{ prettier: false, filename: 'user.vue' }}
+  <script setup>
+  import { useStore } from '@nanostores/vue';
+  import { $userStore } from '@clerk/astro/client';
+
   const user = useStore($userStore);
 
-  if (user === undefined) {
-    // Handle loading state however you like
-    return null;
-  }
-
-  if (user === null) return null;
-
   const updateUser = async () => {
-    await user.update({
-      firstName: "John",
-      lastName: "Doe",
-    });
-  };
-
-  return (
-    <>
-      <button onClick={updateUser}>Click me to update your name</button>
-      <p>user.firstName: {user?.firstName}</p>
-      <p>user.lastName: {user?.lastName}</p>
-    </>
-  );
-}
-```
-
-```vue {{ prettier: false, filename: 'user.vue' }}
-<script setup>
-import { useStore } from '@nanostores/vue';
-import { $userStore } from '@clerk/astro/client';
-
-const user = useStore($userStore);
-
-const updateUser = async () => {
-  if (user.value) {
     await user.value.update({
       firstName: "John",
       lastName: "Doe",
     });
-  }
-};
-</script>
+  };
+  </script>
 
-<template>
-  <div v-if="user === undefined">
-    <!-- Handle loading state however you like -->
-  </div>
+  <template>
+    <div v-if="user === undefined">
+      <!-- Handle loading state however you like -->
+    </div>
 
-  <div v-else-if="user !== null">
-    <button @click="updateUser">Click me to update your name</button>
-    <p>user.firstName: {{ user.firstName }}</p>
-    <p>user.lastName: {{ user.lastName }}</p>
-  </div>
-</template>
-```
+    <div v-else-if="user !== null">
+      <button @click="updateUser">Click me to update your name</button>
+      <p>user.firstName: {{ user.firstName }}</p>
+      <p>user.lastName: {{ user.lastName }}</p>
+    </div>
+  </template>
+  ```
 
-```svelte {{ prettier: false, filename: 'user.svelte' }}
-<script>
-// The $ prefix is reserved in Svelte for its own reactivity system.
-// Alias the imports to avoid conflicts.
-import { $userStore as user } from '@clerk/astro/client';
+  ```svelte {{ prettier: false, filename: 'user.svelte' }}
+  <script>
+  // The $ prefix is reserved in Svelte for its own reactivity system.
+  // Alias the imports to avoid conflicts.
+  import { $userStore as user } from '@clerk/astro/client';
 
-const updateUser = async () => {
-  if ($user) {
+  const updateUser = async () => {
     await $user.update({
       firstName: "John",
       lastName: "Doe",
     });
-  }
-};
-</script>
+  };
+  </script>
 
-{#if $user === undefined}
-  <!-- Handle loading state however you like -->
-{:else if $user !== null}
-  <button on:click={updateUser}>Click me to update your name</button>
-  <p>user.firstName: {$user.firstName}</p>
-  <p>user.lastName: {$user.lastName}</p>
-{/if}
-```
+  {#if $user === undefined}
+    <!-- Handle loading state however you like -->
+  {:else if $user !== null}
+    <button on:click={updateUser}>Click me to update your name</button>
+    <p>user.firstName: {$user.firstName}</p>
+    <p>user.lastName: {$user.lastName}</p>
+  {/if}
+  ```
 </CodeBlockTabs>
 
 ### Reload user data
@@ -173,19 +169,48 @@ The following example demonstrates how to use the `$userStore` store to reload t
 For more information on the `reload()` method, see the [`User` reference.](https://clerk.com/docs/references/javascript/user/user#reload)
 
 <CodeBlockTabs options={['React', 'Vue', 'Svelte']}>
-```tsx {{ prettier: false, filename: 'user.tsx' }}
-import { useStore } from '@nanostores/react';
-import { $userStore } from '@clerk/astro/client';
+  ```tsx {{ prettier: false, filename: 'user.tsx' }}
+  import { useStore } from '@nanostores/react';
+  import { $userStore } from '@clerk/astro/client';
 
-export default function User() {
-  const user = useStore($userStore);
+  export default function User() {
+    const user = useStore($userStore);
 
-  if (user === undefined) {
-    // Handle loading state however you like
-    return null;
+    if (user === undefined) {
+      // Handle loading state however you like
+      return null;
+    }
+
+    if (user === null) return null;
+
+    const updateUser = async () => {
+      // Update data via an API endpoint
+      const updateMetadata = await fetch("/api/updateMetadata");
+
+      // Check if the update was successful
+      if (updateMetadata.message !== "success") {
+        throw new Error("Error updating");
+      }
+
+      // If the update was successful, reload the user data
+      await user.reload();
+    };
+
+    return (
+      <>
+        <button onClick={updateUser}>Click me to update your metadata</button>
+        <p>user role: {user?.publicMetadata.role}</p>
+      </>
+    );
   }
+  ```
 
-  if (user === null) return null;
+  ```vue {{ prettier: false, filename: 'user.vue' }}
+  <script setup>
+  import { useStore } from '@nanostores/vue';
+  import { $userStore } from '@clerk/astro/client';
+
+  const user = useStore($userStore);
 
   const updateUser = async () => {
     // Update data via an API endpoint
@@ -197,86 +222,58 @@ export default function User() {
     }
 
     // If the update was successful, reload the user data
-    await user.reload();
+    await user.value.reload();
   };
+  </script>
 
-  return (
-    <>
-      <button onClick={updateUser}>Click me to update your metadata</button>
-      <p>user role: {user?.publicMetadata.role}</p>
-    </>
-  );
-}
-```
+  <template>
+    <div v-if="user === undefined">
+      <!-- Handle loading state however you like -->
+    </div>
 
-```vue {{ prettier: false, filename: 'user.vue' }}
-<script setup>
-import { useStore } from '@nanostores/vue';
-import { $userStore } from '@clerk/astro/client';
+    <div v-else-if="user !== null">
+      <button @click="updateUser">Click me to update your metadata</button>
+      <p>user role: {{ user?.publicMetadata.role }}</p>
+    </div>
+  </template>
+  ```
 
-const user = useStore($userStore);
+  ```svelte {{ prettier: false, filename: 'user.svelte' }}
+  <script>
+  // The $ prefix is reserved in Svelte for its own reactivity system.
+  // Alias the imports to avoid conflicts.
+  import { useStore } from '@nanostores/svelte';
+  import { $userStore as userStore } from '@clerk/astro/client';
 
-const updateUser = async () => {
-  // Update data via an API endpoint
-  const updateMetadata = await fetch("/api/updateMetadata");
+  const user = useStore(userStore);
 
-  // Check if the update was successful
-  if (updateMetadata.message !== "success") {
-    throw new Error("Error updating");
-  }
+  const updateUser = async () => {
+    if ($user) {
+      try {
+        // Update data via an API endpoint
+        const response = await fetch("/api/updateMetadata");
+        const updateMetadata = await response.json();
 
-  // If the update was successful, reload the user data
-  await user.value.reload();
-};
-</script>
+        // Check if the update was successful
+        if (updateMetadata.message !== "success") {
+          throw new Error("Error updating");
+        }
 
-<template>
-  <div v-if="user === undefined">
-    <!-- Handle loading state however you like -->
-  </div>
-
-  <div v-else-if="user !== null">
-    <button @click="updateUser">Click me to update your metadata</button>
-    <p>user role: {{ user?.publicMetadata.role }}</p>
-  </div>
-</template>
-```
-
-```svelte {{ prettier: false, filename: 'user.svelte' }}
-<script>
-import { useStore } from '@nanostores/svelte';
-import { $userStore as userStore } from '@clerk/astro/client';
-
-const user = useStore(userStore);
-
-const updateUser = async () => {
-  if ($user) {
-    try {
-      // Update data via an API endpoint
-      const response = await fetch("/api/updateMetadata");
-      const updateMetadata = await response.json();
-
-      // Check if the update was successful
-      if (updateMetadata.message !== "success") {
-        throw new Error("Error updating");
+        // If the update was successful, reload the user data
+        await $user.reload();
+      } catch (error) {
+        console.error("Failed to update metadata:", error);
+        // Handle the error appropriately
       }
-
-      // If the update was successful, reload the user data
-      await $user.reload();
-    } catch (error) {
-      console.error("Failed to update metadata:", error);
-      // Handle the error appropriately
     }
-  }
-};
-</script>
+  };
+  </script>
 
-<!-- Handle loading state however you like -->
-{#if $user === undefined}
-  <!-- Loading state content -->
-{:else if $user !== null}
-  <button on:click={updateUser}>Click me to update your metadata</button>
-  <p>user role: {$user.publicMetadata?.role}</p>
-{/if}
-```
+  {#if $user === undefined}
+    <!-- Handle loading state however you like -->
+  {:else if $user !== null}
+    <button on:click={updateUser}>Click me to update your metadata</button>
+    <p>user role: {$user.publicMetadata?.role}</p>
+  {/if}
+  ```
 </CodeBlockTabs>

--- a/docs/references/astro/user-store.mdx
+++ b/docs/references/astro/user-store.mdx
@@ -58,7 +58,7 @@ const user = useStore($userStore);
 ```svelte {{ prettier: false, filename: 'user.svelte' }}
 <script>
 // The $ prefix is reserved in Svelte for its own reactivity system.
-// We're aliasing the imports to avoid conflicts.
+// Alias the imports to avoid conflicts.
 import { $userStore as user } from '@clerk/astro/client';
 </script>
 
@@ -143,7 +143,7 @@ const updateUser = async () => {
 ```svelte {{ prettier: false, filename: 'user.svelte' }}
 <script>
 // The $ prefix is reserved in Svelte for its own reactivity system.
-// We're aliasing the imports to avoid conflicts.
+// Alias the imports to avoid conflicts.
 import { $userStore as user } from '@clerk/astro/client';
 
 const updateUser = async () => {
@@ -172,6 +172,7 @@ The following example demonstrates how to use the `$userStore` store to reload t
 
 For more information on the `reload()` method, see the [`User` reference.](https://clerk.com/docs/references/javascript/user/user#reload)
 
+<CodeBlockTabs options={['React', 'Vue', 'Svelte']}>
 ```tsx {{ prettier: false, filename: 'user.tsx' }}
 import { useStore } from '@nanostores/react';
 import { $userStore } from '@clerk/astro/client';
@@ -207,3 +208,75 @@ export default function User() {
   );
 }
 ```
+
+```vue {{ prettier: false, filename: 'user.vue' }}
+<script setup>
+import { useStore } from '@nanostores/vue';
+import { $userStore } from '@clerk/astro/client';
+
+const user = useStore($userStore);
+
+const updateUser = async () => {
+  // Update data via an API endpoint
+  const updateMetadata = await fetch("/api/updateMetadata");
+
+  // Check if the update was successful
+  if (updateMetadata.message !== "success") {
+    throw new Error("Error updating");
+  }
+
+  // If the update was successful, reload the user data
+  await user.value.reload();
+};
+</script>
+
+<template>
+  <div v-if="user === undefined">
+    <!-- Handle loading state however you like -->
+  </div>
+
+  <div v-else-if="user !== null">
+    <button @click="updateUser">Click me to update your metadata</button>
+    <p>user role: {{ user?.publicMetadata.role }}</p>
+  </div>
+</template>
+```
+
+```svelte {{ prettier: false, filename: 'user.svelte' }}
+<script>
+import { useStore } from '@nanostores/svelte';
+import { $userStore as userStore } from '@clerk/astro/client';
+
+const user = useStore(userStore);
+
+const updateUser = async () => {
+  if ($user) {
+    try {
+      // Update data via an API endpoint
+      const response = await fetch("/api/updateMetadata");
+      const updateMetadata = await response.json();
+
+      // Check if the update was successful
+      if (updateMetadata.message !== "success") {
+        throw new Error("Error updating");
+      }
+
+      // If the update was successful, reload the user data
+      await $user.reload();
+    } catch (error) {
+      console.error("Failed to update metadata:", error);
+      // Handle the error appropriately
+    }
+  }
+};
+</script>
+
+<!-- Handle loading state however you like -->
+{#if $user === undefined}
+  <!-- Loading state content -->
+{:else if $user !== null}
+  <button on:click={updateUser}>Click me to update your metadata</button>
+  <p>user role: {$user.publicMetadata?.role}</p>
+{/if}
+```
+</CodeBlockTabs>

--- a/docs/references/astro/user-store.mdx
+++ b/docs/references/astro/user-store.mdx
@@ -15,6 +15,7 @@ The following example demonstrates how to use the `$userStore` store to access t
 
 For more information, see the [`User` reference.](https://clerk.com/docs/references/javascript/user/user#user-object)
 
+<CodeBlockTabs options={['React', 'Vue', 'Svelte']}>
 ```tsx {{ prettier: false, filename: 'user.tsx' }}
 import { useStore } from '@nanostores/react';
 import { $userStore } from '@clerk/astro/client';
@@ -35,12 +36,49 @@ export default function User() {
 }
 ```
 
+```vue {{ prettier: false, filename: 'user.vue' }}
+<script setup>
+import { useStore } from '@nanostores/vue';
+import { $userStore } from '@clerk/astro/client';
+
+const user = useStore($userStore);
+</script>
+
+<template>
+  <div v-if="user === undefined">
+    <!-- Handle loading state however you like -->
+  </div>
+
+  <div v-else-if="user">Hello {{ user.fullName }}!</div>
+
+  <div v-else>Not signed in</div>
+</template>
+```
+
+```svelte {{ prettier: false, filename: 'user.svelte' }}
+<script>
+// The $ prefix is reserved in Svelte for its own reactivity system.
+// We're aliasing the imports to avoid conflicts.
+import { $userStore as user } from '@clerk/astro/client';
+</script>
+
+{#if $user === undefined}
+  <!-- Handle loading state however you like -->
+{:else if $user}
+  <div>Hello {$user.fullName}!</div>
+{:else}
+  <div>Not signed in</div>
+{/if}
+```
+</CodeBlockTabs>
+
 ### Update the current user data
 
 The following example demonstrates how to use the `$userStore` store to update the current user's data on the client side.
 
 For more information on the `update()` method, see the [`User` reference.](https://clerk.com/docs/references/javascript/user/user#update)
 
+<CodeBlockTabs options={['React', 'Vue', 'Svelte']}>
 ```tsx {{ prettier: false, filename: 'user.tsx' }}
 import { useStore } from '@nanostores/react';
 import { $userStore } from '@clerk/astro/client';
@@ -71,6 +109,62 @@ export default function User() {
   );
 }
 ```
+
+```vue {{ prettier: false, filename: 'user.vue' }}
+<script setup>
+import { useStore } from '@nanostores/vue';
+import { $userStore } from '@clerk/astro/client';
+
+const user = useStore($userStore);
+
+const updateUser = async () => {
+  if (user.value) {
+    await user.value.update({
+      firstName: "John",
+      lastName: "Doe",
+    });
+  }
+};
+</script>
+
+<template>
+  <div v-if="user === undefined">
+    <!-- Handle loading state however you like -->
+  </div>
+
+  <div v-else-if="user !== null">
+    <button @click="updateUser">Click me to update your name</button>
+    <p>user.firstName: {{ user.firstName }}</p>
+    <p>user.lastName: {{ user.lastName }}</p>
+  </div>
+</template>
+```
+
+```svelte {{ prettier: false, filename: 'user.svelte' }}
+<script>
+// The $ prefix is reserved in Svelte for its own reactivity system.
+// We're aliasing the imports to avoid conflicts.
+import { $userStore as user } from '@clerk/astro/client';
+
+const updateUser = async () => {
+  if ($user) {
+    await $user.update({
+      firstName: "John",
+      lastName: "Doe",
+    });
+  }
+};
+</script>
+
+{#if $user === undefined}
+  <!-- Handle loading state however you like -->
+{:else if $user !== null}
+  <button on:click={updateUser}>Click me to update your name</button>
+  <p>user.firstName: {$user.firstName}</p>
+  <p>user.lastName: {$user.lastName}</p>
+{/if}
+```
+</CodeBlockTabs>
 
 ### Reload user data
 


### PR DESCRIPTION
<!--- Add the "deploy-preview" label and add your page previews here -->

> [!IMPORTANT]
> 🔎 Previews:
>
> - https://clerk.com/docs/pr/1329/references/astro/auth-store#how-to-use-the-auth-store-store
> - https://clerk.com/docs/pr/1329/references/astro/clerk-store#how-to-use-the-clerk-store-store
> - https://clerk.com/docs/pr/1329/references/astro/user-store#how-to-use-the-user-store-store
> - https://clerk.com/docs/pr/1329/references/astro/sign-in-store#how-to-use-the-sign-in-store-store
> - https://clerk.com/docs/pr/1329/references/astro/sign-up-store#how-to-use-the-sign-up-store-store
> - https://clerk.com/docs/pr/1329/references/astro/session-store#how-to-use-the-session-store-store
> - https://clerk.com/docs/pr/1329/references/astro/session-list-store#how-to-use-the-session-list-store-store
> - https://clerk.com/docs/pr/1329/references/astro/organization-store#how-to-use-the-organization-store-store

<!--- Describe your changes in detail. Why does this change need to happen? Include any links to Slack discussions, Linear comments, etc. -->

### Explanation:

<!--- How does this PR solve the problem? -->

### This PR:

- As one of Astro's key features is its ability to seamlessly integrate components from various frameworks, this PR demonstrates the use of `@clerk/astro`'s auth stores with both Vue and Svelte components.
- Closes ECO-13
