### PR TITLE
Add explicit callout type to all standard blockquotes

### DIFF
--- a/docs/advanced-usage/satellite-domains.mdx
+++ b/docs/advanced-usage/satellite-domains.mdx
@@ -65,6 +65,7 @@ To access authentication state from a satellite domain, users will be transparen
     <Tab>
       You can configure your satellite application by setting the following environment variables:
 
+      > [!NOTE]
       > In development, your publishable and secret keys will start with `pk_test_` and `sk_test` respectively.
 
       - In the `.env` file associated with your primary domain:

--- a/docs/authentication/social-connections/atlassian.mdx
+++ b/docs/authentication/social-connections/atlassian.mdx
@@ -15,6 +15,7 @@ To make the development flow as smooth as possible, Clerk uses  preconfigured sh
 
 For production instances, you will need to generate your own Client ID and Client Secret using your Atlassian account.
 
+> [!NOTE]
 > The purpose of this guide is to help you create an Atlassian account and an Atlassian OAuth 2.0 Integration - if you're looking for step-by-step  instructions using Clerk to add social connection (OAuth) to your  application, follow the [Social connection (OAuth) guide](/docs/authentication/social-connections/oauth).
 
 ## Before you start

--- a/docs/authentication/social-connections/bitbucket.mdx
+++ b/docs/authentication/social-connections/bitbucket.mdx
@@ -15,6 +15,7 @@ To make the development flow as smooth as possible, Clerk uses  preconfigured sh
 
 For production instances, you will need to generate your own Consumer Key and Consumer Secret using your Bitbucket account.
 
+> [!NOTE]
 > The purpose of this guide is to help you create a Bitbucket account and a Bitbucket OAuth Consumer - if you're looking for step-by-step instructions using Clerk to add social connection (OAuth) to your  application, follow the [Social connection (OAuth) guide](/docs/authentication/social-connections/oauth).
 
 ## Before you start

--- a/docs/authentication/social-connections/box.mdx
+++ b/docs/authentication/social-connections/box.mdx
@@ -15,6 +15,7 @@ To make the development flow as smooth as possible, Clerk uses preconfigured sha
 
 For production instances, you will need to generate your own Client ID and Client secret using your Box account.
 
+> [!NOTE]
 > The purpose of this guide is to help you create a Box developer account and a Box OAuth app - if you're looking for step-by-step instructions using Clerk to add social connection (OAuth) to your application, follow the [Social connection (OAuth) guide](/docs/authentication/social-connections/oauth).
 
 ## Before you start

--- a/docs/authentication/social-connections/coinbase.mdx
+++ b/docs/authentication/social-connections/coinbase.mdx
@@ -15,6 +15,7 @@ To make the development flow as smooth as possible, Clerk uses preconfigured sha
 
 For production instances, you will need to generate your own Client ID and Client secret using your Coinbase account.
 
+> [!NOTE]
 > The purpose of this guide is to help you create a Coinbase developer account and a Coinbase OAuth app - if you're looking for step-by-step instructions using Clerk to add social connection (OAuth) to your application, follow the [Social connection (OAuth) guide](/docs/authentication/social-connections/oauth).
 
 ## Before you start

--- a/docs/authentication/social-connections/discord.mdx
+++ b/docs/authentication/social-connections/discord.mdx
@@ -15,6 +15,7 @@ To make the development flow as smooth as possible, Clerk uses preconfigured sha
 
 For production instances, you will need to generate your own Client ID and Client secret using your Discord account.
 
+> [!NOTE]
 > The purpose of this guide is to help you create a Discord account and a Discord OAuth app - if you're looking for step-by-step instructions using Clerk to add social connection (OAuth) to your application, follow the [Social connection (OAuth) guide](/docs/authentication/social-connections/oauth).
 
 ## Before you start

--- a/docs/authentication/social-connections/dropbox.mdx
+++ b/docs/authentication/social-connections/dropbox.mdx
@@ -15,6 +15,7 @@ To make the development flow as smooth as possible, Clerk uses preconfigured sha
 
 For production instances, you will need to generate your own Client ID and Client secret using your Dropbox account.
 
+> [!NOTE]
 > The purpose of this guide is to help you create a Dropbox account and a Dropbox OAuth app - if you're looking for step-by-step instructions using Clerk to add social connection (OAuth) to your application, follow the [Social connection (OAuth) guide](/docs/authentication/social-connections/oauth).
 
 ## Before you start

--- a/docs/authentication/social-connections/facebook.mdx
+++ b/docs/authentication/social-connections/facebook.mdx
@@ -15,6 +15,7 @@ To make the development flow as smooth as possible, Clerk uses  preconfigured sh
 
 For production instances, you will need to create your own developer account with Facebook and generate your own **App ID** and **App Secret**.
 
+> [!NOTE]
 > The purpose of this guide is to help you set up a Facebook developer account and a Facebook OAuth2.0 project - if you're looking for step-by-step  instructions using Clerk to add Social Connection (OAuth) to your  application, follow the [Social connection (OAuth) guide](/docs/authentication/social-connections/oauth).
 
 ## Before you start

--- a/docs/authentication/social-connections/github.mdx
+++ b/docs/authentication/social-connections/github.mdx
@@ -15,6 +15,7 @@ To make the development flow as smooth as possible, Clerk uses  preconfigured sh
 
 For production instances, you will need to generate your own Client ID and Client secret using your GitHub account.
 
+> [!NOTE]
 > The purpose of this guide is to help you create a GitHub account and a GitHub OAuth app - if you're looking for step-by-step instructions using Clerk to add social connection (OAuth) to your application, follow the [Social connection (OAuth) guide](/docs/authentication/social-connections/oauth).
 
 ## Before you start

--- a/docs/authentication/social-connections/gitlab.mdx
+++ b/docs/authentication/social-connections/gitlab.mdx
@@ -15,6 +15,7 @@ To make the development flow as smooth as possible, Clerk uses  preconfigured sh
 
 For production instances, you will need to generate your own Client ID and Client secret using your GitLab account.
 
+> [!NOTE]
 > The purpose of this guide is to help you create a GitLab account and a  GitLab OAuth app - if you're looking for step-by-step instructions using Clerk to add social connection (OAuth) to your application, follow the [Social connection (OAuth) guide](/docs/authentication/social-connections/oauth).
 
 ## Before you start

--- a/docs/authentication/social-connections/google.mdx
+++ b/docs/authentication/social-connections/google.mdx
@@ -15,6 +15,7 @@ To make the development flow as smooth as possible, Clerk uses  preconfigured sh
 
 For production instances, you will need to create your own developer account with Google and generate your own Client ID and Client secret.
 
+> [!NOTE]
 > The purpose of this guide is to help you setup a Google developer account and a Google OAuth 2.0 project - if you're looking for step-by-step  instructions using Clerk to add Social Connection (OAuth) to your  application, follow the [Social connection (OAuth) guide](/docs/authentication/social-connections/oauth).
 
 ## Before you start

--- a/docs/authentication/social-connections/hubspot.mdx
+++ b/docs/authentication/social-connections/hubspot.mdx
@@ -15,6 +15,7 @@ To make the development flow as smooth as possible, Clerk uses  preconfigured sh
 
 For production instances, you will need to create your own developer account with **HubSpot** and generate your own Client ID and Client secret.
 
+> [!NOTE]
 > The purpose of this guide is to help you set up a HubSpot developer account and a HubSpot OAuth app - if you're looking for step-by-step instructions using Clerk to add social connection (OAuth) to your  application, follow the [Social connection (OAuth) guide](/docs/authentication/social-connections/oauth).
 
 ## Before you start

--- a/docs/authentication/social-connections/line.mdx
+++ b/docs/authentication/social-connections/line.mdx
@@ -13,10 +13,12 @@ Adding social connection with LINE to your app with Clerk is done in a few steps
 
 To make the development flow as smooth as possible, Clerk uses preconfigured shared OAuth credentials and redirect URIs for development instances - no other configuration is needed.
 
+> [!NOTE]
 > Clerk preconfigured shared OAuth credentials are using **Japan** as the LINE region
 
 For production instances, you will need to generate your own Client ID and Client secret using your LINE account.
 
+> [!NOTE]
 > The purpose of this guide is to help you create a LINE account and a LINE OAuth app - if you're looking for step-by-step instructions using Clerk to add social connection (OAuth) to your application, follow the [Social connection (OAuth) guide](/docs/authentication/social-connections/oauth).
 
 ## Before you start

--- a/docs/authentication/social-connections/linear.mdx
+++ b/docs/authentication/social-connections/linear.mdx
@@ -15,6 +15,7 @@ To make the development flow as smooth as possible, Clerk uses preconfigured sha
 
 For production instances, you will need to generate your own Client ID and Client secret using your Linear account.
 
+> [!NOTE]
 > The purpose of this guide is to help you create a Linear OAuth app - if you're looking for step-by-step instructions using Clerk to add social connection (OAuth) to your application, follow the [Social connection (OAuth) guide](/docs/authentication/social-connections/oauth).
 
 ## Before you start

--- a/docs/authentication/social-connections/linkedin.mdx
+++ b/docs/authentication/social-connections/linkedin.mdx
@@ -17,6 +17,7 @@ To make the development flow as smooth as possible, Clerk uses preconfigured sha
 
 For production instances, you will need to generate your own Client ID and Client secret using your LinkedIn account.
 
+> [!NOTE]
 > The purpose of this guide is to help you create a LinkedIn account and a LinkedIn OAuth app - if you're looking for step-by-step instructions using Clerk to add social connection (OAuth) to your application, follow the [Social connection (OAuth) guide](/docs/authentication/social-connections/oauth).
 
 ## Before you start

--- a/docs/authentication/social-connections/notion.mdx
+++ b/docs/authentication/social-connections/notion.mdx
@@ -15,6 +15,7 @@ To make the development flow as smooth as possible, Clerk uses preconfigured sha
 
 For production instances, you will need to generate your own Client ID and Client secret using your LinkedIn account.
 
+> [!NOTE]
 > The purpose of this guide is to help you create a Notion developer account and a Notion OAuth app - if you're looking for step-by-step instructions using Clerk to add social connection (OAuth) to your application, follow the [Social connection (OAuth) guide](/docs/authentication/social-connections/oauth).
 
 ## Before you start

--- a/docs/authentication/social-connections/slack.mdx
+++ b/docs/authentication/social-connections/slack.mdx
@@ -11,12 +11,14 @@ How to set up social connection with Slack
 
 Adding social connection with Slack to your app with Clerk is done in a few steps - you only need to set the **Client ID**, **Client Secret** and **Authorized redirect URL** in your instance settings.
 
+> [!NOTE]
 > Please note that Sign in with Slack doesn't support any additional OAuth scopes other than **openid**, **email**, **profile**, which are requested by default
 
 To make the development flow as smooth as possible, Clerk uses preconfigured shared OAuth credentials and redirect URIs for development instances - no other configuration is needed.
 
 For production instances, you will need to generate your own Client ID and Client secret using your Slack account.
 
+> [!NOTE]
 > The purpose of this guide is to help you create a Slack OAuth app - if you're looking for step-by-step instructions using Clerk to add social connection (OAuth) to your application, follow the [Social connection (OAuth) guide](/docs/authentication/social-connections/oauth).
 
 ## Before you start

--- a/docs/authentication/social-connections/tiktok.mdx
+++ b/docs/authentication/social-connections/tiktok.mdx
@@ -15,6 +15,7 @@ To make the development flow as smooth as possible, Clerk uses  preconfigured sh
 
 For production instances, you will need to create your own developer account with **TikTok** and generate your own Client ID and Client secret.
 
+> [!NOTE]
 > The purpose of this guide is to help you set up a TikTok developer account  and a TikTok OAuth app - if you're looking for step-by-step instructions using Clerk to add social connection (OAuth) to your application, follow the [Social connection (OAuth) guide](/docs/authentication/social-connections/oauth).
 
 ## Before you start
@@ -36,6 +37,7 @@ You'll get redirected to the app creation form. Notice that you need to fill the
 
 Go back to the TikTok panel, paste the value into the **Callback URL** field. Copy the `clerk.[your-domain].com` part of the URL and paste it in the **Redirect domain** field. Hit **Apply** to compete the registration.
 
+> [!NOTE]
 > Your app needs to be reviewed by TikTok before the registration completes. Note that this might take a couple of days.
 
 Once your app is approved, simply copy the **Client Key** and **Client Secret** from the TikTok panel, go back to the Clerk dashboard, open the **Manage credentials** modal for the TikTok provider, and paste them into the respective fields.

--- a/docs/authentication/social-connections/twitch.mdx
+++ b/docs/authentication/social-connections/twitch.mdx
@@ -15,6 +15,7 @@ To make the development flow as smooth as possible, Clerk uses preconfigured sha
 
 For production instances, you will need to generate your own Client ID and Client secret using your Twitch account.
 
+> [!NOTE]
 > The purpose of this guide is to help you create a Twitch account and a Twitch OAuth app - if you're looking for step-by-step instructions using Clerk to add social connection (OAuth) to your application, follow the [Social connection (OAuth) guide](/docs/authentication/social-connections/oauth).
 
 ## Before you start

--- a/docs/authentication/social-connections/twitter.mdx
+++ b/docs/authentication/social-connections/twitter.mdx
@@ -17,6 +17,7 @@ Adding social connection with Twitter to your app with Clerk is done in a few st
 
 Clerk does not currently support preconfigured shared OAuth credentials for Twitter on development instances. You will have to provide custom credentials for both development _and_ production instances, which includes generating your own Client ID and Client Secret using your Twitter Developer account. Don't worry, this guide will walk you through that process in just a few simple steps.
 
+> [!NOTE]
 > The purpose of this guide is to help you create a Twitter account and a Twitter OAuth app - if you're looking for step-by-step instructions using Clerk to add social connection (OAuth) to your application, follow the [Social connection (OAuth) guide](/docs/authentication/social-connections/oauth).
 
 ## Before you start
@@ -30,6 +31,7 @@ If you don't have an existing Twitter Application you've set up for social conne
 
 To do so, go to "[Projects & Apps](https://developer.twitter.com/en/portal/projects-and-apps)" and click "**+ Add App**" to create a new application. After entering a name, you'll be presented with your app's credentials: **API Key** and **API Secret**. Copy those values as you will be needing those shortly.
 
+> [!NOTE]
 > You will need your application to be approved for elevated status to be able to use it with Clerk. You can apply for the status in [Twitter developer dashboard](https://developer.twitter.com/en/portal/products/elevated)
 
 In the Clerk Dashboard, go to **User & Authentication > [Social Connections](https://dashboard.clerk.com/last-active?path=user-authentication/social-connections)** and enable Twitter. In the modal that opened, ensure **Use custom credentials** is enabled and paste the **API Key** and **API Secret** values which you copied in the previous step. Then, copy the **Authorized redirect URI**.

--- a/docs/authentication/social-connections/xero.mdx
+++ b/docs/authentication/social-connections/xero.mdx
@@ -15,6 +15,7 @@ To make the development flow as smooth as possible, Clerk uses preconfigured sha
 
 For production instances, you will need to generate your own Client ID and Client secret using your Xero account.
 
+> [!NOTE]
 > The purpose of this guide is to help you create a Xero developer account and a Xero OAuth app - if you're looking for step-by-step instructions using Clerk to add social connection (OAuth) to your application, follow the [Social connection (OAuth) guide](/docs/authentication/social-connections/oauth).
 
 ## Before you start

--- a/docs/components/authentication/google-one-tap.mdx
+++ b/docs/components/authentication/google-one-tap.mdx
@@ -26,6 +26,7 @@ By default, this component will redirect users back to the page where the authen
 
 The following example includes basic implementation of the `<GoogleOneTap />` component. You can use this as a starting point for your own implementation.
 
+> [!NOTE]
 > `<GoogleOneTap>` does not render if the user is already signed into your Clerk application, so there's no need to manually check if a user is signed in yourself before rendering it.
 
 <Tabs type="framework" items={["Next.js"]}>
@@ -59,6 +60,7 @@ The following example includes basic implementation of the `<GoogleOneTap />` co
 
 The methods in this section are available on instances of the [`Clerk`](/docs/references/javascript/clerk/clerk) class and are used to render and control the `<GoogleOneTap />` component.
 
+> [!NOTE]
 > The examples in this section assume you have completed the [JavaScript quickstart](/docs/quickstarts/javascript) to set up the Clerk JS SDK in your project.
 
 ### `openGoogleOneTap()`

--- a/docs/components/clerk-provider.mdx
+++ b/docs/components/clerk-provider.mdx
@@ -80,6 +80,7 @@ The `<ClerkProvider>` component must be added to your React entrypoint.
 
 {/* TODO: Make dedicated docs pages for these meta-frameworks */}
 
+> [!NOTE]
 > Other meta-frameworks, like [Remix](/docs/quickstarts/remix#configure-clerk-app) and [Gatsby](/docs/quickstarts/gatsby#update-gatsby-config-ts), have wrappers around `<ClerkProvider>` to make their integrations tighter.
 
 ## Properties

--- a/docs/components/customization/overview.mdx
+++ b/docs/components/customization/overview.mdx
@@ -54,6 +54,7 @@ cl-formButtonPrimary cl-button 🔒️ cl-internal-1ta0xpz
 
 Any of the classes listed before the lock icon (🔒️) are safe to rely on, such as `cl-formButtonPrimary` or `cl-button` from the previous example. You'll use these classes to target the necessary elements of the Clerk component.
 
+> [!NOTE]
 > Anything after the lock icon (🔒️) are internal classes used for Clerk's internal styling and should not be modified.
 
 Once you have identified the classes of the element you want to target, there are many ways to apply your custom styles depending on your preference:

--- a/docs/custom-flows/email-password-mfa.mdx
+++ b/docs/custom-flows/email-password-mfa.mdx
@@ -446,6 +446,7 @@ This guide will walk you through how to build a custom email/password sign-in fl
 
       Create a component that handles the sign-in with multi-factor authentication flow.
 
+      > [!NOTE]
       > You can render this component in a custom sign-in or sign-up flow, which you can find examples of in [the Expo quickstart](/docs/quickstarts/expo).
 
       ```tsx {{ filename: 'SignInMFAForm.tsx' }}

--- a/docs/custom-flows/oauth-connections.mdx
+++ b/docs/custom-flows/oauth-connections.mdx
@@ -95,6 +95,7 @@ When using OAuth, the sign-up and sign-in flows are equivalent.
 
     The following example demonstrates a component that creates a custom OAuth sign-in flow for [Google accounts](/docs/authentication/social-connections/google).
 
+    > [!NOTE]
     > You can render this component in a custom sign-in flow, which you can find examples of in [the Expo quickstart](/docs/quickstarts/expo).
 
     ```tsx {{ filename: 'components/SignInWithOAuth.tsx' }}

--- a/docs/deployments/migrate-overview.mdx
+++ b/docs/deployments/migrate-overview.mdx
@@ -18,7 +18,8 @@ With basic export / import, you are taking an export from your previous tool and
 
 You'll also need to provide your `password_hasher` value (The hashing algorithm used to generate the password digest) and in some instances Clerk will transparently upgrade your users' password hashes to the more secure Bcrypt hashing algorithm. More details on this topic are available in the [Create a new user](/docs/reference/backend-api/tag/Users#operation/CreateUser!path=password_hasher\&t=request) Backend API Reference docs.
 
-> **Note:** If you are expecting to import 100k+ users, we recommend reaching out to [support@clerk.dev](mailto:support@clerk.dev) where we can coordinate increases to the rate limits and ensure a seamless import of your data.
+> [!NOTE]
+> If you are expecting to import 100k+ users, we recommend reaching out to [support@clerk.dev](mailto:support@clerk.dev) where we can coordinate increases to the rate limits and ensure a seamless import of your data.
 
 ### Considerations
 

--- a/docs/references/javascript/session.mdx
+++ b/docs/references/javascript/session.mdx
@@ -15,6 +15,7 @@ In certain scenarios, a session might be replaced by another one. This is often 
 
 All sessions that are **expired**, **removed**, **replaced**, **ended** or **abandoned** are not considered valid.
 
+> [!NOTE]
 > For more details regarding the different session states, see our documentation on [session management](/docs/authentication/configuration/session-options).
 
 ## Properties

--- a/docs/references/nodejs/overview.mdx
+++ b/docs/references/nodejs/overview.mdx
@@ -70,4 +70,5 @@ try {
 }
 ```
 
+> [!NOTE]
 > See the guide on [using Clerk with Node.js and Express](/docs/backend-requests/handling/nodejs#express-error-handlers) to learn about Express error handling.

--- a/docs/security/password-protection.mdx
+++ b/docs/security/password-protection.mdx
@@ -9,6 +9,7 @@ description: Clerk refers to the National Institute of Standards and Technology 
 
 Clerk refers to the National Institute of Standards and Technology (NIST) guidelines to determine the character rules for passwords:
 
+> [!NOTE]
 > Verifiers SHALL require subscriber-chosen memorized secrets to be at least 8 characters in length. Verifiers SHOULD permit subscriber-chosen memorized secrets at least 64 characters in length. All printing ASCII [RFC 20](https://datatracker.ietf.org/doc/html/rfc20) characters as well as the space character SHOULD be acceptable in memorized secrets. Unicode [ISO/IEC 10646](https://en.wikipedia.org/wiki/Universal_Coded_Character_Set) characters SHOULD be accepted as well. To make allowances for likely mistyping, verifiers MAY replace multiple consecutive space characters with a single space character prior to verification, provided that the result is at least 8 characters in length. Truncation of the secret SHALL NOT be performed. For purposes of the above length requirements, each Unicode code point SHALL be counted as a single character.
 
 [NIST Special Publication 800-63B](https://pages.nist.gov/800-63-3/sp800-63b.html#sec5)
@@ -61,8 +62,10 @@ This is useful for blocking password sign-ins in the case that:
 
 Clerk uses [zxcvbn-ts](https://zxcvbn-ts.github.io/zxcvbn/) for estimating the strength of passwords and leverages the [Open Web Application Security Project (OWASP) guidelines](https://cheatsheetseries.owasp.org/cheatsheets/Password_Storage_Cheat_Sheet.html) to determine its handling of password strength:
 
+> [!NOTE]
 > OWASP recommends using a password strength estimation library like zxcvbn to evaluate the strength of passwords. This can help identify weak passwords and prevent their use.
 
 For users that set an average/weak password that complies with your organization's policies but could be stronger - Clerk also provides a gentle recommendation to use a stronger password.
 
+> [!NOTE]
 > OWASP recommends providing feedback to users on the strength of their password and offering suggestions for improvement. This can help users create stronger passwords and improve the overall security of the application.

--- a/docs/upgrade-guides/core-2/javascript.mdx
+++ b/docs/upgrade-guides/core-2/javascript.mdx
@@ -78,6 +78,7 @@ As part of this change, the default URL for each of these props has been set to 
 
 ### `afterSignXUrl` changes
 
+> [!NOTE]
 > This section refers to `afterSignXUrl` where `X` could be `Up` or `In` depending on the context.
 
 All `afterSignXUrl` props and `CLERK_AFTER_SIGN_X_URL` environment variables have been deprecated, and should be replaced by one of the following options:

--- a/docs/upgrade-guides/core-2/nextjs.mdx
+++ b/docs/upgrade-guides/core-2/nextjs.mdx
@@ -483,6 +483,7 @@ As part of this change, the default redirect URL for each of these props has bee
 
 ### `afterSignXUrl` changes
 
+> [!NOTE]
 > This section refers to `afterSignXUrl` where `X` could be `Up` or `In` depending on the context.
 
 All `afterSignXUrl` props and `CLERK_AFTER_SIGN_X_URL` environment variables have been deprecated, and should be replaced by one of the following options:

--- a/docs/upgrade-guides/core-2/react.mdx
+++ b/docs/upgrade-guides/core-2/react.mdx
@@ -102,6 +102,7 @@ As part of this change, the default URL for each of these props has been set to 
 
 ### `afterSignXUrl` changes
 
+> [!NOTE]
 > This section refers to `afterSignXUrl` where `X` could be `Up` or `In` depending on the context.
 
 All `afterSignXUrl` props and `CLERK_AFTER_SIGN_X_URL` environment variables have been deprecated, and should be replaced by one of the following options:

--- a/docs/upgrade-guides/core-2/remix.mdx
+++ b/docs/upgrade-guides/core-2/remix.mdx
@@ -122,6 +122,7 @@ As part of this change, the default URL for each of these props has been set to 
 
 ### `afterSignXUrl` changes
 
+> [!NOTE]
 > This section refers to `afterSignXUrl` where `X` could be `Up` or `In` depending on the context.
 
 All `afterSignXUrl` props and `CLERK_AFTER_SIGN_X_URL` environment variables have been deprecated, and should be replaced by one of the following options:


### PR DESCRIPTION
Further to #1339, currently standard blockquotes are being used as callouts. This PR adds `[!NOTE]` to blockquotes that don't have an explicit callout type.

> [!IMPORTANT]
> Callouts should always have an explicit type (e.g. `[!NOTE]`). Blockquotes without a type were treated as `NOTE` callouts for backwards compatibility reasons, but this behaviour will be removed soon so that standard blockquotes can be used as actual blockquotes.