### PR TITLE
Update `<Cards>` usage

### DIFF
--- a/docs/authentication/social-connections/microsoft.mdx
+++ b/docs/authentication/social-connections/microsoft.mdx
@@ -124,20 +124,12 @@ In _production instances_, you must provide custom credentials, which includes g
 
 ## Next steps
 
-<div className="container mx-auto my-4">
-  <div className="grid grid-cols-1 gap-6 md:grid-cols-2">
-    <Cards
-      title="SAML SSO with Microsoft Azure AD"
-      description="Learn how to integrate Microsoft Azure AD with Clerk using SAML SSO."
-      link="/docs/authentication/saml/azure"
-      cta="Learn More"
-    />
+<Cards>
+  - [SAML SSO with Microsoft Azure AD](/docs/authentication/saml/azure)
+  - Learn how to integrate Microsoft Azure AD with Clerk using SAML SSO.
 
-    <Cards
-      title="Account Linking"
-      description="Learn how Clerk handles account linking and manages unverified email addresses from OAuth providers."
-      link="/docs/authentication/social-connections/account-linking"
-      cta="Learn More"
-    />
-  </div>
-</div>
+  ---
+
+  - [Account Linking](/docs/authentication/social-connections/account-linking)
+  - Learn how Clerk handles account linking and manages unverified email addresses from OAuth providers.
+</Cards>

--- a/docs/components/customization/overview.mdx
+++ b/docs/components/customization/overview.mdx
@@ -348,27 +348,17 @@ The following example shows how to style the primary button in a `<SignIn />` co
 
 Here are a few resources you can utilize to customize your Clerk components further:
 
-<div className="container mx-auto my-4">
-  <div className="grid grid-cols-1 gap-6 md:grid-cols-2">
-    <Cards
-      title="Localization"
-      description="Learn how to localize your Clerk components."
-      link="/docs/components/customization/localization"
-      cta="Learn More"
-    />
+<Cards>
+  - [Localization](/docs/components/customization/localization)
+  - Learn how to localize your Clerk components.
 
-    <Cards
-      title="Pre-built themes"
-      description="Explore Clerk's pre-built themes that you can use to quickly style your Clerk components."
-      link="/docs/components/customization/themes"
-      cta="Learn More"
-    />
+  ---
 
-    <Cards
-      title="Customize layouts"
-      description="Learn how to change the layout and links of your Clerk components."
-      link="/docs/components/customization/layout"
-      cta="Learn More"
-    />
-  </div>
-</div>
+  - [Pre-built themes](/docs/components/customization/themes)
+  - Explore Clerk's pre-built themes that you can use to quickly style your Clerk components.
+
+  ---
+
+  - [Customize layouts](/docs/components/customization/layout)
+  - Learn how to change the layout and links of your Clerk components.
+</Cards>

--- a/docs/deployments/migrate-overview.mdx
+++ b/docs/deployments/migrate-overview.mdx
@@ -76,13 +76,7 @@ To use Clerk's migration script, clone the [repository](https://github.com/clerk
 
 Clerk is hard at work writing up more and more specific migration guides and tools. If you have are interested in specific guides please provide more feedback at [https://feedback.clerk.com](https://feedback.clerk.com)
 
-<div className="container mx-auto my-4">
-  <div className="grid grid-cols-1 gap-6 md:grid-cols-2">
-    <Cards
-      title="Firebase"
-      description="Learn how to migrate from Firebase to Clerk quickly and easily."
-      link="/docs/deployments/migrate-from-firebase"
-      cta="Learn more"
-    />
-  </div>
-</div>
+<Cards>
+  - [Firebase](/docs/deployments/migrate-from-firebase)
+  - Learn how to migrate from Firebase to Clerk quickly and easily.
+</Cards>

--- a/docs/integrations/databases/firebase.mdx
+++ b/docs/integrations/databases/firebase.mdx
@@ -189,34 +189,22 @@ Integrating Firebase with Clerk gives you the benefits of using Firebase's featu
 
 ## Next steps
 
-<div className="container mx-auto my-4">
-  <div className="grid grid-cols-1 gap-6 md:grid-cols-2">
-    <Cards
-      title="Use webhooks to sync Firebase data with Clerk"
-      description="Learn how to sync Firebase auth or Firestore data with Clerk data using webhooks."
-      link="/docs/integrations/webhooks/sync-data"
-      cta="Learn More"
-    />
+<Cards>
+  - [Use webhooks to sync Firebase data with Clerk](/docs/integrations/webhooks/sync-data)
+  - Learn how to sync Firebase auth or Firestore data with Clerk data using webhooks.
 
-    <Cards
-      title="Create custom sign-up and sign-in pages in your Next.js app"
-      description="Learn how add custom sign-up and sign-in pages with Clerk components in your Next.js application."
-      link="/docs/references/nextjs/custom-signup-signin-pages"
-      cta="Learn More"
-    />
+  ---
 
-    <Cards
-      title="Deploy to Production"
-      description="Learn how to deploy your Clerk app to production."
-      link="/docs/deployments/overview"
-      cta="Learn More"
-    />
+  - [Create custom sign-up and sign-in pages in your Next.js app](/docs/references/nextjs/custom-signup-signin-pages)
+  - Learn how add custom sign-up and sign-in pages with Clerk components in your Next.js application.
 
-    <Cards
-      title="Deploy to Vercel"
-      description="Learn how to deploy your Clerk app to production on Vercel."
-      link="/docs/deployments/deploy-to-vercel"
-      cta="Learn More"
-    />
-  </div>
-</div>
+  ---
+
+  - [Deploy to Production](/docs/deployments/overview)
+  - Learn how to deploy your Clerk app to production.
+
+  ---
+
+  - [Deploy to Vercel](/docs/deployments/deploy-to-vercel)
+  - Learn how to deploy your Clerk app to production on Vercel.
+</Cards>

--- a/docs/quickstarts/astro.mdx
+++ b/docs/quickstarts/astro.mdx
@@ -168,27 +168,17 @@ Clerk's [Astro SDK](/docs/references/astro/overview) provides a set of component
 
 ## Next steps
 
-<div className="container mx-auto my-4">
-  <div className="grid grid-cols-1 gap-6 md:grid-cols-2">
-    <Cards
-      title="Protect routes using Clerk Middleware"
-      description="Learn how to protect specific routes from unauthenticated users."
-      link="/docs/references/astro/clerk-middleware"
-      cta="Learn More"
-    />
+<Cards>
+  - [Protect routes using Clerk Middleware](/docs/references/astro/clerk-middleware)
+  - Learn how to protect specific routes from unauthenticated users.
 
-    <Cards
-      title="Read session and user data"
-      description="Learn how to use Clerk's stores and helpers to access the active session and user data in your Astro application."
-      link="/docs/references/astro/read-session-data"
-      cta="Learn More"
-    />
+  ---
 
-    <Cards
-      title="Clerk + Astro Quickstart Repo"
-      description="The official companion repo for Clerk's Astro Quickstart."
-      link="https://github.com/clerk/clerk-astro-quickstart"
-      cta="Learn More"
-    />
-  </div>
-</div>
+  - [Read session and user data](/docs/references/astro/read-session-data)
+  - Learn how to use Clerk's stores and helpers to access the active session and user data in your Astro application.
+
+  ---
+
+  - [Clerk + Astro Quickstart Repo](https://github.com/clerk/clerk-astro-quickstart)
+  - The official companion repo for Clerk's Astro Quickstart.
+</Cards>

--- a/docs/quickstarts/expo.mdx
+++ b/docs/quickstarts/expo.mdx
@@ -444,34 +444,22 @@ See the [`expo-updates`](https://docs.expo.dev/versions/latest/sdk/updates) libr
 
 See the following guides to take the next steps toward fleshing out your Expo app.
 
-<div className="container mx-auto my-4">
-  <div className="grid grid-cols-1 gap-6 md:grid-cols-2">
-    <Cards
-      title="OAuth with Expo"
-      description="Learn more how to build a custom OAuth flow with Expo."
-      link="/docs/custom-flows/oauth-connections"
-      cta="Learn More"
-    />
+<Cards>
+  - [OAuth with Expo](/docs/custom-flows/oauth-connections)
+  - Learn more how to build a custom OAuth flow with Expo.
 
-    <Cards
-      title="MFA with Expo"
-      description="Learn more how to build a custom multi-factor authentication flow with Expo."
-      link="/docs/custom-flows/email-password-mfa"
-      cta="Learn More"
-    />
+  ---
 
-    <Cards
-      title="Read session and user data"
-      description="Learn how to read session and user data with Expo."
-      link="/docs/references/expo/expo-read-session-user-data"
-      cta="Learn More"
-    />
+  - [MFA with Expo](/docs/custom-flows/email-password-mfa)
+  - Learn more how to build a custom multi-factor authentication flow with Expo.
 
-    <Cards
-      title="Sign-up and sign-in flow"
-      description="Learn how to build a custom sign-up and sign-in authentication flow."
-      link="/docs/custom-flows/email-password"
-      cta="Learn More"
-    />
-  </div>
-</div>
+  ---
+
+  - [Read session and user data](/docs/references/expo/expo-read-session-user-data)
+  - Learn how to read session and user data with Expo.
+
+  ---
+
+  - [Sign-up and sign-in flow](/docs/custom-flows/email-password)
+  - Learn how to build a custom sign-up and sign-in authentication flow.
+</Cards>

--- a/docs/quickstarts/gatsby.mdx
+++ b/docs/quickstarts/gatsby.mdx
@@ -171,27 +171,17 @@ Learn how to use Clerk to quickly and easily add secure authentication and user 
 
 Now that you have an application integrated with Clerk, you will want to read the following documentation:
 
-<div className="container mx-auto my-4">
-  <div className="grid grid-cols-1 gap-6 md:grid-cols-2">
-    <Cards
-      title="Customization & Localization"
-      description="Learn how to customize and localize the Clerk components."
-      link="/docs/components/customization/overview"
-      cta="Learn More"
-    />
+<Cards>
+  - [Customization & Localization](/docs/components/customization/overview)
+  - Learn how to customize and localize the Clerk components.
 
-    <Cards
-      title="Authentication Components"
-      description="Learn more about all our authentication components."
-      link="/docs/components/authentication/sign-in"
-      cta="Learn More"
-    />
+  ---
 
-    <Cards
-      title="Client Side Helpers"
-      description="Learn more about our client side helpers and how to use them."
-      link="/docs/references/react/use-user"
-      cta="Learn More"
-    />
-  </div>
-</div>
+  - [Authentication Components](/docs/components/authentication/sign-in)
+  - Learn more about all our authentication components.
+
+  ---
+
+  - [Client Side Helpers](/docs/references/react/use-user)
+  - Learn more about our client side helpers and how to use them.
+</Cards>

--- a/docs/quickstarts/javascript.mdx
+++ b/docs/quickstarts/javascript.mdx
@@ -281,27 +281,17 @@ Select your preferred method below to get started.
 
 ### More resouces
 
-<div className="container mx-auto my-4">
-  <div className="grid grid-cols-1 gap-6 md:grid-cols-2">
-    <Cards
-      title="Clerk Class Reference"
-      description="Learn more about the Clerk class and how to use it."
-      link="/docs/references/javascript/clerk/clerk"
-      cta="Learn More"
-    />
+<Cards>
+  - [Clerk Class Reference](/docs/references/javascript/clerk/clerk)
+  - Learn more about the Clerk class and how to use it.
 
-    <Cards
-      title="Authentication Components"
-      description="Learn more about all our authentication components."
-      link="/docs/references/javascript/clerk/clerk#components"
-      cta="Learn More"
-    />
+  ---
 
-    <Cards
-      title="Customization & Localization"
-      description="Learn how to customize and localize the Clerk components."
-      link="/docs/components/customization/overview"
-      cta="Learn More"
-    />
-  </div>
-</div>
+  - [Authentication Components](/docs/references/javascript/clerk/clerk#components)
+  - Learn more about all our authentication components.
+
+  ---
+
+  - [Customization & Localization](/docs/components/customization/overview)
+  - Learn how to customize and localize the Clerk components.
+</Cards>

--- a/docs/quickstarts/nextjs.mdx
+++ b/docs/quickstarts/nextjs.mdx
@@ -168,69 +168,47 @@ description: Add authentication and user management to your Next.js app with Cle
 
 ## Next steps
 
-<div className="container mx-auto my-4">
-  <div className="grid grid-cols-1 gap-6 md:grid-cols-2">
-    <Cards
-      title="Protect routes using Clerk Middleware"
-      description="Learn how to protect specific routes from unauthenticated users."
-      link="/docs/references/nextjs/clerk-middleware"
-      cta="Learn More"
-    />
+<Cards>
+  - [Protect routes using Clerk Middleware](/docs/references/nextjs/clerk-middleware)
+  - Learn how to protect specific routes from unauthenticated users.
 
-    <Cards
-      title="Create custom sign-up and sign-in pages"
-      description="Learn how add custom sign-up and sign-in pages with Clerk components."
-      link="/docs/references/nextjs/custom-signup-signin-pages"
-      cta="Learn More"
-    />
+  ---
 
-    <Cards
-      title="Read user and session data"
-      description="Learn how to use Clerk's hooks and helpers to access the active session and user data in your Next.js application."
-      link="/docs/references/nextjs/read-session-data"
-      cta="Learn More"
-    />
+  - [Create custom sign-up and sign-in pages](/docs/references/nextjs/custom-signup-signin-pages)
+  - Learn how add custom sign-up and sign-in pages with Clerk components.
 
-    <Cards
-      title="Client Side Helpers"
-      description="Learn more about Next.js client side helpers and how to use them."
-      link="/docs/references/nextjs/overview#client-side-helpers"
-      cta="Learn More"
-    />
+  ---
 
-    <Cards
-      title="Next.js SDK Reference"
-      description="Learn more about additional Next.js methods."
-      link="/docs/references/nextjs/overview"
-      cta="Learn More"
-    />
+  - [Read user and session data](/docs/references/nextjs/read-session-data)
+  - Learn how to use Clerk's hooks and helpers to access the active session and user data in your Next.js application.
 
-    <Cards
-      title="Deploy to Production"
-      description="Learn how to deploy your Clerk app to production."
-      link="/docs/deployments/overview"
-      cta="Learn More"
-    />
+  ---
 
-    <Cards
-      title="Deploy to Vercel"
-      description="Learn how to deploy your Clerk app to production on Vercel."
-      link="/docs/deployments/deploy-to-vercel"
-      cta="Learn More"
-    />
+  - [Client Side Helpers](/docs/references/nextjs/overview#client-side-helpers)
+  - Learn more about Next.js client side helpers and how to use them.
 
-    <Cards
-      title="Clerk + Next.js App Router Quickstart Repo"
-      description="The official companion repo for Clerk's Next.js Quickstart using App Router."
-      link="https://github.com/clerk/clerk-nextjs-app-quickstart"
-      cta="Learn More"
-    />
+  ---
 
-    <Cards
-      title="Clerk + Next.js Pages Router Quickstart Repo"
-      description="The official companion repo for Clerk's Next.js Quickstart using Pages Router."
-      link="https://github.com/clerk/clerk-nextjs-pages-quickstart"
-      cta="Learn More"
-    />
-  </div>
-</div>
+  - [Next.js SDK Reference](/docs/references/nextjs/overview)
+  - Learn more about additional Next.js methods.
+
+  ---
+
+  - [Deploy to Production](/docs/deployments/overview)
+  - Learn how to deploy your Clerk app to production.
+
+  ---
+
+  - [Deploy to Vercel](/docs/deployments/deploy-to-vercel)
+  - Learn how to deploy your Clerk app to production on Vercel.
+
+  ---
+
+  - [Clerk + Next.js App Router Quickstart Repo](https://github.com/clerk/clerk-nextjs-app-quickstart)
+  - The official companion repo for Clerk's Next.js Quickstart using App Router.
+
+  ---
+
+  - [Clerk + Next.js Pages Router Quickstart Repo](https://github.com/clerk/clerk-nextjs-pages-quickstart)
+  - The official companion repo for Clerk's Next.js Quickstart using Pages Router.
+</Cards>

--- a/docs/quickstarts/react.mdx
+++ b/docs/quickstarts/react.mdx
@@ -187,27 +187,17 @@ React has many options for handling routing, and you are free to choose the opti
 
 You can also learn more about Clerk components, how to customize them, and how to use Clerk's client side helpers. The following guides will help you get started.
 
-<div className="container mx-auto my-4">
-  <div className="grid grid-cols-1 gap-6 md:grid-cols-2">
-    <Cards
-      title="Prebuilt Components"
-      description="Learn more about Clerk's suite of components that let you quickly add authentication to your app."
-      link="/docs/components/overview"
-      cta="Learn More"
-    />
+<Cards>
+  - [Prebuilt Components](/docs/components/overview)
+  - Learn more about Clerk's suite of components that let you quickly add authentication to your app.
 
-    <Cards
-      title="Customization & Localization"
-      description="Learn how to customize and localize Clerk components."
-      link="/docs/components/customization/overview"
-      cta="Learn More"
-    />
+  ---
 
-    <Cards
-      title="Client Side Helpers"
-      description="Learn more about our client side helpers and how to use them."
-      link="/docs/references/react/use-user"
-      cta="Learn More"
-    />
-  </div>
-</div>
+  - [Customization & Localization](/docs/components/customization/overview)
+  - Learn how to customize and localize Clerk components.
+
+  ---
+
+  - [Client Side Helpers](/docs/references/react/use-user)
+  - Learn more about our client side helpers and how to use them.
+</Cards>

--- a/docs/quickstarts/remix.mdx
+++ b/docs/quickstarts/remix.mdx
@@ -258,34 +258,22 @@ Learn how to use Clerk to quickly and easily add secure authentication and user 
 
 Now that you have an application integrated with Clerk, you will want to read the following documentation:
 
-<div className="container mx-auto my-4">
-  <div className="grid grid-cols-1 gap-6 md:grid-cols-2">
-    <Cards
-      title="Create custom sign-up and sign-in pages"
-      description="Learn how add custom sign-up and sign-in pages with Clerk components."
-      link="/docs/references/remix/custom-signup-signin-pages"
-      cta="Learn More"
-    />
+<Cards>
+  - [Create custom sign-up and sign-in pages](/docs/references/remix/custom-signup-signin-pages)
+  - Learn how add custom sign-up and sign-in pages with Clerk components.
 
-    <Cards
-      title="Read user and session data"
-      description="Learn how to use Clerk's hooks and helpers to access the active session and user data in your Remix application."
-      link="/docs/references/remix/read-session-data"
-      cta="Learn More"
-    />
+  ---
 
-    <Cards
-      title="Customization & Localization"
-      description="Learn how to customize and localize the Clerk components."
-      link="/docs/components/customization/overview"
-      cta="Learn More"
-    />
+  - [Read user and session data](/docs/references/remix/read-session-data)
+  - Learn how to use Clerk's hooks and helpers to access the active session and user data in your Remix application.
 
-    <Cards
-      title="Authentication Components"
-      description="Learn more about all our authentication components."
-      link="/docs/components/authentication/sign-in"
-      cta="Learn More"
-    />
-  </div>
-</div>
+  ---
+
+  - [Customization & Localization](/docs/components/customization/overview)
+  - Learn how to customize and localize the Clerk components.
+
+  ---
+
+  - [Authentication Components](/docs/components/authentication/sign-in)
+  - Learn more about all our authentication components.
+</Cards>

--- a/docs/quickstarts/setup-clerk.mdx
+++ b/docs/quickstarts/setup-clerk.mdx
@@ -31,76 +31,51 @@ Before you can start integrating Clerk into your application, you need to create
 
   Now that your application is created in the Clerk Dashboard, you can integrate it into your codebase. To integrate Clerk into your application, use one of our [quickstarts](/docs/quickstarts/overview):
 
-  <div className="container mx-auto my-4">
-    <div className="grid grid-cols-1 gap-6 md:grid-cols-2">
-      <FrameworkCards
-        title="Next.js"
-        description="Easily add secure, beautiful, and fast authentication to Next.js with Clerk."
-        link="/docs/quickstarts/nextjs"
-        cta="Get Started"
-        icon="/docs/images/logos/nextjs.svg"
-        iconWidth="40"
-      />
+  <Cards>
+    - [Next.js](/docs/quickstarts/nextjs)
+    - Easily add secure, beautiful, and fast authentication to Next.js with Clerk.
+    - ![](/docs/images/logos/nextjs.svg)
 
-      <FrameworkCards
-        title="React"
-        description="Get started installing and initializing Clerk in a new React application."
-        link="/docs/quickstarts/react"
-        cta="Get Started"
-        icon="/docs/images/logos/react.svg"
-      />
+    ---
 
-      <FrameworkCards
-        title="JavaScript"
-        description="Add authentication and user management to your JavaScript application."
-        link="/docs/quickstarts/javascript"
-        cta="Get Started"
-        hideArrow={true}
-        icon="/docs/images/logos/javascript.svg"
-        iconWidth="30"
-      />
+    - [React](/docs/quickstarts/react)
+    - Get started installing and initializing Clerk in a new React application.
+    - ![](/docs/images/logos/react.svg)
 
-      <FrameworkCards
-        title="Remix"
-        description="Easily add secure, edge- and SSR-friendly authentication to Remix with Clerk."
-        link="/docs/quickstarts/remix"
-        cta="Get Started"
-        icon="/docs/images/logos/remix.svg"
-      />
+    ---
 
-      <FrameworkCards
-        title="Gatsby"
-        description="Integrate user management and authentication into your Gatsby application."
-        link="/docs/quickstarts/gatsby"
-        cta="Get Started"
-        hideArrow={true}
-        icon="/docs/images/logos/gatsby.svg"
-      />
+    - [JavaScript](/docs/quickstarts/javascript)
+    - Add authentication and user management to your JavaScript application.
+    - ![](/docs/images/logos/javascript.svg)
 
-      <FrameworkCards
-        title="RedwoodJS"
-        description="Grow your RedwoodJS application with Clerk user management and authentication."
-        link="/docs/references/redwood/overview"
-        cta="Get Started"
-        icon="/docs/images/logos/redwood.svg"
-      />
+    ---
 
-      <FrameworkCards
-        title="Expo / React Native"
-        description="Use Clerk with Expo to authenticate users in your React Native application."
-        link="/docs/quickstarts/expo"
-        cta="Get Started"
-        icon="/docs/images/logos/expo.svg"
-      />
+    - [Remix](/docs/quickstarts/remix)
+    - Easily add secure, edge- and SSR-friendly authentication to Remix with Clerk.
+    - ![](/docs/images/logos/remix.svg)
 
-      <FrameworkCards
-        title="Fastify"
-        description="Learn about installing and initializing Clerk in a new Fastify application."
-        link="/docs/quickstarts/fastify"
-        cta="Get Started"
-        icon="/docs/images/logos/fastify.svg"
-        iconWidth="40"
-      />
-    </div>
-  </div>
+    ---
+
+    - [Gatsby](/docs/quickstarts/gatsby)
+    - Integrate user management and authentication into your Gatsby application.
+    - ![](/docs/images/logos/gatsby.svg)
+
+    ---
+
+    - [RedwoodJS](/docs/references/redwood/overview)
+    - Grow your RedwoodJS application with Clerk user management and authentication.
+    - ![](/docs/images/logos/redwood.svg)
+
+    ---
+
+    - [Expo / React Native](/docs/quickstarts/expo)
+    - Use Clerk with Expo to authenticate users in your React Native application.
+    - ![](/docs/images/logos/expo.svg)
+
+    ---
+
+    - [Fastify](/docs/quickstarts/fastify)
+    - Learn about installing and initializing Clerk in a new Fastify application.
+    - ![](/docs/images/logos/fastify.svg)
+  </Cards>
 </Steps>

--- a/docs/references/astro/react.mdx
+++ b/docs/references/astro/react.mdx
@@ -140,20 +140,12 @@ If you have not set up your Astro application to work with Clerk, visit the [Ast
 
 ## Next steps
 
-<div className="container mx-auto my-4">
-  <div className="grid grid-cols-1 gap-6 md:grid-cols-2">
-    <Cards
-      title="Read user and session data"
-      description="Learn how to use Clerk's hooks and helpers to access the active session and user data in your Astro application."
-      link="/docs/references/astro/read-session-data"
-      cta="Learn More"
-    />
+<Cards>
+  - [Read user and session data](/docs/references/astro/read-session-data)
+  - Learn how to use Clerk's hooks and helpers to access the active session and user data in your Astro application.
 
-    <Cards
-      title="Client side helpers"
-      description="Learn more about Astro client side helpers and how to use them."
-      link="/docs/references/astro/overview#client-side-helpers"
-      cta="Learn More"
-    />
-  </div>
-</div>
+  ---
+
+  - [Client side helpers](/docs/references/astro/overview#client-side-helpers)
+  - Learn more about Astro client side helpers and how to use them.
+</Cards>

--- a/docs/references/expo/web-support/custom-signup-signin-pages.mdx
+++ b/docs/references/expo/web-support/custom-signup-signin-pages.mdx
@@ -58,34 +58,22 @@ This guide uses [Expo Router](https://docs.expo.dev/router/introduction/) and th
 
 Use the following guides to learn more about Clerk components, how to build custom flows for your native apps, and how to use Clerk's client side helpers.
 
-<div className="container mx-auto my-4">
-  <div className="grid grid-cols-1 gap-6 md:grid-cols-2">
-    <Cards
-      title="Prebuilt components"
-      description="Learn more about Clerk's suite of components that let you quickly add authentication to your app."
-      link="/docs/components/overview"
-      cta="Learn More"
-    />
+<Cards>
+  - [Prebuilt components](/docs/components/overview)
+  - Learn more about Clerk's suite of components that let you quickly add authentication to your app.
 
-    <Cards
-      title="Customization & localization"
-      description="Learn how to customize and localize Clerk components."
-      link="/docs/components/customization/overview"
-      cta="Learn More"
-    />
+  ---
 
-    <Cards
-      title="Custom flows"
-      description="Expo native apps require custom flows in place of prebuilt components. Learn more about custom flows."
-      link="/docs/custom-flows/overview"
-      cta="Learn More"
-    />
+  - [Customization & localization](/docs/components/customization/overview)
+  - Learn how to customize and localize Clerk components.
 
-    <Cards
-      title="Client side helpers"
-      description="Learn more about our client side helpers and how to use them."
-      link="/docs/references/react/use-user"
-      cta="Learn More"
-    />
-  </div>
-</div>
+  ---
+
+  - [Custom flows](/docs/custom-flows/overview)
+  - Expo native apps require custom flows in place of prebuilt components. Learn more about custom flows.
+
+  ---
+
+  - [Client side helpers](/docs/references/react/use-user)
+  - Learn more about our client side helpers and how to use them.
+</Cards>

--- a/docs/references/expo/web-support/overview.mdx
+++ b/docs/references/expo/web-support/overview.mdx
@@ -21,34 +21,22 @@ If you already have an Expo project and want to add web support, you must first 
 
 Use the following guides to learn more about Clerk components, how to build custom flows for your native apps, and how to use Clerk's client side helpers.
 
-<div className="container mx-auto my-4">
-  <div className="grid grid-cols-1 gap-6 md:grid-cols-2">
-    <Cards
-      title="Prebuilt components"
-      description="Learn more about Clerk's suite of components that let you quickly add authentication to your app."
-      link="/docs/components/overview"
-      cta="Learn More"
-    />
+<Cards>
+  - [Prebuilt components](/docs/components/overview)
+  - Learn more about Clerk's suite of components that let you quickly add authentication to your app.
 
-    <Cards
-      title="Customization & localization"
-      description="Learn how to customize and localize Clerk components."
-      link="/docs/components/customization/overview"
-      cta="Learn More"
-    />
+  ---
 
-    <Cards
-      title="Custom flows"
-      description="Expo native apps require custom flows in place of prebuilt components. Learn more about custom flows."
-      link="/docs/custom-flows/overview"
-      cta="Learn More"
-    />
+  - [Customization & localization](/docs/components/customization/overview)
+  - Learn how to customize and localize Clerk components.
 
-    <Cards
-      title="Client side helpers"
-      description="Learn more about our client side helpers and how to use them."
-      link="/docs/references/react/use-user"
-      cta="Learn More"
-    />
-  </div>
-</div>
+  ---
+
+  - [Custom flows](/docs/custom-flows/overview)
+  - Expo native apps require custom flows in place of prebuilt components. Learn more about custom flows.
+
+  ---
+
+  - [Client side helpers](/docs/references/react/use-user)
+  - Learn more about our client side helpers and how to use them.
+</Cards>

--- a/docs/references/nextjs/custom-signup-signin-pages.mdx
+++ b/docs/references/nextjs/custom-signup-signin-pages.mdx
@@ -97,34 +97,22 @@ If Clerk's prebuilt components don't meet your specific needs or if you require 
 
 ## Next steps
 
-<div className="container mx-auto my-4">
-  <div className="grid grid-cols-1 gap-6 md:grid-cols-2">
-    <Cards
-      title="Read user and session data"
-      description="Learn how to use Clerk's hooks and helpers to access the active session and user data in your Next.js application."
-      link="/docs/references/nextjs/read-session-data"
-      cta="Learn More"
-    />
+<Cards>
+  - [Read user and session data](/docs/references/nextjs/read-session-data)
+  - Learn how to use Clerk's hooks and helpers to access the active session and user data in your Next.js application.
 
-    <Cards
-      title="Client Side Helpers"
-      description="Learn more about Next.js client side helpers and how to use them."
-      link="/docs/references/nextjs/overview#client-side-helpers"
-      cta="Learn More"
-    />
+  ---
 
-    <Cards
-      title="Next.js SDK Reference"
-      description="Learn more about additional Next.js methods."
-      link="/docs/references/nextjs/overview"
-      cta="Learn More"
-    />
+  - [Client Side Helpers](/docs/references/nextjs/overview#client-side-helpers)
+  - Learn more about Next.js client side helpers and how to use them.
 
-    <Cards
-      title="Clerk Components"
-      description="Learn more about Clerk's prebuilt components that make authentication and user management easy."
-      link="/docs/components/overview"
-      cta="Learn More"
-    />
-  </div>
-</div>
+  ---
+
+  - [Next.js SDK Reference](/docs/references/nextjs/overview)
+  - Learn more about additional Next.js methods.
+
+  ---
+
+  - [Clerk Components](/docs/components/overview)
+  - Learn more about Clerk's prebuilt components that make authentication and user management easy.
+</Cards>

--- a/docs/references/react/add-react-router.mdx
+++ b/docs/references/react/add-react-router.mdx
@@ -297,27 +297,17 @@ Your application is setup with `react-router-dom` and ready for you to add more 
 
 ### Next steps
 
-<div className="container mx-auto my-4">
-  <div className="grid grid-cols-1 gap-6 md:grid-cols-2">
-    <Cards
-      title="Customization & Localization"
-      description="Learn how to customize and localize the Clerk components."
-      link="/docs/components/customization/overview"
-      cta="Learn More"
-    />
+<Cards>
+  - [Customization & Localization](/docs/components/customization/overview)
+  - Learn how to customize and localize the Clerk components.
 
-    <Cards
-      title="Authentication Components"
-      description="Learn more about all our authentication components."
-      link="/docs/components/authentication/sign-in"
-      cta="Learn More"
-    />
+  ---
 
-    <Cards
-      title="Client Side Helpers"
-      description="Learn more about our client side helpers and how to use them."
-      link="/docs/references/react/use-user"
-      cta="Learn More"
-    />
-  </div>
-</div>
+  - [Authentication Components](/docs/components/authentication/sign-in)
+  - Learn more about all our authentication components.
+
+  ---
+
+  - [Client Side Helpers](/docs/references/react/use-user)
+  - Learn more about our client side helpers and how to use them.
+</Cards>

--- a/docs/references/redwood/overview.mdx
+++ b/docs/references/redwood/overview.mdx
@@ -110,27 +110,17 @@ Learn how to use Clerk to quickly and easily add secure authentication and user 
 
 Now that you have an application integrated with Clerk, you will want to read the following documentation:
 
-<div className="container mx-auto my-4">
-  <div className="grid grid-cols-1 gap-6 md:grid-cols-2">
-    <Cards
-      title="Customization & Localization"
-      description="Learn how to customize and localize the Clerk components."
-      link="/docs/components/customization/overview"
-      cta="Learn More"
-    />
+<Cards>
+  - [Customization & Localization](/docs/components/customization/overview)
+  - Learn how to customize and localize the Clerk components.
 
-    <Cards
-      title="Authentication Components"
-      description="Learn more about all our authentication components."
-      link="/docs/components/authentication/sign-in"
-      cta="Learn More"
-    />
+  ---
 
-    <Cards
-      title="Client Side Helpers"
-      description="Learn more about our client side helpers and how to use them."
-      link="/docs/references/react/use-user"
-      cta="Learn More"
-    />
-  </div>
-</div>
+  - [Authentication Components](/docs/components/authentication/sign-in)
+  - Learn more about all our authentication components.
+
+  ---
+
+  - [Client Side Helpers](/docs/references/react/use-user)
+  - Learn more about our client side helpers and how to use them.
+</Cards>

--- a/docs/references/remix/custom-signup-signin-pages.mdx
+++ b/docs/references/remix/custom-signup-signin-pages.mdx
@@ -102,13 +102,7 @@ The functionality of the components are controlled by the instance settings you 
 
 ## Next steps
 
-<div className="container mx-auto my-4">
-  <div className="grid grid-cols-1 gap-6 md:grid-cols-2">
-    <Cards
-      title="Read user and session data"
-      description="Learn how to use Clerk's hooks and helpers to access the active session and user data in your Remix application."
-      link="/docs/references/remix/read-session-data"
-      cta="Learn More"
-    />
-  </div>
-</div>
+<Cards>
+  - [Read user and session data](/docs/references/remix/read-session-data)
+  - Learn how to use Clerk's hooks and helpers to access the active session and user data in your Remix application.
+</Cards>

--- a/docs/references/remix/spa-mode.mdx
+++ b/docs/references/remix/spa-mode.mdx
@@ -168,27 +168,17 @@ description: Clerk supports Remix SPA mode out-of-the-box.
 
 Now that you have an application integrated with Clerk, you will want to read the following documentation:
 
-<div className="container mx-auto my-4">
-  <div className="grid grid-cols-1 gap-6 md:grid-cols-2">
-    <Cards
-      title="Customization & Localization"
-      description="Learn how to customize and localize the Clerk components."
-      link="/docs/components/customization/overview"
-      cta="Learn More"
-    />
+<Cards>
+  - [Customization & Localization](/docs/components/customization/overview)
+  - Learn how to customize and localize the Clerk components.
 
-    <Cards
-      title="Authentication Components"
-      description="Learn more about all our authentication components."
-      link="/docs/components/authentication/sign-in"
-      cta="Learn More"
-    />
+  ---
 
-    <Cards
-      title="Client Side Helpers"
-      description="Learn more about our client side helpers and how to use them."
-      link="/docs/references/remix/read-session-data#client-side"
-      cta="Learn More"
-    />
-  </div>
-</div>
+  - [Authentication Components](/docs/components/authentication/sign-in)
+  - Learn more about all our authentication components.
+
+  ---
+
+  - [Client Side Helpers](/docs/references/remix/read-session-data#client-side)
+  - Learn more about our client side helpers and how to use them.
+</Cards>

--- a/docs/users/web3.mdx
+++ b/docs/users/web3.mdx
@@ -106,34 +106,22 @@ export default async function handler(
 
 Now that you have Web3 authentication in a new Next.js application, and you know how to retrieve the user's Web3 address from both the frontend and the backend, you will want to read the following documentation:
 
-<div className="container mx-auto my-4">
-  <div className="grid grid-cols-1 gap-6 md:grid-cols-2">
-    <Cards
-      title="Customization & Localization"
-      description="Learn how to customize and localize the Clerk components."
-      link="/docs/components/customization/overview"
-      cta="Learn More"
-    />
+<Cards>
+  - [Customization & Localization](/docs/components/customization/overview)
+  - Learn how to customize and localize the Clerk components.
 
-    <Cards
-      title="Authentication Components"
-      description="Learn more about all our authentication components."
-      link="/docs/components/overview"
-      cta="Learn More"
-    />
+  ---
 
-    <Cards
-      title="Client Side Helpers"
-      description="Learn more about our client side helpers and how to use them."
-      link="/docs/references/nextjs/overview#client-side-helpers"
-      cta="Learn More"
-    />
+  - [Authentication Components](/docs/components/overview)
+  - Learn more about all our authentication components.
 
-    <Cards
-      title="Next.js SDK Reference"
-      description="Learn more about additional Next.js methods."
-      link="/docs/references/nextjs/overview"
-      cta="Learn More"
-    />
-  </div>
-</div>
+  ---
+
+  - [Client Side Helpers](/docs/references/nextjs/overview#client-side-helpers)
+  - Learn more about our client side helpers and how to use them.
+
+  ---
+
+  - [Next.js SDK Reference](/docs/references/nextjs/overview)
+  - Learn more about additional Next.js methods.
+</Cards>


### PR DESCRIPTION
This PR updates the usage of the `<Cards>` (and `<FrameworkCards>`) component. The previous usage has been deprecated (and the new usage documented) since #1017.

---

**Before**

```jsx
<div className="container mx-auto my-4">
  <div className="grid grid-cols-1 gap-6 md:grid-cols-2">
    <Cards
      title="SAML SSO with Microsoft Azure AD"
      description="Learn how to integrate Microsoft Azure AD with Clerk using SAML SSO."
      link="/docs/authentication/saml/azure"
      cta="Learn More"
    />

    <Cards
      title="Account Linking"
      description="Learn how Clerk handles account linking and manages unverified email addresses from OAuth providers."
      link="/docs/authentication/social-connections/account-linking"
      cta="Learn More"
    />
  </div>
</div>
```

**After**

```jsx
<Cards>
  - [SAML SSO with Microsoft Azure AD](/docs/authentication/saml/azure)
  - Learn how to integrate Microsoft Azure AD with Clerk using SAML SSO.

  ---

  - [Account Linking](/docs/authentication/social-connections/account-linking)
  - Learn how Clerk handles account linking and manages unverified email addresses from OAuth providers.
</Cards>
```