### PR TITLE
Replace `<Callout>` usage

### DIFF
--- a/docs/account-portal/disable-account-portal.mdx
+++ b/docs/account-portal/disable-account-portal.mdx
@@ -5,9 +5,8 @@ description: Learn how to disable the Account Portal.
 
 # Disabling the Account Portal
 
-<Callout type="danger">
-  We recommend leaving the Account Portal enabled, even if you do choose to set up your own authentication flow. This helps with testing as well as providing an alternative path for users when needed.
-</Callout>
+> [!CAUTION]
+> We recommend leaving the Account Portal enabled, even if you do choose to set up your own authentication flow. This helps with testing as well as providing an alternative path for users when needed.
 
 To disable the Account Portal:
 

--- a/docs/account-portal/getting-started.mdx
+++ b/docs/account-portal/getting-started.mdx
@@ -9,11 +9,10 @@ To integrate the Account Portal into your application, simply follow one of our 
 
 Once your application is set up, all you have to do is fire it up. Clerk will automatically redirect your users to the Account Portal sign-in/sign-up pages. Once a user has successfully authenticated themself, they will be automatically redirected back to your application with an active session.
 
-<Callout type="info" emoji="💡">
-  **Dynamic Development Host Detection**
-
-  For development environments, the development host (e.g. [http://localhost:3000](http://localhost:3000)) is dynamically detected by Clerk at runtime and tied to your client browser. We store this as the ‘home origin’ for your application and it is equivalent to your application domain in production environments.
-</Callout>
+> [!NOTE]
+> **Dynamic Development Host Detection**
+>
+> For development environments, the development host (e.g. [http://localhost:3000](http://localhost:3000)) is dynamically detected by Clerk at runtime and tied to your client browser. We store this as the ‘home origin’ for your application and it is equivalent to your application domain in production environments.
 
 ## Accessing your pages
 

--- a/docs/advanced-usage/clerk-idp.mdx
+++ b/docs/advanced-usage/clerk-idp.mdx
@@ -55,9 +55,8 @@ Clerk can be configured as an identity provider to facilitate Single Sign-On (SS
   }
   ```
 
-  <Callout type="warning" emoji="⚠️">
-    For security reasons, Clerk does not store your Client Secret and cannot show it to you again, so we recommend you download the secret and store it someplace secure.
-  </Callout>
+  > [!WARNING]
+  > For security reasons, Clerk does not store your Client Secret and cannot show it to you again, so we recommend you download the secret and store it someplace secure.
 
   ### Configure OAuth application in client
 

--- a/docs/advanced-usage/satellite-domains.mdx
+++ b/docs/advanced-usage/satellite-domains.mdx
@@ -23,9 +23,8 @@ To access authentication state from a satellite domain, users will be transparen
 <Steps>
   ### Create your application and install Clerk
 
-  <Callout type="warning">
-    Currently, multi-domain can be added to any Next.js or Remix application. For other React frameworks, multi-domain is still supported as long as you do not use server rendering or hydration.
-  </Callout>
+  > [!WARNING]
+  > Currently, multi-domain can be added to any Next.js or Remix application. For other React frameworks, multi-domain is still supported as long as you do not use server rendering or hydration.
 
   To get started, you need to create an application from the [Clerk Dashboard](https://dashboard.clerk.com/). Once you create an instance via the Clerk Dashboard, you will be prompted to choose a domain. This is your primary domain. For the purposes of this guide:
 
@@ -34,9 +33,8 @@ To access authentication state from a satellite domain, users will be transparen
 
   When building your sign-in flow, you must configure it to run within your primary application, e.g. on `/sign-in`.
 
-  <Callout type="info">
-    For more information about creating your application, check out Clerk's [detailed guide](/docs/quickstarts/setup-clerk).
-  </Callout>
+  > [!NOTE]
+  > For more information about creating your application, check out Clerk's [detailed guide](/docs/quickstarts/setup-clerk).
 
   ### Add your first satellite domain
 

--- a/docs/advanced-usage/using-proxies.mdx
+++ b/docs/advanced-usage/using-proxies.mdx
@@ -18,9 +18,8 @@ When using a proxy, all requests to the Frontend API will be made through your d
 
   To get started, you need to create an application from the [Clerk Dashboard](https://dashboard.clerk.com/). Once you create an instance via the Clerk Dashboard, you will be prompted to choose a domain. For the purposes of this guide, the domain will be `app.dev`.
 
-  <Callout type="info">
-    For more information on creating a Clerk application, check out our [Set up your application guide](/docs/quickstarts/setup-clerk).
-  </Callout>
+  > [!NOTE]
+  > For more information on creating a Clerk application, check out our [Set up your application guide](/docs/quickstarts/setup-clerk).
 
   ### Configure your proxy server
 
@@ -105,18 +104,16 @@ When using a proxy, all requests to the Frontend API will be made through your d
     </Tab>
   </Tabs>
 
-  <Callout type="info">
-    Every proxy configuration will be different and we're here to help. Please [reach out](https://clerk.com/contact/support) if there's a specific use-case you're looking to solve.
-  </Callout>
+  > [!NOTE]
+  > Every proxy configuration will be different and we're here to help. Please [reach out](https://clerk.com/contact/support) if there's a specific use-case you're looking to solve.
 
   ### Enable proxying
 
   In order to enable proxying, you need to set a proxy URL for your Clerk instance's domain. This can be done through the Clerk Dashboard or through the Backend API.
 
-  <Callout type="info">
-    To avoid downtime, your proxy must be set up according to the above configuration before it can be enabled for your instance.
-    Make sure your proxy forwards requests to the Clerk Frontend API correctly and includes the required headers.
-  </Callout>
+  > [!NOTE]
+  > To avoid downtime, your proxy must be set up according to the above configuration before it can be enabled for your instance.
+  > Make sure your proxy forwards requests to the Clerk Frontend API correctly and includes the required headers.
 
   <Tabs items={["Dashboard", "Backend API"]}>
     <Tab>

--- a/docs/authentication/configuration/email-sms-templates.mdx
+++ b/docs/authentication/configuration/email-sms-templates.mdx
@@ -37,9 +37,8 @@ Both the email and SMS editor use the [Handlebars](https://handlebarsjs.com/) te
 
 When editing a template in the Clerk Dashboard, you can insert variables at the desired position, so there is no need to write them by hand. Though, you can still do so if you like.
 
-<Callout type="info">
-  In order to unescape special characters, you may need to wrap variables in triple curly braces. For example: `{{{app.name}}}`. This will allow special characters (e.g. `'`, `&`) to appear as displayed and not as escaped HTML entities (e.g. `&apos;`, `&amp;`).
-</Callout>
+> [!NOTE]
+> In order to unescape special characters, you may need to wrap variables in triple curly braces. For example: `{{{app.name}}}`. This will allow special characters (e.g. `'`, `&`) to appear as displayed and not as escaped HTML entities (e.g. `&apos;`, `&amp;`).
 
 ## Edit email templates
 

--- a/docs/authentication/configuration/restrictions.mdx
+++ b/docs/authentication/configuration/restrictions.mdx
@@ -18,9 +18,8 @@ All of these restrictions can be enabled and used together to provide a more sec
 
 ## Allowlist
 
-<Callout type="info">
-  Allowlist is a premium feature and is not available on the Free plan. [Upgrade your plan](https://clerk.com/pricing) to enable this feature.
-</Callout>
+> [!NOTE]
+> Allowlist is a premium feature and is not available on the Free plan. [Upgrade your plan](https://clerk.com/pricing) to enable this feature.
 
 By adding specific identifiers to the allowlist, _only_ users with those identifiers will be able to sign in or sign up for your application, while others will be blocked. This is useful for internal tools, where you want to allow only users with your company domain to have access to the application.
 
@@ -32,15 +31,13 @@ To enable this feature:
 1. In the navigation sidebar, select **User & Authentication > [Restrictions](https://dashboard.clerk.com/last-active?path=user-authentication/restrictions)**.
 1. In the **Allowlist** section, toggle on **Enable allowlist**.
 
-<Callout type="danger">
-  Enabling the Allowlist without adding any identifier exceptions blocks _all_ sign-ins and sign-ups.
-</Callout>
+> [!CAUTION]
+> Enabling the Allowlist without adding any identifier exceptions blocks _all_ sign-ins and sign-ups.
 
 ## Blocklist
 
-<Callout type="info">
-  Blocklist is a premium feature and is not available on the Free plan. [Upgrade your plan](https://clerk.com/pricing) to enable this feature.
-</Callout>
+> [!NOTE]
+> Blocklist is a premium feature and is not available on the Free plan. [Upgrade your plan](https://clerk.com/pricing) to enable this feature.
 
 By adding specific identifiers to the blocklist, users with those identifiers will be blocked from signing up for your application. This is useful for attack prevention, such as when multiple spam accounts sign up for your application. For example, if you add `clerk.dev` as a blocked email domain, it means that anybody with a `@clerk.dev` email address will not be able to sign up for your application.
 
@@ -50,9 +47,8 @@ To enable this feature:
 1. In the navigation sidebar, select **User & Authentication > [Restrictions](https://dashboard.clerk.com/last-active?path=user-authentication/restrictions)**.
 1. In the **Blocklist** section, toggle on **Enable blocklist**.
 
-<Callout type="warning" emoji="⚠️">
-  In the case that you have enabled the allowlist and the blocklist and have added the same identifier in both, the allowlist takes precedence.
-</Callout>
+> [!WARNING]
+> In the case that you have enabled the allowlist and the blocklist and have added the same identifier in both, the allowlist takes precedence.
 
 For additional security, adding an individual email address to the blocklist will also block any attempts to sign up with the email address modified to contain a subaddress. Subaddresses are identified by the presence of any of the following characters in the local part of the email address: `+`, `#`, `=`.
 
@@ -62,9 +58,8 @@ For example, if you add `john.doe@clerk.dev` as a blocked email address, it mean
 
 **Block email subaddresses** allows you to block all email addresses that contain the characters `+`, `=` or `#` from signing up or being added to existing accounts. For example, an email address like `user+sub@clerk.com` will be blocked.
 
-<Callout type="info">
-  Existing accounts with email subaddresses will not be affected by this restriction, and will still be allowed to sign in.
-</Callout>
+> [!NOTE]
+> Existing accounts with email subaddresses will not be affected by this restriction, and will still be allowed to sign in.
 
 To enable this feature:
 

--- a/docs/authentication/configuration/session-options.mdx
+++ b/docs/authentication/configuration/session-options.mdx
@@ -15,9 +15,8 @@ Ultimately, picking the ideal session lifetime is a trade-off between security a
 
 Fortunately, with Clerk you have to ability to fully control the lifetime of your users' sessions. There are two settings for doing so and you can set them via your instance settings in the [Clerk Dashboard](https://dashboard.clerk.com/): Inactivity timeout and Maximum lifetime.
 
-<Callout type="info">
-  Note that either one or both must be enabled at all times. For security reasons, you are not allowed to disable both settings.
-</Callout>
+> [!NOTE]
+> Note that either one or both must be enabled at all times. For security reasons, you are not allowed to disable both settings.
 
 ### Inactivity timeout
 

--- a/docs/authentication/configuration/sign-up-sign-in-options.mdx
+++ b/docs/authentication/configuration/sign-up-sign-in-options.mdx
@@ -28,9 +28,8 @@ When **phone number** is selected as the identifier, a user will sign up with th
 
 Choosing **username** as the identifier enables users to sign up without requiring personal contact information. A username should be from 4 to 64 characters in length and can contain alphanumeric characters, underscores (\_), and dashes (-).
 
-<Callout type="info">
-  If you opt not to collect any contact information, you could choose **Username** and later turn it off in settings and only authenticate with an OAuth social provider.
-</Callout>
+> [!NOTE]
+> If you opt not to collect any contact information, you could choose **Username** and later turn it off in settings and only authenticate with an OAuth social provider.
 
 To update your identifiers after your application has been created:
 

--- a/docs/authentication/saml/account-linking.mdx
+++ b/docs/authentication/saml/account-linking.mdx
@@ -13,9 +13,8 @@ When a user attempts to sign in or sign up, Clerk first checks the provided emai
 
 In the following sections, we'll look at the different scenarios that can occur during this process and explain how Clerk handles each one.
 
-<Callout type="info">
-  Email addresses from SAML providers are considered verified by default.
-</Callout>
+> [!NOTE]
+> Email addresses from SAML providers are considered verified by default.
 
 <Images
   width={2400}

--- a/docs/authentication/saml/authentication-flows.mdx
+++ b/docs/authentication/saml/authentication-flows.mdx
@@ -22,9 +22,8 @@ In an IdP-initiated flow:
 - The user starts the authentication flow from the SAML provider (IdP), by selecting which application (SP) they would like to access.
 - The user is redirected to the application of their choice, gaining access to their account.
 
-<Callout type="info">
-  IdP-Initiated flow carries [a security risk](#risks-of-idp-initiated-flow). We recommend using a SP-Initiated flow whenever possible.
-</Callout>
+> [!NOTE]
+> IdP-Initiated flow carries [a security risk](#risks-of-idp-initiated-flow). We recommend using a SP-Initiated flow whenever possible.
 
 To allow IdP-initiated flows for your Enterprise Connection:
 

--- a/docs/authentication/saml/overview.mdx
+++ b/docs/authentication/saml/overview.mdx
@@ -19,9 +19,8 @@ To support SAML SSO with subdomains,
 1. Select the **Advanced** tab.
 1. Toggle on the **Allow subdomains** option.
 
-<Callout type="info">
-  To enable the **Allow subdomains** option, your SAML connection domain must be an eTLD+1.
-</Callout>
+> [!NOTE]
+> To enable the **Allow subdomains** option, your SAML connection domain must be an eTLD+1.
 
 ## Frequently asked questions (FAQ)
 

--- a/docs/authentication/social-connections/google.mdx
+++ b/docs/authentication/social-connections/google.mdx
@@ -78,9 +78,8 @@ In the Clerk Dashboard configuration screen, you also have an option to block em
 
 For a Google organization with domain `example.com`, blocking email subaddresses will prevent someone with access to email `user@example.com` from signing up with email `user+alias@example.com`. This is a known [Google OAuth vulnerability](https://trufflesecurity.com/blog/google-oauth-is-broken-sort-of/) that could allow unauthorized access since there is no way for a Google organization administrator to suspend or delete the email alias account. As a result, we recommend enabling this setting for Google OAuth.
 
-<Callout type="info">
-  Existing Google accounts with email subaddresses will be blocked by this restriction and will not be able to sign in.
-</Callout>
+> [!NOTE]
+> Existing Google accounts with email subaddresses will be blocked by this restriction and will not be able to sign in.
 
 ## Google One Tap
 

--- a/docs/authentication/social-connections/linkedin-oidc.mdx
+++ b/docs/authentication/social-connections/linkedin-oidc.mdx
@@ -73,9 +73,8 @@ In _production instances_, you must provide custom credentials, which includes g
   1. Select the **Products** tab.
   1. Next to **Sign In with LinkedIn using OpenID Connect**, select **Request access**.
 
-  <Callout type="info">
-    If you need to ensure the longevity of the user's access token without the need for re-authentication, make sure to obtain approval as a [Marketing Developer Platform (MDP) partner](https://learn.microsoft.com/en-us/linkedin/marketing/quick-start?view=li-lms-2023-10#step-1-apply-for-api-access). This is not required if you don't directly interact with the LinkedIn API using the access token.
-  </Callout>
+  > [!NOTE]
+  > If you need to ensure the longevity of the user's access token without the need for re-authentication, make sure to obtain approval as a [Marketing Developer Platform (MDP) partner](https://learn.microsoft.com/en-us/linkedin/marketing/quick-start?view=li-lms-2023-10#step-1-apply-for-api-access). This is not required if you don't directly interact with the LinkedIn API using the access token.
 
   ### Test your OAuth
 

--- a/docs/authentication/social-connections/linkedin.mdx
+++ b/docs/authentication/social-connections/linkedin.mdx
@@ -5,9 +5,8 @@ description: Learn how to set up social connection with LinkedIn.
 
 # LinkedIn (Deprecated)
 
-<Callout type="danger">
-  This page is now deprecated. Please see the new [guide](/docs/authentication/social-connections/linkedin-oidc) on how to set up a social connection with LinkedIn.
-</Callout>
+> [!CAUTION]
+> This page is now deprecated. Please see the new [guide](/docs/authentication/social-connections/linkedin-oidc) on how to set up a social connection with LinkedIn.
 
 ## Overview
 
@@ -40,9 +39,8 @@ The last thing you have to do is to enable the _Sign in with LinkedIn_ product f
 
 ![Enable Sign In with LinkedIn product](/docs/images/authentication-providers/linkedin/9b2aae3fa3612dd7ae3b982b2c5a7e1d41409d49-1064x765.png)
 
-<Callout type="info">
-  If you need to ensure the longevity of the user's access token without the need for re-authentication, make sure to obtain approval as a [Marketing Developer Platform (MDP) partner](https://learn.microsoft.com/en-us/linkedin/marketing/quick-start?view=li-lms-2023-10#step-1-apply-for-api-access). This is not required if you don't directly interact with the LinkedIn API using the access token.
-</Callout>
+> [!NOTE]
+> If you need to ensure the longevity of the user's access token without the need for re-authentication, make sure to obtain approval as a [Marketing Developer Platform (MDP) partner](https://learn.microsoft.com/en-us/linkedin/marketing/quick-start?view=li-lms-2023-10#step-1-apply-for-api-access). This is not required if you don't directly interact with the LinkedIn API using the access token.
 
 Copy the **Application ID** and **Secret** from the previous screen. Go back to the Clerk Dashboard and paste them into the respective fields.
 

--- a/docs/authentication/social-connections/oauth.mdx
+++ b/docs/authentication/social-connections/oauth.mdx
@@ -7,9 +7,8 @@ description: Learn how to effortlessly add social connections to your applicatio
 
 Clerk makes it easy to add social connection capabilities to your application. With social connections, users gain frictionless access to your application by using their existing credentials from an OAuth provider (Google, Facebook, X/Twitter, etc.) without having to go through complicated registration flows. Social connections are designed to simplify the sign-up and sign-in process for the end-user, resulting in higher conversion rates, a streamlined user data collection flow, and an overall better user experience.
 
-<Callout type="info">
-  When using social connections, the sign-up and sign-in flows are equivalent. If a user doesn't have an account and tries to sign in, an account will be made for them, and vice versa.
-</Callout>
+> [!NOTE]
+> When using social connections, the sign-up and sign-in flows are equivalent. If a user doesn't have an account and tries to sign in, an account will be made for them, and vice versa.
 
 The easiest way to add social connections is by using Clerk's [prebuilt components](/docs/components/overview). If you prefer a more custom solution, check out how to [build a completely custom social connection flow](/docs/custom-flows/oauth-connections).
 

--- a/docs/authentication/social-connections/spotify.mdx
+++ b/docs/authentication/social-connections/spotify.mdx
@@ -76,9 +76,8 @@ Clerk does not currently support preconfigured shared OAuth credentials for Spot
 
   Copy the **Client ID** and **Client Secret**. Go back to the Clerk Dashboard, where the modal should still be open, and paste these values into the respective fields.
 
-  <Callout type="info">
-    If the modal or page is not still open, go to the Clerk Dashboard and navigate to **User & Authentication > [Social Connections](https://dashboard.clerk.com/last-active?path=user-authentication/social-connections)**. Click on the settings cog icon next to the Spotify option. You can now paste the **Client ID** and **Client Secret** into their respective fields.
-  </Callout>
+  > [!NOTE]
+  > If the modal or page is not still open, go to the Clerk Dashboard and navigate to **User & Authentication > [Social Connections](https://dashboard.clerk.com/last-active?path=user-authentication/social-connections)**. Click on the settings cog icon next to the Spotify option. You can now paste the **Client ID** and **Client Secret** into their respective fields.
 
   <Images
     width={3024}

--- a/docs/authentication/social-connections/twitter.mdx
+++ b/docs/authentication/social-connections/twitter.mdx
@@ -5,9 +5,8 @@ description: Learn how to set up social connection with Twitter v1.
 
 # Twitter v1 (Deprecated)
 
-<Callout type="danger">
-  [X/Twitter](https://twitter.com/XDevelopers/status/1641222782594990080) considers this method deprecated. We strongly recommend using the [latest version (v2)](/docs/authentication/social-connections/x-twitter) for future-proofing your application.
-</Callout>
+> [!CAUTION]
+> [X/Twitter](https://twitter.com/XDevelopers/status/1641222782594990080) considers this method deprecated. We strongly recommend using the [latest version (v2)](/docs/authentication/social-connections/x-twitter) for future-proofing your application.
 
 How to set up social connection with Twitter v1
 

--- a/docs/authentication/social-connections/x-twitter.mdx
+++ b/docs/authentication/social-connections/x-twitter.mdx
@@ -29,9 +29,8 @@ description: Learn how to set up a social connection with X/Twitter v2 in your C
 
 Clerk does not currently support preconfigured shared OAuth credentials for X/Twitter on development instances. This means you will have to provide custom credentials for both development _and_ production instances, which includes generating your own **Client ID** and **Client Secret** using your X/Twitter Developer account. Don't worry, this tutorial will walk you through that process in just a few simple steps.
 
-<Callout type="warning">
-  X/Twitter v2 is currently not providing email addresses of users. The user will have to fill in their email address manually when they return to your application after authenticating with X/Twitter.
-</Callout>
+> [!WARNING]
+> X/Twitter v2 is currently not providing email addresses of users. The user will have to fill in their email address manually when they return to your application after authenticating with X/Twitter.
 
 <Steps>
   ### Create an X/Twitter application
@@ -81,9 +80,8 @@ Clerk does not currently support preconfigured shared OAuth credentials for X/Tw
 
   Go back to the Clerk Dashboard, where the modal should still be open, and paste these values into the respective fields.
 
-  <Callout type="info">
-    If the modal or page is not still open, go to the Clerk Dashboard and navigate to **User & Authentication > [Social Connections](https://dashboard.clerk.com/last-active?path=user-authentication/social-connections)**. Click on the settings cog icon next to the X/Twitter option. You can now paste the **Client ID** and **Client Secret** into their respective fields.
-  </Callout>
+  > [!NOTE]
+  > If the modal or page is not still open, go to the Clerk Dashboard and navigate to **User & Authentication > [Social Connections](https://dashboard.clerk.com/last-active?path=user-authentication/social-connections)**. Click on the settings cog icon next to the X/Twitter option. You can now paste the **Client ID** and **Client Secret** into their respective fields.
 
   <Images
     width={1512}

--- a/docs/backend-requests/handling/ruby-rails.mdx
+++ b/docs/backend-requests/handling/ruby-rails.mdx
@@ -34,6 +34,5 @@ class AdminController < ApplicationController
 end
 ```
 
-<Callout type="warning">
-  Don't forget to set the environment variable `CLERK_SIGN_IN_URL` or the method `clerk_sign_in_url` will fail.
-</Callout>
+> [!WARNING]
+> Don't forget to set the environment variable `CLERK_SIGN_IN_URL` or the method `clerk_sign_in_url` will fail.

--- a/docs/backend-requests/making/cross-origin.mdx
+++ b/docs/backend-requests/making/cross-origin.mdx
@@ -52,9 +52,8 @@ export default function useClerkSWR(url) {
 
 If you are using [Tanstack Query](https://tanstack.com/query/v4/docs/react/overview), you need to use a query function that throws errors. Since the native Fetch API does not, you can add it in.
 
-<Callout type="warning">
-  Make sure that you have your application wrapped in `<QueryClientProvider />` with a `QueryClient` set.
-</Callout>
+> [!WARNING]
+> Make sure that you have your application wrapped in `<QueryClientProvider />` with a `QueryClient` set.
 
 ```js {{ prettier: false }}
 import { useQuery } from '@tanstack/react-query';

--- a/docs/backend-requests/making/custom-session-token.mdx
+++ b/docs/backend-requests/making/custom-session-token.mdx
@@ -11,10 +11,9 @@ By default, session tokens contain claims that are required for Clerk to functio
 
 This guide will show you how to customize a session token to include additional claims that you may need in your application.
 
-<Callout type="danger">
-  The entire session token has a max size of 4kb. Exceeding this size can have adverse effects, including a possible infinite redirect loop for users who exceed this size in Next.js applications.
-  It's recommended to move particularly large claims out of the JWT and fetch these using a separate API call from your backend.
-</Callout>
+> [!CAUTION]
+> The entire session token has a max size of 4kb. Exceeding this size can have adverse effects, including a possible infinite redirect loop for users who exceed this size in Next.js applications.
+> It's recommended to move particularly large claims out of the JWT and fetch these using a separate API call from your backend.
 
 {/* TODO: Update the H3 to an H2 when the Steps component can accept headings other than H3. */}
 

--- a/docs/backend-requests/making/jwt-templates.mdx
+++ b/docs/backend-requests/making/jwt-templates.mdx
@@ -3,9 +3,8 @@ title: JWT templates
 description: Learn how to create custom JWT templates to generate JSON Web Tokens with Clerk.
 ---
 
-<Callout type="warning">
-  This guide is for creating custom JWT templates in order to generate JSON Web Tokens with Clerk. If you are looking for how to customize your Clerk-generated session token, refer to the [Customize your session token](/docs/backend-requests/making/custom-session-token) guide.
-</Callout>
+> [!WARNING]
+> This guide is for creating custom JWT templates in order to generate JSON Web Tokens with Clerk. If you are looking for how to customize your Clerk-generated session token, refer to the [Customize your session token](/docs/backend-requests/making/custom-session-token) guide.
 
 # JWT templates
 
@@ -57,9 +56,8 @@ In every generated token, there are certain claims that are automatically includ
 
 To include dynamic values in your tokens, you can use shortcodes. Shortcodes are strings that Clerk will replace with the actual values of the corresponding user information when the token is generated.
 
-<Callout type="info">
-  Even though shortcodes are string values, their type in the generated token depends on the original type of the information that's included. For example, `{{user.public_metadata}}` will be substituted for a JSON object, not a string.
-</Callout>
+> [!NOTE]
+> Even though shortcodes are string values, their type in the generated token depends on the original type of the information that's included. For example, `{{user.public_metadata}}` will be substituted for a JSON object, not a string.
 
 #### Metadata in shortcodes
 

--- a/docs/backend-requests/making/same-origin.mdx
+++ b/docs/backend-requests/making/same-origin.mdx
@@ -61,9 +61,8 @@ When you re-focus a page or switch between tabs, SWR automatically revalidates d
 
 If you are using [Tanstack Query](https://tanstack.com/query/v4/docs/react/overview), formally known as React Query, in your application, you need to use a query function that throws errors. Since the native Fetch API does not, you can add it in.
 
-<Callout type="warning">
-  Make sure that you have your application wrapped in `<QueryClientProvider />` with a `QueryClient` set.
-</Callout>
+> [!WARNING]
+> Make sure that you have your application wrapped in `<QueryClientProvider />` with a `QueryClient` set.
 
 ```jsx {{ prettier: false }}
 import { useQuery } from '@tanstack/react-query';

--- a/docs/backend-requests/resources/rate-limits.mdx
+++ b/docs/backend-requests/resources/rate-limits.mdx
@@ -36,6 +36,5 @@ Backend API requests are rate limited per application instance.
 | All other endpoints | | 100 requests per 10 seconds |
 | Get the JWKS of the instance | `GET /v1/jwks` | No rate limit |
 
-<Callout type="info">
-  The `currentUser()` helper uses the `GET /v1/users/me` endpoint, so it is subject to the 100 requests per 10 seconds rate limit.
-</Callout>
+> [!NOTE]
+> The `currentUser()` helper uses the `GET /v1/users/me` endpoint, so it is subject to the 100 requests per 10 seconds rate limit.

--- a/docs/backend-requests/versioning/overview.mdx
+++ b/docs/backend-requests/versioning/overview.mdx
@@ -30,7 +30,6 @@ When making direct API calls to an endpoint, there are two options to specify th
 1. **Query parameter**: Set the `__clerk_api_version` query parameter in your request URL.
 1. **Clerk-API-Version header**: Include a `Clerk-API-Version` header in your requests.
 
-<Callout type="error">
-  You must choose only one method to specify a version. Using both the query parameter and the header simultaneously will lead to an invalid request.
-  The same is also true when the version is invalid.
-</Callout>
+> [!NOTE]
+> You must choose only one method to specify a version. Using both the query parameter and the header simultaneously will lead to an invalid request.
+> The same is also true when the version is invalid.

--- a/docs/components/authentication/sign-in.mdx
+++ b/docs/components/authentication/sign-in.mdx
@@ -14,9 +14,8 @@ description: Clerk's <SignIn /> component renders a UI for signing in users.
 
 The `<SignIn />` component renders a UI for signing in users. The functionality of the `<SignIn />` component is controlled by the instance settings you specify in your [Clerk Dashboard](https://dashboard.clerk.com), such as [sign-in and sign-up options](/docs/authentication/configuration/sign-up-sign-in-options) and [social connections](/docs/authentication/social-connections/overview). You can further customize your `<SignIn />` component by passing additional [properties](#properties) at the time of rendering.
 
-<Callout type="info">
-  The `<SignUp/>` and `<SignIn/>` components cannot render when a user is already signed in, unless the application allows multiple sessions. If a user is already signed in and the application only allows a single session, Clerk will redirect the user to the Home URL instead.
-</Callout>
+> [!NOTE]
+> The `<SignUp/>` and `<SignIn/>` components cannot render when a user is already signed in, unless the application allows multiple sessions. If a user is already signed in and the application only allows a single session, Clerk will redirect the user to the Home URL instead.
 
 ## Properties
 

--- a/docs/components/authentication/sign-up.mdx
+++ b/docs/components/authentication/sign-up.mdx
@@ -14,9 +14,8 @@ description: Clerk's <SignUp /> component renders a UI for signing up users.
 
 The `<SignUp />` component renders a UI for signing up users. The functionality of the `<SignUp />` component is controlled by the instance settings you specify in your [Clerk Dashboard](https://dashboard.clerk.com), such as [sign-in and sign-up options](/docs/authentication/configuration/sign-up-sign-in-options) and [social connections](/docs/authentication/social-connections/overview). You can further customize your `<SignUp />` component by passing additional [properties](#properties) at the time of rendering.
 
-<Callout type="info">
-  The `<SignUp/>` and `<SignIn/>` components cannot render when a user is already signed in, unless the application allows multiple sessions. If a user is already signed in and the application only allows a single session, Clerk will redirect the user to the Home URL instead.
-</Callout>
+> [!NOTE]
+> The `<SignUp/>` and `<SignIn/>` components cannot render when a user is already signed in, unless the application allows multiple sessions. If a user is already signed in and the application only allows a single session, Clerk will redirect the user to the Home URL instead.
 
 ## Properties
 

--- a/docs/components/customization/localization.mdx
+++ b/docs/components/customization/localization.mdx
@@ -5,9 +5,8 @@ description: Use the Clerk localizations package to override and provide predefi
 
 # Localization prop (experimental)
 
-<Callout type="warning">
-  This feature is currently experimental and may not behave as expected. If you encounter any issues, please reach out to [support](https://clerk.com/contact/support) with as much detail as possible.
-</Callout>
+> [!WARNING]
+> This feature is currently experimental and may not behave as expected. If you encounter any issues, please reach out to [support](https://clerk.com/contact/support) with as much detail as possible.
 
 Clerk offers the ability to override the strings for all of the elements in each of the Clerk Components. This allows you to provide localization for your users or change the wording to suit your brand.
 

--- a/docs/custom-flows/add-email.mdx
+++ b/docs/custom-flows/add-email.mdx
@@ -4,9 +4,8 @@ description: Learn how to use Clerk's API to build a custom flow for adding an e
 
 # Build a custom flow for adding an email to a user's account
 
-<Callout type="danger">
-  This guide is for users who want to build a _custom_ user interface using the Clerk API. To use a _prebuilt_ UI, you should use Clerk's [Account Portal pages](/docs/account-portal/overview) or [prebuilt components](/docs/components/overview).
-</Callout>
+> [!CAUTION]
+> This guide is for users who want to build a _custom_ user interface using the Clerk API. To use a _prebuilt_ UI, you should use Clerk's [Account Portal pages](/docs/account-portal/overview) or [prebuilt components](/docs/components/overview).
 
 Users are able to add multiple email addresses to their account.
 

--- a/docs/custom-flows/add-phone.mdx
+++ b/docs/custom-flows/add-phone.mdx
@@ -4,9 +4,8 @@ description: Learn how to use Clerk's API to build a custom flow for adding a ph
 
 # Build a custom flow for adding a phone number to a user's account
 
-<Callout type="danger">
-  This guide is for users who want to build a _custom_ user interface using the Clerk API. To use a _prebuilt_ UI, you should use Clerk's [Account Portal pages](/docs/account-portal/overview) or [prebuilt components](/docs/components/overview).
-</Callout>
+> [!CAUTION]
+> This guide is for users who want to build a _custom_ user interface using the Clerk API. To use a _prebuilt_ UI, you should use Clerk's [Account Portal pages](/docs/account-portal/overview) or [prebuilt components](/docs/components/overview).
 
 Users are able to add multiple phone numbers to their account.
 

--- a/docs/custom-flows/bot-sign-up-protection.mdx
+++ b/docs/custom-flows/bot-sign-up-protection.mdx
@@ -4,9 +4,8 @@ description: Learn how to add Clerk's bot protection to your custom sign-up flow
 
 # Add bot protection to your custom sign-up flow
 
-<Callout type="warning">
-  This guide is for users who want to build a _custom_ user interface using the Clerk API. To implement Clerk's [Bot Protection](/docs/security/bot-protection) feature for your sign-ups using a _prebuilt_ UI, you should use Clerk's [`<SignUp />` component](/docs/components/authentication/sign-up).
-</Callout>
+> [!WARNING]
+> This guide is for users who want to build a _custom_ user interface using the Clerk API. To implement Clerk's [Bot Protection](/docs/security/bot-protection) feature for your sign-ups using a _prebuilt_ UI, you should use Clerk's [`<SignUp />` component](/docs/components/authentication/sign-up).
 
 Clerk provides the ability to add a CAPTCHA widget to your sign-up flows to protect against bot sign-ups. This guide will show you how to add the CAPTCHA widget to your custom sign-up flow.
 

--- a/docs/custom-flows/email-links.mdx
+++ b/docs/custom-flows/email-links.mdx
@@ -15,9 +15,8 @@ Email links are the default passwordless authentication strategy when using Cler
 
 Your users will still be able to choose an alternative authentication (or verification) method even after they've clicked the email link they received in their inbox. Email links are simply the default authentication method for email address-based, passwordless authentication in Clerk.
 
-<Callout type="info">
-  Looking for one-time code (OTP) authentication? Check out our [one-time code authentication](/docs/custom-flows/email-sms-otp) guide.
-</Callout>
+> [!NOTE]
+> Looking for one-time code (OTP) authentication? Check out our [one-time code authentication](/docs/custom-flows/email-sms-otp) guide.
 
 ## Email link flow
 
@@ -53,17 +52,15 @@ If you click on the **Settings cog** icon next to **Email address**, the email a
 
 You can also find the **Verification methods** section on this screen. Here, you can toggle on **Email verification link** if you would like to allow your users to verify their email with an email link. You can also toggle on **Email verification code** if you would like to allow your users to verify their email with a one-time passcode.
 
-<Callout type="info">
-  **Verification methods** are different from **Authentication strategies**. **Verification methods** are used for verifying a user's identifier, such as an email address upon initial sign-up or when updating their profile. **Authentication strategies** are used for authenticating a user, such as when they are signing in to your application.
-</Callout>
+> [!NOTE]
+> **Verification methods** are different from **Authentication strategies**. **Verification methods** are used for verifying a user's identifier, such as an email address upon initial sign-up or when updating their profile. **Authentication strategies** are used for authenticating a user, such as when they are signing in to your application.
 
 ### Enable email link authentication using the Clerk API
 
 In case one of the above integration methods doesn't cover your needs, you can make use of lower-level commands and create a completely custom email link authentication flow.
 
-<Callout type="warning">
-  You still need to configure your instance in order to enable email link authentication, as described at the top of this guide.
-</Callout>
+> [!WARNING]
+> You still need to configure your instance in order to enable email link authentication, as described at the top of this guide.
 
 #### Sign up using a custom flow (Clerk API)
 

--- a/docs/custom-flows/email-sms-otp.mdx
+++ b/docs/custom-flows/email-sms-otp.mdx
@@ -5,9 +5,8 @@ description: Learn how build a custom email or SMS one time code (OTP) authentic
 
 # Build a custom email or SMS OTP authentication flow
 
-<Callout type="warning">
-  This guide is for users who want to build a _custom_ user interface using the Clerk API. To authenticate users with one-time passwords using a _prebuilt_ UI, you should use Clerk's [Account Portal pages](/docs/account-portal/overview) or [prebuilt components](/docs/components/overview).
-</Callout>
+> [!WARNING]
+> This guide is for users who want to build a _custom_ user interface using the Clerk API. To authenticate users with one-time passwords using a _prebuilt_ UI, you should use Clerk's [Account Portal pages](/docs/account-portal/overview) or [prebuilt components](/docs/components/overview).
 
 Clerk supports passwordless authentication, which lets users sign in and sign up without having to remember a password. Instead, users receive a one-time password (OTP), also known as a one-time code, via email or SMS, which they can use to authenticate themselves.
 

--- a/docs/custom-flows/google-one-tap.mdx
+++ b/docs/custom-flows/google-one-tap.mdx
@@ -4,9 +4,8 @@ description: Learn how to build a custom Google One Tap authentication flow usin
 
 # Build a custom Google One Tap authentication flow
 
-<Callout type="danger">
-  This guide is for users who want to build a _custom_ user interface using the Clerk API. To authenticate users with Google One Tap using a _prebuilt_ UI, you should use Clerk's [`<GoogleOneTap>`](/docs/components/authentication/google-one-tap) component.
-</Callout>
+> [!CAUTION]
+> This guide is for users who want to build a _custom_ user interface using the Clerk API. To authenticate users with Google One Tap using a _prebuilt_ UI, you should use Clerk's [`<GoogleOneTap>`](/docs/components/authentication/google-one-tap) component.
 
 [Google One Tap](https://developers.google.com/identity/gsi/web/guides/features) enables users to press a single button to authentication in your Clerk application with a Google account.
 

--- a/docs/custom-flows/multi-session-applications.mdx
+++ b/docs/custom-flows/multi-session-applications.mdx
@@ -5,9 +5,8 @@ description: Learn how to use the Clerk API to add multi-session handling to you
 
 # Build a custom multi-session flow
 
-<Callout type="warning">
-  This guide is for users who want to build a _custom_ user interface using the Clerk API. To implement multi-session handling with a _prebuilt_ UI, you should use Clerk's [`<UserButton />`](/docs/components/user/user-button) component.
-</Callout>
+> [!WARNING]
+> This guide is for users who want to build a _custom_ user interface using the Clerk API. To implement multi-session handling with a _prebuilt_ UI, you should use Clerk's [`<UserButton />`](/docs/components/user/user-button) component.
 
 A multi-session application is an application that allows multiple accounts to be signed in from the same browser at the same time. The user can switch from one account to another seamlessly. Each account is independent from the rest and has access to different resources.
 

--- a/docs/custom-flows/passkeys.mdx
+++ b/docs/custom-flows/passkeys.mdx
@@ -5,9 +5,8 @@ description: Learn how to allow your users authenticate with passkeys with Clerk
 
 # Build a custom authentication flow using passkeys
 
-<Callout type="warning">
-  This guide is for users who want to build a _custom_ user interface using the Clerk API. To authenticate users with passkeys using a _prebuilt_ UI, you should use Clerk's [`<SignIn />`](/docs/components/authentication/sign-in) and [`<UserProfile />`](/docs/components/user/user-profile) components. See [the sign-in and sign-out options docs](/docs/authentication/configuration/sign-up-sign-in-options#passkeys) to learn more.
-</Callout>
+> [!WARNING]
+> This guide is for users who want to build a _custom_ user interface using the Clerk API. To authenticate users with passkeys using a _prebuilt_ UI, you should use Clerk's [`<SignIn />`](/docs/components/authentication/sign-in) and [`<UserProfile />`](/docs/components/user/user-profile) components. See [the sign-in and sign-out options docs](/docs/authentication/configuration/sign-up-sign-in-options#passkeys) to learn more.
 
 Clerk supports passwordless authentication via passkeys, enabling users to sign in without having to remember a password. Instead, users select a passkey associated with their device, which they can use to authenticate themselves.
 

--- a/docs/custom-flows/saml-connections.mdx
+++ b/docs/custom-flows/saml-connections.mdx
@@ -5,9 +5,8 @@ description: Learn how to build a custom SAML connection authentication flow usi
 
 # SAML connections
 
-<Callout type="danger">
-  This guide is for users who want to build a _custom_ user interface using the Clerk API. To authenticate users with SAML connections using a _prebuilt_ UI, you should use Clerk's [Account Portal pages](/docs/account-portal/overview) or [prebuilt components](/docs/components/overview).
-</Callout>
+> [!CAUTION]
+> This guide is for users who want to build a _custom_ user interface using the Clerk API. To authenticate users with SAML connections using a _prebuilt_ UI, you should use Clerk's [Account Portal pages](/docs/account-portal/overview) or [prebuilt components](/docs/components/overview).
 
 ## Before you start
 

--- a/docs/custom-flows/sign-out.mdx
+++ b/docs/custom-flows/sign-out.mdx
@@ -5,9 +5,8 @@ description: Learn how to build a custom sign-out flow using Clerk's signOut() f
 
 # Build a custom sign-out flow
 
-<Callout type="danger">
-  This guide is for users who want to build a _custom_ user interface using the Clerk API. To allow users to sign-out using a _prebuilt_ UI, you should use Clerk's [Account Portal pages](/docs/account-portal/overview) or [prebuilt components](/docs/components/overview)
-</Callout>
+> [!CAUTION]
+> This guide is for users who want to build a _custom_ user interface using the Clerk API. To allow users to sign-out using a _prebuilt_ UI, you should use Clerk's [Account Portal pages](/docs/account-portal/overview) or [prebuilt components](/docs/components/overview)
 
 Clerk's [`<UserButton />`](/docs/components/user/user-button) and [`<SignOutButton />`](/docs/components/unstyled/sign-out-button) components provide a way to sign out users, out of the box. However, if you are building a custom solution, you can use the [`signOut()`](/docs/references/javascript/clerk/clerk#sign-out) function to sign out users.
 

--- a/docs/deployments/changing-domains.mdx
+++ b/docs/deployments/changing-domains.mdx
@@ -7,9 +7,8 @@ description: Learn how to change your Clerk production instance's domain or subd
 
 Learn how to change your Clerk production instance's domain or subdomain.
 
-<Callout type="Info">
-  You cannot change the domain of the [development instance](/docs/deployments/environments#development-instance) of your Clerk application.
-</Callout>
+> [!NOTE]
+> You cannot change the domain of the [development instance](/docs/deployments/environments#development-instance) of your Clerk application.
 
 ## Change domain
 
@@ -64,9 +63,8 @@ For more information on how to update your instance settings using the backend A
 
 After changing your domain, a new **Publishable key** will be automatically generated for your application. You will need to update your environment variables with this new key and redeploy your application. You can find your **Publishable key** on the **[API Keys](https://dashboard.clerk.com/last-active?path=api-keys)** page of the Clerk Dashboard.
 
-<Callout>
-  Failing to update your **Publishable key** will result in Clerk failing to load.
-</Callout>
+> [!NOTE]
+> Failing to update your **Publishable key** will result in Clerk failing to load.
 
 ## Set, change, or remove subdomain
 

--- a/docs/deployments/environments.mdx
+++ b/docs/deployments/environments.mdx
@@ -22,9 +22,8 @@ Some notable examples of `Development`-only characteristics in a Clerk applicati
 - Search engines will not be able to crawl and index your application
 - Development instances have a 100 users cap and user data can not be transferred between instances
 
-<Callout type="info">
-  All paid functionality is available in a `Development` instance. However, when you deploy your application to `Production`, you will be asked to upgrade to a `Pro` account. See [our pricing page](/pricing) for full details.
-</Callout>
+> [!NOTE]
+> All paid functionality is available in a `Development` instance. However, when you deploy your application to `Production`, you will be asked to upgrade to a `Pro` account. See [our pricing page](/pricing) for full details.
 
 ## Production instance
 

--- a/docs/deployments/migrate-from-firebase.mdx
+++ b/docs/deployments/migrate-from-firebase.mdx
@@ -142,9 +142,8 @@ Migrating your user base from Firebase to Clerk is a 2-part process that can be 
   node migrate-to-clerk.js
   ```
 
-  <Callout type="warning">
-    This implementation does not take rate limiting into account. If you have a large user base, you may want to implement a retry mechanism. Clerk will return a `429` status code if you exceed the rate limit. You can find more information about Clerk's rate limits [here](/docs/backend-requests/resources/rate-limits). Keep [Firebase's rate limits](https://firebase.google.com/docs/functions/quotas) in mind as well when exporting your users.
-  </Callout>
+  > [!WARNING]
+  > This implementation does not take rate limiting into account. If you have a large user base, you may want to implement a retry mechanism. Clerk will return a `429` status code if you exceed the rate limit. You can find more information about Clerk's rate limits [here](/docs/backend-requests/resources/rate-limits). Keep [Firebase's rate limits](https://firebase.google.com/docs/functions/quotas) in mind as well when exporting your users.
 
   Once the script has finished running, your user base will be fully migrated to Clerk.
 </Steps>

--- a/docs/deployments/migrate-overview.mdx
+++ b/docs/deployments/migrate-overview.mdx
@@ -54,9 +54,8 @@ As with the Basic Import / Export workflow there are a tradeoffs you'll need to 
 
 Because you'll need both systems available when doing a gradual migration, there is naturally additional short-term costs related to having both running systems at the same time.
 
-<Callout type="info">
-  It's important to note that Clerk only charges by _Monthly Active Users_ and never based on your total number of Users in the user table – so during this period you'll only be charged for users who create an active session within Clerk. Head to our [pricing page](/pricing) to get the full details on how Clerk charges.
-</Callout>
+> [!NOTE]
+> It's important to note that Clerk only charges by _Monthly Active Users_ and never based on your total number of Users in the user table – so during this period you'll only be charged for users who create an active session within Clerk. Head to our [pricing page](/pricing) to get the full details on how Clerk charges.
 
 #### Determining the appropriate length of time
 

--- a/docs/deployments/overview.mdx
+++ b/docs/deployments/overview.mdx
@@ -18,9 +18,8 @@ Before you begin:
 1. You will be prompted with a modal to either clone your development instance settings to your production instance or create your production instance with Clerk's default settings.
 1. The homepage of the dashboard will show you what is still required to deploy your production instance.
 
-<Callout type="warning">
-  For security reasons, **[Social Connections](https://dashboard.clerk.dev/last-active?path=user-authentication/social-connections)**, **[Integrations](https://dashboard.clerk.dev/last-active?path=integrations)**, and **[Paths](https://dashboard.clerk.dev/last-active?path=paths)** settings do not copy over. You will need to set these values again.
-</Callout>
+> [!WARNING]
+> For security reasons, **[Social Connections](https://dashboard.clerk.dev/last-active?path=user-authentication/social-connections)**, **[Integrations](https://dashboard.clerk.dev/last-active?path=integrations)**, and **[Paths](https://dashboard.clerk.dev/last-active?path=paths)** settings do not copy over. You will need to set these values again.
 
 ## API keys and environment variables
 
@@ -48,9 +47,8 @@ To see what DNS records you need to add:
 1. Navigate to the [Clerk Dashboard](https://dashboard.clerk.com/last-active?path=domains).
 1. In the navigation sidebar, select **Domains**.
 
-<Callout type="info">
-  It can take up to 24hrs for DNS Records to fully propagate, so be patient.
-</Callout>
+> [!NOTE]
+> It can take up to 24hrs for DNS Records to fully propagate, so be patient.
 
 ## Authentication across subdomains
 

--- a/docs/deployments/staging-alternatives.mdx
+++ b/docs/deployments/staging-alternatives.mdx
@@ -6,9 +6,8 @@ description:
 
 ## Shared production credentials
 
-<Callout type="danger">
-  This is not recommended. Instead, you should either [set up a staging environment with a separate domain](/docs/deployments/set-up-staging) or [use a preview deployment](/docs/deployments/set-up-preview-environment).
-</Callout>
+> [!CAUTION]
+> This is not recommended. Instead, you should either [set up a staging environment with a separate domain](/docs/deployments/set-up-staging) or [use a preview deployment](/docs/deployments/set-up-preview-environment).
 
 If you do not want to purchase a separate domain, or if you would like to share settings and data between your production and staging environments, you can use a subdomain of your production domain to set up a staging environment.
 

--- a/docs/elements/guides/sign-in.mdx
+++ b/docs/elements/guides/sign-in.mdx
@@ -29,11 +29,10 @@ description: Learn how to build a complete sign-in form with Clerk Elements.
   - Support various password-related features
 </TutorialHero>
 
-<Callout type="info">
-  - Clerk Elements is for [advanced use-cases](/docs/elements/overview#why-use-clerk-elements) that require a high-level of customization. The easiest way to implement Clerk is with our [all-in-one UI components](/docs/components/overview).
-
-  - Clerk Elements currently only works with Next.js App Router and [Clerk Core 2](https://clerk.com/changelog/2024-04-19). As it gets closer to a stable release, support for additional frameworks will be added.
-</Callout>
+> [!NOTE]
+>
+> - Clerk Elements is for [advanced use-cases](/docs/elements/overview#why-use-clerk-elements) that require a high-level of customization. The easiest way to implement Clerk is with our [all-in-one UI components](/docs/components/overview).
+> - Clerk Elements currently only works with Next.js App Router and [Clerk Core 2](https://clerk.com/changelog/2024-04-19). As it gets closer to a stable release, support for additional frameworks will be added.
 
 <Steps>
   ### Add a sign-in route
@@ -57,9 +56,8 @@ description: Learn how to build a complete sign-in form with Clerk Elements.
 
   You will use these two imports to build out the rest of the flow. `<SignIn.Root>` manages the sign-in state and handles connecting the components to Clerk's APIs.
 
-  <Callout type="tip">
-    If you're getting TypeScript errors on the `@clerk/elements` imports you probably have forgotten to set your [`moduleResolution`](https://www.typescriptlang.org/tsconfig/#moduleResolution) in `tsconfig.json` to `bundler`.
-  </Callout>
+  > [!TIP]
+  > If you're getting TypeScript errors on the `@clerk/elements` imports you probably have forgotten to set your [`moduleResolution`](https://www.typescriptlang.org/tsconfig/#moduleResolution) in `tsconfig.json` to `bundler`.
 
   ### Add the start step
 
@@ -117,9 +115,8 @@ description: Learn how to build a complete sign-in form with Clerk Elements.
 
   `<Clerk.Field>` takes care of wiring up the input with the label element, and `<Clerk.FieldError>` will render any field-specific errors that get returned from Clerk's API. The `<SignIn.Action>` component provides common actions that are used throughout the flows. In this case, using the `submit` action to render a submit button for the start form.
 
-  <Callout type="info">
-    If your Clerk instance supports signing in with Google and doesn't require multi-factor authentication (MFA), you should be able to complete a sign-in with the components rendered so far.
-  </Callout>
+  > [!NOTE]
+  > If your Clerk instance supports signing in with Google and doesn't require multi-factor authentication (MFA), you should be able to complete a sign-in with the components rendered so far.
 
   ### Add verification
 
@@ -283,9 +280,8 @@ description: Learn how to build a complete sign-in form with Clerk Elements.
      - `<SignIn.SupportedStrategy>` is also used in the `forgot-password` and `choose-strategy` steps to trigger verification of a supported strategy.
   1. `reset-password` – Allows a verified user to input a new password. If your instance has been set up to accept SMS codes, you can also use `reset_password_phone_code`.
 
-  <Callout>
-    If your instance isn't configured to use passwords, or any of the strategies outlined here, Clerk Elements will log a warning to the console during development.
-  </Callout>
+  > [!NOTE]
+  > If your instance isn't configured to use passwords, or any of the strategies outlined here, Clerk Elements will log a warning to the console during development.
 
   ### Customize and add styling
 

--- a/docs/elements/guides/sign-up.mdx
+++ b/docs/elements/guides/sign-up.mdx
@@ -29,11 +29,10 @@ description: Learn how to build a complete sign-up form with Clerk Elements.
   - Verify a user's identity during a sign-up attempt
 </TutorialHero>
 
-<Callout type="info">
-  - Clerk Elements is for [advanced use-cases](/docs/elements/overview#why-use-clerk-elements) that require a high-level of customization. The easiest way to implement Clerk is with our [all-in-one UI components](/docs/components/overview).
-
-  - Clerk Elements currently only works with Next.js App Router and [Clerk Core 2](https://clerk.com/changelog/2024-04-19). As it gets closer to a stable release, support for additional frameworks will be added.
-</Callout>
+> [!NOTE]
+>
+> - Clerk Elements is for [advanced use-cases](/docs/elements/overview#why-use-clerk-elements) that require a high-level of customization. The easiest way to implement Clerk is with our [all-in-one UI components](/docs/components/overview).
+> - Clerk Elements currently only works with Next.js App Router and [Clerk Core 2](https://clerk.com/changelog/2024-04-19). As it gets closer to a stable release, support for additional frameworks will be added.
 
 <Steps>
   ### Add a sign-up route
@@ -57,9 +56,8 @@ description: Learn how to build a complete sign-up form with Clerk Elements.
 
   You will use these two imports to build out the rest of the flow. `<SignUp.Root>` manages the sign-up state and handles connecting the components to Clerk's APIs.
 
-  <Callout type="tip">
-    If you're getting TypeScript errors on the `@clerk/elements` imports you probably have forgotten to set your [`moduleResolution`](https://www.typescriptlang.org/tsconfig/#moduleResolution) in `tsconfig.json` to `bundler`.
-  </Callout>
+  > [!TIP]
+  > If you're getting TypeScript errors on the `@clerk/elements` imports you probably have forgotten to set your [`moduleResolution`](https://www.typescriptlang.org/tsconfig/#moduleResolution) in `tsconfig.json` to `bundler`.
 
   ### Add the start step
 
@@ -289,9 +287,8 @@ description: Learn how to build a complete sign-up form with Clerk Elements.
 
   If your instance has additional required fields, you can add them the same way you added the `username` field to the continue step.
 
-  <Callout>
-    Under the hood, Clerk Elements will conditionally render the fields that are necessary to complete the sign up attempt, so there's no need to check the state of the sign up attempt yourself.
-  </Callout>
+  > [!NOTE]
+  > Under the hood, Clerk Elements will conditionally render the fields that are necessary to complete the sign up attempt, so there's no need to check the state of the sign up attempt yourself.
 
   ### Customize and add styling
 

--- a/docs/elements/guides/styling.mdx
+++ b/docs/elements/guides/styling.mdx
@@ -4,9 +4,8 @@ description: Learn how to style Clerk Elements.
 
 # Styling for Clerk Elements
 
-<Callout type="info">
-  Clerk Elements is for [advanced use-cases](/docs/elements/overview#why-use-clerk-elements) that require a high-level of customization. If you are using our [all-in-one UI components](/docs/components/overview), learn more about customization through our [Appearance Prop](/docs/components/customization/overview).
-</Callout>
+> [!NOTE]
+> Clerk Elements is for [advanced use-cases](/docs/elements/overview#why-use-clerk-elements) that require a high-level of customization. If you are using our [all-in-one UI components](/docs/components/overview), learn more about customization through our [Appearance Prop](/docs/components/customization/overview).
 
 You can style Clerk Elements components with the following props:
 

--- a/docs/elements/overview.mdx
+++ b/docs/elements/overview.mdx
@@ -4,11 +4,10 @@ description: Learn how to use Clerk Elements to build custom UIs on top of Clerk
 
 # Clerk Elements (Beta)
 
-<Callout type="warning">
-  Clerk Elements is currently in beta with support for Next.js App Router. It is **not yet recommended for production use**.
-
-  If you have any feedback, please reach out to [beta-elements@clerk.dev](mailto:beta-elements@clerk.dev) or head over to the [GitHub Discussion](https://github.com/orgs/clerk/discussions/3315).
-</Callout>
+> [!WARNING]
+> Clerk Elements is currently in beta with support for Next.js App Router. It is **not yet recommended for production use**.
+>
+> If you have any feedback, please reach out to [beta-elements@clerk.dev](mailto:beta-elements@clerk.dev) or head over to the [GitHub Discussion](https://github.com/orgs/clerk/discussions/3315).
 
 Clerk Elements is a library of unstyled, composable components that can be used to build custom UIs on top of Clerk's APIs without having to manage the underlying logic.
 
@@ -49,9 +48,8 @@ To get started, install the Clerk Elements package:
   ```
 </CodeBlockTabs>
 
-<Callout type="important">
-  If your project uses TypeScript, make sure that your [`moduleResolution`](https://www.typescriptlang.org/tsconfig/#moduleResolution) in `tsconfig.json` is set to `bundler`. Otherwise, you might run into issues with resolving TypeScript types from Clerk Elements.
-</Callout>
+> [!IMPORTANT]
+> If your project uses TypeScript, make sure that your [`moduleResolution`](https://www.typescriptlang.org/tsconfig/#moduleResolution) in `tsconfig.json` is set to `bundler`. Otherwise, you might run into issues with resolving TypeScript types from Clerk Elements.
 
 Once you have your project set up, you can start building custom UIs with Clerk Elements using Clerk's guides and examples. For example, to use Clerk Elements to build a custom sign-in flow, you can explore:
 
@@ -59,6 +57,5 @@ Once you have your project set up, you can start building custom UIs with Clerk 
 - [Sign-in examples](/docs/elements/examples/sign-in)
 - [Sign-in components](/docs/elements/reference/sign-in)
 
-<Callout type="info">
-  With the beta release, only sign-up and sign-in flows are supported. Support for building the rest of Clerk's prebuilt components with Elements is actively being worked on.
-</Callout>
+> [!NOTE]
+> With the beta release, only sign-up and sign-in flows are supported. Support for building the rest of Clerk's prebuilt components with Elements is actively being worked on.

--- a/docs/elements/reference/common.mdx
+++ b/docs/elements/reference/common.mdx
@@ -198,9 +198,8 @@ By having access to both `message` and `code` you can enrich the incoming `messa
 
 By default, renders as an `<img>` element with the logo of the parent `<Connection>` as the value of its `src` prop. **Must be a child of [`<Connection>`](#connection)**.
 
-<Callout type="tip">
-  `<Icon>` is designed to give you access to Clerk's social connection logos and has intentionally limited customizability. If you need more customizability, consider options such as [Iconify](https://iconify.design/getting-started/).
-</Callout>
+> [!TIP]
+> `<Icon>` is designed to give you access to Clerk's social connection logos and has intentionally limited customizability. If you need more customizability, consider options such as [Iconify](https://iconify.design/getting-started/).
 
 ### Properties {{ toc: false }}
 
@@ -227,9 +226,8 @@ The following example demonstrates how to render the Google social connection lo
 
 Handles rendering of [`<input />` elements](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input) within Clerk's flows. Supports special `type` prop values to render input types that are unique to authentication and user management flows. Additional props will be passed through to the `<input />`.
 
-<Callout type="info">
-  For screen reader accessibility, always associate a [`<Label>`](#label) with your `<Input>` elements.
-</Callout>
+> [!NOTE]
+> For screen reader accessibility, always associate a [`<Label>`](#label) with your `<Input>` elements.
 
 ### Properties {{ toc: false }}
 
@@ -240,9 +238,8 @@ Handles rendering of [`<input />` elements](https://developer.mozilla.org/en-US/
 | `type?` | `'text' \| 'email' \| 'tel' \| 'otp'* \| 'password'` | Type for the input. Default: `'text'` |
 | `autoComplete?` | `string` | Refers to the [HTML attribute](https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/autocomplete). If `<Input>` is used inside a `<SignIn>` flow and `autoComplete="webauthn"` is set, [passkey autofill](https://developer.chrome.com/docs/identity/webauthn-conditional-ui) will be attempted. |
 
-<Callout type="info">
-  Values denoted with `*` are unique Clerk input types.
-</Callout>
+> [!NOTE]
+> Values denoted with `*` are unique Clerk input types.
 
 The following data attributes are also added to the underlying element:
 

--- a/docs/guides/add-onboarding-flow.mdx
+++ b/docs/guides/add-onboarding-flow.mdx
@@ -17,9 +17,8 @@ In this guide, you will learn how to:
 
 For the sake of this guide, examples are written for Next.js App Router, but can be used with Next.js Pager Router as well. The examples have been pared down to the bare minimum to enable you to easily customize them to your needs.
 
-<Callout type="info" emoji="💡">
-  To see this guide in action, check out the [repository](https://github.com/clerk/clerk-nextjs-onboarding-sample-app/tree/main).
-</Callout>
+> [!NOTE]
+> To see this guide in action, check out the [repository](https://github.com/clerk/clerk-nextjs-onboarding-sample-app/tree/main).
 
 ## Add custom claims to your session token
 

--- a/docs/guides/architecture-scenarios.mdx
+++ b/docs/guides/architecture-scenarios.mdx
@@ -24,9 +24,8 @@ In a B2C scenario, applications generally share the following characteristics:
 - The application branding is that of your company (as in, not white-labelled per customer or organization)
 - The application is accessible under a single domain (for example: `example.com` or `app.example.com`)
 
-<Callout type="info">
-  In the B2C scenario, organizations are generally not necessary since users that sign up to your application typically do not exist as part of a team, organization, or workspace.
-</Callout>
+> [!NOTE]
+> In the B2C scenario, organizations are generally not necessary since users that sign up to your application typically do not exist as part of a team, organization, or workspace.
 
 ## B2B: Business to Business
 
@@ -41,9 +40,8 @@ The user pool for multi-tenant, SaaS applications will generally fall into one o
 1. **Shared user-pool**: the application has a single pool of users. A user can create one account and belong to multiple organizations. The user can have separate roles in each organization.
 1. **Isolated user-pool**: each organization has its own pool of users. A user must create a separate account for each organization.
 
-<Callout type="info">
-  Clerk supports the **shared user-pool** model for B2B scenarios which will be discussed in this section. The **isolated user-pool** model is more relevant in the Platforms scenario which will be discussed in the next section.
-</Callout>
+> [!NOTE]
+> Clerk supports the **shared user-pool** model for B2B scenarios which will be discussed in this section. The **isolated user-pool** model is more relevant in the Platforms scenario which will be discussed in the next section.
 
 B2B SaaS applications with the following characteristics are well-supported with Clerk:
 
@@ -65,9 +63,8 @@ The organization's ID should be stored in your database alongside each resource 
 
 ## Platforms
 
-<Callout type="info">
-  Today, Clerk does not currently support the Platforms scenario. We are working on [Clerk for Platforms](https://feedback.clerk.com/roadmap/3b40265e-d8ae-41b0-a4b3-9c947d460218) to enable developers building platforms to offer their users Clerk's full range of features and customizability.
-</Callout>
+> [!NOTE]
+> Today, Clerk does not currently support the Platforms scenario. We are working on [Clerk for Platforms](https://feedback.clerk.com/roadmap/3b40265e-d8ae-41b0-a4b3-9c947d460218) to enable developers building platforms to offer their users Clerk's full range of features and customizability.
 
 In the Platforms scenario, businesses can create multiple, isolated applications with their own user pools, branding, security policies, and limits. Some examples in this scenario are e-commerce platforms like Shopify, e-learning platforms, and mortgage lending platforms.
 

--- a/docs/guides/authjs-migration.mdx
+++ b/docs/guides/authjs-migration.mdx
@@ -292,9 +292,8 @@ This guide shows how to migrate an application using Auth.js (formerly NextAuth.
     </Tab>
   </Tabs>
 
-  <Callout type="info">
-    You can not access the above from the client side. If you are using one of Clerk's hooks, then you will need to check if `externalID` exists. If it doesn't, then read the `userId`.
-  </Callout>
+  > [!NOTE]
+  > You can not access the above from the client side. If you are using one of Clerk's hooks, then you will need to check if `externalID` exists. If it doesn't, then read the `userId`.
 
   #### Update your database
 

--- a/docs/guides/basic-rbac.mdx
+++ b/docs/guides/basic-rbac.mdx
@@ -32,10 +32,9 @@ In the Clerk Dashboard, navigate to [**Sessions**](https://dashboard.clerk.com/l
   alt="The Sessions page in the Clerk Dashboard with the 'Customize session token' modal opened. The modal has a text field with the JSON 'metadata': '{{user.public_metadata}}'."
 />
 
-<Callout type="danger">
-  The entire session token has a limit of 4kb of data. Exceeding this size can have adverse effects, including a possible infinite redirect loop for users who exceed this size in Next.js applications.
-  It's recommended to move particularly large claims out of the JWT and fetch these using a separate API call from your backend.
-</Callout>
+> [!CAUTION]
+> The entire session token has a limit of 4kb of data. Exceeding this size can have adverse effects, including a possible infinite redirect loop for users who exceed this size in Next.js applications.
+> It's recommended to move particularly large claims out of the JWT and fetch these using a separate API call from your backend.
 
 ## Provide a global TypeScript definition
 
@@ -155,9 +154,8 @@ export default function AdminDashboard() {
 }
 ```
 
-<Callout type="info">
-  You can modify the behavior of the helper function to meet your needs. Maybe it will return the roles that the user has, or you could create a `protectByRole()` and have that function handle the redirect.
-</Callout>
+> [!NOTE]
+> You can modify the behavior of the helper function to meet your needs. Maybe it will return the roles that the user has, or you could create a `protectByRole()` and have that function handle the redirect.
 
 ## Add admin tools to find users and add roles
 

--- a/docs/guides/custom-redirects.mdx
+++ b/docs/guides/custom-redirects.mdx
@@ -85,9 +85,8 @@ export const config = {
 
 You can explicitly define the redirect paths after sign-up or sign-in by using the properties described in this section with Clerk's components. In general, it is recommended to use [environment variables](#environment-variables) instead.
 
-<Callout type="warning">
-  The `afterSignIn`, `afterSignUp`, and `redirectUrl` props are deprecated. If you're still using them, the props described in this section will override them.
-</Callout>
+> [!WARNING]
+> The `afterSignIn`, `afterSignUp`, and `redirectUrl` props are deprecated. If you're still using them, the props described in this section will override them.
 
 ### Fallback redirect URL props
 
@@ -164,17 +163,15 @@ The "force redirect URL" props will _always_ redirect to the provided url after 
   ```
 </CodeBlockTabs>
 
-<Callout type="info" emoji="💡">
-  `<RedirectToSignIn />` or `<RedirectToSignUp />` child components will always take precedence over `<ClerkProvider>`.
-</Callout>
+> [!NOTE]
+> `<RedirectToSignIn />` or `<RedirectToSignUp />` child components will always take precedence over `<ClerkProvider>`.
 
 ### Button components
 
 [`<SignInButton>`](/docs/components/unstyled/sign-in-button) and [`<SignUpButton>`](/docs/components/unstyled/sign-up-button) also accepts these properties.
 
-<Callout type="info">
-  It is recommended to define both `signInFallbackRedirectUrl` and `signUpFallbackRedirectUrl` redirects in each button as some users may choose to sign up after attempting to sign-in, or sign in after attempting to sign-up.
-</Callout>
+> [!NOTE]
+> It is recommended to define both `signInFallbackRedirectUrl` and `signUpFallbackRedirectUrl` redirects in each button as some users may choose to sign up after attempting to sign-in, or sign in after attempting to sign-up.
 
 <CodeBlockTabs type="framework" options={["Next.js"]}>
   ```jsx {{ prettier: false, filename: 'app/sign-in/page.tsx' }}
@@ -203,9 +200,8 @@ The "force redirect URL" props will _always_ redirect to the provided url after 
 
 [`<SignIn>`](/docs/components/authentication/sign-in) and [`<SignUp>`](/docs/components/authentication/sign-up) also accept these properties.
 
-<Callout type="info">
-  It is recommended to define both `signInFallbackRedirectUrl` and `signUpFallbackRedirectUrl` redirects in each component as some users may choose to sign up instead after attempting to sign in.
-</Callout>
+> [!NOTE]
+> It is recommended to define both `signInFallbackRedirectUrl` and `signUpFallbackRedirectUrl` redirects in each component as some users may choose to sign up instead after attempting to sign in.
 
 <CodeBlockTabs type="framework" options={["Next.js"]}>
   ```tsx {{ prettier: false, filename: 'app/page.tsx' }}

--- a/docs/guides/force-organizations.mdx
+++ b/docs/guides/force-organizations.mdx
@@ -115,9 +115,8 @@ This guide will be written for Next.js applications using App Router, but the sa
 
   In the example below, a custom organization switcher is created. It allows a user to select an organization from a list of their memberships. The `useOrganizationList()` hook is used to fetch a list of the user's memberships, and the `setActive` method is used to set the selected organization as active.
 
-  <Callout type="warning">
-    Setting an active organization can only be performed client-side.
-  </Callout>
+  > [!WARNING]
+  > Setting an active organization can only be performed client-side.
 
   ```tsx {{ prettier: false, filename: 'app/custom-org-switcher.tsx' }}
   "use client"
@@ -164,9 +163,8 @@ This guide will be written for Next.js applications using App Router, but the sa
 
   #### Set an active organization based on the URL
 
-  <Callout type="warning">
-    This approach still depends on the `setActive` method, which only runs on the client. Due to this limitation, during SSR, it is possible that `orgId` from `auth()` returns an incorrect value that does not match the organization ID in the URL.
-  </Callout>
+  > [!WARNING]
+  > This approach still depends on the `setActive` method, which only runs on the client. Due to this limitation, during SSR, it is possible that `orgId` from `auth()` returns an incorrect value that does not match the organization ID in the URL.
 
   In some cases, you might want to set an active organization based on the URL. For example, if you have a URL like `/organizations/org_123`, you might want to set `org_123` as the active organization.
 

--- a/docs/guides/transferring-your-app.mdx
+++ b/docs/guides/transferring-your-app.mdx
@@ -16,9 +16,8 @@ To transfer ownership of your application:
 
 To set up a payment method without being charged:
 
-<Callout type="Info">
-  This guide offers a temporary solution for this issue. Clerk is actively working to improve this process.
-</Callout>
+> [!NOTE]
+> This guide offers a temporary solution for this issue. Clerk is actively working to improve this process.
 
 1. Switch to the receiving organization and open the organization switcher at the top-left of the Dashboard.
 1. Select the cog icon (⚙) to manage your organization.

--- a/docs/integrations/analytics/google-analytics.mdx
+++ b/docs/integrations/analytics/google-analytics.mdx
@@ -7,9 +7,8 @@ description: Enable Clerk with Google Analytics to authenticate requests to your
 
 This integration enables Clerk to send user authentication events to the configured Google Analytics property which corresponds to your application.
 
-<Callout type="info">
-  The Google Analytics integration can be enabled only for Production Instances.
-</Callout>
+> [!NOTE]
+> The Google Analytics integration can be enabled only for Production Instances.
 
 To enable the integration, you will need to provide Clerk with the required Google Analytics configuration attributes depending on the type of Google Analytics property. **We support both Universal Analytics and Google Analytics 4 properties.**
 

--- a/docs/integrations/databases/fauna.mdx
+++ b/docs/integrations/databases/fauna.mdx
@@ -31,9 +31,8 @@ Enter a name in the **Name** field that will identify this access provider. The 
 
 Paste the **Publishable key** you copied from the Clerk Dashboard into the **Issuer** field and then prefix it with the `https://` protocol so it follows `https://<YOUR_PUBLISHABLE_KEY>`
 
-<Callout type="info">
-  Make sure you do not add a trailing slash / to the end of the Issuer URL or it will fail.
-</Callout>
+> [!NOTE]
+> Make sure you do not add a trailing slash / to the end of the Issuer URL or it will fail.
 
 Assuming you didn’t use a custom signing key, set the **JWKS endpoint** field to the JSON Web Key Set (JWKS) URL Clerk automatically created with your Frontend API at `https://<YOUR_FRONTEND_API>/.well-known/jwks.json`
 
@@ -126,9 +125,8 @@ const Example = () => {
 };
 ```
 
-<Callout type="info">
-  The `getToken({ template: <your-template-name> })` call is asynchronous and returns a Promise that needs to be resolved before accessing the token value. This token is short-lived for better security and should be called before every request to your Fauna database. The caching and refreshing of the token are handled automatically by Clerk.
-</Callout>
+> [!NOTE]
+> The `getToken({ template: <your-template-name> })` call is asynchronous and returns a Promise that needs to be resolved before accessing the token value. This token is short-lived for better security and should be called before every request to your Fauna database. The caching and refreshing of the token are handled automatically by Clerk.
 
 ## Next steps
 

--- a/docs/integrations/databases/grafbase.mdx
+++ b/docs/integrations/databases/grafbase.mdx
@@ -27,9 +27,8 @@ Once the Grafbase template is created, you will be redirected to the template's 
 
 The Grafbase template will pre-populate the default claims required by Grafbase. You can include additional claims as necessary. [Shortcodes](/docs/backend-requests/making/jwt-templates#shortcodes) are available to make adding dynamic user values easy.
 
-<Callout type="info">
-  If your GraphQL API restricts access based on groups, you’ll need to specify the users groups in the `groups` claim.
-</Callout>
+> [!NOTE]
+> If your GraphQL API restricts access based on groups, you’ll need to specify the users groups in the `groups` claim.
 
 <Images
   width={3024}

--- a/docs/integrations/webhooks/sync-data.mdx
+++ b/docs/integrations/webhooks/sync-data.mdx
@@ -135,9 +135,8 @@ This guide can be adapted to listen for any Clerk event.
 
   Your webhook will need to return either an error code, or a success code, like `200` or `201`. If it returns an error code, the webhook will reflect that in the Dashboard log and it will [retry](/docs/integrations/webhooks/overview#retry). When the webhook returns a success code, there will be no retries and the webhook will show a success status in the Dashboard.
 
-  <Callout type="info">
-    The following Route Handler is not specific to the `user.updated` event and can be used for any webhook event you choose to listen to.
-  </Callout>
+  > [!NOTE]
+  > The following Route Handler is not specific to the `user.updated` event and can be used for any webhook event you choose to listen to.
 
   <Tabs type="framework" items={["Next.js", "Node"]}>
     <Tab>

--- a/docs/organizations/creating-organizations.mdx
+++ b/docs/organizations/creating-organizations.mdx
@@ -4,9 +4,8 @@ description: Learn how to use Clerk's API to build a custom flow for creating or
 
 # Build a custom flow for creating organizations
 
-<Callout type="danger">
-  This guide is for users who want to build a _custom_ user interface using the Clerk API. To create organizations using a _prebuilt_ UI, you should use Clerk's [prebuilt components](/docs/components/overview).
-</Callout>
+> [!CAUTION]
+> This guide is for users who want to build a _custom_ user interface using the Clerk API. To create organizations using a _prebuilt_ UI, you should use Clerk's [prebuilt components](/docs/components/overview).
 
 [Organizations](/docs/organizations/overview) are a powerful feature in Clerk that allow you to group users together and manage their permissions. Organizations can be created and managed using the [Clerk Dashboard](https://dashboard.clerk.dev/), but you can also allow users within your application to create organizations.
 

--- a/docs/organizations/custom-organization-switcher.mdx
+++ b/docs/organizations/custom-organization-switcher.mdx
@@ -4,9 +4,8 @@ description: Learn how to use Clerk's API to build a custom flow for switching b
 
 # Build a custom flow for switching organizations
 
-<Callout type="danger">
-  This guide is for users who want to build a _custom_ user interface using the Clerk API. To switch organizations using a _prebuilt_ UI, you should use Clerk's [`<OrganizationSwitcher />`](/docs/components/organization/organization-switcher) component.
-</Callout>
+> [!CAUTION]
+> This guide is for users who want to build a _custom_ user interface using the Clerk API. To switch organizations using a _prebuilt_ UI, you should use Clerk's [`<OrganizationSwitcher />`](/docs/components/organization/organization-switcher) component.
 
 This guide will demonstrate how to use Clerk's API to build a custom flow for switching between organizations.
 

--- a/docs/organizations/inviting-users.mdx
+++ b/docs/organizations/inviting-users.mdx
@@ -4,9 +4,8 @@ description: Learn how to use Clerk's API to build a custom flow for inviting us
 
 # Build a custom flow for inviting users to an organization
 
-<Callout type="danger">
-  This guide is for users who want to build a _custom_ user interface using the Clerk API. To invite users to an organization using a _prebuilt_ UI, you should use Clerk's [prebuilt components](/docs/components/overview).
-</Callout>
+> [!CAUTION]
+> This guide is for users who want to build a _custom_ user interface using the Clerk API. To invite users to an organization using a _prebuilt_ UI, you should use Clerk's [prebuilt components](/docs/components/overview).
 
 Organization members with appropriate [permissions](/docs/organizations/roles-permissions) can invite new users to their organization and manage those invitations. When an administrator invites a new member, an invitation email is sent out. The invitation recipient can be either an existing user of your application or a new user. If the latter is true, the user will need to register in order to accept the invitation.
 

--- a/docs/organizations/manage-invitations.mdx
+++ b/docs/organizations/manage-invitations.mdx
@@ -4,9 +4,8 @@ description: Learn how to use Clerk's API to build a custom flow for managing a 
 
 # Build a custom flow for managing a user's organization invitations
 
-<Callout type="danger">
-  This guide is for users who want to build a _custom_ user interface using the Clerk API. To use a _prebuilt_ UI, you should use Clerk's [prebuilt components](/docs/components/overview).
-</Callout>
+> [!CAUTION]
+> This guide is for users who want to build a _custom_ user interface using the Clerk API. To use a _prebuilt_ UI, you should use Clerk's [prebuilt components](/docs/components/overview).
 
 This guide will demonstrate how to use Clerk's API to build a custom flow for managing a user's [organization invitations](/docs/organizations/overview#organization-invitations).
 

--- a/docs/organizations/manage-membership-requests.mdx
+++ b/docs/organizations/manage-membership-requests.mdx
@@ -4,9 +4,8 @@ description: Learn how to use Clerk's API to build a custom flow for managing or
 
 # Build a custom flow for managing organization membership requests
 
-<Callout type="danger">
-  This guide is for users who want to build a _custom_ user interface using the Clerk API. To manage organization membership requests using a _prebuilt_ UI, you should use Clerk's [prebuilt components](/docs/components/overview).
-</Callout>
+> [!CAUTION]
+> This guide is for users who want to build a _custom_ user interface using the Clerk API. To manage organization membership requests using a _prebuilt_ UI, you should use Clerk's [prebuilt components](/docs/components/overview).
 
 This guide will demonstrate how to use Clerk's API to build a custom flow for managing [organization membership requests](/docs/organizations/overview#membership-requests).
 

--- a/docs/organizations/managing-roles.mdx
+++ b/docs/organizations/managing-roles.mdx
@@ -4,9 +4,8 @@ description: Learn how to use Clerk's API build a custom flow for managing membe
 
 # Build a custom flow for managing member roles in an organization
 
-<Callout type="danger">
-  This guide is for users who want to build a _custom_ user interface using the Clerk API. To manage member roles in an organization using a _prebuilt_ UI, you should use Clerk's [prebuilt components](/docs/components/overview).
-</Callout>
+> [!CAUTION]
+> This guide is for users who want to build a _custom_ user interface using the Clerk API. To manage member roles in an organization using a _prebuilt_ UI, you should use Clerk's [prebuilt components](/docs/components/overview).
 
 Organization members with appropriate [permissions](/docs/organizations/roles-permissions#permissions) can manage a member's [role](/docs/organizations/roles-permissions#roles) and remove members within an organization.
 

--- a/docs/organizations/metadata.mdx
+++ b/docs/organizations/metadata.mdx
@@ -21,6 +21,5 @@ Both the `Organization` and `Organization Membership` objects have the metadata 
 
 To ease the flow of setting metadata, Clerk provides the `updateOrganizationMetadata()` and `updateOrganizationMembershipMetadata()` methods from the [Backend SDK](https://clerk.com/docs/reference/backend-api), which is a wrapper around the [Backend API](https://clerk.com/docs/reference/backend-api).
 
-<Callout type="warning">
-  Metadata is limited to **8kb** maximum.
-</Callout>
+> [!WARNING]
+> Metadata is limited to **8kb** maximum.

--- a/docs/organizations/overview.mdx
+++ b/docs/organizations/overview.mdx
@@ -7,10 +7,9 @@ description: Learn about how to create and manage Clerk organizations and their 
 
 Organizations are a flexible and scalable way to manage users and their access to resources within your Clerk application. With organizations, you can assign specific roles and permissions to users, making them useful for managing projects, coordinating teams, or facilitating partnerships.
 
-<Callout type="info">
-  To explore organizations in Clerk, check out this demo repo:
-  [https://github.com/clerk/organizations-demo](https://github.com/clerk/organizations-demo)
-</Callout>
+> [!NOTE]
+> To explore organizations in Clerk, check out this demo repo:
+> [https://github.com/clerk/organizations-demo](https://github.com/clerk/organizations-demo)
 
 ## Enable organizations in your application
 

--- a/docs/organizations/roles-permissions.mdx
+++ b/docs/organizations/roles-permissions.mdx
@@ -18,9 +18,8 @@ For each instance, there are currently two default roles:
 - **Admin (`org:admin`)** - Offers full access to organization resources. Members with the admin role have all the [System Permissions](#system-permissions). They can fully manage the organization and organization memberships.
 - **Member (`org:member`)** - Offers limited access to organization resources. Access to organization resources is limited to the "Read members" permission only, by default. They cannot manage the organization and organization memberships, but they can view information about other members in it.
 
-<Callout type="info">
-  If you enabled organizations for your application before December 2023, the **Admin** role is `admin` and the **Member** role is `basic_member`, instead of `org:admin` and `org:member`, respectively.
-</Callout>
+> [!NOTE]
+> If you enabled organizations for your application before December 2023, the **Admin** role is `admin` and the **Member** role is `basic_member`, instead of `org:admin` and `org:member`, respectively.
 
 ### Custom role
 
@@ -34,9 +33,8 @@ To learn more about creating custom roles, see the [Create roles and permissions
 
 When a user creates a new organization, that user is automatically added as the organization's first member and is assigned the **Creator** role. By default, **Admin** (`org:admin`) is the **Creator** role.
 
-<Callout type="warning">
-  You can't delete a role if it's used as the organization's **Creator** role. However, you can [reassign the **Creator** role to another role](/docs/organizations/creator-role).
-</Callout>
+> [!WARNING]
+> You can't delete a role if it's used as the organization's **Creator** role. However, you can [reassign the **Creator** role to another role](/docs/organizations/creator-role).
 
 ## Permissions
 

--- a/docs/organizations/updating-organizations.mdx
+++ b/docs/organizations/updating-organizations.mdx
@@ -4,9 +4,8 @@ description: Learn how to use Clerk's API to build a custom flow for updating an
 
 # Build a custom flow for updating an organization
 
-<Callout type="danger">
-  This guide is for users who want to build a _custom_ user interface using the Clerk API. To update organizations using a _prebuilt_ UI, you should use Clerk's [prebuilt components](/docs/components/overview).
-</Callout>
+> [!CAUTION]
+> This guide is for users who want to build a _custom_ user interface using the Clerk API. To update organizations using a _prebuilt_ UI, you should use Clerk's [prebuilt components](/docs/components/overview).
 
 Organization members with appropriate [permissions](/docs/organizations/roles-permissions) can update an organization. Currently, only the organization name and slug can be updated.
 

--- a/docs/organizations/verified-domains.mdx
+++ b/docs/organizations/verified-domains.mdx
@@ -38,9 +38,8 @@ Once verified domains are enabled, you are required to define which role will be
 
 By default, the options are "Member" and "Admin". However, you can also [create custom roles for your organization](/docs/organizations/create-roles-permissions).
 
-<Callout type="warning">
-  You can't delete an organization role if it's used as the verified domain's default role.
-</Callout>
+> [!WARNING]
+> You can't delete an organization role if it's used as the verified domain's default role.
 
 ## Adding and verifying domains
 

--- a/docs/organizations/viewing-memberships.mdx
+++ b/docs/organizations/viewing-memberships.mdx
@@ -4,9 +4,8 @@ description: Learn how to use Clerk's API to build a custom flow for viewing a u
 
 # Build a custom flow for viewing a user's organization memberships
 
-<Callout type="danger">
-  This guide is for users who want to build a _custom_ user interface using the Clerk API. To view the list of a user's organization memberships using a _prebuilt_ UI, you should use Clerk's [`<OrganizationList/>`](/docs/components/organization/organization-list) component.
-</Callout>
+> [!CAUTION]
+> This guide is for users who want to build a _custom_ user interface using the Clerk API. To view the list of a user's organization memberships using a _prebuilt_ UI, you should use Clerk's [`<OrganizationList/>`](/docs/components/organization/organization-list) component.
 
 This guide will demonstrate how to use Clerk's API to build a custom flow for viewing the list of a user's organization memberships.
 

--- a/docs/quickstarts/fastify.mdx
+++ b/docs/quickstarts/fastify.mdx
@@ -9,9 +9,8 @@ Learn how to use Clerk to easily add authentication focused on security, speed, 
 
 After following this guide, you should have a working Fastify app with public and private routes, authenticated using the `clerkPlugin` and `getAuth` helpers.
 
-<Callout type="info">
-  If you're looking for a more complete example, check out our [Fastify example app](https://github.com/clerk/clerk-fastify-starter/).
-</Callout>
+> [!NOTE]
+> If you're looking for a more complete example, check out our [Fastify example app](https://github.com/clerk/clerk-fastify-starter/).
 
 <Steps>
   ### Install `@clerk/fastify`

--- a/docs/quickstarts/javascript.mdx
+++ b/docs/quickstarts/javascript.mdx
@@ -118,9 +118,8 @@ Select your preferred method below to get started.
       });
       ```
 
-      <Callout type="info">
-        Calling the `load()` method initializes ClerkJS. For more information on the `load()` method and what options you can pass to it, check out the [reference documentation](/docs/references/javascript/clerk/clerk#load).
-      </Callout>
+      > [!NOTE]
+      > Calling the `load()` method initializes ClerkJS. For more information on the `load()` method and what options you can pass to it, check out the [reference documentation](/docs/references/javascript/clerk/clerk#load).
 
       ### Allow users to sign in and out
 

--- a/docs/quickstarts/remix.mdx
+++ b/docs/quickstarts/remix.mdx
@@ -31,9 +31,8 @@ description: Learn how to use Clerk to quickly and easily add secure authenticat
 
 Learn how to use Clerk to quickly and easily add secure authentication and user management to your Remix application. This guide assumes that you are using Remix v2 or later.
 
-<Callout type="info">
-  If you are using Remix SPA mode, follow the [Remix SPA mode guide](/docs/references/remix/spa-mode).
-</Callout>
+> [!NOTE]
+> If you are using Remix SPA mode, follow the [Remix SPA mode guide](/docs/references/remix/spa-mode).
 
 <Steps>
   ### Install `@clerk/remix`

--- a/docs/quickstarts/setup-clerk.mdx
+++ b/docs/quickstarts/setup-clerk.mdx
@@ -6,9 +6,8 @@ description: Set up a new Clerk account and integrate it into a new application.
 
 Before you can start integrating Clerk into your application, you need to create a Clerk account and set up a new application in the Clerk Dashboard. This guide will walk you through those steps.
 
-<Callout type="info">
-  If you're migrating from another platform, see the [migration guides](/docs/deployments/migrate-overview) to learn how to move your data to Clerk.
-</Callout>
+> [!NOTE]
+> If you're migrating from another platform, see the [migration guides](/docs/deployments/migrate-overview) to learn how to move your data to Clerk.
 
 <Steps>
   ### Sign into Clerk

--- a/docs/references/backend/client/get-client-list.mdx
+++ b/docs/references/backend/client/get-client-list.mdx
@@ -3,9 +3,8 @@ title: getClientList() (deprecated)
 description: Retrieves the list of clients.
 ---
 
-<Callout type="danger">
-  This method is now deprecated.
-</Callout>
+> [!CAUTION]
+> This method is now deprecated.
 
 # `getClientList()` (deprecated)
 

--- a/docs/references/backend/sessions/verify-session.mdx
+++ b/docs/references/backend/sessions/verify-session.mdx
@@ -3,9 +3,8 @@ title: verifySession() (deprecated)
 description: Use Clerk's Backend SDK to to verify whether a session with a given ID corresponds to the provided session token.
 ---
 
-<Callout type="danger">
-  This method is now deprecated. Refer to the [Manual JWT Verification](/docs/backend-requests/handling/manual-jwt) guide for the recommended way to verify sessions/tokens.
-</Callout>
+> [!CAUTION]
+> This method is now deprecated. Refer to the [Manual JWT Verification](/docs/backend-requests/handling/manual-jwt) guide for the recommended way to verify sessions/tokens.
 
 # `verifySession()` (deprecated)
 

--- a/docs/references/go/other-examples.mdx
+++ b/docs/references/go/other-examples.mdx
@@ -13,9 +13,8 @@ By executing the code in the snippet below, you will:
 - Fetch all organization memberships and loop through them to get the first one.
 - Get more details about the organization's user.
 
-<Callout type="info">
-  Your Clerk secret key is required. If you are signed into your Clerk Dashboard, your secret key should become visible by selecting the eye icon. Otherwise, you can retrieve your Clerk secret key from the Clerk Dashboard on the **[API Keys](https://dashboard.clerk.com/last-active?path=api-keys)** page.
-</Callout>
+> [!NOTE]
+> Your Clerk secret key is required. If you are signed into your Clerk Dashboard, your secret key should become visible by selecting the eye icon. Otherwise, you can retrieve your Clerk secret key from the Clerk Dashboard on the **[API Keys](https://dashboard.clerk.com/last-active?path=api-keys)** page.
 
 <InjectKeys>
   ```go {{ prettier: false, filename: 'main.go' }}

--- a/docs/references/go/verifying-sessions.mdx
+++ b/docs/references/go/verifying-sessions.mdx
@@ -28,9 +28,8 @@ The claims will then be made available in the `http.Request.Context` for the nex
 
 The following example demonstrates how to use the `WithHeaderAuthorization()` middleware to protect a route. If the user tries accessing the route and their session token is valid, the user's ID and banned status will be returned in the response.
 
-<Callout type="info">
-  Your Clerk secret key is required. If you are signed in to your Clerk Dashboard, your secret key should become visible by selecting the eye icon. Otherwise, you can retrieve your Clerk secret key from the Clerk Dashboard on the **[API Keys](https://dashboard.clerk.com/last-active?path=api-keys)** page.
-</Callout>
+> [!NOTE]
+> Your Clerk secret key is required. If you are signed in to your Clerk Dashboard, your secret key should become visible by selecting the eye icon. Otherwise, you can retrieve your Clerk secret key from the Clerk Dashboard on the **[API Keys](https://dashboard.clerk.com/last-active?path=api-keys)** page.
 
 <InjectKeys>
   ```go {{ prettier: false, filename: 'main.go' }}

--- a/docs/references/javascript/clerk/clerk.mdx
+++ b/docs/references/javascript/clerk/clerk.mdx
@@ -44,12 +44,11 @@ function addListener(listener: ((emission: Resources) => void)): UnsubscribeCall
 | `lastOrganizationInvitation` | [`OrganizationInvitation`](/docs/references/javascript/organization-invitation) \| `null` \| `undefined` |
 | `lastOrganizationMember` | [`OrganizationMembership`](/docs/references/javascript/organization-membership) \| `null` \| `undefined` |
 
-<Callout>
-  Note the following about `User` and `Session`:
-
-  - When there is an active session, `user === session.user`.
-  - When there is no active session, `User` and `Session` will both be `null`.
-</Callout>
+> [!NOTE]
+> Note the following about `User` and `Session`:
+>
+> - When there is an active session, `user === session.user`.
+> - When there is no active session, `User` and `Session` will both be `null`.
 
 ### `authenticateWithMetamask()`
 

--- a/docs/references/javascript/clerk/organization-methods.mdx
+++ b/docs/references/javascript/clerk/organization-methods.mdx
@@ -141,9 +141,8 @@ The following example demonstrates how to retrieve information about the current
 
 Creates an organization programatically.
 
-<Callout type="info">
-  You can use Clerk's [`<CreateOrganization />`](/docs/components/organization/create-organization) component if you prefer a prebuilt user interface.
-</Callout>
+> [!NOTE]
+> You can use Clerk's [`<CreateOrganization />`](/docs/components/organization/create-organization) component if you prefer a prebuilt user interface.
 
 ```typescript {{ prettier: false }}
 function createOrganization({name, slug}: CreateOrganizationParams): Promise<Organization>;

--- a/docs/references/javascript/organization/members.mdx
+++ b/docs/references/javascript/organization/members.mdx
@@ -5,9 +5,8 @@ description: Learn about the methods on the Organization object that allow you t
 
 # Organization membership methods
 
-<Callout type="warning">
-  Organizations must be enabled in your Clerk settings for these methods to work. See the [Organizations overview](/docs/organizations/overview#enable-organizations-in-your-application) to learn more.
-</Callout>
+> [!WARNING]
+> Organizations must be enabled in your Clerk settings for these methods to work. See the [Organizations overview](/docs/organizations/overview#enable-organizations-in-your-application) to learn more.
 
 These methods on the [`Organization`](/docs/references/javascript/organization/organization) object allow you to manage the memberships of an organization.
 

--- a/docs/references/javascript/sign-in/second-factor.mdx
+++ b/docs/references/javascript/sign-in/second-factor.mdx
@@ -13,9 +13,8 @@ Begins the second factor verification process. This step is optional in order to
 
 A common scenario for the second step verification (2FA) is to require a one-time code (OTP) as proof of identity. This is determined by the accepted `strategy` parameter values. Each authentication identifier supports different strategies.
 
-<Callout type="info">
-  While the `phone_code` strategy requires preparation, the `totp` strategy does not - the user can directly attempt the second factor verification in that case.
-</Callout>
+> [!NOTE]
+> While the `phone_code` strategy requires preparation, the `totp` strategy does not - the user can directly attempt the second factor verification in that case.
 
 ```typescript {{ prettier: false }}
 function prepareSecondFactor(params: PrepareSecondFactorParams): Promise<SignIn>;

--- a/docs/references/javascript/sign-in/sign-in.mdx
+++ b/docs/references/javascript/sign-in/sign-in.mdx
@@ -40,9 +40,8 @@ What you must pass to `params` depends on which [sign-in options](/docs/authenti
 
 Optionally, you can complete the sign-in process, fully authenticating the user in one step, if you supply the required fields to `create()`. Otherwise, Clerk's sign-in process provides great flexibility and allows users to easily create multi-step sign-in flows.
 
-<Callout type="warning">
-  Once the sign-in process is complete, pass the `createdSessionId` to the [`setActive()`](/docs/references/javascript/clerk/session-methods#set-active) method on the `Clerk` object. This will set the newly created session as the active session.
-</Callout>
+> [!WARNING]
+> Once the sign-in process is complete, pass the `createdSessionId` to the [`setActive()`](/docs/references/javascript/clerk/session-methods#set-active) method on the `Clerk` object. This will set the newly created session as the active session.
 
 ```typescript {{ prettier: false }}
 function create(params: SignInCreateParams): Promise<SignIn>;

--- a/docs/references/javascript/sign-up/sign-up.mdx
+++ b/docs/references/javascript/sign-up/sign-up.mdx
@@ -47,9 +47,8 @@ What you must pass to `params` depends on which [sign-up options](/docs/authenti
 
 Optionally, you can complete the sign-up process in one step if you supply the required fields to `create()`. Otherwise, Clerk's sign-up process provides great flexibility and allows users to easily create multi-step sign-up flows.
 
-<Callout type="warning">
-  Once the sign-up process is complete, pass the `createdSessionId` to the [`setActive()`](/docs/references/javascript/clerk/session-methods#set-active) method on the `Clerk` object. This will set the newly created session as the active session.
-</Callout>
+> [!WARNING]
+> Once the sign-up process is complete, pass the `createdSessionId` to the [`setActive()`](/docs/references/javascript/clerk/session-methods#set-active) method on the `Clerk` object. This will set the newly created session as the active session.
 
 ```typescript {{ prettier: false }}
 function create(params: SignUpCreateParams): Promise<SignUpResource>;

--- a/docs/references/javascript/user/create-metadata.mdx
+++ b/docs/references/javascript/user/create-metadata.mdx
@@ -13,9 +13,8 @@ The following examples assume that you have followed the [quickstart](/docs/quic
 
 Adds an email address for the user. A new [`EmailAddress`][email-ref] will be created and associated with the user.
 
-<Callout type="warning">
-  **Email address** must be enabled as an identifier in your Clerk settings for this method to work. See the [Identifiers](/docs/authentication/configuration/sign-up-sign-in-options#identifiers) section to learn more.
-</Callout>
+> [!WARNING]
+> **Email address** must be enabled as an identifier in your Clerk settings for this method to work. See the [Identifiers](/docs/authentication/configuration/sign-up-sign-in-options#identifiers) section to learn more.
 
 ```typescript {{ prettier: false }}
 function createEmailAddress: (params: CreateEmailAddressParams) => Promise<EmailAddress>;
@@ -99,9 +98,8 @@ The following example adds `test@test.com` as an email address for the user. If 
 
 Adds a phone number for the user. A new [`PhoneNumber`][phone-ref] will be created and associated with the user.
 
-<Callout type="warning">
-  **Phone number** must be enabled as an identifier in your Clerk settings for this method to work. See the [Identifiers](/docs/authentication/configuration/sign-up-sign-in-options#identifiers) section to learn more.
-</Callout>
+> [!WARNING]
+> **Phone number** must be enabled as an identifier in your Clerk settings for this method to work. See the [Identifiers](/docs/authentication/configuration/sign-up-sign-in-options#identifiers) section to learn more.
 
 ```typescript {{ prettier: false }}
 function createPhoneNumber: (params: CreatePhoneNumberParams) => Promise<PhoneNumber>;
@@ -185,9 +183,8 @@ The following example adds `15551234567` as a phone number for the user. If the 
 
 Adds a web3 wallet for the user. A new [`Web3Wallet<`][web3-ref] will be created and associated with the user.
 
-<Callout type="warning">
-  A Web3 provider must be enabled in your Clerk settings for this method to work. See the [Web3 authentication](/docs/authentication/configuration/sign-up-sign-in-options#web3-authentication) section to learn more.
-</Callout>
+> [!WARNING]
+> A Web3 provider must be enabled in your Clerk settings for this method to work. See the [Web3 authentication](/docs/authentication/configuration/sign-up-sign-in-options#web3-authentication) section to learn more.
 
 ```typescript {{ prettier: false }}
 function createWeb3Wallet: (params: CreateWeb3WalletParams) => Promise<Web3Wallet>;
@@ -271,9 +268,8 @@ The following example adds `0x0123456789ABCDEF0123456789ABCDEF01234567` as a web
 
 Adds an external account for the user. A new [`ExternalAccount`][exacc-ref] will be created and associated with the user. This method is useful if you want to allow an already signed-in user to connect their account with an external provider, such as Facebook, GitHub, etc., so that they can sign in with that provider in the future.
 
-<Callout type="warning">
-  The social provider that you want to connect to must be enabled in your Clerk settings for this method to work. See the [Social connections (OAuth)](/docs/authentication/configuration/sign-up-sign-in-options#social-connections-o-auth) section to learn more.
-</Callout>
+> [!WARNING]
+> The social provider that you want to connect to must be enabled in your Clerk settings for this method to work. See the [Social connections (OAuth)](/docs/authentication/configuration/sign-up-sign-in-options#social-connections-o-auth) section to learn more.
 
 ```typescript {{ prettier: false }}
 function createExternalAccount: (params: CreateExternalAccountParams) => Promise<ExternalAccount>;

--- a/docs/references/javascript/user/totp.mdx
+++ b/docs/references/javascript/user/totp.mdx
@@ -5,9 +5,8 @@ description: Learn about the methods on the User object that allow you to genera
 
 # Time-based One-time Password (TOTP)
 
-<Callout type="warning">
-  **Authenticator application** and **Backup codes** must be enabled as multi-factor strategies in your Clerk settings for these methods to work. See the [Multi-factor authentication](/docs/authentication/configuration/sign-up-sign-in-options#set-up-multi-factor-authentication) section to learn more.
-</Callout>
+> [!WARNING]
+> **Authenticator application** and **Backup codes** must be enabled as multi-factor strategies in your Clerk settings for these methods to work. See the [Multi-factor authentication](/docs/authentication/configuration/sign-up-sign-in-options#set-up-multi-factor-authentication) section to learn more.
 
 Clerk supports multi-factor authentication (MFA) using Time-based One-time Password (TOTP) as a second factor. TOTP is a widely used standard for generating one-time passwords that are valid for a short period of time.
 

--- a/docs/references/javascript/user/user.mdx
+++ b/docs/references/javascript/user/user.mdx
@@ -483,9 +483,8 @@ Learn more:
 
 For an example of how to use this method, see the [Passkeys custom flows documentation](/docs/custom-flows/passkeys#create-user-passkeys).
 
-<Callout type="Info">
-  When creating a passkey for a user in a multi-domain Clerk app, `createPasskey()` must be called from the primary domain.
-</Callout>
+> [!NOTE]
+> When creating a passkey for a user in a multi-domain Clerk app, `createPasskey()` must be called from the primary domain.
 
 ### `isPrimaryIdentification()`
 

--- a/docs/references/nextjs/auth-middleware.mdx
+++ b/docs/references/nextjs/auth-middleware.mdx
@@ -5,9 +5,8 @@ description: The `authMiddleware()` method allows you to protect your Next.js ap
 
 # `authMiddleware()`
 
-<Callout type="danger">
-  This method is now deprecated. Please use [`clerkMiddleware()`](/docs/references/nextjs/clerk-middleware) instead.
-</Callout>
+> [!CAUTION]
+> This method is now deprecated. Please use [`clerkMiddleware()`](/docs/references/nextjs/clerk-middleware) instead.
 
 The `authMiddleware()` helper integrates Clerk authentication into your Next.js application through middleware. `authMiddleware()` is compatible with both the App and Pages routers.
 
@@ -15,10 +14,9 @@ The `authMiddleware()` helper integrates Clerk authentication into your Next.js 
 
 Create a `middleware.ts` file. If your application uses the `src/` directory, your `middleware.ts` file should be placed inside the `src/` folder. If you are not using a `src/` directory, place the `middleware.ts` file in your root directory.
 
-<Callout type="info">
-  For more information about middleware in Next.js, see the [Next.js
-  documentation](https://nextjs.org/docs/pages/building-your-application/routing/middleware).
-</Callout>
+> [!NOTE]
+> For more information about middleware in Next.js, see the [Next.js
+> documentation](https://nextjs.org/docs/pages/building-your-application/routing/middleware).
 
 ```ts {{ prettier: false, filename: 'middleware.ts' }}
 import { authMiddleware } from "@clerk/nextjs/server";

--- a/docs/references/nextjs/auth.mdx
+++ b/docs/references/nextjs/auth.mdx
@@ -18,9 +18,8 @@ The `auth()` helper does require [Middleware](/docs/references/nextjs/clerk-midd
 
 ### `protect()`
 
-<Callout type="warning">
-  `auth().protect()` only works for App Router and is considered experimental.
-</Callout>
+> [!WARNING]
+> `auth().protect()` only works for App Router and is considered experimental.
 
 You can use the `protect()` helper in two ways:
 
@@ -58,9 +57,8 @@ For more information on how to use `protect()`, see the [examples](#use-auth-to-
 | - | - | - |
 | `returnBackUrl?` | `string \| URL` | The URL to redirect the user back to after they sign in. |
 
-<Callout type="info">
-  `auth()` on the server-side can only access redirect URLs defined via [environment variables](/docs/deployments/clerk-environment-variables#sign-in-and-sign-up-redirects) or [`clerkMiddleware` dynamic keys](/docs/references/nextjs/clerk-middleware#dynamic-keys).
-</Callout>
+> [!NOTE]
+> `auth()` on the server-side can only access redirect URLs defined via [environment variables](/docs/deployments/clerk-environment-variables#sign-in-and-sign-up-redirects) or [`clerkMiddleware` dynamic keys](/docs/references/nextjs/clerk-middleware#dynamic-keys).
 
 ## Use `auth()` to retrieve `userId`
 

--- a/docs/references/nextjs/clerk-middleware.mdx
+++ b/docs/references/nextjs/clerk-middleware.mdx
@@ -11,9 +11,8 @@ The `clerkMiddleware()` helper integrates Clerk authentication into your Next.js
 
 Create a `middleware.ts` file at the root of your project, or in your `src/` directory if you have one.
 
-<Callout level="info">
-  For more information about Middleware in Next.js, see the [Next.js documentation](https://nextjs.org/docs/pages/building-your-application/routing/middleware).
-</Callout>
+> [!NOTE]
+> For more information about Middleware in Next.js, see the [Next.js documentation](https://nextjs.org/docs/pages/building-your-application/routing/middleware).
 
 ```tsx {{ prettier: false, filename: 'middleware.ts' }}
 import { clerkMiddleware } from '@clerk/nextjs/server';
@@ -358,6 +357,5 @@ When providing `CLERK_ENCRYPTION_KEY`, it is recommended to use a 32-byte (256-b
 openssl rand --hex 32
 ```
 
-<Callout type="info">
-  Dynamic keys are not accessible on the client-side.
-</Callout>
+> [!NOTE]
+> Dynamic keys are not accessible on the client-side.

--- a/docs/references/nextjs/custom-signup-signin-pages.mdx
+++ b/docs/references/nextjs/custom-signup-signin-pages.mdx
@@ -12,9 +12,8 @@ If Clerk's prebuilt components don't meet your specific needs or if you require 
 > [!NOTE]
 > Watch the video version of this guide on the Clerk YouTube channel  → [YouTube (4 minutes)](https://youtu.be/fsuHLafTYyg).
 
-<Callout>
-  Just getting started with Clerk and Next.js? Check out the [quickstart tutorial](/docs/quickstarts/nextjs)!
-</Callout>
+> [!NOTE]
+> Just getting started with Clerk and Next.js? Check out the [quickstart tutorial](/docs/quickstarts/nextjs)!
 
 {/* TODO: Update these Steps once Steps component accepts other headings types. These headings should be H2s. */}
 

--- a/docs/references/nextjs/get-auth.mdx
+++ b/docs/references/nextjs/get-auth.mdx
@@ -7,9 +7,8 @@ description: The getAuth() helper retrieves the authentication state allowing yo
 
 The `getAuth()` helper retrieves the authentication state, allowing you to protect your API routes or gather relevant data.
 
-<Callout type="info">
-  If you are using App Router, use the [`auth()` helper](/docs/references/nextjs/auth) instead.
-</Callout>
+> [!NOTE]
+> If you are using App Router, use the [`auth()` helper](/docs/references/nextjs/auth) instead.
 
 ## Parameters
 

--- a/docs/references/nextjs/read-session-data.mdx
+++ b/docs/references/nextjs/read-session-data.mdx
@@ -19,9 +19,8 @@ The `currentUser()` helper will return the [`Backend User`](/docs/references/bac
 
 Under the hood, `currentUser()` uses the [`clerkClient`](/docs/references/backend/overview) wrapper to make a call to Clerk's Backend API. **This does count towards the [Backend API Request Rate Limit](/docs/backend-requests/resources/rate-limits#rate-limits)**. This also uses `fetch()` so it is automatically deduped per request.
 
-<Callout type="info">
-  Any requests from a Client Component to a Route Handler will read the session from cookies and will not need the token sent as a Bearer token.
-</Callout>
+> [!NOTE]
+> Any requests from a Client Component to a Route Handler will read the session from cookies and will not need the token sent as a Bearer token.
 
 <Tabs items={["Server components and actions", "Route Handler", "Route Handler w/ User Fetch"]}>
   <Tab>
@@ -153,9 +152,8 @@ Under the hood, `currentUser()` uses the [`clerkClient`](/docs/references/backen
   <Tab>
     You can access the active session and user data in your `getServerSideProps` using the `getAuth()` helper.
 
-    <Callout type="info" emoji="ℹ️">
-      Please note the addition of `buildClerkProps` in the return statement, which informs the Clerk React helpers of the authentication state during server-side rendering (like `useAuth()`, `<SignedIn>`, and `<SignedOut>`).
-    </Callout>
+    > [!NOTE]
+    > Please note the addition of `buildClerkProps` in the return statement, which informs the Clerk React helpers of the authentication state during server-side rendering (like `useAuth()`, `<SignedIn>`, and `<SignedOut>`).
 
     ```tsx {{ prettier: false, filename: 'pages/example.tsx' }}
     import { getAuth, buildClerkProps } from "@clerk/nextjs/server";

--- a/docs/references/nextjs/usage-with-older-versions.mdx
+++ b/docs/references/nextjs/usage-with-older-versions.mdx
@@ -7,9 +7,8 @@ description: Learn how to use Clerk with older versions of Next.js.
 
 Clerk's [prebuilt components](/docs/components/overview) are exported from the `@clerk/nextjs` package and leverage APIs from Next.js itself. These APIs often change between major Next.js releases. While Clerk tries to offer the highest compatibility for any supported Next.js version, for Next.js 12 and older, you need to modify your setup.
 
-<Callout type="warning">
-  Clerk highly recommends updating your Next.js version as older versions won't receive any updates in the future. Read [their upgrade guides](https://nextjs.org/docs/pages/building-your-application/upgrading) to learn more.
-</Callout>
+> [!WARNING]
+> Clerk highly recommends updating your Next.js version as older versions won't receive any updates in the future. Read [their upgrade guides](https://nextjs.org/docs/pages/building-your-application/upgrading) to learn more.
 
 <Steps>
   ### Install `@clerk/nextjs` v4

--- a/docs/references/nodejs/available-methods.mdx
+++ b/docs/references/nodejs/available-methods.mdx
@@ -66,9 +66,8 @@ The example below shows how to use `createClerkClient` to create a `clerkClient`
 
 The following options are available for you to customize the behaviour of the `clerkClient` object.
 
-<Callout type="info">
-  Most options can also be set as environment variables so that you don't need to pass anything to the constructor.
-</Callout>
+> [!NOTE]
+> Most options can also be set as environment variables so that you don't need to pass anything to the constructor.
 
 | Option | Description | Default | Environment variable |
 | - | - | - | - |

--- a/docs/references/react/overview.mdx
+++ b/docs/references/react/overview.mdx
@@ -7,9 +7,8 @@ description: Learn how to integrate React into your Clerk application.
 
 Clerk React is a wrapper around ClerkJS. It is the recommended way to integrate Clerk into your React application.
 
-<Callout type="warning">
-  If you are using Next.js, please make sure to install `@clerk/nextjs` as `@clerk/clerk-react` is incompatible. See the [Next.js](/docs/references/nextjs/overview) documentation for more information.
-</Callout>
+> [!WARNING]
+> If you are using Next.js, please make sure to install `@clerk/nextjs` as `@clerk/clerk-react` is incompatible. See the [Next.js](/docs/references/nextjs/overview) documentation for more information.
 
 Clerk React provides React.js implementations of [Clerk Components](/docs/components/overview); highly customizable, pre-built components that you can use to build beautiful user management applications. You can find display components for building [sign-in](/docs/components/authentication/sign-in), [sign-up](/docs/components/authentication/sign-up), [account switching](/docs/components/user/user-button), and [user profile management](/docs/components/user/user-profile) pages as well as flow [control components](/docs/components/control/signed-in) that act as helpers for implementing a seamless authentication experience.
 

--- a/docs/references/react/use-clerk.mdx
+++ b/docs/references/react/use-clerk.mdx
@@ -7,9 +7,8 @@ description: Clerk's useClerk() hook is used to access the Clerk object, which c
 
 The `useClerk()` hook provides access to the [`Clerk`](/docs/references/javascript/clerk/clerk) object, giving you the ability to build alternatives to any Clerk Component.
 
-<Callout type="warning">
-  This is intended to be used for advanced use cases, like building a completely custom OAuth flow or as an escape hatch for getting access to the `Clerk` object.
-</Callout>
+> [!WARNING]
+> This is intended to be used for advanced use cases, like building a completely custom OAuth flow or as an escape hatch for getting access to the `Clerk` object.
 
 ## `useClerk()` returns
 

--- a/docs/references/react/use-organization-list.mdx
+++ b/docs/references/react/use-organization-list.mdx
@@ -17,9 +17,8 @@ The `useOrganizationList()` hook allows you to retrieve the memberships, invitat
 | `userInvitations` | `true` or an object with [`status: OrganizationInvitationStatus`](#organization-invitation-status) or any of the properties described in [Shared properties](#shared-properties). If set to `true`, all default properties will be used. |
 | `userSuggestions` | `true` or an object with [`status: OrganizationSuggestionsStatus \| OrganizationSuggestionStatus[]`](#organization-suggestion-status) or any of the properties described in [Shared properties](#shared-properties). If set to `true`, all default properties will be used. |
 
-<Callout type="warning">
-  By default, the `userMemberships`, `userInvitations`, and `userSuggestions` attributes are not populated. You must pass `true` or an object with the desired [properties](#shared-properties) to fetch and paginate the data.
-</Callout>
+> [!WARNING]
+> By default, the `userMemberships`, `userInvitations`, and `userSuggestions` attributes are not populated. You must pass `true` or an object with the desired [properties](#shared-properties) to fetch and paginate the data.
 
 ### Shared properties
 

--- a/docs/references/react/use-organization.mdx
+++ b/docs/references/react/use-organization.mdx
@@ -18,9 +18,8 @@ The `useOrganization()` hook is used to retrieve attributes of the currently act
 | `memberships?` | `true` or an object with [`role: OrganizationCustomRoleKey[]`](#organization-custome-role-key) or any of the properties described in [Shared properties](#shared-properties). If set to `true`, all default properties will be used. |
 | `domains?` | `true` or an object with [`enrollmentMode: OrganizationEnrollmentMode`](#organization-enrollment-mode) or any of the properties described in [Shared properties](#shared-properties). If set to `true`, all default properties will be used. |
 
-<Callout type="warning">
-  By default, the `memberships`, `invitations`, `membershipRequests`, and `domains` attributes are not populated. You must pass `true` or an object with the desired [properties](#shared-properties) to fetch and paginate the data.
-</Callout>
+> [!WARNING]
+> By default, the `memberships`, `invitations`, `membershipRequests`, and `domains` attributes are not populated. You must pass `true` or an object with the desired [properties](#shared-properties) to fetch and paginate the data.
 
 ### Shared properties
 
@@ -59,9 +58,8 @@ type OrganizationInvitationStatus = "pending" | "accepted" | "revoked";
 type OrganizationEnrollmentMode = "manual_invitation" | "automatic_invitation" | "automatic_suggestion";
 ```
 
-<Callout type="info">
-  These attributes are updating automatically and will re-render their respective components whenever you set a different organization using the [`setActive({ organization })`](/docs/references/javascript/clerk/session-methods#set-active) method or update any of the memberships or invitations. No need for you to manage updating anything manually.
-</Callout>
+> [!NOTE]
+> These attributes are updating automatically and will re-render their respective components whenever you set a different organization using the [`setActive({ organization })`](/docs/references/javascript/clerk/session-methods#set-active) method or update any of the memberships or invitations. No need for you to manage updating anything manually.
 
 ## `useOrganization()` returns
 

--- a/docs/references/redwood/overview.mdx
+++ b/docs/references/redwood/overview.mdx
@@ -52,9 +52,8 @@ Learn how to use Clerk to quickly and easily add secure authentication and user 
   yarn rw setup auth clerk --force
   ```
 
-  <Callout type="info">
-    The `--force` flag is needed to overwrite the existing dbAuth logic, that is set by default.
-  </Callout>
+  > [!NOTE]
+  > The `--force` flag is needed to overwrite the existing dbAuth logic, that is set by default.
 
   You can now access Clerk functions through the Redwood `useAuth()` hook, which is exported from `src/web/auth.tsx`, or you can use the Clerk components directly.
 

--- a/docs/references/remix/custom-signup-signin-pages.mdx
+++ b/docs/references/remix/custom-signup-signin-pages.mdx
@@ -9,9 +9,8 @@ If Clerk's prebuilt components don't meet your specific needs or if you require 
 
 The functionality of the components are controlled by the instance settings you specify in your [Clerk Dashboard](https://dashboard.clerk.com).
 
-<Callout>
-  Just getting started with Clerk and Remix? Check out the [quickstart tutorial](/docs/quickstarts/remix)!
-</Callout>
+> [!NOTE]
+> Just getting started with Clerk and Remix? Check out the [quickstart tutorial](/docs/quickstarts/remix)!
 
 <Steps>
   ## Build your sign-up page

--- a/docs/references/remix/spa-mode.mdx
+++ b/docs/references/remix/spa-mode.mdx
@@ -22,10 +22,9 @@ description: Clerk supports Remix SPA mode out-of-the-box.
   - Protecting your pages
 </TutorialHero>
 
-<Callout type="info">
-  This guide explains how to use Clerk with [Remix in SPA mode](https://remix.run/docs/en/main/guides/spa-mode).
-  If you are using Remix with SSR, follow the [Remix quickstart](/docs/quickstarts/remix).
-</Callout>
+> [!NOTE]
+> This guide explains how to use Clerk with [Remix in SPA mode](https://remix.run/docs/en/main/guides/spa-mode).
+> If you are using Remix with SSR, follow the [Remix quickstart](/docs/quickstarts/remix).
 
 <Steps>
   ### Install `@clerk/remix`
@@ -57,9 +56,8 @@ description: Clerk supports Remix SPA mode out-of-the-box.
 
   3. Add your key to your `.env` file.
 
-  <Callout type="warning">
-    You will not need the Clerk Secret Key in Remix SPA mode, as it should never be used on the client side.
-  </Callout>
+  > [!WARNING]
+  > You will not need the Clerk Secret Key in Remix SPA mode, as it should never be used on the client side.
 
   The final result should look as follows:
 

--- a/docs/security/customize-user-lockout.mdx
+++ b/docs/security/customize-user-lockout.mdx
@@ -7,9 +7,8 @@ description: Use Clerk to limit the number of times a user can attempt to sign i
 
 Clerk provides an Account Lockout feature in order to protect user credentials against brute force attacks. You can customize the number of times a sign in can be attempted before the account is locked to prevent further sign-in attempts, and how long such a lockout lasts.
 
-<Callout type="info">
-  This feature is applicable to user accounts that use [passwords](https://dashboard.clerk.com/last-active?path=user-authentication/email-phone-username) or [backup codes](https://dashboard.clerk.com/last-active?path=user-authentication/multi-factor).
-</Callout>
+> [!NOTE]
+> This feature is applicable to user accounts that use [passwords](https://dashboard.clerk.com/last-active?path=user-authentication/email-phone-username) or [backup codes](https://dashboard.clerk.com/last-active?path=user-authentication/multi-factor).
 
 1. In your Clerk Dashboard, navigate to **User & Authentication > [Attack Protection](https://dashboard.clerk.com/last-active?path=user-authentication/attack-protection)**.
 1. To change the number of failed attempts before a user is locked out, under **Maximum attempt limit,** enter a new number of failed attempts allowed. (The default is 100 attempts.)

--- a/docs/security/password-protection.mdx
+++ b/docs/security/password-protection.mdx
@@ -48,9 +48,8 @@ This is useful for blocking password sign-ins in the case that:
 - The user was able to set a compromised password because protection was off at the time
 - The user was migrated to Clerk along with their existing password digest
 
-<Callout type="Info">
-  Password reset for compromised passwords uses the same flow as "forgot password". The user will need to authenticate first via an OTP code sent to their email or phone and only then they will be able to set a new — more secure — password.
-</Callout>
+> [!NOTE]
+> Password reset for compromised passwords uses the same flow as "forgot password". The user will need to authenticate first via an OTP code sent to their email or phone and only then they will be able to set a new — more secure — password.
 
 #### Limitations
 

--- a/docs/security/unlock-user-accounts.mdx
+++ b/docs/security/unlock-user-accounts.mdx
@@ -5,9 +5,8 @@ description: Use the Clerk Dashboard to unlock user accounts.
 
 # Unlock user accounts from the Clerk Dashboard
 
-<Callout type="info">
-  This feature is applicable to a subset of actions. Find a [full list here](/docs/security/user-lock-guide#related-actions)
-</Callout>
+> [!NOTE]
+> This feature is applicable to a subset of actions. Find a [full list here](/docs/security/user-lock-guide#related-actions)
 
 Users with admin roles can override lockouts through the Clerk Dashboard.
 

--- a/docs/security/user-lock-guide.mdx
+++ b/docs/security/user-lock-guide.mdx
@@ -44,6 +44,5 @@ When a user exceeds the maximum sign-in attempts, the Clerk [`<SignIn />`](/docs
   alt="The Clerk component sign-in form with a red alert stating 'Your account is locked. You will be able to try again in 59 minutes. For more information, please contact support.'"
 />
 
-<Callout type="info">
-  Currently, users cannot unlock their own account or submit a request to the admin to be unlocked ("self-service unlock"). This is an upcoming feature, so please check Clerk's [changelog](https://clerk.com/blog) periodically to find out when it is available. Until then, you can [programmatically lock and unlock user accounts with a custom flow](/docs/security/programmatically-lock-user-accounts).
-</Callout>
+> [!NOTE]
+> Currently, users cannot unlock their own account or submit a request to the admin to be unlocked ("self-service unlock"). This is an upcoming feature, so please check Clerk's [changelog](https://clerk.com/blog) periodically to find out when it is available. Until then, you can [programmatically lock and unlock user accounts with a custom flow](/docs/security/programmatically-lock-user-accounts).

--- a/docs/telemetry.mdx
+++ b/docs/telemetry.mdx
@@ -26,9 +26,8 @@ Examples of data we are interested in:
 - What associated framework versions are being used? (e.g. what `next` version is being used along with `@clerk/nextjs`)
 - Usage of new features
 
-<Callout type="info">
-  We regularly audit this list to ensure it is an accurate representation of the data we are collecting. To audit telemetry data sent from our SDKs yourself, you can set a `CLERK_TELEMETRY_DEBUG=1` environment variable in your application. In this mode, telemetry events are only logged to the console and not sent to Clerk.
-</Callout>
+> [!NOTE]
+> We regularly audit this list to ensure it is an accurate representation of the data we are collecting. To audit telemetry data sent from our SDKs yourself, you can set a `CLERK_TELEMETRY_DEBUG=1` environment variable in your application. In this mode, telemetry events are only logged to the console and not sent to Clerk.
 
 An example event looks like this:
 
@@ -64,9 +63,8 @@ We will never share with or sell telemetry data to third parties. The data is us
 
 ### Environment variables
 
-<Callout type="warning">
-  Note that the variable name might differ between frameworks. See the [framework specific instructions](#framework-specific-instructions) below.
-</Callout>
+> [!WARNING]
+> Note that the variable name might differ between frameworks. See the [framework specific instructions](#framework-specific-instructions) below.
 
 For meta-framework SDKs, you can opt-out of telemetry collection by setting the environment variable:
 

--- a/docs/testing/overview.mdx
+++ b/docs/testing/overview.mdx
@@ -15,9 +15,8 @@ To avoid sending an email or SMS message with a one time passcode (OTP) during t
 
 Testing Tokens enable bypassing various bot detection mechanisms that typically safeguard Clerk applications against malicious bots, thus allowing test suites to run uninhibited. Without Testing Tokens, you may encounter "Bot traffic detected" errors in your requests.
 
-<Callout type="info">
-  While manually implementing the following logic in your test suite is possible, Clerk offers [Playwright](/docs/testing/playwright) and [Cypress](/docs/testing/cypress) integrations which will automatically take care of all of this.
-</Callout>
+> [!NOTE]
+> While manually implementing the following logic in your test suite is possible, Clerk offers [Playwright](/docs/testing/playwright) and [Cypress](/docs/testing/cypress) integrations which will automatically take care of all of this.
 
 Obtained via the [Backend API](https://clerk.com/docs/reference/backend-api/tag/Testing-Tokens), Testing Tokens are short-lived and valid only for the specific instance for which they are issued. Testing Tokens are only available in development instances.
 

--- a/docs/testing/playwright.mdx
+++ b/docs/testing/playwright.mdx
@@ -22,9 +22,8 @@ Before diving in, you might want to start by visiting the [Playwright starter](h
 
   Set your publishable and secret keys in your test runner, as the `CLERK_PUBLISHABLE_KEY` and `CLERK_SECRET_KEY` environment variables respectively.
 
-  <Callout type="warning">
-    Ensure you provide the secret key in a secure manner, to avoid leaking it to third parties. For example, if you are using GitHub Actions, refer to [_Using secrets in GitHub Actions_](https://docs.github.com/en/actions/security-guides/using-secrets-in-github-actions).
-  </Callout>
+  > [!WARNING]
+  > Ensure you provide the secret key in a secure manner, to avoid leaking it to third parties. For example, if you are using GitHub Actions, refer to [_Using secrets in GitHub Actions_](https://docs.github.com/en/actions/security-guides/using-secrets-in-github-actions).
 
   ### Global setup
 
@@ -41,10 +40,9 @@ Before diving in, you might want to start by visiting the [Playwright starter](h
 
   `clerkSetup` will obtain a [Testing Token](/docs/testing/overview#testing-tokens) when your test suite starts, making it available for all subsequent tests to use.
 
-  <Callout type="info">
-    You can set the Testing Token yourself as opposed to calling `clerkSetup`, by
-    setting it in the `CLERK_TESTING_TOKEN` environment variable.
-  </Callout>
+  > [!NOTE]
+  > You can set the Testing Token yourself as opposed to calling `clerkSetup`, by
+  > setting it in the `CLERK_TESTING_TOKEN` environment variable.
 
   ### Use `setupClerkTestingToken`
 

--- a/docs/testing/test-emails-and-phones.mdx
+++ b/docs/testing/test-emails-and-phones.mdx
@@ -29,9 +29,8 @@ If your development instance requires a higher allowance of monthly SMS messages
 
 Every development instance has "test mode" enabled by default. If you need to use "test mode" on a production instance, you can enable it via the Clerk Dashboard or via the Backend API.
 
-<Callout type="warning">
-  You should not be using "test mode" on any instance that manages actual customers.
-</Callout>
+> [!WARNING]
+> You should not be using "test mode" on any instance that manages actual customers.
 
 ### Test mode via the Clerk Dashboard
 

--- a/docs/troubleshooting/create-a-minimal-reproduction.mdx
+++ b/docs/troubleshooting/create-a-minimal-reproduction.mdx
@@ -62,9 +62,8 @@ The best way to create a minimal reproduction is to start fresh, with a minimal 
 
   Add a README file to the root of the repository that contains the steps that must be taken in the app in order to produce the error (click X button, sign in using Y provider, etc).
 
-  <Callout type="warning">
-    This step is only required if you are submitting the minimal reproduction to the Clerk support team.
-  </Callout>
+  > [!WARNING]
+  > This step is only required if you are submitting the minimal reproduction to the Clerk support team.
 </Steps>
 
 It’s important throughout this process to be vigilant about removing code that is not necessary to produce the issue. The ideal result is that the repository gets to the state where the exact same issue is able to be produced, with the fewest lines of code possible to get to that point (beyond the baseline included in the templates).

--- a/docs/upgrade-guides/api-keys.mdx
+++ b/docs/upgrade-guides/api-keys.mdx
@@ -5,9 +5,8 @@ description: Dive into Clerk's latest V3 update.
 
 # Publishable and secret keys
 
-<Callout type="info">
-  If your application was created after January 18, 2023, you're already using publishable and secret keys.
-</Callout>
+> [!NOTE]
+> If your application was created after January 18, 2023, you're already using publishable and secret keys.
 
 In early Clerk SDKs, developers were required to configure three keys:
 
@@ -24,8 +23,7 @@ The name and format of these keys are common among developer tools, and we adopt
 
 Although legacy keys will remain operational, we have updated our documentation and code samples to use the new Publishable Key and Secret Key format.
 
-<Callout type="danger">
-  Legacy keys cannot be mixed with the new publishable and secret keys. It is important that you replace all keys at once.
-</Callout>
+> [!CAUTION]
+> Legacy keys cannot be mixed with the new publishable and secret keys. It is important that you replace all keys at once.
 
 We recommend updating at your earliest convenience.

--- a/docs/upgrade-guides/core-2/backend.mdx
+++ b/docs/upgrade-guides/core-2/backend.mdx
@@ -607,10 +607,9 @@ There are a number of Clerk primitives that contain images, and previously they 
 
 As part of this major version, a number of previously deprecated props, arugments, methods, etc. have been removed. Additionally there have been some changes to things that are only used internally, or only used very rarely. It's highly unlikely that any given app will encounter any of these items, but they are all breaking changes, so they have all been documented below.
 
-<Callout type="info">
-  For this section more than any other one, please use the CLI upgrade tool (`npx @clerk/upgrade`). Changes in this
-  section are very unlikely to appear in your codebase, the tool will save time looking for them.
-</Callout>
+> [!NOTE]
+> For this section more than any other one, please use the CLI upgrade tool (`npx @clerk/upgrade`). Changes in this
+> section are very unlikely to appear in your codebase, the tool will save time looking for them.
 
 #### Deprecation removals
 

--- a/docs/upgrade-guides/core-2/chrome-extension.mdx
+++ b/docs/upgrade-guides/core-2/chrome-extension.mdx
@@ -220,10 +220,9 @@ There are a number of Clerk primitives that contain images, and previously they 
 
 As part of this major version, a number of previously deprecated props, arugments, methods, etc. have been removed. Additionally there have been some changes to things that are only used internally, or only used very rarely. It's highly unlikely that any given app will encounter any of these items, but they are all breaking changes, so they have all been documented below.
 
-<Callout type="info">
-  For this section more than any other one, please use the CLI upgrade tool (`npx @clerk/upgrade`). Changes in this
-  section are very unlikely to appear in your codebase, the tool will save time looking for them.
-</Callout>
+> [!NOTE]
+> For this section more than any other one, please use the CLI upgrade tool (`npx @clerk/upgrade`). Changes in this
+> section are very unlikely to appear in your codebase, the tool will save time looking for them.
 
 #### Deprecation removals
 

--- a/docs/upgrade-guides/core-2/component-redesign.mdx
+++ b/docs/upgrade-guides/core-2/component-redesign.mdx
@@ -7,9 +7,8 @@ description: "Learn how to handle changes as a result of redesigned components i
 
 The new version ships with improved design and UX across all of Clerk's [UI components](/docs/components/overview). If you have used the [`appearance` prop](/docs/components/customization/overview) or tokens for a [custom theme](/docs/components/customization/overview#create-a-custom-theme), you will likely need to make some adjustments to ensure your styling is still looking great. If you're using the [localization prop](/docs/components/customization/localization) you will likely need to make adjustments to account for added or removed localization keys.
 
-<Callout type="info">
-  If you are not customizing the appearance of your components, or using `localization`, you can skip this section. If you are, we recommend using our CLI (`npx @clerk/upgrade`) to scan for changes required as part of the component redesign more quickly.
-</Callout>
+> [!NOTE]
+> If you are not customizing the appearance of your components, or using `localization`, you can skip this section. If you are, we recommend using our CLI (`npx @clerk/upgrade`) to scan for changes required as part of the component redesign more quickly.
 
 The sections below contain more info on each change made to the customization ids and localization keys for reference. Regardless of how thoroughly you have reviewed the following information, we still recommend that you ensure that you have taken some time to manually look through each of your views to ensure that everything looks good still.
 

--- a/docs/upgrade-guides/core-2/expo.mdx
+++ b/docs/upgrade-guides/core-2/expo.mdx
@@ -208,10 +208,9 @@ There are a number of Clerk primitives that contain images, and previously they 
 
 As part of this major version, a number of previously deprecated props, arugments, methods, etc. have been removed. Additionally there have been some changes to things that are only used internally, or only used very rarely. It's highly unlikely that any given app will encounter any of these items, but they are all breaking changes, so they have all been documented below.
 
-<Callout type="info">
-  For this section more than any other one, please use the CLI upgrade tool (`npx @clerk/upgrade`). Changes in this
-  section are very unlikely to appear in your codebase, the tool will save time looking for them.
-</Callout>
+> [!NOTE]
+> For this section more than any other one, please use the CLI upgrade tool (`npx @clerk/upgrade`). Changes in this
+> section are very unlikely to appear in your codebase, the tool will save time looking for them.
 
 #### Deprecation removals
 

--- a/docs/upgrade-guides/core-2/fastify.mdx
+++ b/docs/upgrade-guides/core-2/fastify.mdx
@@ -142,10 +142,9 @@ There are a number of Clerk primitives that contain images, and previously they 
 
 As part of this major version, a number of previously deprecated props, arugments, methods, etc. have been removed. Additionally there have been some changes to things that are only used internally, or only used very rarely. It's highly unlikely that any given app will encounter any of these items, but they are all breaking changes, so they have all been documented below.
 
-<Callout type="info">
-  For this section more than any other one, please use the CLI upgrade tool (`npx @clerk/upgrade`). Changes in this
-  section are very unlikely to appear in your codebase, the tool will save time looking for them.
-</Callout>
+> [!NOTE]
+> For this section more than any other one, please use the CLI upgrade tool (`npx @clerk/upgrade`). Changes in this
+> section are very unlikely to appear in your codebase, the tool will save time looking for them.
 
 #### Deprecation removals
 

--- a/docs/upgrade-guides/core-2/javascript.mdx
+++ b/docs/upgrade-guides/core-2/javascript.mdx
@@ -87,9 +87,8 @@ All `afterSignXUrl` props and `CLERK_AFTER_SIGN_X_URL` environment variables hav
 
 In general, use the environment variables over the props.
 
-<Callout type="warning">
-  If neither value is set, Clerk will redirect to the `redirect_url` if present, otherwise it will redirect to `/`.
-</Callout>
+> [!WARNING]
+> If neither value is set, Clerk will redirect to the `redirect_url` if present, otherwise it will redirect to `/`.
 
 To retain the current behavior of your app without any changes, you can switch `afterSignXUrl` with `signXFallbackRedirectUrl` as such:
 
@@ -484,10 +483,9 @@ There have been changes to return signatures for some functions. Since Clerk's A
 
 As part of this major version, a number of previously deprecated props, arugments, methods, etc. have been removed. Additionally there have been some changes to things that are only used internally, or only used very rarely. It's highly unlikely that any given app will encounter any of these items, but they are all breaking changes, so they have all been documented below.
 
-<Callout type="info">
-  For this section more than any other one, please use the CLI upgrade tool (`npx @clerk/upgrade`). Changes in this
-  section are very unlikely to appear in your codebase, the tool will save time looking for them.
-</Callout>
+> [!NOTE]
+> For this section more than any other one, please use the CLI upgrade tool (`npx @clerk/upgrade`). Changes in this
+> section are very unlikely to appear in your codebase, the tool will save time looking for them.
 
 #### Deprecation removals
 

--- a/docs/upgrade-guides/core-2/nextjs.mdx
+++ b/docs/upgrade-guides/core-2/nextjs.mdx
@@ -372,9 +372,8 @@ Of course, in most cases you'll have a more complicated setup than this. You can
 
 As part of this release, some of the top-level exports of `@clerk/nextjs` have been changed in order to improve bundle size and tree-shaking efficiency. These changes have resulted in a \~75% reduction in build size for middleware bundles. However, you will likely need to make some changes to import paths as a result.
 
-<Callout type="info">
-  Use [the CLI tool](#cli-upgrade-helper) to automatically find occurences of imports that need to be changed.
-</Callout>
+> [!NOTE]
+> Use [the CLI tool](#cli-upgrade-helper) to automatically find occurences of imports that need to be changed.
 
 <Accordion
   titles={["@clerk/nextjs/server", "@clerk/nextjs/errors", "@clerk/nextjs/app-beta", "@clerk/nextjs/ssr", "@clerk/nextjs/edge-middleware", "@clerk/nextjs/edge-middlewarefiles", "@clerk/nextjs/api"]}
@@ -492,9 +491,8 @@ All `afterSignXUrl` props and `CLERK_AFTER_SIGN_X_URL` environment variables hav
 
 In general, use the environment variables over the props.
 
-<Callout type="warning">
-  If neither value is set, Clerk will redirect to the `redirect_url` if present, otherwise it will redirect to `/`.
-</Callout>
+> [!WARNING]
+> If neither value is set, Clerk will redirect to the `redirect_url` if present, otherwise it will redirect to `/`.
 
 To retain the current behavior of your app without any changes, you can switch `afterSignXUrl` with `signXFallbackRedirectUrl` as such:
 
@@ -593,10 +591,9 @@ There are a number of Clerk primitives that contain images, and previously they 
 
 As part of this major version, a number of previously deprecated props, arugments, methods, etc. have been removed. Additionally there have been some changes to things that are only used internally, or only used very rarely. It's highly unlikely that any given app will encounter any of these items, but they are all breaking changes, so they have all been documented below.
 
-<Callout type="info">
-  For this section more than any other one, please use the CLI upgrade tool (`npx @clerk/upgrade`). Changes in this
-  section are very unlikely to appear in your codebase, the tool will save time looking for them.
-</Callout>
+> [!NOTE]
+> For this section more than any other one, please use the CLI upgrade tool (`npx @clerk/upgrade`). Changes in this
+> section are very unlikely to appear in your codebase, the tool will save time looking for them.
 
 #### Deprecation removals
 

--- a/docs/upgrade-guides/core-2/node.mdx
+++ b/docs/upgrade-guides/core-2/node.mdx
@@ -187,10 +187,9 @@ There are a number of Clerk primitives that contain images, and previously they 
 
 As part of this major version, a number of previously deprecated props, arugments, methods, etc. have been removed. Additionally there have been some changes to things that are only used internally, or only used very rarely. It's highly unlikely that any given app will encounter any of these items, but they are all breaking changes, so they have all been documented below.
 
-<Callout type="info">
-  For this section more than any other one, please use the CLI upgrade tool (`npx @clerk/upgrade`). Changes in this
-  section are very unlikely to appear in your codebase, the tool will save time looking for them.
-</Callout>
+> [!NOTE]
+> For this section more than any other one, please use the CLI upgrade tool (`npx @clerk/upgrade`). Changes in this
+> section are very unlikely to appear in your codebase, the tool will save time looking for them.
 
 #### Deprecation removals
 

--- a/docs/upgrade-guides/core-2/react.mdx
+++ b/docs/upgrade-guides/core-2/react.mdx
@@ -111,9 +111,8 @@ All `afterSignXUrl` props and `CLERK_AFTER_SIGN_X_URL` environment variables hav
 
 In general, use the environment variables over the props.
 
-<Callout type="warning">
-  If neither value is set, Clerk will redirect to the `redirect_url` if present, otherwise it will redirect to `/`.
-</Callout>
+> [!WARNING]
+> If neither value is set, Clerk will redirect to the `redirect_url` if present, otherwise it will redirect to `/`.
 
 To retain the current behavior of your app without any changes, you can switch `afterSignXUrl` with `signXFallbackRedirectUrl` as such:
 
@@ -245,10 +244,9 @@ There are a number of Clerk primitives that contain images, and previously they 
 
 As part of this major version, a number of previously deprecated props, arugments, methods, etc. have been removed. Additionally there have been some changes to things that are only used internally, or only used very rarely. It's highly unlikely that any given app will encounter any of these items, but they are all breaking changes, so they have all been documented below.
 
-<Callout type="info">
-  For this section more than any other one, please use the CLI upgrade tool (`npx @clerk/upgrade`). Changes in this
-  section are very unlikely to appear in your codebase, the tool will save time looking for them.
-</Callout>
+> [!NOTE]
+> For this section more than any other one, please use the CLI upgrade tool (`npx @clerk/upgrade`). Changes in this
+> section are very unlikely to appear in your codebase, the tool will save time looking for them.
 
 #### Deprecation removals
 

--- a/docs/upgrade-guides/core-2/remix.mdx
+++ b/docs/upgrade-guides/core-2/remix.mdx
@@ -131,9 +131,8 @@ All `afterSignXUrl` props and `CLERK_AFTER_SIGN_X_URL` environment variables hav
 
 In general, use the environment variables over the props.
 
-<Callout type="warning">
-  If neither value is set, Clerk will redirect to the `redirect_url` if present, otherwise it will redirect to `/`.
-</Callout>
+> [!WARNING]
+> If neither value is set, Clerk will redirect to the `redirect_url` if present, otherwise it will redirect to `/`.
 
 To retain the current behavior of your app without any changes, you can switch `afterSignXUrl` with `signXFallbackRedirectUrl` as such:
 
@@ -232,10 +231,9 @@ There are a number of Clerk primitives that contain images, and previously they 
 
 As part of this major version, a number of previously deprecated props, arugments, methods, etc. have been removed. Additionally there have been some changes to things that are only used internally, or only used very rarely. It's highly unlikely that any given app will encounter any of these items, but they are all breaking changes, so they have all been documented below.
 
-<Callout type="info">
-  For this section more than any other one, please use the CLI upgrade tool (`npx @clerk/upgrade`). Changes in this
-  section are very unlikely to appear in your codebase, the tool will save time looking for them.
-</Callout>
+> [!NOTE]
+> For this section more than any other one, please use the CLI upgrade tool (`npx @clerk/upgrade`). Changes in this
+> section are very unlikely to appear in your codebase, the tool will save time looking for them.
 
 #### Deprecation removals
 

--- a/docs/upgrade-guides/long-term-support.mdx
+++ b/docs/upgrade-guides/long-term-support.mdx
@@ -11,9 +11,8 @@ After the LTS period ends, there will be no further changes to the code for that
 
 ## Schedule
 
-<Callout type="info">
-  Future time ranges are listed when a specific target date is not yet determined. The version "Core `N`" refers to [how Clerk SDKs are versioned and released](/docs/upgrade-guides/sdk-versioning).
-</Callout>
+> [!NOTE]
+> Future time ranges are listed when a specific target date is not yet determined. The version "Core `N`" refers to [how Clerk SDKs are versioned and released](/docs/upgrade-guides/sdk-versioning).
 
 | Version | Status | As Of | Until |
 | - | - | - | - |

--- a/docs/upgrade-guides/progressive-sign-up.mdx
+++ b/docs/upgrade-guides/progressive-sign-up.mdx
@@ -5,9 +5,8 @@ description: Progressive Sign Up is a new Sign Up flow that was introduced in Q2
 
 # Progressive Sign Up
 
-<Callout type="info">
-  If your application was created after June 7, 2022, you're already using Progressive Sign Up.
-</Callout>
+> [!NOTE]
+> If your application was created after June 7, 2022, you're already using Progressive Sign Up.
 
 Progressive Sign Up is a new Sign Up flow introduced in Q2 2022, that aims to improve upon the previous implementation by handling more scenarios and adhering more strictly to the authentication settings of the instance. Additionally, it allows Web3 authentication to be used together with the regular authentication settings.
 

--- a/docs/upgrade-guides/upgrading-from-v2-to-v3.mdx
+++ b/docs/upgrade-guides/upgrading-from-v2-to-v3.mdx
@@ -148,9 +148,8 @@ The `createEmailLinkFlow` and `authenticateWithRedirect` calls have had paramete
 
 ## Next.js server-side changes
 
-<Callout type="info">
-  Before starting this guide, please complete the [Client-side changes](#client-side-changes-all-frameworks).
-</Callout>
+> [!NOTE]
+> Before starting this guide, please complete the [Client-side changes](#client-side-changes-all-frameworks).
 
 ### API routes
 
@@ -188,9 +187,8 @@ export const middleware = withEdgeMiddlewareAuth((req, ev) => {
 
 ## Express server-side changes
 
-<Callout type="info">
-  Before starting this guide, please complete the [Client-side changes](#client-side-changes-all-frameworks).
-</Callout>
+> [!NOTE]
+> Before starting this guide, please complete the [Client-side changes](#client-side-changes-all-frameworks).
 
 ### Middleware
 

--- a/docs/upgrade-guides/url-based-session-syncing.mdx
+++ b/docs/upgrade-guides/url-based-session-syncing.mdx
@@ -5,15 +5,13 @@ description: Learn how Clerk development instances keep track of session state.
 
 # URL-based session syncing
 
-<Callout type="warning">
-  All development instance Clerk apps created after December 6th, 2022 use URL-based session syncing by default, and cannot opt out.
-</Callout>
+> [!WARNING]
+> All development instance Clerk apps created after December 6th, 2022 use URL-based session syncing by default, and cannot opt out.
 
 URL-based session syncing (previously known as Cookieless Development mode) configures your frontend and your Clerk Frontend API to communicate information about the current session state via URL decoration.
 
-<Callout type="info">
-  This mode only applies to Development Instances. Production instances remain unaffected and continue communicating with Frontend API using first-party, HttpOnly cookies.
-</Callout>
+> [!NOTE]
+> This mode only applies to Development Instances. Production instances remain unaffected and continue communicating with Frontend API using first-party, HttpOnly cookies.
 
 ## Migrate to URL-based session syncing
 

--- a/docs/users/invitations.mdx
+++ b/docs/users/invitations.mdx
@@ -115,9 +115,8 @@ You can either use a cURL command or Clerk's [JavaScript Backend SDK](/docs/refe
   </Tab>
 </Tabs>
 
-<Callout type="warning">
-  Revoking an invitation does **not** prevent the user from signing up on their own. If you're looking for invitation-only applications, please refer to our [allowlist feature](/docs/authentication/configuration/restrictions#allowlist).
-</Callout>
+> [!WARNING]
+> Revoking an invitation does **not** prevent the user from signing up on their own. If you're looking for invitation-only applications, please refer to our [allowlist feature](/docs/authentication/configuration/restrictions#allowlist).
 
 ## Custom flow
 

--- a/docs/users/metadata.mdx
+++ b/docs/users/metadata.mdx
@@ -13,9 +13,8 @@ Metadata allows for custom data to be saved on the [`User` object](/docs/users/o
 | Public | Read access | Read & write access |
 | Unsafe | Read & write access | Read & write access |
 
-<Callout type="warning">
-  Metadata is limited to **8kb** maximum.
-</Callout>
+> [!WARNING]
+> Metadata is limited to **8kb** maximum.
 
 ## Private metadata
 


### PR DESCRIPTION
This PR updates removes usage of the `<Callout>` component, in favour of blockquote-based callouts. `<Callout>` has been deprecated since the blockquote-based callout syntax was documented in #1017.

---

**Before**

```jsx
<Callout type="danger">
  We recommend leaving the Account Portal enabled, even if you do choose to set up your own authentication flow. This helps with testing as well as providing an alternative path for users when needed.
</Callout>
```

**After**

```markdown
> [!CAUTION]
> We recommend leaving the Account Portal enabled, even if you do choose to set up your own authentication flow. This helps with testing as well as providing an alternative path for users when needed.
```