### PR TITLE
docs(elements): Add docs for `FieldState` `config` field

### DIFF
--- a/docs/elements/reference/common.mdx
+++ b/docs/elements/reference/common.mdx
@@ -111,13 +111,13 @@ By having access to both `message` and `code` you can enrich the incoming `messa
 
 Enables you to programmatically access additional information from the parent `<Field>` component. By default, you'll have access to `state`. `state` will also contain the field's [`ValidityState`](https://developer.mozilla.org/en-US/docs/Web/API/ValidityState). `<FieldState>` is useful for implementing animations if you need direct access to the `state` value.
 
-If you use `<Input type="password" validatePassword>`, additional information in the form of `message`, `codes`, and `config` is provided.
+If you use `<Input type="password" validatePassword>`, additional information in the form of `message` and `codes` is provided.
 
 ### Properties {{ toc: false }}
 
 | Name | Type | Description |
 | - | - | - |
-| `children` | `(args: { state: 'success' \| 'error' \| 'warning' \| 'info' \| 'idle'; message: string \| undefined; codes: ErrorMessageKey[] \| undefined, config: PasswordConfig }) => React.ReactNode` | Use this function to access the field's state. Optionally, information regarding password validation is given. |
+| `children` | `(args: { state: 'success' \| 'error' \| 'warning' \| 'info' \| 'idle'; message: string \| undefined; codes: (string | [string, Record<string, string | number>])[] \| undefined }) => React.ReactNode` | Use this function to access the field's state. Optionally, information regarding password validation is given. |
 
 ### Usage {{ toc: false }}
 
@@ -140,8 +140,7 @@ If you're using [`<Input type="password" validatePassword>`](#input-type-passwor
 | Name | Type | Description |
 | - | - | - |
 | `message` | `string` | The standardized English message generated for the current state of the input. This message is generated based on the codes associated with the `<FieldState>`. |
-| `codes` | `string[]` | The codes associated with the `<FieldState>`. You can use these codes to return a custom `message` or localize its contents. |
-| `config` | `{ allowed_special_characters: string; min_length: number; max_length: number; require_special_char: boolean; require_numbers: boolean; require_uppercase: boolean; require_lowercase: boolean; }` | The password complexity configuration for your application. |
+| `codes` | `(string | [string, Record<string, string | number>])[]` | The error codes associated with the `<FieldState>`. You can use these codes to return a custom `message` or localize its contents. |
 
 Initially, the `<Input>` will have a `state` of `idle` until the user interacts with the input. Depending on the user's input, the `state` will change to `'success' | 'error' | 'warning' | 'info'`.
 
@@ -150,12 +149,11 @@ Initially, the `<Input>` will have a `state` of `idle` until the user interacts 
   <Clerk.Label>Password</Clerk.Label>
   <Clerk.Input type="password" validatePassword />
   <Clerk.FieldState>
-    {({ state, codes, message, config }) => (
+    {({ state, codes, message }) => (
       <div>
         <pre>Field state: {state}</pre>
         <pre>Field msg: {message}</pre>
-        <pre>Codes: {codes?.join(', ')}</pre>
-        <pre>Config: {JSON.stringify(config, null, 2)}</pre>
+        <pre>Codes: {JSON.stringify(codes, null, 2)}</pre>
       </div>
     )}
   </Clerk.FieldState>

--- a/docs/elements/reference/common.mdx
+++ b/docs/elements/reference/common.mdx
@@ -117,7 +117,7 @@ If you use `<Input type="password" validatePassword>`, additional information in
 
 | Name | Type | Description |
 | - | - | - |
-| `children` | `(args: { state: 'success' \| 'error' \| 'warning' \| 'info' \| 'idle'; message: string \| undefined; codes: (string | [string, Record<string, string | number>])[] \| undefined }) => React.ReactNode` | Use this function to access the field's state. Optionally, information regarding password validation is given. |
+| `children` | `(args: { state: 'success' \| 'error' \| 'warning' \| 'info' \| 'idle'; message: string \| undefined; codes: (string \| [string, Record<string, string \| number>])[] \| undefined }) => React.ReactNode` | Use this function to access the field's state. Optionally, information regarding password validation is given. |
 
 ### Usage {{ toc: false }}
 

--- a/docs/elements/reference/common.mdx
+++ b/docs/elements/reference/common.mdx
@@ -111,13 +111,13 @@ By having access to both `message` and `code` you can enrich the incoming `messa
 
 Enables you to programmatically access additional information from the parent `<Field>` component. By default, you'll have access to `state`. `state` will also contain the field's [`ValidityState`](https://developer.mozilla.org/en-US/docs/Web/API/ValidityState). `<FieldState>` is useful for implementing animations if you need direct access to the `state` value.
 
-If you use `<Input type="password" validatePassword>`, additional information in the form of `message` and `codes` is provided.
+If you use `<Input type="password" validatePassword>`, additional information in the form of `message`, `codes`, and `config` is provided.
 
 ### Properties {{ toc: false }}
 
 | Name | Type | Description |
 | - | - | - |
-| `children` | `(args: { state: 'success' \| 'error' \| 'warning' \| 'info' \| 'idle'; message: string \| undefined; codes: ErrorMessageKey[] \| undefined }) => React.ReactNode` | Use this function to access the field's state. Optionally, information regarding password validation is given. |
+| `children` | `(args: { state: 'success' \| 'error' \| 'warning' \| 'info' \| 'idle'; message: string \| undefined; codes: ErrorMessageKey[] \| undefined, config: PasswordConfig }) => React.ReactNode` | Use this function to access the field's state. Optionally, information regarding password validation is given. |
 
 ### Usage {{ toc: false }}
 
@@ -137,8 +137,11 @@ If you use `<Input type="password" validatePassword>`, additional information in
 
 If you're using [`<Input type="password" validatePassword>`](#input-type-password), the `<FieldState>`'s children function receives additional arguments:
 
-- `message` - The standardized English message generated for the current state of the input. This message is generated based on the codes associated with the `<FieldState>`.
-- `codes` -  The codes associated with the `<FieldState>`. You can use these codes to return custom `message` or localize its contents.
+| Name | Type | Description |
+| - | - | - |
+| `message` | `string` | The standardized English message generated for the current state of the input. This message is generated based on the codes associated with the `<FieldState>`. |
+| `codes` | `string[]` | The codes associated with the `<FieldState>`. You can use these codes to return a custom `message` or localize its contents. |
+| `config` | `{ allowed_special_characters: string; min_length: number; max_length: number; require_special_char: boolean; require_numbers: boolean; require_uppercase: boolean; require_lowercase: boolean; }` | The password complexity configuration for your application. |
 
 Initially, the `<Input>` will have a `state` of `idle` until the user interacts with the input. Depending on the user's input, the `state` will change to `'success' | 'error' | 'warning' | 'info'`.
 

--- a/docs/elements/reference/common.mdx
+++ b/docs/elements/reference/common.mdx
@@ -140,7 +140,7 @@ If you're using [`<Input type="password" validatePassword>`](#input-type-passwor
 | Name | Type | Description |
 | - | - | - |
 | `message` | `string` | The standardized English message generated for the current state of the input. This message is generated based on the codes associated with the `<FieldState>`. |
-| `codes` | `(string | [string, Record<string, string | number>])[]` | The error codes associated with the `<FieldState>`. You can use these codes to return a custom `message` or localize its contents. |
+| `codes` | `(string \| [string, Record<string, string \| number>])[]` | The error codes associated with the `<FieldState>`. You can use these codes to return a custom `message` or localize its contents. |
 
 Initially, the `<Input>` will have a `state` of `idle` until the user interacts with the input. Depending on the user's input, the `state` will change to `'success' | 'error' | 'warning' | 'info'`.
 

--- a/docs/elements/reference/common.mdx
+++ b/docs/elements/reference/common.mdx
@@ -150,11 +150,12 @@ Initially, the `<Input>` will have a `state` of `idle` until the user interacts 
   <Clerk.Label>Password</Clerk.Label>
   <Clerk.Input type="password" validatePassword />
   <Clerk.FieldState>
-    {({ state, codes, message }) => (
+    {({ state, codes, message, config }) => (
       <div>
         <pre>Field state: {state}</pre>
         <pre>Field msg: {message}</pre>
         <pre>Codes: {codes?.join(', ')}</pre>
+        <pre>Config: {JSON.stringify(config, null, 2)}</pre>
       </div>
     )}
   </Clerk.FieldState>


### PR DESCRIPTION
<!--- Add the "deploy-preview" label and add your page previews here -->

> [!IMPORTANT]
> 🔎 Previews:
>
> - https://clerk.com/docs/pr/1330/elements/reference/common#input-type-password-validate-password
>
> 🚫 Waiting For Release:
>
> - https://github.com/clerk/javascript/pull/3812

<!--- Describe your changes in detail. Why does this change need to happen? Include any links to Slack discussions, Linear comments, etc. -->

### Explanation:

Add docs for new `config` field for `FieldState`.

### This PR:

-
