### PR TITLE
Replace code block `diff` lang with `del`/`ins` props

### DIFF
--- a/docs/integrations/webhooks/sync-data.mdx
+++ b/docs/integrations/webhooks/sync-data.mdx
@@ -353,13 +353,13 @@ This guide can be adapted to listen for any Clerk event.
 
   In the following example, the `if` statement will narrow the type to the `user.created` type and using `evt.data` will give you autocompletion and type safety for that event.
 
-  ```diff {{ prettier: false, filename: 'app/api/webhooks/route.ts' }}
-  - console.log(`Webhook with and ID of ${id} and type of ${eventType}`)
-  - console.log('Webhook body:', body)
+  ```jsx {{ prettier: false, filename: 'app/api/webhooks/route.ts', del: [1, 2], ins: [[4, 6]] }}
+  console.log(`Webhook with and ID of ${id} and type of ${eventType}`)
+  console.log('Webhook body:', body)
 
-  + if (evt.type === 'user.created') {
-  +   console.log('userId:', evt.data.id)
-  + }
+  if (evt.type === 'user.created') {
+    console.log('userId:', evt.data.id)
+  }
   ```
 
   If you want to handle types yourself, you can import the following types from your backend SDK, such as `@clerk/nextjs/server`.

--- a/docs/integrations/webhooks/sync-data.mdx
+++ b/docs/integrations/webhooks/sync-data.mdx
@@ -353,7 +353,7 @@ This guide can be adapted to listen for any Clerk event.
 
   In the following example, the `if` statement will narrow the type to the `user.created` type and using `evt.data` will give you autocompletion and type safety for that event.
 
-  ```jsx {{ prettier: false, filename: 'app/api/webhooks/route.ts', del: [1, 2], ins: [[4, 6]] }}
+  ```ts {{ prettier: false, filename: 'app/api/webhooks/route.ts', del: [1, 2], ins: [[4, 6]] }}
   console.log(`Webhook with and ID of ${id} and type of ${eventType}`)
   console.log('Webhook body:', body)
 

--- a/docs/references/astro/migrating-from-astro-community-sdk.mdx
+++ b/docs/references/astro/migrating-from-astro-community-sdk.mdx
@@ -38,20 +38,20 @@ With Clerk's official SDK, `clerk-js` is hotloaded by default, and the option to
 
 The following changes are required in your Astro configuration file:
 
-```diff {{ prettier: false }}
+```jsx {{ prettier: false, del: [[4, 7]], ins: [8] }}
 import { defineConfig } from "astro/config";
 import node from "@astrojs/node";
 
-- import clerk from "astro-clerk-auth/hotload";
-- import clerk from "astro-clerk-auth/integration/hotload";
-- import clerk from "astro-clerk-auth";
-- import clerk from "astro-clerk-auth/integration";
-+ import clerk from "@clerk/astro";
+import clerk from "astro-clerk-auth/hotload";
+import clerk from "astro-clerk-auth/integration/hotload";
+import clerk from "astro-clerk-auth";
+import clerk from "astro-clerk-auth/integration";
+import clerk from "@clerk/astro";
 
 export default defineConfig({
-      integrations: [clerk()],
-      adapter: node({ mode: "standalone" }),
-      output: "server",
+  integrations: [clerk()],
+  adapter: node({ mode: "standalone" }),
+  output: "server",
 });
 ```
 
@@ -59,15 +59,15 @@ export default defineConfig({
 
 The prefix for environment variables used in client-side code has been updated to align with Astro's [best practices](https://docs.astro.build/en/guides/environment-variables/). This change affects all [environment variables](https://clerk.com/docs/deployments/clerk-environment-variables) supported by Clerk.
 
-```diff {{ prettier: false }}
-- PUBLIC_ASTRO_APP_CLERK_PUBLISHABLE_KEY=
-+ PUBLIC_CLERK_PUBLISHABLE_KEY=
+```{{ prettier: false, del: [1, 4, 7], ins: [2, 5, 8] }}
+PUBLIC_ASTRO_APP_CLERK_PUBLISHABLE_KEY=
+PUBLIC_CLERK_PUBLISHABLE_KEY=
 
-- PUBLIC_ASTRO_APP_CLERK_SIGN_IN_URL=
-+ PUBLIC_CLERK_SIGN_IN_URL=
+PUBLIC_ASTRO_APP_CLERK_SIGN_IN_URL=
+PUBLIC_CLERK_SIGN_IN_URL=
 
-- PUBLIC_ASTRO_APP_*=
-+ PUBLIC_*=
+PUBLIC_ASTRO_APP_*=
+PUBLIC_*=
 
 ```
 
@@ -75,54 +75,53 @@ The prefix for environment variables used in client-side code has been updated t
 
 The Astro components have been restructured to provide a more consistent API. The following changes are required to import your Astro components:
 
-```diff {{ prettier: false }}
-- import { UserProfile } from "@clerk/astro/components/interactive"
-+ import { UserProfile } from "@clerk/astro/components"
+```jsx {{ prettier: false, del: [1, 4, 7], ins: [2, 5, 8] }}
+import { UserProfile } from "@clerk/astro/components/interactive"
+import { UserProfile } from "@clerk/astro/components"
 
-- import { Protect } from "@clerk/astro/components/control"
-+ import { Protect } from "@clerk/astro/components"
+import { Protect } from "@clerk/astro/components/control"
+import { Protect } from "@clerk/astro/components"
 
-- import { SignInButton } from "@clerk/astro/components/unstyled"
-+ import { SignInButton } from "@clerk/astro/components"
-
+import { SignInButton } from "@clerk/astro/components/unstyled"
+import { SignInButton } from "@clerk/astro/components"
 ```
 
 ### Stores
 
 Submodule `/stores` was replaced with `/client`. The following changes are required to import the [stores](/docs/references/astro/overview#client-side-helpers):
 
-```diff {{ prettier: false }}
-- import { $clerk } from "astro-clerk-auth/stores"
-+ import { $clerkStore } from "@clerk/astro/client"
+```jsx {{ prettier: false, del: [1, 5, 6], ins: [2, 7, 8] }}
+import { $clerk } from "astro-clerk-auth/stores"
+import { $clerkStore } from "@clerk/astro/client"
 
 
-- import { $csrState } from "astro-clerk-auth/stores"
-- import { $initialState } from "astro-clerk-auth/stores"
-+ import { $userStore } from "@clerk/astro/client"
-+ import { $sessionStore } from "@clerk/astro/client"
+import { $csrState } from "astro-clerk-auth/stores"
+import { $initialState } from "astro-clerk-auth/stores"
+import { $userStore } from "@clerk/astro/client"
+import { $sessionStore } from "@clerk/astro/client"
 ```
 
 ### Submodule removal
 
 Submodule `/v0` was dropped completely and the previously exported constants are no longer available.
 
-```diff {{ prettier: false }}
-- import { apiKey, secretKey, DOMAIN, ... } from "astro-clerk-auth/v0"
+```jsx {{ prettier: false, del: [1] }}
+import { apiKey, secretKey, DOMAIN, ... } from "astro-clerk-auth/v0"
 ```
 
 ### `clerkClient` changes
 
 The `clerkClient` variable has been deprecated and should now be used as a function that accepts the Astro context.
 
-```diff {{ prettier: false }}
+```tsx {{ prettier: false, del: [2, 6], ins: [3, 7] }}
 import type { APIRoute } from "astro";
-- import { clerkClient } from "astro-clerk-auth/v0"
-+ import { clerkClient } from "@clerk/astro/server"
+import { clerkClient } from "astro-clerk-auth/v0"
+import { clerkClient } from "@clerk/astro/server"
 
 export const GET: APIRoute = async (context) => {
--   clerkClient.users.getUser(...)
-+   clerkClient(context).users.getUser(...)
-  ...
+  clerkClient.users.getUser(...)
+  clerkClient(context).users.getUser(...)
+...
 };
 ```
 
@@ -132,40 +131,40 @@ With the community SDK, there were to ways to use a React component inside a `.a
 
 To avoid confusion, the official SDK removes the `/components/react` submodule.
 
-```diff {{ prettier: false }}
+```astro {{ prettier: false, del: [2, 6], ins: [3, 7] }}
 ---
-- import { SignedIn } from "@clerk/astro/components/react";
-+ import { SignedIn } from "@clerk/astro/react";
+import { SignedIn } from "@clerk/astro/components/react";
+import { SignedIn } from "@clerk/astro/react";
 ---
 
-- <SignedIn>
-+ <SignedIn client:load>
-    {...}
+<SignedIn>
+<SignedIn client:load>
+  {...}
 </SignedIn>
 ```
 
 To use a React component inside a `.jsx` or `.tsx` file, update the import path.
 
-```diff {{ prettier: false }}
+```jsx {{ prettier: false, del: [6], ins: [7] }}
 import {
-    SignInButton,
-    SignedIn,
-    SignedOut,
-    UserButton
-- } from '@clerk/astro/client/react'
-+ } from '@clerk/astro/react'
+  SignInButton,
+  SignedIn,
+  SignedOut,
+  UserButton
+} from '@clerk/astro/client/react'
+} from '@clerk/astro/react'
 
 export default function Header() {
-      return (
-        <>
-          <p>My App</p>
-          <SignedOut>
-            <SignInButton />
-          </SignedOut>
-          <SignedIn>
-            <UserButton />
-          </SignedIn>
-        </>
-      )
+  return (
+    <>
+      <p>My App</p>
+      <SignedOut>
+        <SignInButton />
+      </SignedOut>
+      <SignedIn>
+        <UserButton />
+      </SignedIn>
+    </>
+  )
 }
 ```

--- a/docs/references/astro/migrating-from-astro-community-sdk.mdx
+++ b/docs/references/astro/migrating-from-astro-community-sdk.mdx
@@ -38,7 +38,7 @@ With Clerk's official SDK, `clerk-js` is hotloaded by default, and the option to
 
 The following changes are required in your Astro configuration file:
 
-```jsx {{ prettier: false, del: [[4, 7]], ins: [8] }}
+```js {{ prettier: false, del: [[4, 7]], ins: [8] }}
 import { defineConfig } from "astro/config";
 import node from "@astrojs/node";
 
@@ -75,7 +75,7 @@ PUBLIC_*=
 
 The Astro components have been restructured to provide a more consistent API. The following changes are required to import your Astro components:
 
-```jsx {{ prettier: false, del: [1, 4, 7], ins: [2, 5, 8] }}
+```js {{ prettier: false, del: [1, 4, 7], ins: [2, 5, 8] }}
 import { UserProfile } from "@clerk/astro/components/interactive"
 import { UserProfile } from "@clerk/astro/components"
 
@@ -90,7 +90,7 @@ import { SignInButton } from "@clerk/astro/components"
 
 Submodule `/stores` was replaced with `/client`. The following changes are required to import the [stores](/docs/references/astro/overview#client-side-helpers):
 
-```jsx {{ prettier: false, del: [1, 5, 6], ins: [2, 7, 8] }}
+```js {{ prettier: false, del: [1, 5, 6], ins: [2, 7, 8] }}
 import { $clerk } from "astro-clerk-auth/stores"
 import { $clerkStore } from "@clerk/astro/client"
 
@@ -105,7 +105,7 @@ import { $sessionStore } from "@clerk/astro/client"
 
 Submodule `/v0` was dropped completely and the previously exported constants are no longer available.
 
-```jsx {{ prettier: false, del: [1] }}
+```js {{ prettier: false, del: [1] }}
 import { apiKey, secretKey, DOMAIN, ... } from "astro-clerk-auth/v0"
 ```
 
@@ -113,7 +113,7 @@ import { apiKey, secretKey, DOMAIN, ... } from "astro-clerk-auth/v0"
 
 The `clerkClient` variable has been deprecated and should now be used as a function that accepts the Astro context.
 
-```tsx {{ prettier: false, del: [2, 6], ins: [3, 7] }}
+```ts {{ prettier: false, del: [2, 6], ins: [3, 7] }}
 import type { APIRoute } from "astro";
 import { clerkClient } from "astro-clerk-auth/v0"
 import { clerkClient } from "@clerk/astro/server"

--- a/docs/upgrade-guides/core-2/backend.mdx
+++ b/docs/upgrade-guides/core-2/backend.mdx
@@ -67,7 +67,7 @@ If you are having trouble with `npx`, it's also possible to install directly wit
 
 There has been a change to the way the params of the `authenticateRequest` function are structured. The `request` param, formerly included in an `options` object, has been moved to stand on its own as the first param to the function, while the `options` object remains as the second param. Example below:
 
-```jsx {{ prettier: false, del: [1], ins: [2] }}
+```js {{ prettier: false, del: [1], ins: [2] }}
 clerkClient.authenticateRequest({ ...opts, request })
 clerkClient.authenticateRequest(request, { ...opts })
 ```
@@ -90,7 +90,7 @@ Some top level import paths have been changed in order to improve tree-shaking a
   <AccordionPanel>
     The `verifyJwt` import path has changed from `@clerk/backend` to `@clerk/backend/jwt`. You must update your import path in order for it to work correctly. Example below of the fix that needs to be made
 
-    ```jsx {{ prettier: false, del: [1], ins: [2] }}
+    ```js {{ prettier: false, del: [1], ins: [2] }}
     import { verifyJwt } from "@clerk/backend"
     import { verifyJwt } from "@clerk/backend/jwt"
     ```
@@ -99,7 +99,7 @@ Some top level import paths have been changed in order to improve tree-shaking a
   <AccordionPanel>
     The `decodeJwt` import path has changed from `@clerk/backend` to `@clerk/backend/jwt`. You must update your import path in order for it to work correctly. Example below of the fix that needs to be made
 
-    ```jsx {{ prettier: false, del: [1], ins: [2] }}
+    ```js {{ prettier: false, del: [1], ins: [2] }}
     import { decodeJwt } from "@clerk/backend"
     import { decodeJwt } from "@clerk/backend/jwt"
     ```
@@ -108,7 +108,7 @@ Some top level import paths have been changed in order to improve tree-shaking a
   <AccordionPanel>
     The `signJwt` import path has changed from `@clerk/backend` to `@clerk/backend/jwt`. You must update your import path in order for it to work correctly. Example below of the fix that needs to be made
 
-    ```jsx {{ prettier: false, del: [1], ins: [2] }}
+    ```js {{ prettier: false, del: [1], ins: [2] }}
     import { signJwt } from "@clerk/backend"
     import { signJwt } from "@clerk/backend/jwt"
     ```
@@ -117,7 +117,7 @@ Some top level import paths have been changed in order to improve tree-shaking a
   <AccordionPanel>
     The `constants` import path has changed from `@clerk/backend` to `@clerk/backend/internal`. You must update your import path in order for it to work correctly. Note that internal imports are not intended for usage and are outside the scope of semver. Example below of the fix that needs to be made:
 
-    ```jsx {{ prettier: false, del: [1], ins: [2] }}
+    ```js {{ prettier: false, del: [1], ins: [2] }}
     import { constants } from "@clerk/backend"
     import { constants } from "@clerk/backend/internal"
     ```
@@ -126,7 +126,7 @@ Some top level import paths have been changed in order to improve tree-shaking a
   <AccordionPanel>
     The `redirect` import path has changed from `@clerk/backend` to `@clerk/backend/internal`. You must update your import path in order for it to work correctly. Note that internal imports are not intended for usage and are outside the scope of semver. Example below of the fix that needs to be made:
 
-    ```jsx {{ prettier: false, del: [1], ins: [2] }}
+    ```js {{ prettier: false, del: [1], ins: [2] }}
     import { redirect } from "@clerk/backend"
     import { redirect } from "@clerk/backend/internal"
     ```
@@ -135,7 +135,7 @@ Some top level import paths have been changed in order to improve tree-shaking a
   <AccordionPanel>
     The `createAuthenticateRequest` import path has changed from `@clerk/backend` to `@clerk/backend/internal`. You must update your import path in order for it to work correctly. Note that internal imports are not intended for usage and are outside the scope of semver. Example below of the fix that needs to be made:
 
-    ```jsx {{ prettier: false, del: [1], ins: [2] }}
+    ```js {{ prettier: false, del: [1], ins: [2] }}
     import { createAuthenticateRequest } from "@clerk/backend"
     import { createAuthenticateRequest } from "@clerk/backend/internal"
     ```
@@ -144,7 +144,7 @@ Some top level import paths have been changed in order to improve tree-shaking a
   <AccordionPanel>
     The `createIsomorphicRequest` import path has changed from `@clerk/backend` to `@clerk/backend/internal`. You must update your import path in order for it to work correctly. Note that internal imports are not intended for usage and are outside the scope of semver. Example below of the fix that needs to be made:
 
-    ```jsx {{ prettier: false, del: [1], ins: [2] }}
+    ```js {{ prettier: false, del: [1], ins: [2] }}
     import { createIsomorphicRequest } from "@clerk/backend"
     import { createIsomorphicRequest } from "@clerk/backend/internal"
     ```
@@ -153,7 +153,7 @@ Some top level import paths have been changed in order to improve tree-shaking a
   <AccordionPanel>
     The `createIsomorphicRequest` import was intended for those building custom Clerk integrations for frameworks and has been moved to `@clerk/backend/internal` to reflect this. Please use caution when using internal imports as they are outside the bounds of semver.
 
-    ```jsx {{ prettier: false, del: [1], ins: [2] }}
+    ```js {{ prettier: false, del: [1], ins: [2] }}
     import { createIsomorphicRequest } from "@clerk/backend"
     import { createIsomorphicRequest } from "@clerk/backend/internal"
     ```
@@ -162,7 +162,7 @@ Some top level import paths have been changed in order to improve tree-shaking a
   <AccordionPanel>
     The `SignJWTError` import path has changed from `@clerk/backend` to `@clerk/backend/errors`. You must update your import path in order for it to work correctly. Example below of the fix that needs to be made:
 
-    ```jsx {{ prettier: false, del: [1], ins: [2] }}
+    ```js {{ prettier: false, del: [1], ins: [2] }}
     import { SignJWTError } from "@clerk/backend"
     import { SignJWTError } from "@clerk/backend/errors"
     ```
@@ -171,7 +171,7 @@ Some top level import paths have been changed in order to improve tree-shaking a
   <AccordionPanel>
     The `TokenVerificationError` import path has changed from `@clerk/backend` to `@clerk/backend/errors`. You must update your import path in order for it to work correctly. Example below of the fix that needs to be made:
 
-    ```jsx {{ prettier: false, del: [1], ins: [2] }}
+    ```js {{ prettier: false, del: [1], ins: [2] }}
     import { TokenVerificationError } from "@clerk/backend"
     import { TokenVerificationError } from "@clerk/backend/errors"
     ```
@@ -180,7 +180,7 @@ Some top level import paths have been changed in order to improve tree-shaking a
   <AccordionPanel>
     The `TokenVerificationErrorAction` import path has changed from `@clerk/backend` to `@clerk/backend/errors`. You must update your import path in order for it to work correctly. Example below of the fix that needs to be made:
 
-    ```jsx {{ prettier: false, del: [1], ins: [2] }}
+    ```js {{ prettier: false, del: [1], ins: [2] }}
     import { TokenVerificationErrorAction } from "@clerk/backend"
     import { TokenVerificationErrorAction } from "@clerk/backend/errors"
     ```
@@ -189,7 +189,7 @@ Some top level import paths have been changed in order to improve tree-shaking a
   <AccordionPanel>
     The `TokenVerificationErrorReason` import path has changed from `@clerk/backend` to `@clerk/backend/errors`. You must update your import path in order for it to work correctly. Example below of the fix that needs to be made:
 
-    ```jsx {{ prettier: false, del: [1], ins: [2] }}
+    ```js {{ prettier: false, del: [1], ins: [2] }}
     import { TokenVerificationErrorReason } from "@clerk/backend"
     import { TokenVerificationErrorReason } from "@clerk/backend/errors"
     ```
@@ -202,7 +202,7 @@ The `httpOptions` parameter was removed from the internal `buildRequest` functio
 
 The internal change looks like this:
 
-```jsx {{ prettier: false, del: [1], ins: [2, 3] }}
+```js {{ prettier: false, del: [1], ins: [2, 3] }}
 const r = buildRequest({ httpOptions: { headers: {} }})
 const request = buildRequest()
 request({ headerParams: {} })
@@ -269,7 +269,7 @@ There were some changes made to pagination-related arguments passed into functio
   <AccordionPanel>
     There have been a couple changes to the pagination arguments that can be passed into this function - `limit` has been renamed to `pageSize`, and `offset` has been renamed to `initialPage`. This will help to make it more clear and simple to reason about pagination control. Example of how changes might look below:
 
-    ```jsx {{ prettier: false, del: [2, 4], ins: [3, 5] }}
+    ```js {{ prettier: false, del: [2, 4], ins: [3, 5] }}
     const { data } = await organization.getRoles({
       limit: 10,
       pageSize: 10,
@@ -282,7 +282,7 @@ There were some changes made to pagination-related arguments passed into functio
   <AccordionPanel>
     There have been a couple changes to the pagination arguments that can be passed into this function - `limit` has been renamed to `pageSize`, and `offset` has been renamed to `initialPage`. This will help to make it more clear and simple to reason about pagination control. Example of how changes might look below:
 
-    ```jsx {{ prettier: false, del: [2, 4], ins: [3, 5] }}
+    ```js {{ prettier: false, del: [2, 4], ins: [3, 5] }}
     const { data } = await organization.getMemberships({
       limit: 10,
       pageSize: 10,
@@ -295,7 +295,7 @@ There were some changes made to pagination-related arguments passed into functio
   <AccordionPanel>
     There have been a couple changes to the pagination arguments that can be passed into this function - `limit` has been renamed to `pageSize`, and `offset` has been renamed to `initialPage`. This will help to make it more clear and simple to reason about pagination control. Example of how changes might look below:
 
-    ```jsx {{ prettier: false, del: [2, 4], ins: [3, 5] }}
+    ```js {{ prettier: false, del: [2, 4], ins: [3, 5] }}
     const { data } = await organization.getDomains({
       limit: 10,
       pageSize: 10,
@@ -308,7 +308,7 @@ There were some changes made to pagination-related arguments passed into functio
   <AccordionPanel>
     There have been a couple changes to the pagination arguments that can be passed into this function - `limit` has been renamed to `pageSize`, and `offset` has been renamed to `initialPage`. This will help to make it more clear and simple to reason about pagination control. Example of how changes might look below:
 
-    ```jsx {{ prettier: false, del: [2, 4], ins: [3, 5] }}
+    ```js {{ prettier: false, del: [2, 4], ins: [3, 5] }}
     const { data } = await organization.getInvitations({
       limit: 10,
       pageSize: 10,
@@ -321,7 +321,7 @@ There were some changes made to pagination-related arguments passed into functio
   <AccordionPanel>
     There have been a couple changes to the pagination arguments that can be passed into this function - `limit` has been renamed to `pageSize`, and `offset` has been renamed to `initialPage`. This will help to make it more clear and simple to reason about pagination control. Example of how changes might look below:
 
-    ```jsx {{ prettier: false, del: [2, 4], ins: [3, 5] }}
+    ```js {{ prettier: false, del: [2, 4], ins: [3, 5] }}
     const { data } = await organization.getMembershipRequests({
       limit: 10,
       pageSize: 10,
@@ -334,7 +334,7 @@ There were some changes made to pagination-related arguments passed into functio
   <AccordionPanel>
     There have been a couple changes to the pagination arguments that can be passed into this function - `limit` has been renamed to `pageSize`, and `offset` has been renamed to `initialPage`. This will help to make it more clear and simple to reason about pagination control. Example of how changes might look below:
 
-    ```jsx {{ prettier: false, del: [2, 4], ins: [3, 5] }}
+    ```js {{ prettier: false, del: [2, 4], ins: [3, 5] }}
     const { data } = await user.getOrganizationInvitations({
       limit: 10,
       pageSize: 10,
@@ -347,7 +347,7 @@ There were some changes made to pagination-related arguments passed into functio
   <AccordionPanel>
     There have been a couple changes to the pagination arguments that can be passed into this function - `limit` has been renamed to `pageSize`, and `offset` has been renamed to `initialPage`. This will help to make it more clear and simple to reason about pagination control. Example of how changes might look below:
 
-    ```jsx {{ prettier: false, del: [2, 4], ins: [3, 5] }}
+    ```js {{ prettier: false, del: [2, 4], ins: [3, 5] }}
     const { data } = await user.getOrganizationSuggestions({
       limit: 10,
       pageSize: 10,
@@ -360,7 +360,7 @@ There were some changes made to pagination-related arguments passed into functio
   <AccordionPanel>
     There have been a couple changes to the pagination arguments that can be passed into this function - `limit` has been renamed to `pageSize`, and `offset` has been renamed to `initialPage`. This will help to make it more clear and simple to reason about pagination control. Example of how changes might look below:
 
-    ```jsx {{ prettier: false, del: [2, 4], ins: [3, 5] }}
+    ```js {{ prettier: false, del: [2, 4], ins: [3, 5] }}
     const { data } = await user.getOrganizationMemberships({
       limit: 10,
       pageSize: 10,
@@ -373,7 +373,7 @@ There were some changes made to pagination-related arguments passed into functio
   <AccordionPanel>
     There have been a couple changes to the pagination arguments that can be passed into this function - `limit` has been renamed to `pageSize`, and `offset` has been renamed to `initialPage`. This will help to make it more clear and simple to reason about pagination control. Example of how changes might look below:
 
-    ```jsx {{ prettier: false, del: [2, 4], ins: [3, 5] }}
+    ```js {{ prettier: false, del: [2, 4], ins: [3, 5] }}
     const { data } = await clients.getClientList({
       limit: 10,
       pageSize: 10,
@@ -386,7 +386,7 @@ There were some changes made to pagination-related arguments passed into functio
   <AccordionPanel>
     There have been a couple changes to the pagination arguments that can be passed into this function - `limit` has been renamed to `pageSize`, and `offset` has been renamed to `initialPage`. This will help to make it more clear and simple to reason about pagination control. Example of how changes might look below:
 
-    ```jsx {{ prettier: false, del: [2, 4], ins: [3, 5] }}
+    ```js {{ prettier: false, del: [2, 4], ins: [3, 5] }}
     const { data } = await sessions.getSessionList({
       limit: 10,
       pageSize: 10,
@@ -409,7 +409,7 @@ There have been changes to return signatures for some functions. Since Clerk's A
 
     Here's an example of how the response shape would change with this modification:
 
-    ```jsx {{ prettier: false, del: [1], ins: [2] }}
+    ```js {{ prettier: false, del: [1], ins: [2] }}
     const data = await clerkClient.users.getOrganizationMembershipList()
     const { data, totalCount } = await clerkClient.users.getOrganizationMembershipList()
     ```
@@ -420,7 +420,7 @@ There have been changes to return signatures for some functions. Since Clerk's A
 
     Here's an example of how the response shape would change with this modification:
 
-    ```jsx {{ prettier: false, del: [1], ins: [2] }}
+    ```js {{ prettier: false, del: [1], ins: [2] }}
     const data = await clerkClient.users.getOrganizationInvitationList()
     const { data, totalCount } = await clerkClient.users.getOrganizationInvitationList()
     ```
@@ -429,7 +429,7 @@ There have been changes to return signatures for some functions. Since Clerk's A
   <AccordionPanel>
     The return type for this function was previously `[Items]` but has now been updated to `{ data: [Items], totalCount: number }`. Since Clerk's API responses are paginated, the `totalCount` property is helpful in determining the total number of items in the response easily. A before/after code example can be seen below:
 
-    ```jsx {{ prettier: false, del: [5], ins: [6] }}
+    ```js {{ prettier: false, del: [5], ins: [6] }}
     const data = await clerkClient.organizations.getOrganizationInvitationList({
       organizationId: "...",
     })
@@ -442,7 +442,7 @@ There have been changes to return signatures for some functions. Since Clerk's A
   <AccordionPanel>
     The return type for this function was previously `[Items]` but has now been updated to `{ data: [Items], totalCount: number }`. Since Clerk's API responses are paginated, the `totalCount` property is helpful in determining the total number of items in the response easily. A before/after code example can be seen below:
 
-    ```jsx {{ prettier: false, del: [4], ins: [5] }}
+    ```js {{ prettier: false, del: [4], ins: [5] }}
     const { user } = useUser()
     const membershipList = user.getOrganizationMembershipList()
 
@@ -456,7 +456,7 @@ There have been changes to return signatures for some functions. Since Clerk's A
 
     Here's an example of how the response shape would change with this modification:
 
-    ```jsx {{ prettier: false, del: [1], ins: [2] }}
+    ```js {{ prettier: false, del: [1], ins: [2] }}
     const data = await clerkClient.users.getOrganizationList()
     const { data, totalCount } = await clerkClient.users.getOrganizationList()
     ```
@@ -465,7 +465,7 @@ There have been changes to return signatures for some functions. Since Clerk's A
   <AccordionPanel>
     The return type for this function was previously `[Items]` but has now been updated to `{ data: [Items], totalCount: number }`. Since Clerk's API responses are paginated, the `totalCount` property is helpful in determining the total number of items in the response easily. A before/after code example can be seen below:
 
-    ```jsx {{ prettier: false, del: [4], ins: [5] }}
+    ```js {{ prettier: false, del: [4], ins: [5] }}
     const { organization } = useOrganization()
     const orgList = organization.getOrganizationList()
 
@@ -479,7 +479,7 @@ There have been changes to return signatures for some functions. Since Clerk's A
 
     Here's an example of how the response shape would change with this modification:
 
-    ```jsx {{ prettier: false, del: [1], ins: [2] }}
+    ```js {{ prettier: false, del: [1], ins: [2] }}
     const data = await clerkClient.invitations.getInvitationList()
     const { data, totalCount } = await clerkClient.invitations.getInvitationList()
     ```
@@ -490,7 +490,7 @@ There have been changes to return signatures for some functions. Since Clerk's A
 
     Here's an example of how the response shape would change with this modification:
 
-    ```jsx {{ prettier: false, del: [1], ins: [2] }}
+    ```js {{ prettier: false, del: [1], ins: [2] }}
     const data = await clerkClient.sessions.getSessionList()
     const { data, totalCount } = await clerkClient.sessions.getSessionList()
     ```
@@ -501,7 +501,7 @@ There have been changes to return signatures for some functions. Since Clerk's A
 
     Here's an example of how the response shape would change with this modification:
 
-    ```jsx {{ prettier: false, del: [1], ins: [2] }}
+    ```js {{ prettier: false, del: [1], ins: [2] }}
     const data = await clerkClient.users.getUserList()
     const { data, totalCount } = await clerkClient.users.getUserList()
     ```
@@ -512,7 +512,7 @@ There have been changes to return signatures for some functions. Since Clerk's A
 
     Here's an example of how the response shape would change with this modification:
 
-    ```jsx {{ prettier: false, del: [1], ins: [2] }}
+    ```js {{ prettier: false, del: [1], ins: [2] }}
     const data = await clerkClient.allowlistIdentifiers.getAllowlistIdentifierList()
     const { data, totalCount } = await clerkClient.allowlistIdentifiers.getAllowlistIdentifierList()
     ```
@@ -523,7 +523,7 @@ There have been changes to return signatures for some functions. Since Clerk's A
 
     Here's an example of how the response shape would change with this modification:
 
-    ```jsx {{ prettier: false, del: [1], ins: [2] }}
+    ```js {{ prettier: false, del: [1], ins: [2] }}
     const data = await clerkClient.clients.getClientList()
     const { data, totalCount } = await clerkClient.allowlistIdentifiers.getClientList()
     ```
@@ -534,7 +534,7 @@ There have been changes to return signatures for some functions. Since Clerk's A
 
     Here's an example of how the response shape would change with this modification:
 
-    ```jsx {{ prettier: false, del: [1], ins: [2] }}
+    ```js {{ prettier: false, del: [1], ins: [2] }}
     const data = await clerkClient.redirectUrls.getRedirectUrlList()
     const { data, totalCount } = await clerkClient.redirectUrls.getRedirectUrlList()
     ```
@@ -545,7 +545,7 @@ There have been changes to return signatures for some functions. Since Clerk's A
 
     Here's an example of how the response shape would change with this modification:
 
-    ```jsx {{ prettier: false, del: [1], ins: [2] }}
+    ```js {{ prettier: false, del: [1], ins: [2] }}
     const data = await clerkClient.users.getUserOauthAccessToken()
     const { data, totalCount } = await clerkClient.users.getUserOauthAccessToken()
     ```
@@ -556,7 +556,7 @@ There have been changes to return signatures for some functions. Since Clerk's A
 
     Here's an example of how the response shape would change with this modification:
 
-    ```jsx {{ prettier: false, del: [1], ins: [2] }}
+    ```js {{ prettier: false, del: [1], ins: [2] }}
     const data = await clerkClient.users.getOrganizationMembershipList()
     const { data, totalCount } = await clerkClient.users.getOrganizationMembershipList()
     ```
@@ -620,7 +620,7 @@ As part of this major version, a number of previously deprecated props, arugment
   <AccordionPanel>
     If you are updating a user's password via the [`User.update` method](/docs/references/javascript/user/user#update), it must be changed to [`User.updatePassword`](/docs/references/javascript/user/password-management#update-password) instead. This method will require the current password as well as the desired new password. We made this update to improve the security of password changes. Example below:
 
-    ```jsx {{ prettier: false, del: [1], ins: [[3, 7]] }}
+    ```js {{ prettier: false, del: [1], ins: [[3, 7]] }}
     user.update({ password: 'foo' });
 
     user.updatePassword({
@@ -634,7 +634,7 @@ As part of this major version, a number of previously deprecated props, arugment
   <AccordionPanel>
     The `frontendApi` argument passed to `createClerkClient` must be changed to `publishableKey`. Note that the values of the two keys are different, so both keys and values need to be changed. You can find your application's publishable key in the Clerk dashboard. Also note that the import value has changed for creating a new Clerk client, which will be addressed by a separate line item if relevant to your codebase.
 
-    ```jsx {{ prettier: false, del: [1, 4, 7], ins: [2, 5, 8] }}
+    ```js {{ prettier: false, del: [1, 4, 7], ins: [2, 5, 8] }}
     import { Clerk } from '@clerk/backend';
     import { createClerkClient } from '@clerk/backend';
 
@@ -649,7 +649,7 @@ As part of this major version, a number of previously deprecated props, arugment
   <AccordionPanel>
     The `apiKey` argument passed to `createClerkClient` must be changed to `secretKey`. Also note that the import value has changed for creating a new Clerk client, which will be addressed by a separate line item if relevant to your codebase.
 
-    ```jsx {{ prettier: false, del: [1, 4, 7], ins: [2, 5, 8] }}
+    ```js {{ prettier: false, del: [1, 4, 7], ins: [2, 5, 8] }}
     import { Clerk } from '@clerk/backend';
     import { createClerkClient } from '@clerk/backend';
 
@@ -686,7 +686,7 @@ As part of this major version, a number of previously deprecated props, arugment
   <AccordionPanel>
     The `pkgVersion` parameter was removed from the `loadInterstitialFromLocal`, `loadInterstitialFromBAPI`, and `buildPublicInterstitialUrl` functions. Use `clerkJSVersion` instead. Example:
 
-    ```jsx {{ prettier: false, del: [1], ins: [2] }}
+    ```js {{ prettier: false, del: [1], ins: [2] }}
     loadInterstitialFromLocal({ pkgVersion: "..." })
     loadInterstitialFromLocal({ clerkJSVersion: "..." })
     ```
@@ -695,7 +695,7 @@ As part of this major version, a number of previously deprecated props, arugment
   <AccordionPanel>
     The `clerkClient.__unstable_options` property was removed. Previously, you could use it to update the internal options. Instead, create a new ` clerkClient` instance using `createClerkClient` and pass the options in this way. For example:
 
-    ```jsx {{ prettier: false, del: [5], ins: [6] }}
+    ```js {{ prettier: false, del: [5], ins: [6] }}
     import { createClerkClient } from "@clerk/backend"
 
     const clerkClient = createClerkClient({ secretKey: "old" })
@@ -735,7 +735,7 @@ As part of this major version, a number of previously deprecated props, arugment
   <AccordionPanel>
     The `members_count` attribute of the `Organization` resource has been renamed to `membersCount` to match the naming convention of other attributes.
 
-    ```jsx {{ prettier: false, del: [1], ins: [2] }}
+    ```js {{ prettier: false, del: [1], ins: [2] }}
     organization.members_count
     organization.membersCount
     ```

--- a/docs/upgrade-guides/core-2/backend.mdx
+++ b/docs/upgrade-guides/core-2/backend.mdx
@@ -67,9 +67,9 @@ If you are having trouble with `npx`, it's also possible to install directly wit
 
 There has been a change to the way the params of the `authenticateRequest` function are structured. The `request` param, formerly included in an `options` object, has been moved to stand on its own as the first param to the function, while the `options` object remains as the second param. Example below:
 
-```diff {{ prettier: false }}
-- clerkClient.authenticateRequest({ ...opts, request })
-+ clerkClient.authenticateRequest(request, { ...opts })
+```jsx {{ prettier: false, del: [1], ins: [2] }}
+clerkClient.authenticateRequest({ ...opts, request })
+clerkClient.authenticateRequest(request, { ...opts })
 ```
 
 ### `clockSkewInSeconds` -> `clockSkewInMs`
@@ -90,108 +90,108 @@ Some top level import paths have been changed in order to improve tree-shaking a
   <AccordionPanel>
     The `verifyJwt` import path has changed from `@clerk/backend` to `@clerk/backend/jwt`. You must update your import path in order for it to work correctly. Example below of the fix that needs to be made
 
-    ```diff {{ prettier: false }}
-    - import { verifyJwt } from "@clerk/backend"
-    + import { verifyJwt } from "@clerk/backend/jwt"
+    ```jsx {{ prettier: false, del: [1], ins: [2] }}
+    import { verifyJwt } from "@clerk/backend"
+    import { verifyJwt } from "@clerk/backend/jwt"
     ```
   </AccordionPanel>
 
   <AccordionPanel>
     The `decodeJwt` import path has changed from `@clerk/backend` to `@clerk/backend/jwt`. You must update your import path in order for it to work correctly. Example below of the fix that needs to be made
 
-    ```diff {{ prettier: false }}
-    - import { decodeJwt } from "@clerk/backend"
-    + import { decodeJwt } from "@clerk/backend/jwt"
+    ```jsx {{ prettier: false, del: [1], ins: [2] }}
+    import { decodeJwt } from "@clerk/backend"
+    import { decodeJwt } from "@clerk/backend/jwt"
     ```
   </AccordionPanel>
 
   <AccordionPanel>
     The `signJwt` import path has changed from `@clerk/backend` to `@clerk/backend/jwt`. You must update your import path in order for it to work correctly. Example below of the fix that needs to be made
 
-    ```diff {{ prettier: false }}
-    - import { signJwt } from "@clerk/backend"
-    + import { signJwt } from "@clerk/backend/jwt"
+    ```jsx {{ prettier: false, del: [1], ins: [2] }}
+    import { signJwt } from "@clerk/backend"
+    import { signJwt } from "@clerk/backend/jwt"
     ```
   </AccordionPanel>
 
   <AccordionPanel>
     The `constants` import path has changed from `@clerk/backend` to `@clerk/backend/internal`. You must update your import path in order for it to work correctly. Note that internal imports are not intended for usage and are outside the scope of semver. Example below of the fix that needs to be made:
 
-    ```diff {{ prettier: false }}
-    - import { constants } from "@clerk/backend"
-    + import { constants } from "@clerk/backend/internal"
+    ```jsx {{ prettier: false, del: [1], ins: [2] }}
+    import { constants } from "@clerk/backend"
+    import { constants } from "@clerk/backend/internal"
     ```
   </AccordionPanel>
 
   <AccordionPanel>
     The `redirect` import path has changed from `@clerk/backend` to `@clerk/backend/internal`. You must update your import path in order for it to work correctly. Note that internal imports are not intended for usage and are outside the scope of semver. Example below of the fix that needs to be made:
 
-    ```diff {{ prettier: false }}
-    - import { redirect } from "@clerk/backend"
-    + import { redirect } from "@clerk/backend/internal"
+    ```jsx {{ prettier: false, del: [1], ins: [2] }}
+    import { redirect } from "@clerk/backend"
+    import { redirect } from "@clerk/backend/internal"
     ```
   </AccordionPanel>
 
   <AccordionPanel>
     The `createAuthenticateRequest` import path has changed from `@clerk/backend` to `@clerk/backend/internal`. You must update your import path in order for it to work correctly. Note that internal imports are not intended for usage and are outside the scope of semver. Example below of the fix that needs to be made:
 
-    ```diff {{ prettier: false }}
-    - import { createAuthenticateRequest } from "@clerk/backend"
-    + import { createAuthenticateRequest } from "@clerk/backend/internal"
+    ```jsx {{ prettier: false, del: [1], ins: [2] }}
+    import { createAuthenticateRequest } from "@clerk/backend"
+    import { createAuthenticateRequest } from "@clerk/backend/internal"
     ```
   </AccordionPanel>
 
   <AccordionPanel>
     The `createIsomorphicRequest` import path has changed from `@clerk/backend` to `@clerk/backend/internal`. You must update your import path in order for it to work correctly. Note that internal imports are not intended for usage and are outside the scope of semver. Example below of the fix that needs to be made:
 
-    ```diff {{ prettier: false }}
-    - import { createIsomorphicRequest } from "@clerk/backend"
-    + import { createIsomorphicRequest } from "@clerk/backend/internal"
+    ```jsx {{ prettier: false, del: [1], ins: [2] }}
+    import { createIsomorphicRequest } from "@clerk/backend"
+    import { createIsomorphicRequest } from "@clerk/backend/internal"
     ```
   </AccordionPanel>
 
   <AccordionPanel>
     The `createIsomorphicRequest` import was intended for those building custom Clerk integrations for frameworks and has been moved to `@clerk/backend/internal` to reflect this. Please use caution when using internal imports as they are outside the bounds of semver.
 
-    ```diff {{ prettier: false }}
-    - import { createIsomorphicRequest } from "@clerk/backend"
-    + import { createIsomorphicRequest } from "@clerk/backend/internal"
+    ```jsx {{ prettier: false, del: [1], ins: [2] }}
+    import { createIsomorphicRequest } from "@clerk/backend"
+    import { createIsomorphicRequest } from "@clerk/backend/internal"
     ```
   </AccordionPanel>
 
   <AccordionPanel>
     The `SignJWTError` import path has changed from `@clerk/backend` to `@clerk/backend/errors`. You must update your import path in order for it to work correctly. Example below of the fix that needs to be made:
 
-    ```diff {{ prettier: false }}
-    - import { SignJWTError } from "@clerk/backend"
-    + import { SignJWTError } from "@clerk/backend/errors"
+    ```jsx {{ prettier: false, del: [1], ins: [2] }}
+    import { SignJWTError } from "@clerk/backend"
+    import { SignJWTError } from "@clerk/backend/errors"
     ```
   </AccordionPanel>
 
   <AccordionPanel>
     The `TokenVerificationError` import path has changed from `@clerk/backend` to `@clerk/backend/errors`. You must update your import path in order for it to work correctly. Example below of the fix that needs to be made:
 
-    ```diff {{ prettier: false }}
-    - import { TokenVerificationError } from "@clerk/backend"
-    + import { TokenVerificationError } from "@clerk/backend/errors"
+    ```jsx {{ prettier: false, del: [1], ins: [2] }}
+    import { TokenVerificationError } from "@clerk/backend"
+    import { TokenVerificationError } from "@clerk/backend/errors"
     ```
   </AccordionPanel>
 
   <AccordionPanel>
     The `TokenVerificationErrorAction` import path has changed from `@clerk/backend` to `@clerk/backend/errors`. You must update your import path in order for it to work correctly. Example below of the fix that needs to be made:
 
-    ```diff {{ prettier: false }}
-    - import { TokenVerificationErrorAction } from "@clerk/backend"
-    + import { TokenVerificationErrorAction } from "@clerk/backend/errors"
+    ```jsx {{ prettier: false, del: [1], ins: [2] }}
+    import { TokenVerificationErrorAction } from "@clerk/backend"
+    import { TokenVerificationErrorAction } from "@clerk/backend/errors"
     ```
   </AccordionPanel>
 
   <AccordionPanel>
     The `TokenVerificationErrorReason` import path has changed from `@clerk/backend` to `@clerk/backend/errors`. You must update your import path in order for it to work correctly. Example below of the fix that needs to be made:
 
-    ```diff {{ prettier: false }}
-    - import { TokenVerificationErrorReason } from "@clerk/backend"
-    + import { TokenVerificationErrorReason } from "@clerk/backend/errors"
+    ```jsx {{ prettier: false, del: [1], ins: [2] }}
+    import { TokenVerificationErrorReason } from "@clerk/backend"
+    import { TokenVerificationErrorReason } from "@clerk/backend/errors"
     ```
   </AccordionPanel>
 </Accordion>
@@ -202,10 +202,10 @@ The `httpOptions` parameter was removed from the internal `buildRequest` functio
 
 The internal change looks like this:
 
-```diff {{ prettier: false }}
-- const r = buildRequest({ httpOptions: { headers: {} }})
-+ const request = buildRequest()
-+ request({ headerParams: {} })
+```jsx {{ prettier: false, del: [1], ins: [2, 3] }}
+const r = buildRequest({ httpOptions: { headers: {} }})
+const request = buildRequest()
+request({ headerParams: {} })
 ```
 
 ### Removed: `orgs` claim on JWT
@@ -269,130 +269,130 @@ There were some changes made to pagination-related arguments passed into functio
   <AccordionPanel>
     There have been a couple changes to the pagination arguments that can be passed into this function - `limit` has been renamed to `pageSize`, and `offset` has been renamed to `initialPage`. This will help to make it more clear and simple to reason about pagination control. Example of how changes might look below:
 
-    ```diff {{ prettier: false }}
-      const { data } = await organization.getRoles({
-    -   limit: 10,
-    +   pageSize: 10,
-    -   offset: 10,
-    +   initialPage: 2,
-      })
+    ```jsx {{ prettier: false, del: [2, 4], ins: [3, 5] }}
+    const { data } = await organization.getRoles({
+      limit: 10,
+      pageSize: 10,
+      offset: 10,
+      initialPage: 2,
+    })
     ```
   </AccordionPanel>
 
   <AccordionPanel>
     There have been a couple changes to the pagination arguments that can be passed into this function - `limit` has been renamed to `pageSize`, and `offset` has been renamed to `initialPage`. This will help to make it more clear and simple to reason about pagination control. Example of how changes might look below:
 
-    ```diff {{ prettier: false }}
-      const { data } = await organization.getMemberships({
-    -   limit: 10,
-    +   pageSize: 10,
-    -   offset: 10,
-    +   initialPage: 2,
-      })
+    ```jsx {{ prettier: false, del: [2, 4], ins: [3, 5] }}
+    const { data } = await organization.getMemberships({
+      limit: 10,
+      pageSize: 10,
+      offset: 10,
+      initialPage: 2,
+    })
     ```
   </AccordionPanel>
 
   <AccordionPanel>
     There have been a couple changes to the pagination arguments that can be passed into this function - `limit` has been renamed to `pageSize`, and `offset` has been renamed to `initialPage`. This will help to make it more clear and simple to reason about pagination control. Example of how changes might look below:
 
-    ```diff {{ prettier: false }}
-      const { data } = await organization.getDomains({
-    -   limit: 10,
-    +   pageSize: 10,
-    -   offset: 10,
-    +   initialPage: 2,
-      })
+    ```jsx {{ prettier: false, del: [2, 4], ins: [3, 5] }}
+    const { data } = await organization.getDomains({
+      limit: 10,
+      pageSize: 10,
+      offset: 10,
+      initialPage: 2,
+    })
     ```
   </AccordionPanel>
 
   <AccordionPanel>
     There have been a couple changes to the pagination arguments that can be passed into this function - `limit` has been renamed to `pageSize`, and `offset` has been renamed to `initialPage`. This will help to make it more clear and simple to reason about pagination control. Example of how changes might look below:
 
-    ```diff {{ prettier: false }}
-      const { data } = await organization.getInvitations({
-    -   limit: 10,
-    +   pageSize: 10,
-    -   offset: 10,
-    +   initialPage: 2,
-      })
+    ```jsx {{ prettier: false, del: [2, 4], ins: [3, 5] }}
+    const { data } = await organization.getInvitations({
+      limit: 10,
+      pageSize: 10,
+      offset: 10,
+      initialPage: 2,
+    })
     ```
   </AccordionPanel>
 
   <AccordionPanel>
     There have been a couple changes to the pagination arguments that can be passed into this function - `limit` has been renamed to `pageSize`, and `offset` has been renamed to `initialPage`. This will help to make it more clear and simple to reason about pagination control. Example of how changes might look below:
 
-    ```diff {{ prettier: false }}
-      const { data } = await organization.getMembershipRequests({
-    -   limit: 10,
-    +   pageSize: 10,
-    -   offset: 10,
-    +   initialPage: 2,
-      })
+    ```jsx {{ prettier: false, del: [2, 4], ins: [3, 5] }}
+    const { data } = await organization.getMembershipRequests({
+      limit: 10,
+      pageSize: 10,
+      offset: 10,
+      initialPage: 2,
+    })
     ```
   </AccordionPanel>
 
   <AccordionPanel>
     There have been a couple changes to the pagination arguments that can be passed into this function - `limit` has been renamed to `pageSize`, and `offset` has been renamed to `initialPage`. This will help to make it more clear and simple to reason about pagination control. Example of how changes might look below:
 
-    ```diff {{ prettier: false }}
-      const { data } = await user.getOrganizationInvitations({
-    -   limit: 10,
-    +   pageSize: 10,
-    -   offset: 10,
-    +   initialPage: 2,
-      })
+    ```jsx {{ prettier: false, del: [2, 4], ins: [3, 5] }}
+    const { data } = await user.getOrganizationInvitations({
+      limit: 10,
+      pageSize: 10,
+      offset: 10,
+      initialPage: 2,
+    })
     ```
   </AccordionPanel>
 
   <AccordionPanel>
     There have been a couple changes to the pagination arguments that can be passed into this function - `limit` has been renamed to `pageSize`, and `offset` has been renamed to `initialPage`. This will help to make it more clear and simple to reason about pagination control. Example of how changes might look below:
 
-    ```diff {{ prettier: false }}
-      const { data } = await user.getOrganizationSuggestions({
-    -   limit: 10,
-    +   pageSize: 10,
-    -   offset: 10,
-    +   initialPage: 2,
-      })
+    ```jsx {{ prettier: false, del: [2, 4], ins: [3, 5] }}
+    const { data } = await user.getOrganizationSuggestions({
+      limit: 10,
+      pageSize: 10,
+      offset: 10,
+      initialPage: 2,
+    })
     ```
   </AccordionPanel>
 
   <AccordionPanel>
     There have been a couple changes to the pagination arguments that can be passed into this function - `limit` has been renamed to `pageSize`, and `offset` has been renamed to `initialPage`. This will help to make it more clear and simple to reason about pagination control. Example of how changes might look below:
 
-    ```diff {{ prettier: false }}
-      const { data } = await user.getOrganizationMemberships({
-    -   limit: 10,
-    +   pageSize: 10,
-    -   offset: 10,
-    +   initialPage: 2,
-      })
+    ```jsx {{ prettier: false, del: [2, 4], ins: [3, 5] }}
+    const { data } = await user.getOrganizationMemberships({
+      limit: 10,
+      pageSize: 10,
+      offset: 10,
+      initialPage: 2,
+    })
     ```
   </AccordionPanel>
 
   <AccordionPanel>
     There have been a couple changes to the pagination arguments that can be passed into this function - `limit` has been renamed to `pageSize`, and `offset` has been renamed to `initialPage`. This will help to make it more clear and simple to reason about pagination control. Example of how changes might look below:
 
-    ```diff {{ prettier: false }}
-      const { data } = await clients.getClientList({
-    -   limit: 10,
-    +   pageSize: 10,
-    -   offset: 10,
-    +   initialPage: 2,
-      })
+    ```jsx {{ prettier: false, del: [2, 4], ins: [3, 5] }}
+    const { data } = await clients.getClientList({
+      limit: 10,
+      pageSize: 10,
+      offset: 10,
+      initialPage: 2,
+    })
     ```
   </AccordionPanel>
 
   <AccordionPanel>
     There have been a couple changes to the pagination arguments that can be passed into this function - `limit` has been renamed to `pageSize`, and `offset` has been renamed to `initialPage`. This will help to make it more clear and simple to reason about pagination control. Example of how changes might look below:
 
-    ```diff {{ prettier: false }}
-      const { data } = await sessions.getSessionList({
-    -   limit: 10,
-    +   pageSize: 10,
-    -   offset: 10,
-    +   initialPage: 2,
-      })
+    ```jsx {{ prettier: false, del: [2, 4], ins: [3, 5] }}
+    const { data } = await sessions.getSessionList({
+      limit: 10,
+      pageSize: 10,
+      offset: 10,
+      initialPage: 2,
+    })
     ```
   </AccordionPanel>
 </Accordion>
@@ -409,9 +409,9 @@ There have been changes to return signatures for some functions. Since Clerk's A
 
     Here's an example of how the response shape would change with this modification:
 
-    ```diff {{ prettier: false }}
-    - const data = await clerkClient.users.getOrganizationMembershipList()
-    + const { data, totalCount } = await clerkClient.users.getOrganizationMembershipList()
+    ```jsx {{ prettier: false, del: [1], ins: [2] }}
+    const data = await clerkClient.users.getOrganizationMembershipList()
+    const { data, totalCount } = await clerkClient.users.getOrganizationMembershipList()
     ```
   </AccordionPanel>
 
@@ -420,34 +420,34 @@ There have been changes to return signatures for some functions. Since Clerk's A
 
     Here's an example of how the response shape would change with this modification:
 
-    ```diff {{ prettier: false }}
-    - const data = await clerkClient.users.getOrganizationInvitationList()
-    + const { data, totalCount } = await clerkClient.users.getOrganizationInvitationList()
+    ```jsx {{ prettier: false, del: [1], ins: [2] }}
+    const data = await clerkClient.users.getOrganizationInvitationList()
+    const { data, totalCount } = await clerkClient.users.getOrganizationInvitationList()
     ```
   </AccordionPanel>
 
   <AccordionPanel>
     The return type for this function was previously `[Items]` but has now been updated to `{ data: [Items], totalCount: number }`. Since Clerk's API responses are paginated, the `totalCount` property is helpful in determining the total number of items in the response easily. A before/after code example can be seen below:
 
-    ```diff {{ prettier: false }}
-      const data = await clerkClient.organizations.getOrganizationInvitationList({
-        organizationId: "...",
-      })
+    ```jsx {{ prettier: false, del: [5], ins: [6] }}
+    const data = await clerkClient.organizations.getOrganizationInvitationList({
+      organizationId: "...",
+    })
 
-    - data.forEach(() => {})
-    + data.data.forEach(() => {})
+    data.forEach(() => {})
+    data.data.forEach(() => {})
     ```
   </AccordionPanel>
 
   <AccordionPanel>
     The return type for this function was previously `[Items]` but has now been updated to `{ data: [Items], totalCount: number }`. Since Clerk's API responses are paginated, the `totalCount` property is helpful in determining the total number of items in the response easily. A before/after code example can be seen below:
 
-    ```diff {{ prettier: false }}
-      const { user } = useUser()
-      const membershipList = user.getOrganizationMembershipList()
+    ```jsx {{ prettier: false, del: [4], ins: [5] }}
+    const { user } = useUser()
+    const membershipList = user.getOrganizationMembershipList()
 
-    - membershipList.forEach(() => {})
-    + membershipList.data.forEach(() => {})
+    membershipList.forEach(() => {})
+    membershipList.data.forEach(() => {})
     ```
   </AccordionPanel>
 
@@ -456,21 +456,21 @@ There have been changes to return signatures for some functions. Since Clerk's A
 
     Here's an example of how the response shape would change with this modification:
 
-    ```diff {{ prettier: false }}
-    - const data = await clerkClient.users.getOrganizationList()
-    + const { data, totalCount } = await clerkClient.users.getOrganizationList()
+    ```jsx {{ prettier: false, del: [1], ins: [2] }}
+    const data = await clerkClient.users.getOrganizationList()
+    const { data, totalCount } = await clerkClient.users.getOrganizationList()
     ```
   </AccordionPanel>
 
   <AccordionPanel>
     The return type for this function was previously `[Items]` but has now been updated to `{ data: [Items], totalCount: number }`. Since Clerk's API responses are paginated, the `totalCount` property is helpful in determining the total number of items in the response easily. A before/after code example can be seen below:
 
-    ```diff {{ prettier: false }}
-      const { organization } = useOrganization()
-      const orgList = organization.getOrganizationList()
+    ```jsx {{ prettier: false, del: [4], ins: [5] }}
+    const { organization } = useOrganization()
+    const orgList = organization.getOrganizationList()
 
-    - orgList.forEach(() => {})
-    + orgList.data.forEach(() => {})
+    orgList.forEach(() => {})
+    orgList.data.forEach(() => {})
     ```
   </AccordionPanel>
 
@@ -479,9 +479,9 @@ There have been changes to return signatures for some functions. Since Clerk's A
 
     Here's an example of how the response shape would change with this modification:
 
-    ```diff {{ prettier: false }}
-    - const data = await clerkClient.invitations.getInvitationList()
-    + const { data, totalCount } = await clerkClient.invitations.getInvitationList()
+    ```jsx {{ prettier: false, del: [1], ins: [2] }}
+    const data = await clerkClient.invitations.getInvitationList()
+    const { data, totalCount } = await clerkClient.invitations.getInvitationList()
     ```
   </AccordionPanel>
 
@@ -490,9 +490,9 @@ There have been changes to return signatures for some functions. Since Clerk's A
 
     Here's an example of how the response shape would change with this modification:
 
-    ```diff {{ prettier: false }}
-    - const data = await clerkClient.sessions.getSessionList()
-    + const { data, totalCount } = await clerkClient.sessions.getSessionList()
+    ```jsx {{ prettier: false, del: [1], ins: [2] }}
+    const data = await clerkClient.sessions.getSessionList()
+    const { data, totalCount } = await clerkClient.sessions.getSessionList()
     ```
   </AccordionPanel>
 
@@ -501,9 +501,9 @@ There have been changes to return signatures for some functions. Since Clerk's A
 
     Here's an example of how the response shape would change with this modification:
 
-    ```diff {{ prettier: false }}
-    - const data = await clerkClient.users.getUserList()
-    + const { data, totalCount } = await clerkClient.users.getUserList()
+    ```jsx {{ prettier: false, del: [1], ins: [2] }}
+    const data = await clerkClient.users.getUserList()
+    const { data, totalCount } = await clerkClient.users.getUserList()
     ```
   </AccordionPanel>
 
@@ -512,9 +512,9 @@ There have been changes to return signatures for some functions. Since Clerk's A
 
     Here's an example of how the response shape would change with this modification:
 
-    ```diff {{ prettier: false }}
-    - const data = await clerkClient.allowlistIdentifiers.getAllowlistIdentifierList()
-    + const { data, totalCount } = await clerkClient.allowlistIdentifiers.getAllowlistIdentifierList()
+    ```jsx {{ prettier: false, del: [1], ins: [2] }}
+    const data = await clerkClient.allowlistIdentifiers.getAllowlistIdentifierList()
+    const { data, totalCount } = await clerkClient.allowlistIdentifiers.getAllowlistIdentifierList()
     ```
   </AccordionPanel>
 
@@ -523,9 +523,9 @@ There have been changes to return signatures for some functions. Since Clerk's A
 
     Here's an example of how the response shape would change with this modification:
 
-    ```diff {{ prettier: false }}
-    - const data = await clerkClient.clients.getClientList()
-    + const { data, totalCount } = await clerkClient.allowlistIdentifiers.getClientList()
+    ```jsx {{ prettier: false, del: [1], ins: [2] }}
+    const data = await clerkClient.clients.getClientList()
+    const { data, totalCount } = await clerkClient.allowlistIdentifiers.getClientList()
     ```
   </AccordionPanel>
 
@@ -534,9 +534,9 @@ There have been changes to return signatures for some functions. Since Clerk's A
 
     Here's an example of how the response shape would change with this modification:
 
-    ```diff {{ prettier: false }}
-    - const data = await clerkClient.redirectUrls.getRedirectUrlList()
-    + const { data, totalCount } = await clerkClient.redirectUrls.getRedirectUrlList()
+    ```jsx {{ prettier: false, del: [1], ins: [2] }}
+    const data = await clerkClient.redirectUrls.getRedirectUrlList()
+    const { data, totalCount } = await clerkClient.redirectUrls.getRedirectUrlList()
     ```
   </AccordionPanel>
 
@@ -545,9 +545,9 @@ There have been changes to return signatures for some functions. Since Clerk's A
 
     Here's an example of how the response shape would change with this modification:
 
-    ```diff {{ prettier: false }}
-    - const data = await clerkClient.users.getUserOauthAccessToken()
-    + const { data, totalCount } = await clerkClient.users.getUserOauthAccessToken()
+    ```jsx {{ prettier: false, del: [1], ins: [2] }}
+    const data = await clerkClient.users.getUserOauthAccessToken()
+    const { data, totalCount } = await clerkClient.users.getUserOauthAccessToken()
     ```
   </AccordionPanel>
 
@@ -556,9 +556,9 @@ There have been changes to return signatures for some functions. Since Clerk's A
 
     Here's an example of how the response shape would change with this modification:
 
-    ```diff {{ prettier: false }}
-    - const data = await clerkClient.users.getOrganizationMembershipList()
-    + const { data, totalCount } = await clerkClient.users.getOrganizationMembershipList()
+    ```jsx {{ prettier: false, del: [1], ins: [2] }}
+    const data = await clerkClient.users.getOrganizationMembershipList()
+    const { data, totalCount } = await clerkClient.users.getOrganizationMembershipList()
     ```
   </AccordionPanel>
 </Accordion>
@@ -620,44 +620,44 @@ As part of this major version, a number of previously deprecated props, arugment
   <AccordionPanel>
     If you are updating a user's password via the [`User.update` method](/docs/references/javascript/user/user#update), it must be changed to [`User.updatePassword`](/docs/references/javascript/user/password-management#update-password) instead. This method will require the current password as well as the desired new password. We made this update to improve the security of password changes. Example below:
 
-    ```diff {{ prettier: false }}
-    - user.update({ password: 'foo' });
+    ```jsx {{ prettier: false, del: [1], ins: [[3, 7]] }}
+    user.update({ password: 'foo' });
 
-    + user.updatePassword({
-    +   currentPassword: 'bar',
-    +   newPassword: 'foo',
-    +   signOutOfOtherSessions: true,
-    + });
+    user.updatePassword({
+      currentPassword: 'bar',
+      newPassword: 'foo',
+      signOutOfOtherSessions: true,
+    });
     ```
   </AccordionPanel>
 
   <AccordionPanel>
     The `frontendApi` argument passed to `createClerkClient` must be changed to `publishableKey`. Note that the values of the two keys are different, so both keys and values need to be changed. You can find your application's publishable key in the Clerk dashboard. Also note that the import value has changed for creating a new Clerk client, which will be addressed by a separate line item if relevant to your codebase.
 
-    ```diff {{ prettier: false }}
-    - import { Clerk } from '@clerk/backend';
-    + import { createClerkClient } from '@clerk/backend';
+    ```jsx {{ prettier: false, del: [1, 4, 7], ins: [2, 5, 8] }}
+    import { Clerk } from '@clerk/backend';
+    import { createClerkClient } from '@clerk/backend';
 
-    - const clerkClient = Clerk({ frontendApi: '...' });
-    + const clerkClient = createClerkClient({ publishableKey: '...' });
+    const clerkClient = Clerk({ frontendApi: '...' });
+    const clerkClient = createClerkClient({ publishableKey: '...' });
 
-    - clerkClient.authenticateRequest({ frontendApi: '...' });
-    + clerkClient.authenticateRequest({ publishableKey: '...' });
+    clerkClient.authenticateRequest({ frontendApi: '...' });
+    clerkClient.authenticateRequest({ publishableKey: '...' });
     ```
   </AccordionPanel>
 
   <AccordionPanel>
     The `apiKey` argument passed to `createClerkClient` must be changed to `secretKey`. Also note that the import value has changed for creating a new Clerk client, which will be addressed by a separate line item if relevant to your codebase.
 
-    ```diff {{ prettier: false }}
-    - import { Clerk } from '@clerk/backend';
-    + import { createClerkClient } from '@clerk/backend';
+    ```jsx {{ prettier: false, del: [1, 4, 7], ins: [2, 5, 8] }}
+    import { Clerk } from '@clerk/backend';
+    import { createClerkClient } from '@clerk/backend';
 
-    - const clerkClient = Clerk({ apiKey: '...' });
-    + const clerkClient = createClerkClient({ secretKey: '...' });
+    const clerkClient = Clerk({ apiKey: '...' });
+    const clerkClient = createClerkClient({ secretKey: '...' });
 
-    - clerkClient.authenticateRequest({ apiKey: '...' });
-    + clerkClient.authenticateRequest({ secretKey: '...' });
+    clerkClient.authenticateRequest({ apiKey: '...' });
+    clerkClient.authenticateRequest({ secretKey: '...' });
     ```
   </AccordionPanel>
 </Accordion>
@@ -686,22 +686,22 @@ As part of this major version, a number of previously deprecated props, arugment
   <AccordionPanel>
     The `pkgVersion` parameter was removed from the `loadInterstitialFromLocal`, `loadInterstitialFromBAPI`, and `buildPublicInterstitialUrl` functions. Use `clerkJSVersion` instead. Example:
 
-    ```diff {{ prettier: false }}
-    - loadInterstitialFromLocal({ pkgVersion: "..." })
-    + loadInterstitialFromLocal({ clerkJSVersion: "..." })
+    ```jsx {{ prettier: false, del: [1], ins: [2] }}
+    loadInterstitialFromLocal({ pkgVersion: "..." })
+    loadInterstitialFromLocal({ clerkJSVersion: "..." })
     ```
   </AccordionPanel>
 
   <AccordionPanel>
     The `clerkClient.__unstable_options` property was removed. Previously, you could use it to update the internal options. Instead, create a new ` clerkClient` instance using `createClerkClient` and pass the options in this way. For example:
 
-    ```diff {{ prettier: false }}
-      import { createClerkClient } from "@clerk/backend"
+    ```jsx {{ prettier: false, del: [5], ins: [6] }}
+    import { createClerkClient } from "@clerk/backend"
 
-      const clerkClient = createClerkClient({ secretKey: "old" })
+    const clerkClient = createClerkClient({ secretKey: "old" })
 
-    - clerkClient.__unstable_options.secretKey = "new"
-    + const newClerkClient = createClerkClient({ secretKey: "new" })
+    clerkClient.__unstable_options.secretKey = "new"
+    const newClerkClient = createClerkClient({ secretKey: "new" })
     ```
   </AccordionPanel>
 
@@ -735,9 +735,9 @@ As part of this major version, a number of previously deprecated props, arugment
   <AccordionPanel>
     The `members_count` attribute of the `Organization` resource has been renamed to `membersCount` to match the naming convention of other attributes.
 
-    ```diff {{ prettier: false }}
-    - organization.members_count
-    + organization.membersCount
+    ```jsx {{ prettier: false, del: [1], ins: [2] }}
+    organization.members_count
+    organization.membersCount
     ```
   </AccordionPanel>
 </Accordion>

--- a/docs/upgrade-guides/core-2/chrome-extension.mdx
+++ b/docs/upgrade-guides/core-2/chrome-extension.mdx
@@ -233,7 +233,7 @@ As part of this major version, a number of previously deprecated props, arugment
   <AccordionPanel>
     If you are updating a user's password via the [`User.update` method](/docs/references/javascript/user/user#update), it must be changed to [`User.updatePassword`](/docs/references/javascript/user/password-management#update-password) instead. This method will require the current password as well as the desired new password. We made this update to improve the security of password changes. Example below:
 
-    ```jsx {{ prettier: false, del: [1], ins: [[3, 7]] }}
+    ```js {{ prettier: false, del: [1], ins: [[3, 7]] }}
     user.update({ password: 'foo' });
 
     user.updatePassword({
@@ -253,7 +253,7 @@ As part of this major version, a number of previously deprecated props, arugment
   <AccordionPanel>
     There have been a couple changes to the pagination arguments that can be passed into this function - `limit` has been renamed to `pageSize`, and `offset` has been renamed to `initialPage`. This will help to make it more clear and simple to reason about pagination control. Example of how changes might look below:
 
-    ```jsx {{ prettier: false, del: [2, 4], ins: [3, 5] }}
+    ```js {{ prettier: false, del: [2, 4], ins: [3, 5] }}
     const { data } = await organization.getRoles({
       limit: 10,
       pageSize: 10,
@@ -266,7 +266,7 @@ As part of this major version, a number of previously deprecated props, arugment
   <AccordionPanel>
     There have been a couple changes to the pagination arguments that can be passed into this function - `limit` has been renamed to `pageSize`, and `offset` has been renamed to `initialPage`. This will help to make it more clear and simple to reason about pagination control. Example of how changes might look below:
 
-    ```jsx {{ prettier: false, del: [2, 4], ins: [3, 5] }}
+    ```js {{ prettier: false, del: [2, 4], ins: [3, 5] }}
     const { data } = await organization.getMemberships({
       limit: 10,
       pageSize: 10,
@@ -279,7 +279,7 @@ As part of this major version, a number of previously deprecated props, arugment
   <AccordionPanel>
     There have been a couple changes to the pagination arguments that can be passed into this function - `limit` has been renamed to `pageSize`, and `offset` has been renamed to `initialPage`. This will help to make it more clear and simple to reason about pagination control. Example of how changes might look below:
 
-    ```jsx {{ prettier: false, del: [2, 4], ins: [3, 5] }}
+    ```js {{ prettier: false, del: [2, 4], ins: [3, 5] }}
     const { data } = await organization.getDomains({
       limit: 10,
       pageSize: 10,
@@ -292,7 +292,7 @@ As part of this major version, a number of previously deprecated props, arugment
   <AccordionPanel>
     There have been a couple changes to the pagination arguments that can be passed into this function - `limit` has been renamed to `pageSize`, and `offset` has been renamed to `initialPage`. This will help to make it more clear and simple to reason about pagination control. Example of how changes might look below:
 
-    ```jsx {{ prettier: false, del: [2, 4], ins: [3, 5] }}
+    ```js {{ prettier: false, del: [2, 4], ins: [3, 5] }}
     const { data } = await organization.getInvitations({
       limit: 10,
       pageSize: 10,
@@ -305,7 +305,7 @@ As part of this major version, a number of previously deprecated props, arugment
   <AccordionPanel>
     There have been a couple changes to the pagination arguments that can be passed into this function - `limit` has been renamed to `pageSize`, and `offset` has been renamed to `initialPage`. This will help to make it more clear and simple to reason about pagination control. Example of how changes might look below:
 
-    ```jsx {{ prettier: false, del: [2, 4], ins: [3, 5] }}
+    ```js {{ prettier: false, del: [2, 4], ins: [3, 5] }}
     const { data } = await organization.getMembershipRequests({
       limit: 10,
       pageSize: 10,
@@ -318,7 +318,7 @@ As part of this major version, a number of previously deprecated props, arugment
   <AccordionPanel>
     There have been a couple changes to the pagination arguments that can be passed into this function - `limit` has been renamed to `pageSize`, and `offset` has been renamed to `initialPage`. This will help to make it more clear and simple to reason about pagination control. Example of how changes might look below:
 
-    ```jsx {{ prettier: false, del: [2, 4], ins: [3, 5] }}
+    ```js {{ prettier: false, del: [2, 4], ins: [3, 5] }}
     const { data } = await user.getOrganizationInvitations({
       limit: 10,
       pageSize: 10,
@@ -331,7 +331,7 @@ As part of this major version, a number of previously deprecated props, arugment
   <AccordionPanel>
     There have been a couple changes to the pagination arguments that can be passed into this function - `limit` has been renamed to `pageSize`, and `offset` has been renamed to `initialPage`. This will help to make it more clear and simple to reason about pagination control. Example of how changes might look below:
 
-    ```jsx {{ prettier: false, del: [2, 4], ins: [3, 5] }}
+    ```js {{ prettier: false, del: [2, 4], ins: [3, 5] }}
     const { data } = await user.getOrganizationSuggestions({
       limit: 10,
       pageSize: 10,
@@ -344,7 +344,7 @@ As part of this major version, a number of previously deprecated props, arugment
   <AccordionPanel>
     There have been a couple changes to the pagination arguments that can be passed into this function - `limit` has been renamed to `pageSize`, and `offset` has been renamed to `initialPage`. This will help to make it more clear and simple to reason about pagination control. Example of how changes might look below:
 
-    ```jsx {{ prettier: false, del: [2, 4], ins: [3, 5] }}
+    ```js {{ prettier: false, del: [2, 4], ins: [3, 5] }}
     const { data } = await user.getOrganizationMemberships({
       limit: 10,
       pageSize: 10,
@@ -359,7 +359,7 @@ As part of this major version, a number of previously deprecated props, arugment
 
     Here's an example of how the response shape would change with this modification:
 
-    ```jsx {{ prettier: false, del: [1], ins: [2] }}
+    ```js {{ prettier: false, del: [1], ins: [2] }}
     const data = await clerkClient.users.getOrganizationMembershipList()
     const { data, totalCount } = await clerkClient.users.getOrganizationMembershipList()
     ```
@@ -370,7 +370,7 @@ As part of this major version, a number of previously deprecated props, arugment
 
     Here's an example of how the response shape would change with this modification:
 
-    ```jsx {{ prettier: false, del: [1], ins: [2] }}
+    ```js {{ prettier: false, del: [1], ins: [2] }}
     const data = await clerkClient.users.getOrganizationInvitationList()
     const { data, totalCount } = await clerkClient.users.getOrganizationInvitationList()
     ```
@@ -379,7 +379,7 @@ As part of this major version, a number of previously deprecated props, arugment
   <AccordionPanel>
     The return type for this function was previously `[Items]` but has now been updated to `{ data: [Items], totalCount: number }`. Since Clerk's API responses are paginated, the `totalCount` property is helpful in determining the total number of items in the response easily. A before/after code example can be seen below:
 
-    ```jsx {{ prettier: false, del: [5], ins: [6] }}
+    ```js {{ prettier: false, del: [5], ins: [6] }}
     const data = await clerkClient.organizations.getOrganizationInvitationList({
       organizationId: "...",
     })
@@ -392,7 +392,7 @@ As part of this major version, a number of previously deprecated props, arugment
   <AccordionPanel>
     The return type for this function was previously `[Items]` but has now been updated to `{ data: [Items], totalCount: number }`. Since Clerk's API responses are paginated, the `totalCount` property is helpful in determining the total number of items in the response easily. A before/after code example can be seen below:
 
-    ```jsx {{ prettier: false, del: [4], ins: [5] }}
+    ```js {{ prettier: false, del: [4], ins: [5] }}
     const { user } = useUser()
     const membershipList = user.getOrganizationMembershipList()
 
@@ -406,7 +406,7 @@ As part of this major version, a number of previously deprecated props, arugment
 
     Here's an example of how the response shape would change with this modification:
 
-    ```jsx {{ prettier: false, del: [1], ins: [2] }}
+    ```js {{ prettier: false, del: [1], ins: [2] }}
     const data = await clerkClient.users.getOrganizationList()
     const { data, totalCount } = await clerkClient.users.getOrganizationList()
     ```
@@ -415,7 +415,7 @@ As part of this major version, a number of previously deprecated props, arugment
   <AccordionPanel>
     The return type for this function was previously `[Items]` but has now been updated to `{ data: [Items], totalCount: number }`. Since Clerk's API responses are paginated, the `totalCount` property is helpful in determining the total number of items in the response easily. A before/after code example can be seen below:
 
-    ```jsx {{ prettier: false, del: [4], ins: [5] }}
+    ```js {{ prettier: false, del: [4], ins: [5] }}
     const { organization } = useOrganization()
     const orgList = organization.getOrganizationList()
 
@@ -429,7 +429,7 @@ As part of this major version, a number of previously deprecated props, arugment
 
     Here's an example of how the response shape would change with this modification:
 
-    ```jsx {{ prettier: false, del: [1], ins: [2] }}
+    ```js {{ prettier: false, del: [1], ins: [2] }}
     const data = await clerkClient.invitations.getInvitationList()
     const { data, totalCount } = await clerkClient.invitations.getInvitationList()
     ```
@@ -440,7 +440,7 @@ As part of this major version, a number of previously deprecated props, arugment
 
     Here's an example of how the response shape would change with this modification:
 
-    ```jsx {{ prettier: false, del: [1], ins: [2] }}
+    ```js {{ prettier: false, del: [1], ins: [2] }}
     const data = await clerkClient.sessions.getSessionList()
     const { data, totalCount } = await clerkClient.sessions.getSessionList()
     ```
@@ -451,7 +451,7 @@ As part of this major version, a number of previously deprecated props, arugment
 
     Here's an example of how the response shape would change with this modification:
 
-    ```jsx {{ prettier: false, del: [1], ins: [2] }}
+    ```js {{ prettier: false, del: [1], ins: [2] }}
     const data = await clerkClient.users.getUserList()
     const { data, totalCount } = await clerkClient.users.getUserList()
     ```
@@ -462,7 +462,7 @@ As part of this major version, a number of previously deprecated props, arugment
 
     Here's an example of how the response shape would change with this modification:
 
-    ```jsx {{ prettier: false, del: [1], ins: [2] }}
+    ```js {{ prettier: false, del: [1], ins: [2] }}
     const data = await clerkClient.allowlistIdentifiers.getAllowlistIdentifierList()
     const { data, totalCount } = await clerkClient.allowlistIdentifiers.getAllowlistIdentifierList()
     ```
@@ -473,7 +473,7 @@ As part of this major version, a number of previously deprecated props, arugment
 
     Here's an example of how the response shape would change with this modification:
 
-    ```jsx {{ prettier: false, del: [1], ins: [2] }}
+    ```js {{ prettier: false, del: [1], ins: [2] }}
     const data = await clerkClient.clients.getClientList()
     const { data, totalCount } = await clerkClient.allowlistIdentifiers.getClientList()
     ```
@@ -484,7 +484,7 @@ As part of this major version, a number of previously deprecated props, arugment
 
     Here's an example of how the response shape would change with this modification:
 
-    ```jsx {{ prettier: false, del: [1], ins: [2] }}
+    ```js {{ prettier: false, del: [1], ins: [2] }}
     const data = await clerkClient.redirectUrls.getRedirectUrlList()
     const { data, totalCount } = await clerkClient.redirectUrls.getRedirectUrlList()
     ```
@@ -495,7 +495,7 @@ As part of this major version, a number of previously deprecated props, arugment
 
     Here's an example of how the response shape would change with this modification:
 
-    ```jsx {{ prettier: false, del: [1], ins: [2] }}
+    ```js {{ prettier: false, del: [1], ins: [2] }}
     const data = await clerkClient.users.getUserOauthAccessToken()
     const { data, totalCount } = await clerkClient.users.getUserOauthAccessToken()
     ```
@@ -504,7 +504,7 @@ As part of this major version, a number of previously deprecated props, arugment
   <AccordionPanel>
     `setSession` should be replaced with `setActive`. The format of the parameters has changed slightly - `setActive` takes an object where `setSession` took params directly. The `setActive` function also can accept an `organization` param that is used to set the currently active organization. The return signature did not change. Read the [API documentation](/docs/references/javascript/clerk/session-methods#set-active) for more detail. This function should be expected to be returned from one of the following Clerk hooks: `useSessionList`, `useSignUp`, or `useSignIn`. Some migration examples:
 
-    ```jsx {{ prettier: false, del: [1, 4, 7], ins: [2, 5, 8] }}
+    ```js {{ prettier: false, del: [1, 4, 7], ins: [2, 5, 8] }}
     await setSession('sessionID', () => void)
     await setActive({ session: 'sessionID',  beforeEmit: () => void })
 
@@ -534,7 +534,7 @@ As part of this major version, a number of previously deprecated props, arugment
   <AccordionPanel>
     Passing a string as an argument to `Organization.create` is no longer possible - instead, pass an object with the `name` property.
 
-    ```jsx {{ prettier: false, del: [1], ins: [2] }}
+    ```js {{ prettier: false, del: [1], ins: [2] }}
     Organization.create('...');
     Organization.create({ name: '...' });
     ```
@@ -543,7 +543,7 @@ As part of this major version, a number of previously deprecated props, arugment
   <AccordionPanel>
     The `Organization.getPendingInvitations()` method has been removed. You can use `Organization.getInvitations` instead.
 
-    ```jsx {{ prettier: false, del: [1], ins: [2] }}
+    ```js {{ prettier: false, del: [1], ins: [2] }}
     Organization.getPendingInvitations();
     Organization.getInvitations({ status: 'pending' });
     ```

--- a/docs/upgrade-guides/core-2/chrome-extension.mdx
+++ b/docs/upgrade-guides/core-2/chrome-extension.mdx
@@ -98,9 +98,9 @@ type StorageCache = {
 
 And here's a full before/after example:
 
-```diff {{ prettier: false }}
-- <ClerkProvider tokenCache={/* ... */}>
-+ <ClerkProvider storageCache={/* ... */}>
+```jsx {{ prettier: false, del: [1], ins: [2] }}
+<ClerkProvider tokenCache={/* ... */}>
+<ClerkProvider storageCache={/* ... */}>
 ```
 
 ### Component design adjustments
@@ -115,9 +115,9 @@ Defining redirect URLs for after sign up, in, and/or out via the Clerk dashboard
 
 As part of this change, the default URL for each of these props has been set to `/`, so if you are passing `/` explicitly to any one of the above props, that line is no longer necessary and can be removed.
 
-```diff {{ prettier: false }}
-- <UserButton afterSignOutUrl='/' />
-+ <UserButton />
+```jsx {{ prettier: false, del: [1], ins: [2] }}
+<UserButton afterSignOutUrl='/' />
+<UserButton />
 ```
 
 ### Removed: `orgs` claim on JWT
@@ -233,14 +233,14 @@ As part of this major version, a number of previously deprecated props, arugment
   <AccordionPanel>
     If you are updating a user's password via the [`User.update` method](/docs/references/javascript/user/user#update), it must be changed to [`User.updatePassword`](/docs/references/javascript/user/password-management#update-password) instead. This method will require the current password as well as the desired new password. We made this update to improve the security of password changes. Example below:
 
-    ```diff {{ prettier: false }}
-    - user.update({ password: 'foo' });
+    ```jsx {{ prettier: false, del: [1], ins: [[3, 7]] }}
+    user.update({ password: 'foo' });
 
-    + user.updatePassword({
-    +   currentPassword: 'bar',
-    +   newPassword: 'foo',
-    +   signOutOfOtherSessions: true,
-    + });
+    user.updatePassword({
+      currentPassword: 'bar',
+      newPassword: 'foo',
+      signOutOfOtherSessions: true,
+    });
     ```
   </AccordionPanel>
 </Accordion>
@@ -253,104 +253,104 @@ As part of this major version, a number of previously deprecated props, arugment
   <AccordionPanel>
     There have been a couple changes to the pagination arguments that can be passed into this function - `limit` has been renamed to `pageSize`, and `offset` has been renamed to `initialPage`. This will help to make it more clear and simple to reason about pagination control. Example of how changes might look below:
 
-    ```diff {{ prettier: false }}
-      const { data } = await organization.getRoles({
-    -   limit: 10,
-    +   pageSize: 10,
-    -   offset: 10,
-    +   initialPage: 2,
-      })
+    ```jsx {{ prettier: false, del: [2, 4], ins: [3, 5] }}
+    const { data } = await organization.getRoles({
+      limit: 10,
+      pageSize: 10,
+      offset: 10,
+      initialPage: 2,
+    })
     ```
   </AccordionPanel>
 
   <AccordionPanel>
     There have been a couple changes to the pagination arguments that can be passed into this function - `limit` has been renamed to `pageSize`, and `offset` has been renamed to `initialPage`. This will help to make it more clear and simple to reason about pagination control. Example of how changes might look below:
 
-    ```diff {{ prettier: false }}
-      const { data } = await organization.getMemberships({
-    -   limit: 10,
-    +   pageSize: 10,
-    -   offset: 10,
-    +   initialPage: 2,
-      })
+    ```jsx {{ prettier: false, del: [2, 4], ins: [3, 5] }}
+    const { data } = await organization.getMemberships({
+      limit: 10,
+      pageSize: 10,
+      offset: 10,
+      initialPage: 2,
+    })
     ```
   </AccordionPanel>
 
   <AccordionPanel>
     There have been a couple changes to the pagination arguments that can be passed into this function - `limit` has been renamed to `pageSize`, and `offset` has been renamed to `initialPage`. This will help to make it more clear and simple to reason about pagination control. Example of how changes might look below:
 
-    ```diff {{ prettier: false }}
-      const { data } = await organization.getDomains({
-    -   limit: 10,
-    +   pageSize: 10,
-    -   offset: 10,
-    +   initialPage: 2,
-      })
+    ```jsx {{ prettier: false, del: [2, 4], ins: [3, 5] }}
+    const { data } = await organization.getDomains({
+      limit: 10,
+      pageSize: 10,
+      offset: 10,
+      initialPage: 2,
+    })
     ```
   </AccordionPanel>
 
   <AccordionPanel>
     There have been a couple changes to the pagination arguments that can be passed into this function - `limit` has been renamed to `pageSize`, and `offset` has been renamed to `initialPage`. This will help to make it more clear and simple to reason about pagination control. Example of how changes might look below:
 
-    ```diff {{ prettier: false }}
-      const { data } = await organization.getInvitations({
-    -   limit: 10,
-    +   pageSize: 10,
-    -   offset: 10,
-    +   initialPage: 2,
-      })
+    ```jsx {{ prettier: false, del: [2, 4], ins: [3, 5] }}
+    const { data } = await organization.getInvitations({
+      limit: 10,
+      pageSize: 10,
+      offset: 10,
+      initialPage: 2,
+    })
     ```
   </AccordionPanel>
 
   <AccordionPanel>
     There have been a couple changes to the pagination arguments that can be passed into this function - `limit` has been renamed to `pageSize`, and `offset` has been renamed to `initialPage`. This will help to make it more clear and simple to reason about pagination control. Example of how changes might look below:
 
-    ```diff {{ prettier: false }}
-      const { data } = await organization.getMembershipRequests({
-    -   limit: 10,
-    +   pageSize: 10,
-    -   offset: 10,
-    +   initialPage: 2,
-      })
+    ```jsx {{ prettier: false, del: [2, 4], ins: [3, 5] }}
+    const { data } = await organization.getMembershipRequests({
+      limit: 10,
+      pageSize: 10,
+      offset: 10,
+      initialPage: 2,
+    })
     ```
   </AccordionPanel>
 
   <AccordionPanel>
     There have been a couple changes to the pagination arguments that can be passed into this function - `limit` has been renamed to `pageSize`, and `offset` has been renamed to `initialPage`. This will help to make it more clear and simple to reason about pagination control. Example of how changes might look below:
 
-    ```diff {{ prettier: false }}
-      const { data } = await user.getOrganizationInvitations({
-    -   limit: 10,
-    +   pageSize: 10,
-    -   offset: 10,
-    +   initialPage: 2,
-      })
+    ```jsx {{ prettier: false, del: [2, 4], ins: [3, 5] }}
+    const { data } = await user.getOrganizationInvitations({
+      limit: 10,
+      pageSize: 10,
+      offset: 10,
+      initialPage: 2,
+    })
     ```
   </AccordionPanel>
 
   <AccordionPanel>
     There have been a couple changes to the pagination arguments that can be passed into this function - `limit` has been renamed to `pageSize`, and `offset` has been renamed to `initialPage`. This will help to make it more clear and simple to reason about pagination control. Example of how changes might look below:
 
-    ```diff {{ prettier: false }}
-      const { data } = await user.getOrganizationSuggestions({
-    -   limit: 10,
-    +   pageSize: 10,
-    -   offset: 10,
-    +   initialPage: 2,
-      })
+    ```jsx {{ prettier: false, del: [2, 4], ins: [3, 5] }}
+    const { data } = await user.getOrganizationSuggestions({
+      limit: 10,
+      pageSize: 10,
+      offset: 10,
+      initialPage: 2,
+    })
     ```
   </AccordionPanel>
 
   <AccordionPanel>
     There have been a couple changes to the pagination arguments that can be passed into this function - `limit` has been renamed to `pageSize`, and `offset` has been renamed to `initialPage`. This will help to make it more clear and simple to reason about pagination control. Example of how changes might look below:
 
-    ```diff {{ prettier: false }}
-      const { data } = await user.getOrganizationMemberships({
-    -   limit: 10,
-    +   pageSize: 10,
-    -   offset: 10,
-    +   initialPage: 2,
-      })
+    ```jsx {{ prettier: false, del: [2, 4], ins: [3, 5] }}
+    const { data } = await user.getOrganizationMemberships({
+      limit: 10,
+      pageSize: 10,
+      offset: 10,
+      initialPage: 2,
+    })
     ```
   </AccordionPanel>
 
@@ -359,9 +359,9 @@ As part of this major version, a number of previously deprecated props, arugment
 
     Here's an example of how the response shape would change with this modification:
 
-    ```diff {{ prettier: false }}
-    - const data = await clerkClient.users.getOrganizationMembershipList()
-    + const { data, totalCount } = await clerkClient.users.getOrganizationMembershipList()
+    ```jsx {{ prettier: false, del: [1], ins: [2] }}
+    const data = await clerkClient.users.getOrganizationMembershipList()
+    const { data, totalCount } = await clerkClient.users.getOrganizationMembershipList()
     ```
   </AccordionPanel>
 
@@ -370,34 +370,34 @@ As part of this major version, a number of previously deprecated props, arugment
 
     Here's an example of how the response shape would change with this modification:
 
-    ```diff {{ prettier: false }}
-    - const data = await clerkClient.users.getOrganizationInvitationList()
-    + const { data, totalCount } = await clerkClient.users.getOrganizationInvitationList()
+    ```jsx {{ prettier: false, del: [1], ins: [2] }}
+    const data = await clerkClient.users.getOrganizationInvitationList()
+    const { data, totalCount } = await clerkClient.users.getOrganizationInvitationList()
     ```
   </AccordionPanel>
 
   <AccordionPanel>
     The return type for this function was previously `[Items]` but has now been updated to `{ data: [Items], totalCount: number }`. Since Clerk's API responses are paginated, the `totalCount` property is helpful in determining the total number of items in the response easily. A before/after code example can be seen below:
 
-    ```diff {{ prettier: false }}
-      const data = await clerkClient.organizations.getOrganizationInvitationList({
-        organizationId: "...",
-      })
+    ```jsx {{ prettier: false, del: [5], ins: [6] }}
+    const data = await clerkClient.organizations.getOrganizationInvitationList({
+      organizationId: "...",
+    })
 
-    - data.forEach(() => {})
-    + data.data.forEach(() => {})
+    data.forEach(() => {})
+    data.data.forEach(() => {})
     ```
   </AccordionPanel>
 
   <AccordionPanel>
     The return type for this function was previously `[Items]` but has now been updated to `{ data: [Items], totalCount: number }`. Since Clerk's API responses are paginated, the `totalCount` property is helpful in determining the total number of items in the response easily. A before/after code example can be seen below:
 
-    ```diff {{ prettier: false }}
-      const { user } = useUser()
-      const membershipList = user.getOrganizationMembershipList()
+    ```jsx {{ prettier: false, del: [4], ins: [5] }}
+    const { user } = useUser()
+    const membershipList = user.getOrganizationMembershipList()
 
-    - membershipList.forEach(() => {})
-    + membershipList.data.forEach(() => {})
+    membershipList.forEach(() => {})
+    membershipList.data.forEach(() => {})
     ```
   </AccordionPanel>
 
@@ -406,21 +406,21 @@ As part of this major version, a number of previously deprecated props, arugment
 
     Here's an example of how the response shape would change with this modification:
 
-    ```diff {{ prettier: false }}
-    - const data = await clerkClient.users.getOrganizationList()
-    + const { data, totalCount } = await clerkClient.users.getOrganizationList()
+    ```jsx {{ prettier: false, del: [1], ins: [2] }}
+    const data = await clerkClient.users.getOrganizationList()
+    const { data, totalCount } = await clerkClient.users.getOrganizationList()
     ```
   </AccordionPanel>
 
   <AccordionPanel>
     The return type for this function was previously `[Items]` but has now been updated to `{ data: [Items], totalCount: number }`. Since Clerk's API responses are paginated, the `totalCount` property is helpful in determining the total number of items in the response easily. A before/after code example can be seen below:
 
-    ```diff {{ prettier: false }}
-      const { organization } = useOrganization()
-      const orgList = organization.getOrganizationList()
+    ```jsx {{ prettier: false, del: [4], ins: [5] }}
+    const { organization } = useOrganization()
+    const orgList = organization.getOrganizationList()
 
-    - orgList.forEach(() => {})
-    + orgList.data.forEach(() => {})
+    orgList.forEach(() => {})
+    orgList.data.forEach(() => {})
     ```
   </AccordionPanel>
 
@@ -429,9 +429,9 @@ As part of this major version, a number of previously deprecated props, arugment
 
     Here's an example of how the response shape would change with this modification:
 
-    ```diff {{ prettier: false }}
-    - const data = await clerkClient.invitations.getInvitationList()
-    + const { data, totalCount } = await clerkClient.invitations.getInvitationList()
+    ```jsx {{ prettier: false, del: [1], ins: [2] }}
+    const data = await clerkClient.invitations.getInvitationList()
+    const { data, totalCount } = await clerkClient.invitations.getInvitationList()
     ```
   </AccordionPanel>
 
@@ -440,9 +440,9 @@ As part of this major version, a number of previously deprecated props, arugment
 
     Here's an example of how the response shape would change with this modification:
 
-    ```diff {{ prettier: false }}
-    - const data = await clerkClient.sessions.getSessionList()
-    + const { data, totalCount } = await clerkClient.sessions.getSessionList()
+    ```jsx {{ prettier: false, del: [1], ins: [2] }}
+    const data = await clerkClient.sessions.getSessionList()
+    const { data, totalCount } = await clerkClient.sessions.getSessionList()
     ```
   </AccordionPanel>
 
@@ -451,9 +451,9 @@ As part of this major version, a number of previously deprecated props, arugment
 
     Here's an example of how the response shape would change with this modification:
 
-    ```diff {{ prettier: false }}
-    - const data = await clerkClient.users.getUserList()
-    + const { data, totalCount } = await clerkClient.users.getUserList()
+    ```jsx {{ prettier: false, del: [1], ins: [2] }}
+    const data = await clerkClient.users.getUserList()
+    const { data, totalCount } = await clerkClient.users.getUserList()
     ```
   </AccordionPanel>
 
@@ -462,9 +462,9 @@ As part of this major version, a number of previously deprecated props, arugment
 
     Here's an example of how the response shape would change with this modification:
 
-    ```diff {{ prettier: false }}
-    - const data = await clerkClient.allowlistIdentifiers.getAllowlistIdentifierList()
-    + const { data, totalCount } = await clerkClient.allowlistIdentifiers.getAllowlistIdentifierList()
+    ```jsx {{ prettier: false, del: [1], ins: [2] }}
+    const data = await clerkClient.allowlistIdentifiers.getAllowlistIdentifierList()
+    const { data, totalCount } = await clerkClient.allowlistIdentifiers.getAllowlistIdentifierList()
     ```
   </AccordionPanel>
 
@@ -473,9 +473,9 @@ As part of this major version, a number of previously deprecated props, arugment
 
     Here's an example of how the response shape would change with this modification:
 
-    ```diff {{ prettier: false }}
-    - const data = await clerkClient.clients.getClientList()
-    + const { data, totalCount } = await clerkClient.allowlistIdentifiers.getClientList()
+    ```jsx {{ prettier: false, del: [1], ins: [2] }}
+    const data = await clerkClient.clients.getClientList()
+    const { data, totalCount } = await clerkClient.allowlistIdentifiers.getClientList()
     ```
   </AccordionPanel>
 
@@ -484,9 +484,9 @@ As part of this major version, a number of previously deprecated props, arugment
 
     Here's an example of how the response shape would change with this modification:
 
-    ```diff {{ prettier: false }}
-    - const data = await clerkClient.redirectUrls.getRedirectUrlList()
-    + const { data, totalCount } = await clerkClient.redirectUrls.getRedirectUrlList()
+    ```jsx {{ prettier: false, del: [1], ins: [2] }}
+    const data = await clerkClient.redirectUrls.getRedirectUrlList()
+    const { data, totalCount } = await clerkClient.redirectUrls.getRedirectUrlList()
     ```
   </AccordionPanel>
 
@@ -495,24 +495,24 @@ As part of this major version, a number of previously deprecated props, arugment
 
     Here's an example of how the response shape would change with this modification:
 
-    ```diff {{ prettier: false }}
-    - const data = await clerkClient.users.getUserOauthAccessToken()
-    + const { data, totalCount } = await clerkClient.users.getUserOauthAccessToken()
+    ```jsx {{ prettier: false, del: [1], ins: [2] }}
+    const data = await clerkClient.users.getUserOauthAccessToken()
+    const { data, totalCount } = await clerkClient.users.getUserOauthAccessToken()
     ```
   </AccordionPanel>
 
   <AccordionPanel>
     `setSession` should be replaced with `setActive`. The format of the parameters has changed slightly - `setActive` takes an object where `setSession` took params directly. The `setActive` function also can accept an `organization` param that is used to set the currently active organization. The return signature did not change. Read the [API documentation](/docs/references/javascript/clerk/session-methods#set-active) for more detail. This function should be expected to be returned from one of the following Clerk hooks: `useSessionList`, `useSignUp`, or `useSignIn`. Some migration examples:
 
-    ```diff {{ prettier: false }}
-    - await setSession('sessionID', () => void)
-    + await setActive({ session: 'sessionID',  beforeEmit: () => void })
+    ```jsx {{ prettier: false, del: [1, 4, 7], ins: [2, 5, 8] }}
+    await setSession('sessionID', () => void)
+    await setActive({ session: 'sessionID',  beforeEmit: () => void })
 
-    - await setSession(sessionObj)
-    + await setActive({ session: sessionObj })
+    await setSession(sessionObj)
+    await setActive({ session: sessionObj })
 
-    - await setSession(sessionObj, () => void)
-    + await setActive({ session: sessionObj,  beforeEmit: () => void })
+    await setSession(sessionObj, () => void)
+    await setActive({ session: sessionObj,  beforeEmit: () => void })
     ```
 
     `setActive` also supports setting an active organization:
@@ -534,18 +534,18 @@ As part of this major version, a number of previously deprecated props, arugment
   <AccordionPanel>
     Passing a string as an argument to `Organization.create` is no longer possible - instead, pass an object with the `name` property.
 
-    ```diff {{ prettier: false }}
-    - Organization.create('...');
-    + Organization.create({ name: '...' });
+    ```jsx {{ prettier: false, del: [1], ins: [2] }}
+    Organization.create('...');
+    Organization.create({ name: '...' });
     ```
   </AccordionPanel>
 
   <AccordionPanel>
     The `Organization.getPendingInvitations()` method has been removed. You can use `Organization.getInvitations` instead.
 
-    ```diff {{ prettier: false }}
-    - Organization.getPendingInvitations();
-    + Organization.getInvitations({ status: 'pending' });
+    ```jsx {{ prettier: false, del: [1], ins: [2] }}
+    Organization.getPendingInvitations();
+    Organization.getInvitations({ status: 'pending' });
     ```
   </AccordionPanel>
 </Accordion>

--- a/docs/upgrade-guides/core-2/expo.mdx
+++ b/docs/upgrade-guides/core-2/expo.mdx
@@ -221,7 +221,7 @@ As part of this major version, a number of previously deprecated props, arugment
   <AccordionPanel>
     If you are updating a user's password via the [`User.update` method](/docs/references/javascript/user/user#update), it must be changed to [`User.updatePassword`](/docs/references/javascript/user/password-management#update-password) instead. This method will require the current password as well as the desired new password. We made this update to improve the security of password changes. Example below:
 
-    ```jsx {{ prettier: false, del: [1], ins: [[3, 7]] }}
+    ```js {{ prettier: false, del: [1], ins: [[3, 7]] }}
     user.update({ password: 'foo' });
 
     user.updatePassword({
@@ -245,7 +245,7 @@ As part of this major version, a number of previously deprecated props, arugment
   <AccordionPanel>
     There have been a couple changes to the pagination arguments that can be passed into this function - `limit` has been renamed to `pageSize`, and `offset` has been renamed to `initialPage`. This will help to make it more clear and simple to reason about pagination control. Example of how changes might look below:
 
-    ```jsx {{ prettier: false, del: [2, 4], ins: [3, 5] }}
+    ```js {{ prettier: false, del: [2, 4], ins: [3, 5] }}
     const { data } = await organization.getRoles({
       limit: 10,
       pageSize: 10,
@@ -258,7 +258,7 @@ As part of this major version, a number of previously deprecated props, arugment
   <AccordionPanel>
     There have been a couple changes to the pagination arguments that can be passed into this function - `limit` has been renamed to `pageSize`, and `offset` has been renamed to `initialPage`. This will help to make it more clear and simple to reason about pagination control. Example of how changes might look below:
 
-    ```jsx {{ prettier: false, del: [2, 4], ins: [3, 5] }}
+    ```js {{ prettier: false, del: [2, 4], ins: [3, 5] }}
     const { data } = await organization.getMemberships({
       limit: 10,
       pageSize: 10,
@@ -271,7 +271,7 @@ As part of this major version, a number of previously deprecated props, arugment
   <AccordionPanel>
     There have been a couple changes to the pagination arguments that can be passed into this function - `limit` has been renamed to `pageSize`, and `offset` has been renamed to `initialPage`. This will help to make it more clear and simple to reason about pagination control. Example of how changes might look below:
 
-    ```jsx {{ prettier: false, del: [2, 4], ins: [3, 5] }}
+    ```js {{ prettier: false, del: [2, 4], ins: [3, 5] }}
     const { data } = await organization.getDomains({
       limit: 10,
       pageSize: 10,
@@ -284,7 +284,7 @@ As part of this major version, a number of previously deprecated props, arugment
   <AccordionPanel>
     There have been a couple changes to the pagination arguments that can be passed into this function - `limit` has been renamed to `pageSize`, and `offset` has been renamed to `initialPage`. This will help to make it more clear and simple to reason about pagination control. Example of how changes might look below:
 
-    ```jsx {{ prettier: false, del: [2, 4], ins: [3, 5] }}
+    ```js {{ prettier: false, del: [2, 4], ins: [3, 5] }}
     const { data } = await organization.getInvitations({
       limit: 10,
       pageSize: 10,
@@ -297,7 +297,7 @@ As part of this major version, a number of previously deprecated props, arugment
   <AccordionPanel>
     There have been a couple changes to the pagination arguments that can be passed into this function - `limit` has been renamed to `pageSize`, and `offset` has been renamed to `initialPage`. This will help to make it more clear and simple to reason about pagination control. Example of how changes might look below:
 
-    ```jsx {{ prettier: false, del: [2, 4], ins: [3, 5] }}
+    ```js {{ prettier: false, del: [2, 4], ins: [3, 5] }}
     const { data } = await organization.getMembershipRequests({
       limit: 10,
       pageSize: 10,
@@ -310,7 +310,7 @@ As part of this major version, a number of previously deprecated props, arugment
   <AccordionPanel>
     There have been a couple changes to the pagination arguments that can be passed into this function - `limit` has been renamed to `pageSize`, and `offset` has been renamed to `initialPage`. This will help to make it more clear and simple to reason about pagination control. Example of how changes might look below:
 
-    ```jsx {{ prettier: false, del: [2, 4], ins: [3, 5] }}
+    ```js {{ prettier: false, del: [2, 4], ins: [3, 5] }}
     const { data } = await user.getOrganizationInvitations({
       limit: 10,
       pageSize: 10,
@@ -323,7 +323,7 @@ As part of this major version, a number of previously deprecated props, arugment
   <AccordionPanel>
     There have been a couple changes to the pagination arguments that can be passed into this function - `limit` has been renamed to `pageSize`, and `offset` has been renamed to `initialPage`. This will help to make it more clear and simple to reason about pagination control. Example of how changes might look below:
 
-    ```jsx {{ prettier: false, del: [2, 4], ins: [3, 5] }}
+    ```js {{ prettier: false, del: [2, 4], ins: [3, 5] }}
     const { data } = await user.getOrganizationSuggestions({
       limit: 10,
       pageSize: 10,
@@ -336,7 +336,7 @@ As part of this major version, a number of previously deprecated props, arugment
   <AccordionPanel>
     There have been a couple changes to the pagination arguments that can be passed into this function - `limit` has been renamed to `pageSize`, and `offset` has been renamed to `initialPage`. This will help to make it more clear and simple to reason about pagination control. Example of how changes might look below:
 
-    ```jsx {{ prettier: false, del: [2, 4], ins: [3, 5] }}
+    ```js {{ prettier: false, del: [2, 4], ins: [3, 5] }}
     const { data } = await user.getOrganizationMemberships({
       limit: 10,
       pageSize: 10,
@@ -351,7 +351,7 @@ As part of this major version, a number of previously deprecated props, arugment
 
     Here's an example of how the response shape would change with this modification:
 
-    ```jsx {{ prettier: false, del: [1], ins: [2] }}
+    ```js {{ prettier: false, del: [1], ins: [2] }}
     const data = await clerkClient.users.getOrganizationMembershipList()
     const { data, totalCount } = await clerkClient.users.getOrganizationMembershipList()
     ```
@@ -362,7 +362,7 @@ As part of this major version, a number of previously deprecated props, arugment
 
     Here's an example of how the response shape would change with this modification:
 
-    ```jsx {{ prettier: false, del: [1], ins: [2] }}
+    ```js {{ prettier: false, del: [1], ins: [2] }}
     const data = await clerkClient.users.getOrganizationInvitationList()
     const { data, totalCount } = await clerkClient.users.getOrganizationInvitationList()
     ```
@@ -371,7 +371,7 @@ As part of this major version, a number of previously deprecated props, arugment
   <AccordionPanel>
     The return type for this function was previously `[Items]` but has now been updated to `{ data: [Items], totalCount: number }`. Since Clerk's API responses are paginated, the `totalCount` property is helpful in determining the total number of items in the response easily. A before/after code example can be seen below:
 
-    ```jsx {{ prettier: false, del: [5], ins: [6] }}
+    ```js {{ prettier: false, del: [5], ins: [6] }}
     const data = await clerkClient.organizations.getOrganizationInvitationList({
       organizationId: "...",
     })
@@ -384,7 +384,7 @@ As part of this major version, a number of previously deprecated props, arugment
   <AccordionPanel>
     The return type for this function was previously `[Items]` but has now been updated to `{ data: [Items], totalCount: number }`. Since Clerk's API responses are paginated, the `totalCount` property is helpful in determining the total number of items in the response easily. A before/after code example can be seen below:
 
-    ```jsx {{ prettier: false, del: [4], ins: [5] }}
+    ```js {{ prettier: false, del: [4], ins: [5] }}
     const { user } = useUser()
     const membershipList = user.getOrganizationMembershipList()
 
@@ -398,7 +398,7 @@ As part of this major version, a number of previously deprecated props, arugment
 
     Here's an example of how the response shape would change with this modification:
 
-    ```jsx {{ prettier: false, del: [1], ins: [2] }}
+    ```js {{ prettier: false, del: [1], ins: [2] }}
     const data = await clerkClient.users.getOrganizationList()
     const { data, totalCount } = await clerkClient.users.getOrganizationList()
     ```
@@ -407,7 +407,7 @@ As part of this major version, a number of previously deprecated props, arugment
   <AccordionPanel>
     The return type for this function was previously `[Items]` but has now been updated to `{ data: [Items], totalCount: number }`. Since Clerk's API responses are paginated, the `totalCount` property is helpful in determining the total number of items in the response easily. A before/after code example can be seen below:
 
-    ```jsx {{ prettier: false, del: [4], ins: [5] }}
+    ```js {{ prettier: false, del: [4], ins: [5] }}
     const { organization } = useOrganization()
     const orgList = organization.getOrganizationList()
 
@@ -421,7 +421,7 @@ As part of this major version, a number of previously deprecated props, arugment
 
     Here's an example of how the response shape would change with this modification:
 
-    ```jsx {{ prettier: false, del: [1], ins: [2] }}
+    ```js {{ prettier: false, del: [1], ins: [2] }}
     const data = await clerkClient.invitations.getInvitationList()
     const { data, totalCount } = await clerkClient.invitations.getInvitationList()
     ```
@@ -432,7 +432,7 @@ As part of this major version, a number of previously deprecated props, arugment
 
     Here's an example of how the response shape would change with this modification:
 
-    ```jsx {{ prettier: false, del: [1], ins: [2] }}
+    ```js {{ prettier: false, del: [1], ins: [2] }}
     const data = await clerkClient.sessions.getSessionList()
     const { data, totalCount } = await clerkClient.sessions.getSessionList()
     ```
@@ -443,7 +443,7 @@ As part of this major version, a number of previously deprecated props, arugment
 
     Here's an example of how the response shape would change with this modification:
 
-    ```jsx {{ prettier: false, del: [1], ins: [2] }}
+    ```js {{ prettier: false, del: [1], ins: [2] }}
     const data = await clerkClient.users.getUserList()
     const { data, totalCount } = await clerkClient.users.getUserList()
     ```
@@ -454,7 +454,7 @@ As part of this major version, a number of previously deprecated props, arugment
 
     Here's an example of how the response shape would change with this modification:
 
-    ```jsx {{ prettier: false, del: [1], ins: [2] }}
+    ```js {{ prettier: false, del: [1], ins: [2] }}
     const data = await clerkClient.allowlistIdentifiers.getAllowlistIdentifierList()
     const { data, totalCount } = await clerkClient.allowlistIdentifiers.getAllowlistIdentifierList()
     ```
@@ -465,7 +465,7 @@ As part of this major version, a number of previously deprecated props, arugment
 
     Here's an example of how the response shape would change with this modification:
 
-    ```jsx {{ prettier: false, del: [1], ins: [2] }}
+    ```js {{ prettier: false, del: [1], ins: [2] }}
     const data = await clerkClient.clients.getClientList()
     const { data, totalCount } = await clerkClient.allowlistIdentifiers.getClientList()
     ```
@@ -476,7 +476,7 @@ As part of this major version, a number of previously deprecated props, arugment
 
     Here's an example of how the response shape would change with this modification:
 
-    ```jsx {{ prettier: false, del: [1], ins: [2] }}
+    ```js {{ prettier: false, del: [1], ins: [2] }}
     const data = await clerkClient.redirectUrls.getRedirectUrlList()
     const { data, totalCount } = await clerkClient.redirectUrls.getRedirectUrlList()
     ```
@@ -487,7 +487,7 @@ As part of this major version, a number of previously deprecated props, arugment
 
     Here's an example of how the response shape would change with this modification:
 
-    ```jsx {{ prettier: false, del: [1], ins: [2] }}
+    ```js {{ prettier: false, del: [1], ins: [2] }}
     const data = await clerkClient.users.getUserOauthAccessToken()
     const { data, totalCount } = await clerkClient.users.getUserOauthAccessToken()
     ```
@@ -496,7 +496,7 @@ As part of this major version, a number of previously deprecated props, arugment
   <AccordionPanel>
     `setSession` should be replaced with `setActive`. The format of the parameters has changed slightly - `setActive` takes an object where `setSession` took params directly. The `setActive` function also can accept an `organization` param that is used to set the currently active organization. The return signature did not change. Read the [API documentation](/docs/references/javascript/clerk/session-methods#set-active) for more detail. This function should be expected to be returned from one of the following Clerk hooks: `useSessionList`, `useSignUp`, or `useSignIn`. Some migration examples:
 
-    ```jsx {{ prettier: false, del: [1, 4, 7], ins: [2, 5, 8] }}
+    ```js {{ prettier: false, del: [1, 4, 7], ins: [2, 5, 8] }}
     await setSession('sessionID', () => void)
     await setActive({ session: 'sessionID',  beforeEmit: () => void })
 
@@ -527,7 +527,7 @@ As part of this major version, a number of previously deprecated props, arugment
   <AccordionPanel>
     Passing a string as an argument to `Organization.create` is no longer possible - instead, pass an object with the `name` property.
 
-    ```jsx {{ prettier: false, del: [1], ins: [2] }}
+    ```js {{ prettier: false, del: [1], ins: [2] }}
     Organization.create('...');
     Organization.create({ name: '...' });
     ```
@@ -536,7 +536,7 @@ As part of this major version, a number of previously deprecated props, arugment
   <AccordionPanel>
     The `Organization.getPendingInvitations()` method has been removed. You can use `Organization.getInvitations` instead.
 
-    ```jsx {{ prettier: false, del: [1], ins: [2] }}
+    ```js {{ prettier: false, del: [1], ins: [2] }}
     Organization.getPendingInvitations();
     Organization.getInvitations({ status: 'pending' });
     ```

--- a/docs/upgrade-guides/core-2/expo.mdx
+++ b/docs/upgrade-guides/core-2/expo.mdx
@@ -95,9 +95,9 @@ Defining redirect URLs for after sign up, in, and/or out via the Clerk dashboard
 
 As part of this change, the default URL for each of these props has been set to `/`, so if you are passing `/` explicitly to any one of the above props, that line is no longer necessary and can be removed.
 
-```diff {{ prettier: false }}
-- <UserButton afterSignOutUrl='/' />
-+ <UserButton />
+```jsx {{ prettier: false, del: [1], ins: [2] }}
+<UserButton afterSignOutUrl='/' />
+<UserButton />
 ```
 
 ### Removed: `orgs` claim on JWT
@@ -221,14 +221,14 @@ As part of this major version, a number of previously deprecated props, arugment
   <AccordionPanel>
     If you are updating a user's password via the [`User.update` method](/docs/references/javascript/user/user#update), it must be changed to [`User.updatePassword`](/docs/references/javascript/user/password-management#update-password) instead. This method will require the current password as well as the desired new password. We made this update to improve the security of password changes. Example below:
 
-    ```diff {{ prettier: false }}
-    - user.update({ password: 'foo' });
+    ```jsx {{ prettier: false, del: [1], ins: [[3, 7]] }}
+    user.update({ password: 'foo' });
 
-    + user.updatePassword({
-    +   currentPassword: 'bar',
-    +   newPassword: 'foo',
-    +   signOutOfOtherSessions: true,
-    + });
+    user.updatePassword({
+      currentPassword: 'bar',
+      newPassword: 'foo',
+      signOutOfOtherSessions: true,
+    });
     ```
   </AccordionPanel>
 
@@ -245,104 +245,104 @@ As part of this major version, a number of previously deprecated props, arugment
   <AccordionPanel>
     There have been a couple changes to the pagination arguments that can be passed into this function - `limit` has been renamed to `pageSize`, and `offset` has been renamed to `initialPage`. This will help to make it more clear and simple to reason about pagination control. Example of how changes might look below:
 
-    ```diff {{ prettier: false }}
-      const { data } = await organization.getRoles({
-    -   limit: 10,
-    +   pageSize: 10,
-    -   offset: 10,
-    +   initialPage: 2,
-      })
+    ```jsx {{ prettier: false, del: [2, 4], ins: [3, 5] }}
+    const { data } = await organization.getRoles({
+      limit: 10,
+      pageSize: 10,
+      offset: 10,
+      initialPage: 2,
+    })
     ```
   </AccordionPanel>
 
   <AccordionPanel>
     There have been a couple changes to the pagination arguments that can be passed into this function - `limit` has been renamed to `pageSize`, and `offset` has been renamed to `initialPage`. This will help to make it more clear and simple to reason about pagination control. Example of how changes might look below:
 
-    ```diff {{ prettier: false }}
-      const { data } = await organization.getMemberships({
-    -   limit: 10,
-    +   pageSize: 10,
-    -   offset: 10,
-    +   initialPage: 2,
-      })
+    ```jsx {{ prettier: false, del: [2, 4], ins: [3, 5] }}
+    const { data } = await organization.getMemberships({
+      limit: 10,
+      pageSize: 10,
+      offset: 10,
+      initialPage: 2,
+    })
     ```
   </AccordionPanel>
 
   <AccordionPanel>
     There have been a couple changes to the pagination arguments that can be passed into this function - `limit` has been renamed to `pageSize`, and `offset` has been renamed to `initialPage`. This will help to make it more clear and simple to reason about pagination control. Example of how changes might look below:
 
-    ```diff {{ prettier: false }}
-      const { data } = await organization.getDomains({
-    -   limit: 10,
-    +   pageSize: 10,
-    -   offset: 10,
-    +   initialPage: 2,
-      })
+    ```jsx {{ prettier: false, del: [2, 4], ins: [3, 5] }}
+    const { data } = await organization.getDomains({
+      limit: 10,
+      pageSize: 10,
+      offset: 10,
+      initialPage: 2,
+    })
     ```
   </AccordionPanel>
 
   <AccordionPanel>
     There have been a couple changes to the pagination arguments that can be passed into this function - `limit` has been renamed to `pageSize`, and `offset` has been renamed to `initialPage`. This will help to make it more clear and simple to reason about pagination control. Example of how changes might look below:
 
-    ```diff {{ prettier: false }}
-      const { data } = await organization.getInvitations({
-    -   limit: 10,
-    +   pageSize: 10,
-    -   offset: 10,
-    +   initialPage: 2,
-      })
+    ```jsx {{ prettier: false, del: [2, 4], ins: [3, 5] }}
+    const { data } = await organization.getInvitations({
+      limit: 10,
+      pageSize: 10,
+      offset: 10,
+      initialPage: 2,
+    })
     ```
   </AccordionPanel>
 
   <AccordionPanel>
     There have been a couple changes to the pagination arguments that can be passed into this function - `limit` has been renamed to `pageSize`, and `offset` has been renamed to `initialPage`. This will help to make it more clear and simple to reason about pagination control. Example of how changes might look below:
 
-    ```diff {{ prettier: false }}
-      const { data } = await organization.getMembershipRequests({
-    -   limit: 10,
-    +   pageSize: 10,
-    -   offset: 10,
-    +   initialPage: 2,
-      })
+    ```jsx {{ prettier: false, del: [2, 4], ins: [3, 5] }}
+    const { data } = await organization.getMembershipRequests({
+      limit: 10,
+      pageSize: 10,
+      offset: 10,
+      initialPage: 2,
+    })
     ```
   </AccordionPanel>
 
   <AccordionPanel>
     There have been a couple changes to the pagination arguments that can be passed into this function - `limit` has been renamed to `pageSize`, and `offset` has been renamed to `initialPage`. This will help to make it more clear and simple to reason about pagination control. Example of how changes might look below:
 
-    ```diff {{ prettier: false }}
-      const { data } = await user.getOrganizationInvitations({
-    -   limit: 10,
-    +   pageSize: 10,
-    -   offset: 10,
-    +   initialPage: 2,
-      })
+    ```jsx {{ prettier: false, del: [2, 4], ins: [3, 5] }}
+    const { data } = await user.getOrganizationInvitations({
+      limit: 10,
+      pageSize: 10,
+      offset: 10,
+      initialPage: 2,
+    })
     ```
   </AccordionPanel>
 
   <AccordionPanel>
     There have been a couple changes to the pagination arguments that can be passed into this function - `limit` has been renamed to `pageSize`, and `offset` has been renamed to `initialPage`. This will help to make it more clear and simple to reason about pagination control. Example of how changes might look below:
 
-    ```diff {{ prettier: false }}
-      const { data } = await user.getOrganizationSuggestions({
-    -   limit: 10,
-    +   pageSize: 10,
-    -   offset: 10,
-    +   initialPage: 2,
-      })
+    ```jsx {{ prettier: false, del: [2, 4], ins: [3, 5] }}
+    const { data } = await user.getOrganizationSuggestions({
+      limit: 10,
+      pageSize: 10,
+      offset: 10,
+      initialPage: 2,
+    })
     ```
   </AccordionPanel>
 
   <AccordionPanel>
     There have been a couple changes to the pagination arguments that can be passed into this function - `limit` has been renamed to `pageSize`, and `offset` has been renamed to `initialPage`. This will help to make it more clear and simple to reason about pagination control. Example of how changes might look below:
 
-    ```diff {{ prettier: false }}
-      const { data } = await user.getOrganizationMemberships({
-    -   limit: 10,
-    +   pageSize: 10,
-    -   offset: 10,
-    +   initialPage: 2,
-      })
+    ```jsx {{ prettier: false, del: [2, 4], ins: [3, 5] }}
+    const { data } = await user.getOrganizationMemberships({
+      limit: 10,
+      pageSize: 10,
+      offset: 10,
+      initialPage: 2,
+    })
     ```
   </AccordionPanel>
 
@@ -351,9 +351,9 @@ As part of this major version, a number of previously deprecated props, arugment
 
     Here's an example of how the response shape would change with this modification:
 
-    ```diff {{ prettier: false }}
-    - const data = await clerkClient.users.getOrganizationMembershipList()
-    + const { data, totalCount } = await clerkClient.users.getOrganizationMembershipList()
+    ```jsx {{ prettier: false, del: [1], ins: [2] }}
+    const data = await clerkClient.users.getOrganizationMembershipList()
+    const { data, totalCount } = await clerkClient.users.getOrganizationMembershipList()
     ```
   </AccordionPanel>
 
@@ -362,34 +362,34 @@ As part of this major version, a number of previously deprecated props, arugment
 
     Here's an example of how the response shape would change with this modification:
 
-    ```diff {{ prettier: false }}
-    - const data = await clerkClient.users.getOrganizationInvitationList()
-    + const { data, totalCount } = await clerkClient.users.getOrganizationInvitationList()
+    ```jsx {{ prettier: false, del: [1], ins: [2] }}
+    const data = await clerkClient.users.getOrganizationInvitationList()
+    const { data, totalCount } = await clerkClient.users.getOrganizationInvitationList()
     ```
   </AccordionPanel>
 
   <AccordionPanel>
     The return type for this function was previously `[Items]` but has now been updated to `{ data: [Items], totalCount: number }`. Since Clerk's API responses are paginated, the `totalCount` property is helpful in determining the total number of items in the response easily. A before/after code example can be seen below:
 
-    ```diff {{ prettier: false }}
-      const data = await clerkClient.organizations.getOrganizationInvitationList({
-        organizationId: "...",
-      })
+    ```jsx {{ prettier: false, del: [5], ins: [6] }}
+    const data = await clerkClient.organizations.getOrganizationInvitationList({
+      organizationId: "...",
+    })
 
-    - data.forEach(() => {})
-    + data.data.forEach(() => {})
+    data.forEach(() => {})
+    data.data.forEach(() => {})
     ```
   </AccordionPanel>
 
   <AccordionPanel>
     The return type for this function was previously `[Items]` but has now been updated to `{ data: [Items], totalCount: number }`. Since Clerk's API responses are paginated, the `totalCount` property is helpful in determining the total number of items in the response easily. A before/after code example can be seen below:
 
-    ```diff {{ prettier: false }}
-      const { user } = useUser()
-      const membershipList = user.getOrganizationMembershipList()
+    ```jsx {{ prettier: false, del: [4], ins: [5] }}
+    const { user } = useUser()
+    const membershipList = user.getOrganizationMembershipList()
 
-    - membershipList.forEach(() => {})
-    + membershipList.data.forEach(() => {})
+    membershipList.forEach(() => {})
+    membershipList.data.forEach(() => {})
     ```
   </AccordionPanel>
 
@@ -398,21 +398,21 @@ As part of this major version, a number of previously deprecated props, arugment
 
     Here's an example of how the response shape would change with this modification:
 
-    ```diff {{ prettier: false }}
-    - const data = await clerkClient.users.getOrganizationList()
-    + const { data, totalCount } = await clerkClient.users.getOrganizationList()
+    ```jsx {{ prettier: false, del: [1], ins: [2] }}
+    const data = await clerkClient.users.getOrganizationList()
+    const { data, totalCount } = await clerkClient.users.getOrganizationList()
     ```
   </AccordionPanel>
 
   <AccordionPanel>
     The return type for this function was previously `[Items]` but has now been updated to `{ data: [Items], totalCount: number }`. Since Clerk's API responses are paginated, the `totalCount` property is helpful in determining the total number of items in the response easily. A before/after code example can be seen below:
 
-    ```diff {{ prettier: false }}
-      const { organization } = useOrganization()
-      const orgList = organization.getOrganizationList()
+    ```jsx {{ prettier: false, del: [4], ins: [5] }}
+    const { organization } = useOrganization()
+    const orgList = organization.getOrganizationList()
 
-    - orgList.forEach(() => {})
-    + orgList.data.forEach(() => {})
+    orgList.forEach(() => {})
+    orgList.data.forEach(() => {})
     ```
   </AccordionPanel>
 
@@ -421,9 +421,9 @@ As part of this major version, a number of previously deprecated props, arugment
 
     Here's an example of how the response shape would change with this modification:
 
-    ```diff {{ prettier: false }}
-    - const data = await clerkClient.invitations.getInvitationList()
-    + const { data, totalCount } = await clerkClient.invitations.getInvitationList()
+    ```jsx {{ prettier: false, del: [1], ins: [2] }}
+    const data = await clerkClient.invitations.getInvitationList()
+    const { data, totalCount } = await clerkClient.invitations.getInvitationList()
     ```
   </AccordionPanel>
 
@@ -432,9 +432,9 @@ As part of this major version, a number of previously deprecated props, arugment
 
     Here's an example of how the response shape would change with this modification:
 
-    ```diff {{ prettier: false }}
-    - const data = await clerkClient.sessions.getSessionList()
-    + const { data, totalCount } = await clerkClient.sessions.getSessionList()
+    ```jsx {{ prettier: false, del: [1], ins: [2] }}
+    const data = await clerkClient.sessions.getSessionList()
+    const { data, totalCount } = await clerkClient.sessions.getSessionList()
     ```
   </AccordionPanel>
 
@@ -443,9 +443,9 @@ As part of this major version, a number of previously deprecated props, arugment
 
     Here's an example of how the response shape would change with this modification:
 
-    ```diff {{ prettier: false }}
-    - const data = await clerkClient.users.getUserList()
-    + const { data, totalCount } = await clerkClient.users.getUserList()
+    ```jsx {{ prettier: false, del: [1], ins: [2] }}
+    const data = await clerkClient.users.getUserList()
+    const { data, totalCount } = await clerkClient.users.getUserList()
     ```
   </AccordionPanel>
 
@@ -454,9 +454,9 @@ As part of this major version, a number of previously deprecated props, arugment
 
     Here's an example of how the response shape would change with this modification:
 
-    ```diff {{ prettier: false }}
-    - const data = await clerkClient.allowlistIdentifiers.getAllowlistIdentifierList()
-    + const { data, totalCount } = await clerkClient.allowlistIdentifiers.getAllowlistIdentifierList()
+    ```jsx {{ prettier: false, del: [1], ins: [2] }}
+    const data = await clerkClient.allowlistIdentifiers.getAllowlistIdentifierList()
+    const { data, totalCount } = await clerkClient.allowlistIdentifiers.getAllowlistIdentifierList()
     ```
   </AccordionPanel>
 
@@ -465,9 +465,9 @@ As part of this major version, a number of previously deprecated props, arugment
 
     Here's an example of how the response shape would change with this modification:
 
-    ```diff {{ prettier: false }}
-    - const data = await clerkClient.clients.getClientList()
-    + const { data, totalCount } = await clerkClient.allowlistIdentifiers.getClientList()
+    ```jsx {{ prettier: false, del: [1], ins: [2] }}
+    const data = await clerkClient.clients.getClientList()
+    const { data, totalCount } = await clerkClient.allowlistIdentifiers.getClientList()
     ```
   </AccordionPanel>
 
@@ -476,9 +476,9 @@ As part of this major version, a number of previously deprecated props, arugment
 
     Here's an example of how the response shape would change with this modification:
 
-    ```diff {{ prettier: false }}
-    - const data = await clerkClient.redirectUrls.getRedirectUrlList()
-    + const { data, totalCount } = await clerkClient.redirectUrls.getRedirectUrlList()
+    ```jsx {{ prettier: false, del: [1], ins: [2] }}
+    const data = await clerkClient.redirectUrls.getRedirectUrlList()
+    const { data, totalCount } = await clerkClient.redirectUrls.getRedirectUrlList()
     ```
   </AccordionPanel>
 
@@ -487,24 +487,24 @@ As part of this major version, a number of previously deprecated props, arugment
 
     Here's an example of how the response shape would change with this modification:
 
-    ```diff {{ prettier: false }}
-    - const data = await clerkClient.users.getUserOauthAccessToken()
-    + const { data, totalCount } = await clerkClient.users.getUserOauthAccessToken()
+    ```jsx {{ prettier: false, del: [1], ins: [2] }}
+    const data = await clerkClient.users.getUserOauthAccessToken()
+    const { data, totalCount } = await clerkClient.users.getUserOauthAccessToken()
     ```
   </AccordionPanel>
 
   <AccordionPanel>
     `setSession` should be replaced with `setActive`. The format of the parameters has changed slightly - `setActive` takes an object where `setSession` took params directly. The `setActive` function also can accept an `organization` param that is used to set the currently active organization. The return signature did not change. Read the [API documentation](/docs/references/javascript/clerk/session-methods#set-active) for more detail. This function should be expected to be returned from one of the following Clerk hooks: `useSessionList`, `useSignUp`, or `useSignIn`. Some migration examples:
 
-    ```diff {{ prettier: false }}
-    - await setSession('sessionID', () => void)
-    + await setActive({ session: 'sessionID',  beforeEmit: () => void })
+    ```jsx {{ prettier: false, del: [1, 4, 7], ins: [2, 5, 8] }}
+    await setSession('sessionID', () => void)
+    await setActive({ session: 'sessionID',  beforeEmit: () => void })
 
-    - await setSession(sessionObj)
-    + await setActive({ session: sessionObj })
+    await setSession(sessionObj)
+    await setActive({ session: sessionObj })
 
-    - await setSession(sessionObj, () => void)
-    + await setActive({ session: sessionObj,  beforeEmit: () => void })
+    await setSession(sessionObj, () => void)
+    await setActive({ session: sessionObj,  beforeEmit: () => void })
     ```
 
     `setActive` also supports setting an active organization:
@@ -527,18 +527,18 @@ As part of this major version, a number of previously deprecated props, arugment
   <AccordionPanel>
     Passing a string as an argument to `Organization.create` is no longer possible - instead, pass an object with the `name` property.
 
-    ```diff {{ prettier: false }}
-    - Organization.create('...');
-    + Organization.create({ name: '...' });
+    ```jsx {{ prettier: false, del: [1], ins: [2] }}
+    Organization.create('...');
+    Organization.create({ name: '...' });
     ```
   </AccordionPanel>
 
   <AccordionPanel>
     The `Organization.getPendingInvitations()` method has been removed. You can use `Organization.getInvitations` instead.
 
-    ```diff {{ prettier: false }}
-    - Organization.getPendingInvitations();
-    + Organization.getInvitations({ status: 'pending' });
+    ```jsx {{ prettier: false, del: [1], ins: [2] }}
+    Organization.getPendingInvitations();
+    Organization.getInvitations({ status: 'pending' });
     ```
   </AccordionPanel>
 
@@ -557,19 +557,19 @@ As part of this major version, a number of previously deprecated props, arugment
   <AccordionPanel>
     The `signOutCallback` prop on the [`<SignOutButton />` component](/docs/components/unstyled/sign-out-button) has been removed. Instead, you can use the `redirectUrl` prop. Example below:
 
-    ```diff {{ prettier: false }}
-      import { SignOutButton } from "@clerk/clerk-react";
+    ```jsx {{ prettier: false, del: [6], ins: [7] }}
+    import { SignOutButton } from "@clerk/clerk-react";
 
-      export const Signout = () => {
-        return (
-          <SignOutButton
-    -       signOutCallback={() => { window.location.href = "/your-path" }}
-    +       redirectUrl="/your-path"
-          >
-            <button>Sign Out</button>
-          </SignOutButton>
-        )
-      }
+    export const Signout = () => {
+      return (
+        <SignOutButton
+          signOutCallback={() => { window.location.href = "/your-path" }}
+          redirectUrl="/your-path"
+        >
+          <button>Sign Out</button>
+        </SignOutButton>
+      )
+    }
     ```
   </AccordionPanel>
 </Accordion>

--- a/docs/upgrade-guides/core-2/fastify.mdx
+++ b/docs/upgrade-guides/core-2/fastify.mdx
@@ -155,7 +155,7 @@ As part of this major version, a number of previously deprecated props, arugment
   <AccordionPanel>
     If you are updating a user's password via the [`User.update` method](/docs/references/javascript/user/user#update), it must be changed to [`User.updatePassword`](/docs/references/javascript/user/password-management#update-password) instead. This method will require the current password as well as the desired new password. We made this update to improve the security of password changes. Example below:
 
-    ```jsx {{ prettier: false, del: [1], ins: [[3, 7]] }}
+    ```js {{ prettier: false, del: [1], ins: [[3, 7]] }}
     user.update({ password: 'foo' });
 
     user.updatePassword({
@@ -177,7 +177,7 @@ As part of this major version, a number of previously deprecated props, arugment
   <AccordionPanel>
     The `apiKey` argument passed to `createClerkClient` must be changed to `secretKey`.
 
-    ```jsx {{ prettier: false, del: [3], ins: [4] }}
+    ```js {{ prettier: false, del: [3], ins: [4] }}
     import { createClerkClient } from '@clerk/fastify';
 
     createClerkClient({ apiKey: '...' });
@@ -188,7 +188,7 @@ As part of this major version, a number of previously deprecated props, arugment
   <AccordionPanel>
     The `frontendApi` argument passed to `createClerkClient` must be changed to `publishableKey`. Note that the values of the two keys are different, so both keys and values need to be changed. You can find your application's publishable key in the Clerk dashboard.
 
-    ```jsx {{ prettier: false, del: [3], ins: [4] }}
+    ```js {{ prettier: false, del: [3], ins: [4] }}
     import { createClerkClient } from '@clerk/fastify';
 
     createClerkClient({ frontendApi: '...' });
@@ -199,7 +199,7 @@ As part of this major version, a number of previously deprecated props, arugment
   <AccordionPanel>
     The `frontendApi` argument passed to `clerkPlugin` must be changed to `publishableKey`. Note that the values of the two keys are different, so both keys and values need to be changed. You can find your application's publishable key in the Clerk dashboard.
 
-    ```jsx {{ prettier: false, del: [3], ins: [4] }}
+    ```js {{ prettier: false, del: [3], ins: [4] }}
     import { clerkPlugin } from '@clerk/fastify';
 
     fastify.register(clerkPlugin, { frontendApi: '...' });
@@ -216,7 +216,7 @@ As part of this major version, a number of previously deprecated props, arugment
   <AccordionPanel>
     There have been a couple changes to the pagination arguments that can be passed into this function - `limit` has been renamed to `pageSize`, and `offset` has been renamed to `initialPage`. This will help to make it more clear and simple to reason about pagination control. Example of how changes might look below:
 
-    ```jsx {{ prettier: false, del: [2, 4], ins: [3, 5] }}
+    ```js {{ prettier: false, del: [2, 4], ins: [3, 5] }}
     const { data } = await organization.getRoles({
       limit: 10,
       pageSize: 10,
@@ -229,7 +229,7 @@ As part of this major version, a number of previously deprecated props, arugment
   <AccordionPanel>
     There have been a couple changes to the pagination arguments that can be passed into this function - `limit` has been renamed to `pageSize`, and `offset` has been renamed to `initialPage`. This will help to make it more clear and simple to reason about pagination control. Example of how changes might look below:
 
-    ```jsx {{ prettier: false, del: [2, 4], ins: [3, 5] }}
+    ```js {{ prettier: false, del: [2, 4], ins: [3, 5] }}
     const { data } = await organization.getMemberships({
       limit: 10,
       pageSize: 10,
@@ -242,7 +242,7 @@ As part of this major version, a number of previously deprecated props, arugment
   <AccordionPanel>
     There have been a couple changes to the pagination arguments that can be passed into this function - `limit` has been renamed to `pageSize`, and `offset` has been renamed to `initialPage`. This will help to make it more clear and simple to reason about pagination control. Example of how changes might look below:
 
-    ```jsx {{ prettier: false, del: [2, 4], ins: [3, 5] }}
+    ```js {{ prettier: false, del: [2, 4], ins: [3, 5] }}
     const { data } = await organization.getDomains({
       limit: 10,
       pageSize: 10,
@@ -255,7 +255,7 @@ As part of this major version, a number of previously deprecated props, arugment
   <AccordionPanel>
     There have been a couple changes to the pagination arguments that can be passed into this function - `limit` has been renamed to `pageSize`, and `offset` has been renamed to `initialPage`. This will help to make it more clear and simple to reason about pagination control. Example of how changes might look below:
 
-    ```jsx {{ prettier: false, del: [2, 4], ins: [3, 5] }}
+    ```js {{ prettier: false, del: [2, 4], ins: [3, 5] }}
     const { data } = await organization.getInvitations({
       limit: 10,
       pageSize: 10,
@@ -268,7 +268,7 @@ As part of this major version, a number of previously deprecated props, arugment
   <AccordionPanel>
     There have been a couple changes to the pagination arguments that can be passed into this function - `limit` has been renamed to `pageSize`, and `offset` has been renamed to `initialPage`. This will help to make it more clear and simple to reason about pagination control. Example of how changes might look below:
 
-    ```jsx {{ prettier: false, del: [2, 4], ins: [3, 5] }}
+    ```js {{ prettier: false, del: [2, 4], ins: [3, 5] }}
     const { data } = await organization.getMembershipRequests({
       limit: 10,
       pageSize: 10,
@@ -281,7 +281,7 @@ As part of this major version, a number of previously deprecated props, arugment
   <AccordionPanel>
     There have been a couple changes to the pagination arguments that can be passed into this function - `limit` has been renamed to `pageSize`, and `offset` has been renamed to `initialPage`. This will help to make it more clear and simple to reason about pagination control. Example of how changes might look below:
 
-    ```jsx {{ prettier: false, del: [2, 4], ins: [3, 5] }}
+    ```js {{ prettier: false, del: [2, 4], ins: [3, 5] }}
     const { data } = await user.getOrganizationInvitations({
       limit: 10,
       pageSize: 10,
@@ -294,7 +294,7 @@ As part of this major version, a number of previously deprecated props, arugment
   <AccordionPanel>
     There have been a couple changes to the pagination arguments that can be passed into this function - `limit` has been renamed to `pageSize`, and `offset` has been renamed to `initialPage`. This will help to make it more clear and simple to reason about pagination control. Example of how changes might look below:
 
-    ```jsx {{ prettier: false, del: [2, 4], ins: [3, 5] }}
+    ```js {{ prettier: false, del: [2, 4], ins: [3, 5] }}
     const { data } = await user.getOrganizationSuggestions({
       limit: 10,
       pageSize: 10,
@@ -307,7 +307,7 @@ As part of this major version, a number of previously deprecated props, arugment
   <AccordionPanel>
     There have been a couple changes to the pagination arguments that can be passed into this function - `limit` has been renamed to `pageSize`, and `offset` has been renamed to `initialPage`. This will help to make it more clear and simple to reason about pagination control. Example of how changes might look below:
 
-    ```jsx {{ prettier: false, del: [2, 4], ins: [3, 5] }}
+    ```js {{ prettier: false, del: [2, 4], ins: [3, 5] }}
     const { data } = await user.getOrganizationMemberships({
       limit: 10,
       pageSize: 10,
@@ -322,7 +322,7 @@ As part of this major version, a number of previously deprecated props, arugment
 
     Here's an example of how the response shape would change with this modification:
 
-    ```jsx {{ prettier: false, del: [1], ins: [2] }}
+    ```js {{ prettier: false, del: [1], ins: [2] }}
     const data = await clerkClient.users.getOrganizationMembershipList()
     const { data, totalCount } = await clerkClient.users.getOrganizationMembershipList()
     ```
@@ -333,7 +333,7 @@ As part of this major version, a number of previously deprecated props, arugment
 
     Here's an example of how the response shape would change with this modification:
 
-    ```jsx {{ prettier: false, del: [1], ins: [2] }}
+    ```js {{ prettier: false, del: [1], ins: [2] }}
     const data = await clerkClient.users.getOrganizationInvitationList()
     const { data, totalCount } = await clerkClient.users.getOrganizationInvitationList()
     ```
@@ -342,7 +342,7 @@ As part of this major version, a number of previously deprecated props, arugment
   <AccordionPanel>
     The return type for this function was previously `[Items]` but has now been updated to `{ data: [Items], totalCount: number }`. Since Clerk's API responses are paginated, the `totalCount` property is helpful in determining the total number of items in the response easily. A before/after code example can be seen below:
 
-    ```jsx {{ prettier: false, del: [5], ins: [6] }}
+    ```js {{ prettier: false, del: [5], ins: [6] }}
     const data = await clerkClient.organizations.getOrganizationInvitationList({
       organizationId: "...",
     })
@@ -355,7 +355,7 @@ As part of this major version, a number of previously deprecated props, arugment
   <AccordionPanel>
     The return type for this function was previously `[Items]` but has now been updated to `{ data: [Items], totalCount: number }`. Since Clerk's API responses are paginated, the `totalCount` property is helpful in determining the total number of items in the response easily. A before/after code example can be seen below:
 
-    ```jsx {{ prettier: false, del: [4], ins: [5] }}
+    ```js {{ prettier: false, del: [4], ins: [5] }}
     const { user } = useUser()
     const membershipList = user.getOrganizationMembershipList()
 
@@ -369,7 +369,7 @@ As part of this major version, a number of previously deprecated props, arugment
 
     Here's an example of how the response shape would change with this modification:
 
-    ```jsx {{ prettier: false, del: [1], ins: [2] }}
+    ```js {{ prettier: false, del: [1], ins: [2] }}
     const data = await clerkClient.users.getOrganizationList()
     const { data, totalCount } = await clerkClient.users.getOrganizationList()
     ```
@@ -378,7 +378,7 @@ As part of this major version, a number of previously deprecated props, arugment
   <AccordionPanel>
     The return type for this function was previously `[Items]` but has now been updated to `{ data: [Items], totalCount: number }`. Since Clerk's API responses are paginated, the `totalCount` property is helpful in determining the total number of items in the response easily. A before/after code example can be seen below:
 
-    ```jsx {{ prettier: false, del: [4], ins: [5] }}
+    ```js {{ prettier: false, del: [4], ins: [5] }}
     const { organization } = useOrganization()
     const orgList = organization.getOrganizationList()
 
@@ -392,7 +392,7 @@ As part of this major version, a number of previously deprecated props, arugment
 
     Here's an example of how the response shape would change with this modification:
 
-    ```jsx {{ prettier: false, del: [1], ins: [2] }}
+    ```js {{ prettier: false, del: [1], ins: [2] }}
     const data = await clerkClient.invitations.getInvitationList()
     const { data, totalCount } = await clerkClient.invitations.getInvitationList()
     ```
@@ -403,7 +403,7 @@ As part of this major version, a number of previously deprecated props, arugment
 
     Here's an example of how the response shape would change with this modification:
 
-    ```jsx {{ prettier: false, del: [1], ins: [2] }}
+    ```js {{ prettier: false, del: [1], ins: [2] }}
     const data = await clerkClient.sessions.getSessionList()
     const { data, totalCount } = await clerkClient.sessions.getSessionList()
     ```
@@ -414,7 +414,7 @@ As part of this major version, a number of previously deprecated props, arugment
 
     Here's an example of how the response shape would change with this modification:
 
-    ```jsx {{ prettier: false, del: [1], ins: [2] }}
+    ```js {{ prettier: false, del: [1], ins: [2] }}
     const data = await clerkClient.users.getUserList()
     const { data, totalCount } = await clerkClient.users.getUserList()
     ```
@@ -425,7 +425,7 @@ As part of this major version, a number of previously deprecated props, arugment
 
     Here's an example of how the response shape would change with this modification:
 
-    ```jsx {{ prettier: false, del: [1], ins: [2] }}
+    ```js {{ prettier: false, del: [1], ins: [2] }}
     const data = await clerkClient.allowlistIdentifiers.getAllowlistIdentifierList()
     const { data, totalCount } = await clerkClient.allowlistIdentifiers.getAllowlistIdentifierList()
     ```
@@ -436,7 +436,7 @@ As part of this major version, a number of previously deprecated props, arugment
 
     Here's an example of how the response shape would change with this modification:
 
-    ```jsx {{ prettier: false, del: [1], ins: [2] }}
+    ```js {{ prettier: false, del: [1], ins: [2] }}
     const data = await clerkClient.clients.getClientList()
     const { data, totalCount } = await clerkClient.allowlistIdentifiers.getClientList()
     ```
@@ -447,7 +447,7 @@ As part of this major version, a number of previously deprecated props, arugment
 
     Here's an example of how the response shape would change with this modification:
 
-    ```jsx {{ prettier: false, del: [1], ins: [2] }}
+    ```js {{ prettier: false, del: [1], ins: [2] }}
     const data = await clerkClient.redirectUrls.getRedirectUrlList()
     const { data, totalCount } = await clerkClient.redirectUrls.getRedirectUrlList()
     ```
@@ -458,7 +458,7 @@ As part of this major version, a number of previously deprecated props, arugment
 
     Here's an example of how the response shape would change with this modification:
 
-    ```jsx {{ prettier: false, del: [1], ins: [2] }}
+    ```js {{ prettier: false, del: [1], ins: [2] }}
     const data = await clerkClient.users.getUserOauthAccessToken()
     const { data, totalCount } = await clerkClient.users.getUserOauthAccessToken()
     ```
@@ -471,7 +471,7 @@ As part of this major version, a number of previously deprecated props, arugment
   <AccordionPanel>
     The `Clerk` default import has changed to `createClerkClient` and been moved to a named import rather than default. You must update your import path in order for it to work correctly. Example below of the fix that needs to be made:
 
-    ```jsx {{ prettier: false, del: [1], ins: [2] }}
+    ```js {{ prettier: false, del: [1], ins: [2] }}
     import Clerk from "@clerk/fastify"
     import { createClerkClient } from "@clerk/fastify"
     ```

--- a/docs/upgrade-guides/core-2/fastify.mdx
+++ b/docs/upgrade-guides/core-2/fastify.mdx
@@ -155,14 +155,14 @@ As part of this major version, a number of previously deprecated props, arugment
   <AccordionPanel>
     If you are updating a user's password via the [`User.update` method](/docs/references/javascript/user/user#update), it must be changed to [`User.updatePassword`](/docs/references/javascript/user/password-management#update-password) instead. This method will require the current password as well as the desired new password. We made this update to improve the security of password changes. Example below:
 
-    ```diff {{ prettier: false }}
-    - user.update({ password: 'foo' });
+    ```jsx {{ prettier: false, del: [1], ins: [[3, 7]] }}
+    user.update({ password: 'foo' });
 
-    + user.updatePassword({
-    +   currentPassword: 'bar',
-    +   newPassword: 'foo',
-    +   signOutOfOtherSessions: true,
-    + });
+    user.updatePassword({
+      currentPassword: 'bar',
+      newPassword: 'foo',
+      signOutOfOtherSessions: true,
+    });
     ```
   </AccordionPanel>
 
@@ -177,33 +177,33 @@ As part of this major version, a number of previously deprecated props, arugment
   <AccordionPanel>
     The `apiKey` argument passed to `createClerkClient` must be changed to `secretKey`.
 
-    ```diff {{ prettier: false }}
+    ```jsx {{ prettier: false, del: [3], ins: [4] }}
     import { createClerkClient } from '@clerk/fastify';
 
-    - createClerkClient({ apiKey: '...' });
-    + createClerkClient({ secretKey: '...' });
+    createClerkClient({ apiKey: '...' });
+    createClerkClient({ secretKey: '...' });
     ```
   </AccordionPanel>
 
   <AccordionPanel>
     The `frontendApi` argument passed to `createClerkClient` must be changed to `publishableKey`. Note that the values of the two keys are different, so both keys and values need to be changed. You can find your application's publishable key in the Clerk dashboard.
 
-    ```diff {{ prettier: false }}
+    ```jsx {{ prettier: false, del: [3], ins: [4] }}
     import { createClerkClient } from '@clerk/fastify';
 
-    - createClerkClient({ frontendApi: '...' });
-    + createClerkClient({ publishableKey: '...' });
+    createClerkClient({ frontendApi: '...' });
+    createClerkClient({ publishableKey: '...' });
     ```
   </AccordionPanel>
 
   <AccordionPanel>
     The `frontendApi` argument passed to `clerkPlugin` must be changed to `publishableKey`. Note that the values of the two keys are different, so both keys and values need to be changed. You can find your application's publishable key in the Clerk dashboard.
 
-    ```diff {{ prettier: false }}
+    ```jsx {{ prettier: false, del: [3], ins: [4] }}
     import { clerkPlugin } from '@clerk/fastify';
 
-    - fastify.register(clerkPlugin, { frontendApi: '...' });
-    + fastify.register(clerkPlugin, { publishableKey: '...' });
+    fastify.register(clerkPlugin, { frontendApi: '...' });
+    fastify.register(clerkPlugin, { publishableKey: '...' });
     ```
   </AccordionPanel>
 </Accordion>
@@ -216,104 +216,104 @@ As part of this major version, a number of previously deprecated props, arugment
   <AccordionPanel>
     There have been a couple changes to the pagination arguments that can be passed into this function - `limit` has been renamed to `pageSize`, and `offset` has been renamed to `initialPage`. This will help to make it more clear and simple to reason about pagination control. Example of how changes might look below:
 
-    ```diff {{ prettier: false }}
-      const { data } = await organization.getRoles({
-    -   limit: 10,
-    +   pageSize: 10,
-    -   offset: 10,
-    +   initialPage: 2,
-      })
+    ```jsx {{ prettier: false, del: [2, 4], ins: [3, 5] }}
+    const { data } = await organization.getRoles({
+      limit: 10,
+      pageSize: 10,
+      offset: 10,
+      initialPage: 2,
+    })
     ```
   </AccordionPanel>
 
   <AccordionPanel>
     There have been a couple changes to the pagination arguments that can be passed into this function - `limit` has been renamed to `pageSize`, and `offset` has been renamed to `initialPage`. This will help to make it more clear and simple to reason about pagination control. Example of how changes might look below:
 
-    ```diff {{ prettier: false }}
-      const { data } = await organization.getMemberships({
-    -   limit: 10,
-    +   pageSize: 10,
-    -   offset: 10,
-    +   initialPage: 2,
-      })
+    ```jsx {{ prettier: false, del: [2, 4], ins: [3, 5] }}
+    const { data } = await organization.getMemberships({
+      limit: 10,
+      pageSize: 10,
+      offset: 10,
+      initialPage: 2,
+    })
     ```
   </AccordionPanel>
 
   <AccordionPanel>
     There have been a couple changes to the pagination arguments that can be passed into this function - `limit` has been renamed to `pageSize`, and `offset` has been renamed to `initialPage`. This will help to make it more clear and simple to reason about pagination control. Example of how changes might look below:
 
-    ```diff {{ prettier: false }}
-      const { data } = await organization.getDomains({
-    -   limit: 10,
-    +   pageSize: 10,
-    -   offset: 10,
-    +   initialPage: 2,
-      })
+    ```jsx {{ prettier: false, del: [2, 4], ins: [3, 5] }}
+    const { data } = await organization.getDomains({
+      limit: 10,
+      pageSize: 10,
+      offset: 10,
+      initialPage: 2,
+    })
     ```
   </AccordionPanel>
 
   <AccordionPanel>
     There have been a couple changes to the pagination arguments that can be passed into this function - `limit` has been renamed to `pageSize`, and `offset` has been renamed to `initialPage`. This will help to make it more clear and simple to reason about pagination control. Example of how changes might look below:
 
-    ```diff {{ prettier: false }}
-      const { data } = await organization.getInvitations({
-    -   limit: 10,
-    +   pageSize: 10,
-    -   offset: 10,
-    +   initialPage: 2,
-      })
+    ```jsx {{ prettier: false, del: [2, 4], ins: [3, 5] }}
+    const { data } = await organization.getInvitations({
+      limit: 10,
+      pageSize: 10,
+      offset: 10,
+      initialPage: 2,
+    })
     ```
   </AccordionPanel>
 
   <AccordionPanel>
     There have been a couple changes to the pagination arguments that can be passed into this function - `limit` has been renamed to `pageSize`, and `offset` has been renamed to `initialPage`. This will help to make it more clear and simple to reason about pagination control. Example of how changes might look below:
 
-    ```diff {{ prettier: false }}
-      const { data } = await organization.getMembershipRequests({
-    -   limit: 10,
-    +   pageSize: 10,
-    -   offset: 10,
-    +   initialPage: 2,
-      })
+    ```jsx {{ prettier: false, del: [2, 4], ins: [3, 5] }}
+    const { data } = await organization.getMembershipRequests({
+      limit: 10,
+      pageSize: 10,
+      offset: 10,
+      initialPage: 2,
+    })
     ```
   </AccordionPanel>
 
   <AccordionPanel>
     There have been a couple changes to the pagination arguments that can be passed into this function - `limit` has been renamed to `pageSize`, and `offset` has been renamed to `initialPage`. This will help to make it more clear and simple to reason about pagination control. Example of how changes might look below:
 
-    ```diff {{ prettier: false }}
-      const { data } = await user.getOrganizationInvitations({
-    -   limit: 10,
-    +   pageSize: 10,
-    -   offset: 10,
-    +   initialPage: 2,
-      })
+    ```jsx {{ prettier: false, del: [2, 4], ins: [3, 5] }}
+    const { data } = await user.getOrganizationInvitations({
+      limit: 10,
+      pageSize: 10,
+      offset: 10,
+      initialPage: 2,
+    })
     ```
   </AccordionPanel>
 
   <AccordionPanel>
     There have been a couple changes to the pagination arguments that can be passed into this function - `limit` has been renamed to `pageSize`, and `offset` has been renamed to `initialPage`. This will help to make it more clear and simple to reason about pagination control. Example of how changes might look below:
 
-    ```diff {{ prettier: false }}
-      const { data } = await user.getOrganizationSuggestions({
-    -   limit: 10,
-    +   pageSize: 10,
-    -   offset: 10,
-    +   initialPage: 2,
-      })
+    ```jsx {{ prettier: false, del: [2, 4], ins: [3, 5] }}
+    const { data } = await user.getOrganizationSuggestions({
+      limit: 10,
+      pageSize: 10,
+      offset: 10,
+      initialPage: 2,
+    })
     ```
   </AccordionPanel>
 
   <AccordionPanel>
     There have been a couple changes to the pagination arguments that can be passed into this function - `limit` has been renamed to `pageSize`, and `offset` has been renamed to `initialPage`. This will help to make it more clear and simple to reason about pagination control. Example of how changes might look below:
 
-    ```diff {{ prettier: false }}
-      const { data } = await user.getOrganizationMemberships({
-    -   limit: 10,
-    +   pageSize: 10,
-    -   offset: 10,
-    +   initialPage: 2,
-      })
+    ```jsx {{ prettier: false, del: [2, 4], ins: [3, 5] }}
+    const { data } = await user.getOrganizationMemberships({
+      limit: 10,
+      pageSize: 10,
+      offset: 10,
+      initialPage: 2,
+    })
     ```
   </AccordionPanel>
 
@@ -322,9 +322,9 @@ As part of this major version, a number of previously deprecated props, arugment
 
     Here's an example of how the response shape would change with this modification:
 
-    ```diff {{ prettier: false }}
-    - const data = await clerkClient.users.getOrganizationMembershipList()
-    + const { data, totalCount } = await clerkClient.users.getOrganizationMembershipList()
+    ```jsx {{ prettier: false, del: [1], ins: [2] }}
+    const data = await clerkClient.users.getOrganizationMembershipList()
+    const { data, totalCount } = await clerkClient.users.getOrganizationMembershipList()
     ```
   </AccordionPanel>
 
@@ -333,34 +333,34 @@ As part of this major version, a number of previously deprecated props, arugment
 
     Here's an example of how the response shape would change with this modification:
 
-    ```diff {{ prettier: false }}
-    - const data = await clerkClient.users.getOrganizationInvitationList()
-    + const { data, totalCount } = await clerkClient.users.getOrganizationInvitationList()
+    ```jsx {{ prettier: false, del: [1], ins: [2] }}
+    const data = await clerkClient.users.getOrganizationInvitationList()
+    const { data, totalCount } = await clerkClient.users.getOrganizationInvitationList()
     ```
   </AccordionPanel>
 
   <AccordionPanel>
     The return type for this function was previously `[Items]` but has now been updated to `{ data: [Items], totalCount: number }`. Since Clerk's API responses are paginated, the `totalCount` property is helpful in determining the total number of items in the response easily. A before/after code example can be seen below:
 
-    ```diff {{ prettier: false }}
-      const data = await clerkClient.organizations.getOrganizationInvitationList({
-        organizationId: "...",
-      })
+    ```jsx {{ prettier: false, del: [5], ins: [6] }}
+    const data = await clerkClient.organizations.getOrganizationInvitationList({
+      organizationId: "...",
+    })
 
-    - data.forEach(() => {})
-    + data.data.forEach(() => {})
+    data.forEach(() => {})
+    data.data.forEach(() => {})
     ```
   </AccordionPanel>
 
   <AccordionPanel>
     The return type for this function was previously `[Items]` but has now been updated to `{ data: [Items], totalCount: number }`. Since Clerk's API responses are paginated, the `totalCount` property is helpful in determining the total number of items in the response easily. A before/after code example can be seen below:
 
-    ```diff {{ prettier: false }}
-      const { user } = useUser()
-      const membershipList = user.getOrganizationMembershipList()
+    ```jsx {{ prettier: false, del: [4], ins: [5] }}
+    const { user } = useUser()
+    const membershipList = user.getOrganizationMembershipList()
 
-    - membershipList.forEach(() => {})
-    + membershipList.data.forEach(() => {})
+    membershipList.forEach(() => {})
+    membershipList.data.forEach(() => {})
     ```
   </AccordionPanel>
 
@@ -369,21 +369,21 @@ As part of this major version, a number of previously deprecated props, arugment
 
     Here's an example of how the response shape would change with this modification:
 
-    ```diff {{ prettier: false }}
-    - const data = await clerkClient.users.getOrganizationList()
-    + const { data, totalCount } = await clerkClient.users.getOrganizationList()
+    ```jsx {{ prettier: false, del: [1], ins: [2] }}
+    const data = await clerkClient.users.getOrganizationList()
+    const { data, totalCount } = await clerkClient.users.getOrganizationList()
     ```
   </AccordionPanel>
 
   <AccordionPanel>
     The return type for this function was previously `[Items]` but has now been updated to `{ data: [Items], totalCount: number }`. Since Clerk's API responses are paginated, the `totalCount` property is helpful in determining the total number of items in the response easily. A before/after code example can be seen below:
 
-    ```diff {{ prettier: false }}
-      const { organization } = useOrganization()
-      const orgList = organization.getOrganizationList()
+    ```jsx {{ prettier: false, del: [4], ins: [5] }}
+    const { organization } = useOrganization()
+    const orgList = organization.getOrganizationList()
 
-    - orgList.forEach(() => {})
-    + orgList.data.forEach(() => {})
+    orgList.forEach(() => {})
+    orgList.data.forEach(() => {})
     ```
   </AccordionPanel>
 
@@ -392,9 +392,9 @@ As part of this major version, a number of previously deprecated props, arugment
 
     Here's an example of how the response shape would change with this modification:
 
-    ```diff {{ prettier: false }}
-    - const data = await clerkClient.invitations.getInvitationList()
-    + const { data, totalCount } = await clerkClient.invitations.getInvitationList()
+    ```jsx {{ prettier: false, del: [1], ins: [2] }}
+    const data = await clerkClient.invitations.getInvitationList()
+    const { data, totalCount } = await clerkClient.invitations.getInvitationList()
     ```
   </AccordionPanel>
 
@@ -403,9 +403,9 @@ As part of this major version, a number of previously deprecated props, arugment
 
     Here's an example of how the response shape would change with this modification:
 
-    ```diff {{ prettier: false }}
-    - const data = await clerkClient.sessions.getSessionList()
-    + const { data, totalCount } = await clerkClient.sessions.getSessionList()
+    ```jsx {{ prettier: false, del: [1], ins: [2] }}
+    const data = await clerkClient.sessions.getSessionList()
+    const { data, totalCount } = await clerkClient.sessions.getSessionList()
     ```
   </AccordionPanel>
 
@@ -414,9 +414,9 @@ As part of this major version, a number of previously deprecated props, arugment
 
     Here's an example of how the response shape would change with this modification:
 
-    ```diff {{ prettier: false }}
-    - const data = await clerkClient.users.getUserList()
-    + const { data, totalCount } = await clerkClient.users.getUserList()
+    ```jsx {{ prettier: false, del: [1], ins: [2] }}
+    const data = await clerkClient.users.getUserList()
+    const { data, totalCount } = await clerkClient.users.getUserList()
     ```
   </AccordionPanel>
 
@@ -425,9 +425,9 @@ As part of this major version, a number of previously deprecated props, arugment
 
     Here's an example of how the response shape would change with this modification:
 
-    ```diff {{ prettier: false }}
-    - const data = await clerkClient.allowlistIdentifiers.getAllowlistIdentifierList()
-    + const { data, totalCount } = await clerkClient.allowlistIdentifiers.getAllowlistIdentifierList()
+    ```jsx {{ prettier: false, del: [1], ins: [2] }}
+    const data = await clerkClient.allowlistIdentifiers.getAllowlistIdentifierList()
+    const { data, totalCount } = await clerkClient.allowlistIdentifiers.getAllowlistIdentifierList()
     ```
   </AccordionPanel>
 
@@ -436,9 +436,9 @@ As part of this major version, a number of previously deprecated props, arugment
 
     Here's an example of how the response shape would change with this modification:
 
-    ```diff {{ prettier: false }}
-    - const data = await clerkClient.clients.getClientList()
-    + const { data, totalCount } = await clerkClient.allowlistIdentifiers.getClientList()
+    ```jsx {{ prettier: false, del: [1], ins: [2] }}
+    const data = await clerkClient.clients.getClientList()
+    const { data, totalCount } = await clerkClient.allowlistIdentifiers.getClientList()
     ```
   </AccordionPanel>
 
@@ -447,9 +447,9 @@ As part of this major version, a number of previously deprecated props, arugment
 
     Here's an example of how the response shape would change with this modification:
 
-    ```diff {{ prettier: false }}
-    - const data = await clerkClient.redirectUrls.getRedirectUrlList()
-    + const { data, totalCount } = await clerkClient.redirectUrls.getRedirectUrlList()
+    ```jsx {{ prettier: false, del: [1], ins: [2] }}
+    const data = await clerkClient.redirectUrls.getRedirectUrlList()
+    const { data, totalCount } = await clerkClient.redirectUrls.getRedirectUrlList()
     ```
   </AccordionPanel>
 
@@ -458,9 +458,9 @@ As part of this major version, a number of previously deprecated props, arugment
 
     Here's an example of how the response shape would change with this modification:
 
-    ```diff {{ prettier: false }}
-    - const data = await clerkClient.users.getUserOauthAccessToken()
-    + const { data, totalCount } = await clerkClient.users.getUserOauthAccessToken()
+    ```jsx {{ prettier: false, del: [1], ins: [2] }}
+    const data = await clerkClient.users.getUserOauthAccessToken()
+    const { data, totalCount } = await clerkClient.users.getUserOauthAccessToken()
     ```
   </AccordionPanel>
 
@@ -471,9 +471,9 @@ As part of this major version, a number of previously deprecated props, arugment
   <AccordionPanel>
     The `Clerk` default import has changed to `createClerkClient` and been moved to a named import rather than default. You must update your import path in order for it to work correctly. Example below of the fix that needs to be made:
 
-    ```diff {{ prettier: false }}
-    - import Clerk from "@clerk/fastify"
-    + import { createClerkClient } from "@clerk/fastify"
+    ```jsx {{ prettier: false, del: [1], ins: [2] }}
+    import Clerk from "@clerk/fastify"
+    import { createClerkClient } from "@clerk/fastify"
     ```
   </AccordionPanel>
 </Accordion>

--- a/docs/upgrade-guides/core-2/javascript.mdx
+++ b/docs/upgrade-guides/core-2/javascript.mdx
@@ -223,7 +223,7 @@ There were some changes made to pagination-related arguments passed into functio
   <AccordionPanel>
     There have been a couple changes to the pagination arguments that can be passed into this function - `limit` has been renamed to `pageSize`, and `offset` has been renamed to `initialPage`. This will help to make it more clear and simple to reason about pagination control. Example of how changes might look below:
 
-    ```jsx {{ prettier: false, del: [2, 4], ins: [3, 5] }}
+    ```js {{ prettier: false, del: [2, 4], ins: [3, 5] }}
     const { data } = await organization.getRoles({
       limit: 10,
       pageSize: 10,
@@ -236,7 +236,7 @@ There were some changes made to pagination-related arguments passed into functio
   <AccordionPanel>
     There have been a couple changes to the pagination arguments that can be passed into this function - `limit` has been renamed to `pageSize`, and `offset` has been renamed to `initialPage`. This will help to make it more clear and simple to reason about pagination control. Example of how changes might look below:
 
-    ```jsx {{ prettier: false, del: [2, 4], ins: [3, 5] }}
+    ```js {{ prettier: false, del: [2, 4], ins: [3, 5] }}
     const { data } = await organization.getMemberships({
       limit: 10,
       pageSize: 10,
@@ -249,7 +249,7 @@ There were some changes made to pagination-related arguments passed into functio
   <AccordionPanel>
     There have been a couple changes to the pagination arguments that can be passed into this function - `limit` has been renamed to `pageSize`, and `offset` has been renamed to `initialPage`. This will help to make it more clear and simple to reason about pagination control. Example of how changes might look below:
 
-    ```jsx {{ prettier: false, del: [2, 4], ins: [3, 5] }}
+    ```js {{ prettier: false, del: [2, 4], ins: [3, 5] }}
     const { data } = await organization.getDomains({
       limit: 10,
       pageSize: 10,
@@ -262,7 +262,7 @@ There were some changes made to pagination-related arguments passed into functio
   <AccordionPanel>
     There have been a couple changes to the pagination arguments that can be passed into this function - `limit` has been renamed to `pageSize`, and `offset` has been renamed to `initialPage`. This will help to make it more clear and simple to reason about pagination control. Example of how changes might look below:
 
-    ```jsx {{ prettier: false, del: [2, 4], ins: [3, 5] }}
+    ```js {{ prettier: false, del: [2, 4], ins: [3, 5] }}
     const { data } = await organization.getInvitations({
       limit: 10,
       pageSize: 10,
@@ -275,7 +275,7 @@ There were some changes made to pagination-related arguments passed into functio
   <AccordionPanel>
     There have been a couple changes to the pagination arguments that can be passed into this function - `limit` has been renamed to `pageSize`, and `offset` has been renamed to `initialPage`. This will help to make it more clear and simple to reason about pagination control. Example of how changes might look below:
 
-    ```jsx {{ prettier: false, del: [2, 4], ins: [3, 5] }}
+    ```js {{ prettier: false, del: [2, 4], ins: [3, 5] }}
     const { data } = await organization.getMembershipRequests({
       limit: 10,
       pageSize: 10,
@@ -288,7 +288,7 @@ There were some changes made to pagination-related arguments passed into functio
   <AccordionPanel>
     There have been a couple changes to the pagination arguments that can be passed into this function - `limit` has been renamed to `pageSize`, and `offset` has been renamed to `initialPage`. This will help to make it more clear and simple to reason about pagination control. Example of how changes might look below:
 
-    ```jsx {{ prettier: false, del: [2, 4], ins: [3, 5] }}
+    ```js {{ prettier: false, del: [2, 4], ins: [3, 5] }}
     const { data } = await user.getOrganizationInvitations({
       limit: 10,
       pageSize: 10,
@@ -301,7 +301,7 @@ There were some changes made to pagination-related arguments passed into functio
   <AccordionPanel>
     There have been a couple changes to the pagination arguments that can be passed into this function - `limit` has been renamed to `pageSize`, and `offset` has been renamed to `initialPage`. This will help to make it more clear and simple to reason about pagination control. Example of how changes might look below:
 
-    ```jsx {{ prettier: false, del: [2, 4], ins: [3, 5] }}
+    ```js {{ prettier: false, del: [2, 4], ins: [3, 5] }}
     const { data } = await user.getOrganizationSuggestions({
       limit: 10,
       pageSize: 10,
@@ -314,7 +314,7 @@ There were some changes made to pagination-related arguments passed into functio
   <AccordionPanel>
     There have been a couple changes to the pagination arguments that can be passed into this function - `limit` has been renamed to `pageSize`, and `offset` has been renamed to `initialPage`. This will help to make it more clear and simple to reason about pagination control. Example of how changes might look below:
 
-    ```jsx {{ prettier: false, del: [2, 4], ins: [3, 5] }}
+    ```js {{ prettier: false, del: [2, 4], ins: [3, 5] }}
     const { data } = await user.getOrganizationMemberships({
       limit: 10,
       pageSize: 10,
@@ -337,7 +337,7 @@ There have been changes to return signatures for some functions. Since Clerk's A
 
     Here's an example of how the response shape would change with this modification:
 
-    ```jsx {{ prettier: false, del: [1], ins: [2] }}
+    ```js {{ prettier: false, del: [1], ins: [2] }}
     const data = await clerkClient.users.getOrganizationMembershipList()
     const { data, totalCount } = await clerkClient.users.getOrganizationMembershipList()
     ```
@@ -348,7 +348,7 @@ There have been changes to return signatures for some functions. Since Clerk's A
 
     Here's an example of how the response shape would change with this modification:
 
-    ```jsx {{ prettier: false, del: [1], ins: [2] }}
+    ```js {{ prettier: false, del: [1], ins: [2] }}
     const data = await clerkClient.users.getOrganizationInvitationList()
     const { data, totalCount } = await clerkClient.users.getOrganizationInvitationList()
     ```
@@ -357,7 +357,7 @@ There have been changes to return signatures for some functions. Since Clerk's A
   <AccordionPanel>
     The return type for this function was previously `[Items]` but has now been updated to `{ data: [Items], totalCount: number }`. Since Clerk's API responses are paginated, the `totalCount` property is helpful in determining the total number of items in the response easily. A before/after code example can be seen below:
 
-    ```jsx {{ prettier: false, del: [5], ins: [6] }}
+    ```js {{ prettier: false, del: [5], ins: [6] }}
     const data = await clerkClient.organizations.getOrganizationInvitationList({
       organizationId: "...",
     })
@@ -370,7 +370,7 @@ There have been changes to return signatures for some functions. Since Clerk's A
   <AccordionPanel>
     The return type for this function was previously `[Items]` but has now been updated to `{ data: [Items], totalCount: number }`. Since Clerk's API responses are paginated, the `totalCount` property is helpful in determining the total number of items in the response easily. A before/after code example can be seen below:
 
-    ```jsx {{ prettier: false, del: [4], ins: [5] }}
+    ```js {{ prettier: false, del: [4], ins: [5] }}
     const { user } = useUser()
     const membershipList = user.getOrganizationMembershipList()
 
@@ -384,7 +384,7 @@ There have been changes to return signatures for some functions. Since Clerk's A
 
     Here's an example of how the response shape would change with this modification:
 
-    ```jsx {{ prettier: false, del: [1], ins: [2] }}
+    ```js {{ prettier: false, del: [1], ins: [2] }}
     const data = await clerkClient.users.getOrganizationList()
     const { data, totalCount } = await clerkClient.users.getOrganizationList()
     ```
@@ -393,7 +393,7 @@ There have been changes to return signatures for some functions. Since Clerk's A
   <AccordionPanel>
     The return type for this function was previously `[Items]` but has now been updated to `{ data: [Items], totalCount: number }`. Since Clerk's API responses are paginated, the `totalCount` property is helpful in determining the total number of items in the response easily. A before/after code example can be seen below:
 
-    ```jsx {{ prettier: false, del: [4], ins: [5] }}
+    ```js {{ prettier: false, del: [4], ins: [5] }}
     const { organization } = useOrganization()
     const orgList = organization.getOrganizationList()
 
@@ -407,7 +407,7 @@ There have been changes to return signatures for some functions. Since Clerk's A
 
     Here's an example of how the response shape would change with this modification:
 
-    ```jsx {{ prettier: false, del: [1], ins: [2] }}
+    ```js {{ prettier: false, del: [1], ins: [2] }}
     const data = await clerkClient.invitations.getInvitationList()
     const { data, totalCount } = await clerkClient.invitations.getInvitationList()
     ```
@@ -418,7 +418,7 @@ There have been changes to return signatures for some functions. Since Clerk's A
 
     Here's an example of how the response shape would change with this modification:
 
-    ```jsx {{ prettier: false, del: [1], ins: [2] }}
+    ```js {{ prettier: false, del: [1], ins: [2] }}
     const data = await clerkClient.sessions.getSessionList()
     const { data, totalCount } = await clerkClient.sessions.getSessionList()
     ```
@@ -429,7 +429,7 @@ There have been changes to return signatures for some functions. Since Clerk's A
 
     Here's an example of how the response shape would change with this modification:
 
-    ```jsx {{ prettier: false, del: [1], ins: [2] }}
+    ```js {{ prettier: false, del: [1], ins: [2] }}
     const data = await clerkClient.users.getUserList()
     const { data, totalCount } = await clerkClient.users.getUserList()
     ```
@@ -440,7 +440,7 @@ There have been changes to return signatures for some functions. Since Clerk's A
 
     Here's an example of how the response shape would change with this modification:
 
-    ```jsx {{ prettier: false, del: [1], ins: [2] }}
+    ```js {{ prettier: false, del: [1], ins: [2] }}
     const data = await clerkClient.allowlistIdentifiers.getAllowlistIdentifierList()
     const { data, totalCount } = await clerkClient.allowlistIdentifiers.getAllowlistIdentifierList()
     ```
@@ -451,7 +451,7 @@ There have been changes to return signatures for some functions. Since Clerk's A
 
     Here's an example of how the response shape would change with this modification:
 
-    ```jsx {{ prettier: false, del: [1], ins: [2] }}
+    ```js {{ prettier: false, del: [1], ins: [2] }}
     const data = await clerkClient.clients.getClientList()
     const { data, totalCount } = await clerkClient.allowlistIdentifiers.getClientList()
     ```
@@ -462,7 +462,7 @@ There have been changes to return signatures for some functions. Since Clerk's A
 
     Here's an example of how the response shape would change with this modification:
 
-    ```jsx {{ prettier: false, del: [1], ins: [2] }}
+    ```js {{ prettier: false, del: [1], ins: [2] }}
     const data = await clerkClient.redirectUrls.getRedirectUrlList()
     const { data, totalCount } = await clerkClient.redirectUrls.getRedirectUrlList()
     ```
@@ -473,7 +473,7 @@ There have been changes to return signatures for some functions. Since Clerk's A
 
     Here's an example of how the response shape would change with this modification:
 
-    ```jsx {{ prettier: false, del: [1], ins: [2] }}
+    ```js {{ prettier: false, del: [1], ins: [2] }}
     const data = await clerkClient.users.getUserOauthAccessToken()
     const { data, totalCount } = await clerkClient.users.getUserOauthAccessToken()
     ```
@@ -497,7 +497,7 @@ As part of this major version, a number of previously deprecated props, arugment
   <AccordionPanel>
     If you are updating a user's password via the [`User.update` method](/docs/references/javascript/user/user#update), it must be changed to [`User.updatePassword`](/docs/references/javascript/user/password-management#update-password) instead. This method will require the current password as well as the desired new password. We made this update to improve the security of password changes. Example below:
 
-    ```jsx {{ prettier: false, del: [1], ins: [[3, 7]] }}
+    ```js {{ prettier: false, del: [1], ins: [[3, 7]] }}
     user.update({ password: 'foo' });
 
     user.updatePassword({
@@ -559,7 +559,7 @@ As part of this major version, a number of previously deprecated props, arugment
   <AccordionPanel>
     `setSession` should be replaced with `setActive`. The format of the parameters has changed slightly - `setActive` takes an object where `setSession` took params directly. The `setActive` function also can accept an `organization` param that is used to set the currently active organization. The return signature did not change. Read the [API documentation](/docs/references/javascript/clerk/session-methods#set-active) for more detail. This function should be expected to be returned from one of the following Clerk hooks: `useSessionList`, `useSignUp`, or `useSignIn`. Some migration examples:
 
-    ```jsx {{ prettier: false, del: [1, 4, 7], ins: [2, 5, 8] }}
+    ```js {{ prettier: false, del: [1, 4, 7], ins: [2, 5, 8] }}
     await setSession('sessionID', () => void)
     await setActive({ session: 'sessionID',  beforeEmit: () => void })
 
@@ -590,7 +590,7 @@ As part of this major version, a number of previously deprecated props, arugment
   <AccordionPanel>
     Passing a string as an argument to `Organization.create` is no longer possible - instead, pass an object with the `name` property.
 
-    ```jsx {{ prettier: false, del: [1], ins: [2] }}
+    ```js {{ prettier: false, del: [1], ins: [2] }}
     Organization.create('...');
     Organization.create({ name: '...' });
     ```
@@ -599,7 +599,7 @@ As part of this major version, a number of previously deprecated props, arugment
   <AccordionPanel>
     The `Organization.getPendingInvitations()` method has been removed. You can use `Organization.getInvitations` instead.
 
-    ```jsx {{ prettier: false, del: [1], ins: [2] }}
+    ```js {{ prettier: false, del: [1], ins: [2] }}
     Organization.getPendingInvitations();
     Organization.getInvitations({ status: 'pending' });
     ```
@@ -632,7 +632,7 @@ As part of this major version, a number of previously deprecated props, arugment
   <AccordionPanel>
     The `getOrganizationMemberships` [method on the `Clerk` class](/docs/references/javascript/clerk/clerk#organization) has been removed. Instead, use `getOrganizationMemberships` on a user instance.
 
-    ```jsx {{ prettier: false, del: [1], ins: [2] }}
+    ```js {{ prettier: false, del: [1], ins: [2] }}
     Clerk.getOrganizationMemberships();
     user.getOrganizationMemberships();
     ```
@@ -679,7 +679,7 @@ As part of this major version, a number of previously deprecated props, arugment
   <AccordionPanel>
     The top level `Clerk` import was changed to a named export, like `{ Clerk }`. This is just a name change and can be treated as a text replacement, no changes to the params or return types.
 
-    ```jsx {{ prettier: false, del: [1], ins: [2] }}
+    ```js {{ prettier: false, del: [1], ins: [2] }}
     import Clerk from '@clerk/clerk-js';
     import { Clerk } from '@clerk/clerk-js';
     ```

--- a/docs/upgrade-guides/core-2/javascript.mdx
+++ b/docs/upgrade-guides/core-2/javascript.mdx
@@ -71,9 +71,9 @@ Defining redirect URLs for after sign up, in, and/or out via the Clerk dashboard
 
 As part of this change, the default URL for each of these props has been set to `/`, so if you are passing `/` explicitly to any one of the above props, that line is no longer necessary and can be removed.
 
-```diff {{ prettier: false }}
-- <UserButton afterSignOutUrl='/' />
-+ <UserButton />
+```jsx {{ prettier: false, del: [1], ins: [2] }}
+<UserButton afterSignOutUrl='/' />
+<UserButton />
 ```
 
 ### `afterSignXUrl` changes
@@ -93,9 +93,9 @@ In general, use the environment variables over the props.
 
 To retain the current behavior of your app without any changes, you can switch `afterSignXUrl` with `signXFallbackRedirectUrl` as such:
 
-```diff {{ prettier: false }}
-- <SignIn afterSignInUrl='/foo' />
-+ <SignIn signInFallbackRedirectUrl='/foo' />
+```jsx {{ prettier: false, del: [1], ins: [2] }}
+<SignIn afterSignInUrl='/foo' />
+<SignIn signInFallbackRedirectUrl='/foo' />
 ```
 
 #### Why this is changing
@@ -223,104 +223,104 @@ There were some changes made to pagination-related arguments passed into functio
   <AccordionPanel>
     There have been a couple changes to the pagination arguments that can be passed into this function - `limit` has been renamed to `pageSize`, and `offset` has been renamed to `initialPage`. This will help to make it more clear and simple to reason about pagination control. Example of how changes might look below:
 
-    ```diff {{ prettier: false }}
-      const { data } = await organization.getRoles({
-    -   limit: 10,
-    +   pageSize: 10,
-    -   offset: 10,
-    +   initialPage: 2,
-      })
+    ```jsx {{ prettier: false, del: [2, 4], ins: [3, 5] }}
+    const { data } = await organization.getRoles({
+      limit: 10,
+      pageSize: 10,
+      offset: 10,
+      initialPage: 2,
+    })
     ```
   </AccordionPanel>
 
   <AccordionPanel>
     There have been a couple changes to the pagination arguments that can be passed into this function - `limit` has been renamed to `pageSize`, and `offset` has been renamed to `initialPage`. This will help to make it more clear and simple to reason about pagination control. Example of how changes might look below:
 
-    ```diff {{ prettier: false }}
-      const { data } = await organization.getMemberships({
-    -   limit: 10,
-    +   pageSize: 10,
-    -   offset: 10,
-    +   initialPage: 2,
-      })
+    ```jsx {{ prettier: false, del: [2, 4], ins: [3, 5] }}
+    const { data } = await organization.getMemberships({
+      limit: 10,
+      pageSize: 10,
+      offset: 10,
+      initialPage: 2,
+    })
     ```
   </AccordionPanel>
 
   <AccordionPanel>
     There have been a couple changes to the pagination arguments that can be passed into this function - `limit` has been renamed to `pageSize`, and `offset` has been renamed to `initialPage`. This will help to make it more clear and simple to reason about pagination control. Example of how changes might look below:
 
-    ```diff {{ prettier: false }}
-      const { data } = await organization.getDomains({
-    -   limit: 10,
-    +   pageSize: 10,
-    -   offset: 10,
-    +   initialPage: 2,
-      })
+    ```jsx {{ prettier: false, del: [2, 4], ins: [3, 5] }}
+    const { data } = await organization.getDomains({
+      limit: 10,
+      pageSize: 10,
+      offset: 10,
+      initialPage: 2,
+    })
     ```
   </AccordionPanel>
 
   <AccordionPanel>
     There have been a couple changes to the pagination arguments that can be passed into this function - `limit` has been renamed to `pageSize`, and `offset` has been renamed to `initialPage`. This will help to make it more clear and simple to reason about pagination control. Example of how changes might look below:
 
-    ```diff {{ prettier: false }}
-      const { data } = await organization.getInvitations({
-    -   limit: 10,
-    +   pageSize: 10,
-    -   offset: 10,
-    +   initialPage: 2,
-      })
+    ```jsx {{ prettier: false, del: [2, 4], ins: [3, 5] }}
+    const { data } = await organization.getInvitations({
+      limit: 10,
+      pageSize: 10,
+      offset: 10,
+      initialPage: 2,
+    })
     ```
   </AccordionPanel>
 
   <AccordionPanel>
     There have been a couple changes to the pagination arguments that can be passed into this function - `limit` has been renamed to `pageSize`, and `offset` has been renamed to `initialPage`. This will help to make it more clear and simple to reason about pagination control. Example of how changes might look below:
 
-    ```diff {{ prettier: false }}
-      const { data } = await organization.getMembershipRequests({
-    -   limit: 10,
-    +   pageSize: 10,
-    -   offset: 10,
-    +   initialPage: 2,
-      })
+    ```jsx {{ prettier: false, del: [2, 4], ins: [3, 5] }}
+    const { data } = await organization.getMembershipRequests({
+      limit: 10,
+      pageSize: 10,
+      offset: 10,
+      initialPage: 2,
+    })
     ```
   </AccordionPanel>
 
   <AccordionPanel>
     There have been a couple changes to the pagination arguments that can be passed into this function - `limit` has been renamed to `pageSize`, and `offset` has been renamed to `initialPage`. This will help to make it more clear and simple to reason about pagination control. Example of how changes might look below:
 
-    ```diff {{ prettier: false }}
-      const { data } = await user.getOrganizationInvitations({
-    -   limit: 10,
-    +   pageSize: 10,
-    -   offset: 10,
-    +   initialPage: 2,
-      })
+    ```jsx {{ prettier: false, del: [2, 4], ins: [3, 5] }}
+    const { data } = await user.getOrganizationInvitations({
+      limit: 10,
+      pageSize: 10,
+      offset: 10,
+      initialPage: 2,
+    })
     ```
   </AccordionPanel>
 
   <AccordionPanel>
     There have been a couple changes to the pagination arguments that can be passed into this function - `limit` has been renamed to `pageSize`, and `offset` has been renamed to `initialPage`. This will help to make it more clear and simple to reason about pagination control. Example of how changes might look below:
 
-    ```diff {{ prettier: false }}
-      const { data } = await user.getOrganizationSuggestions({
-    -   limit: 10,
-    +   pageSize: 10,
-    -   offset: 10,
-    +   initialPage: 2,
-      })
+    ```jsx {{ prettier: false, del: [2, 4], ins: [3, 5] }}
+    const { data } = await user.getOrganizationSuggestions({
+      limit: 10,
+      pageSize: 10,
+      offset: 10,
+      initialPage: 2,
+    })
     ```
   </AccordionPanel>
 
   <AccordionPanel>
     There have been a couple changes to the pagination arguments that can be passed into this function - `limit` has been renamed to `pageSize`, and `offset` has been renamed to `initialPage`. This will help to make it more clear and simple to reason about pagination control. Example of how changes might look below:
 
-    ```diff {{ prettier: false }}
-      const { data } = await user.getOrganizationMemberships({
-    -   limit: 10,
-    +   pageSize: 10,
-    -   offset: 10,
-    +   initialPage: 2,
-      })
+    ```jsx {{ prettier: false, del: [2, 4], ins: [3, 5] }}
+    const { data } = await user.getOrganizationMemberships({
+      limit: 10,
+      pageSize: 10,
+      offset: 10,
+      initialPage: 2,
+    })
     ```
   </AccordionPanel>
 </Accordion>
@@ -337,9 +337,9 @@ There have been changes to return signatures for some functions. Since Clerk's A
 
     Here's an example of how the response shape would change with this modification:
 
-    ```diff {{ prettier: false }}
-    - const data = await clerkClient.users.getOrganizationMembershipList()
-    + const { data, totalCount } = await clerkClient.users.getOrganizationMembershipList()
+    ```jsx {{ prettier: false, del: [1], ins: [2] }}
+    const data = await clerkClient.users.getOrganizationMembershipList()
+    const { data, totalCount } = await clerkClient.users.getOrganizationMembershipList()
     ```
   </AccordionPanel>
 
@@ -348,34 +348,34 @@ There have been changes to return signatures for some functions. Since Clerk's A
 
     Here's an example of how the response shape would change with this modification:
 
-    ```diff {{ prettier: false }}
-    - const data = await clerkClient.users.getOrganizationInvitationList()
-    + const { data, totalCount } = await clerkClient.users.getOrganizationInvitationList()
+    ```jsx {{ prettier: false, del: [1], ins: [2] }}
+    const data = await clerkClient.users.getOrganizationInvitationList()
+    const { data, totalCount } = await clerkClient.users.getOrganizationInvitationList()
     ```
   </AccordionPanel>
 
   <AccordionPanel>
     The return type for this function was previously `[Items]` but has now been updated to `{ data: [Items], totalCount: number }`. Since Clerk's API responses are paginated, the `totalCount` property is helpful in determining the total number of items in the response easily. A before/after code example can be seen below:
 
-    ```diff {{ prettier: false }}
-      const data = await clerkClient.organizations.getOrganizationInvitationList({
-        organizationId: "...",
-      })
+    ```jsx {{ prettier: false, del: [5], ins: [6] }}
+    const data = await clerkClient.organizations.getOrganizationInvitationList({
+      organizationId: "...",
+    })
 
-    - data.forEach(() => {})
-    + data.data.forEach(() => {})
+    data.forEach(() => {})
+    data.data.forEach(() => {})
     ```
   </AccordionPanel>
 
   <AccordionPanel>
     The return type for this function was previously `[Items]` but has now been updated to `{ data: [Items], totalCount: number }`. Since Clerk's API responses are paginated, the `totalCount` property is helpful in determining the total number of items in the response easily. A before/after code example can be seen below:
 
-    ```diff {{ prettier: false }}
-      const { user } = useUser()
-      const membershipList = user.getOrganizationMembershipList()
+    ```jsx {{ prettier: false, del: [4], ins: [5] }}
+    const { user } = useUser()
+    const membershipList = user.getOrganizationMembershipList()
 
-    - membershipList.forEach(() => {})
-    + membershipList.data.forEach(() => {})
+    membershipList.forEach(() => {})
+    membershipList.data.forEach(() => {})
     ```
   </AccordionPanel>
 
@@ -384,21 +384,21 @@ There have been changes to return signatures for some functions. Since Clerk's A
 
     Here's an example of how the response shape would change with this modification:
 
-    ```diff {{ prettier: false }}
-    - const data = await clerkClient.users.getOrganizationList()
-    + const { data, totalCount } = await clerkClient.users.getOrganizationList()
+    ```jsx {{ prettier: false, del: [1], ins: [2] }}
+    const data = await clerkClient.users.getOrganizationList()
+    const { data, totalCount } = await clerkClient.users.getOrganizationList()
     ```
   </AccordionPanel>
 
   <AccordionPanel>
     The return type for this function was previously `[Items]` but has now been updated to `{ data: [Items], totalCount: number }`. Since Clerk's API responses are paginated, the `totalCount` property is helpful in determining the total number of items in the response easily. A before/after code example can be seen below:
 
-    ```diff {{ prettier: false }}
-      const { organization } = useOrganization()
-      const orgList = organization.getOrganizationList()
+    ```jsx {{ prettier: false, del: [4], ins: [5] }}
+    const { organization } = useOrganization()
+    const orgList = organization.getOrganizationList()
 
-    - orgList.forEach(() => {})
-    + orgList.data.forEach(() => {})
+    orgList.forEach(() => {})
+    orgList.data.forEach(() => {})
     ```
   </AccordionPanel>
 
@@ -407,9 +407,9 @@ There have been changes to return signatures for some functions. Since Clerk's A
 
     Here's an example of how the response shape would change with this modification:
 
-    ```diff {{ prettier: false }}
-    - const data = await clerkClient.invitations.getInvitationList()
-    + const { data, totalCount } = await clerkClient.invitations.getInvitationList()
+    ```jsx {{ prettier: false, del: [1], ins: [2] }}
+    const data = await clerkClient.invitations.getInvitationList()
+    const { data, totalCount } = await clerkClient.invitations.getInvitationList()
     ```
   </AccordionPanel>
 
@@ -418,9 +418,9 @@ There have been changes to return signatures for some functions. Since Clerk's A
 
     Here's an example of how the response shape would change with this modification:
 
-    ```diff {{ prettier: false }}
-    - const data = await clerkClient.sessions.getSessionList()
-    + const { data, totalCount } = await clerkClient.sessions.getSessionList()
+    ```jsx {{ prettier: false, del: [1], ins: [2] }}
+    const data = await clerkClient.sessions.getSessionList()
+    const { data, totalCount } = await clerkClient.sessions.getSessionList()
     ```
   </AccordionPanel>
 
@@ -429,9 +429,9 @@ There have been changes to return signatures for some functions. Since Clerk's A
 
     Here's an example of how the response shape would change with this modification:
 
-    ```diff {{ prettier: false }}
-    - const data = await clerkClient.users.getUserList()
-    + const { data, totalCount } = await clerkClient.users.getUserList()
+    ```jsx {{ prettier: false, del: [1], ins: [2] }}
+    const data = await clerkClient.users.getUserList()
+    const { data, totalCount } = await clerkClient.users.getUserList()
     ```
   </AccordionPanel>
 
@@ -440,9 +440,9 @@ There have been changes to return signatures for some functions. Since Clerk's A
 
     Here's an example of how the response shape would change with this modification:
 
-    ```diff {{ prettier: false }}
-    - const data = await clerkClient.allowlistIdentifiers.getAllowlistIdentifierList()
-    + const { data, totalCount } = await clerkClient.allowlistIdentifiers.getAllowlistIdentifierList()
+    ```jsx {{ prettier: false, del: [1], ins: [2] }}
+    const data = await clerkClient.allowlistIdentifiers.getAllowlistIdentifierList()
+    const { data, totalCount } = await clerkClient.allowlistIdentifiers.getAllowlistIdentifierList()
     ```
   </AccordionPanel>
 
@@ -451,9 +451,9 @@ There have been changes to return signatures for some functions. Since Clerk's A
 
     Here's an example of how the response shape would change with this modification:
 
-    ```diff {{ prettier: false }}
-    - const data = await clerkClient.clients.getClientList()
-    + const { data, totalCount } = await clerkClient.allowlistIdentifiers.getClientList()
+    ```jsx {{ prettier: false, del: [1], ins: [2] }}
+    const data = await clerkClient.clients.getClientList()
+    const { data, totalCount } = await clerkClient.allowlistIdentifiers.getClientList()
     ```
   </AccordionPanel>
 
@@ -462,9 +462,9 @@ There have been changes to return signatures for some functions. Since Clerk's A
 
     Here's an example of how the response shape would change with this modification:
 
-    ```diff {{ prettier: false }}
-    - const data = await clerkClient.redirectUrls.getRedirectUrlList()
-    + const { data, totalCount } = await clerkClient.redirectUrls.getRedirectUrlList()
+    ```jsx {{ prettier: false, del: [1], ins: [2] }}
+    const data = await clerkClient.redirectUrls.getRedirectUrlList()
+    const { data, totalCount } = await clerkClient.redirectUrls.getRedirectUrlList()
     ```
   </AccordionPanel>
 
@@ -473,9 +473,9 @@ There have been changes to return signatures for some functions. Since Clerk's A
 
     Here's an example of how the response shape would change with this modification:
 
-    ```diff {{ prettier: false }}
-    - const data = await clerkClient.users.getUserOauthAccessToken()
-    + const { data, totalCount } = await clerkClient.users.getUserOauthAccessToken()
+    ```jsx {{ prettier: false, del: [1], ins: [2] }}
+    const data = await clerkClient.users.getUserOauthAccessToken()
+    const { data, totalCount } = await clerkClient.users.getUserOauthAccessToken()
     ```
   </AccordionPanel>
 </Accordion>
@@ -497,14 +497,14 @@ As part of this major version, a number of previously deprecated props, arugment
   <AccordionPanel>
     If you are updating a user's password via the [`User.update` method](/docs/references/javascript/user/user#update), it must be changed to [`User.updatePassword`](/docs/references/javascript/user/password-management#update-password) instead. This method will require the current password as well as the desired new password. We made this update to improve the security of password changes. Example below:
 
-    ```diff {{ prettier: false }}
-    - user.update({ password: 'foo' });
+    ```jsx {{ prettier: false, del: [1], ins: [[3, 7]] }}
+    user.update({ password: 'foo' });
 
-    + user.updatePassword({
-    +   currentPassword: 'bar',
-    +   newPassword: 'foo',
-    +   signOutOfOtherSessions: true,
-    + });
+    user.updatePassword({
+      currentPassword: 'bar',
+      newPassword: 'foo',
+      signOutOfOtherSessions: true,
+    });
     ```
   </AccordionPanel>
 
@@ -559,15 +559,15 @@ As part of this major version, a number of previously deprecated props, arugment
   <AccordionPanel>
     `setSession` should be replaced with `setActive`. The format of the parameters has changed slightly - `setActive` takes an object where `setSession` took params directly. The `setActive` function also can accept an `organization` param that is used to set the currently active organization. The return signature did not change. Read the [API documentation](/docs/references/javascript/clerk/session-methods#set-active) for more detail. This function should be expected to be returned from one of the following Clerk hooks: `useSessionList`, `useSignUp`, or `useSignIn`. Some migration examples:
 
-    ```diff {{ prettier: false }}
-    - await setSession('sessionID', () => void)
-    + await setActive({ session: 'sessionID',  beforeEmit: () => void })
+    ```jsx {{ prettier: false, del: [1, 4, 7], ins: [2, 5, 8] }}
+    await setSession('sessionID', () => void)
+    await setActive({ session: 'sessionID',  beforeEmit: () => void })
 
-    - await setSession(sessionObj)
-    + await setActive({ session: sessionObj })
+    await setSession(sessionObj)
+    await setActive({ session: sessionObj })
 
-    - await setSession(sessionObj, () => void)
-    + await setActive({ session: sessionObj,  beforeEmit: () => void })
+    await setSession(sessionObj, () => void)
+    await setActive({ session: sessionObj,  beforeEmit: () => void })
     ```
 
     `setActive` also supports setting an active organization:
@@ -590,18 +590,18 @@ As part of this major version, a number of previously deprecated props, arugment
   <AccordionPanel>
     Passing a string as an argument to `Organization.create` is no longer possible - instead, pass an object with the `name` property.
 
-    ```diff {{ prettier: false }}
-    - Organization.create('...');
-    + Organization.create({ name: '...' });
+    ```jsx {{ prettier: false, del: [1], ins: [2] }}
+    Organization.create('...');
+    Organization.create({ name: '...' });
     ```
   </AccordionPanel>
 
   <AccordionPanel>
     The `Organization.getPendingInvitations()` method has been removed. You can use `Organization.getInvitations` instead.
 
-    ```diff {{ prettier: false }}
-    - Organization.getPendingInvitations();
-    + Organization.getInvitations({ status: 'pending' });
+    ```jsx {{ prettier: false, del: [1], ins: [2] }}
+    Organization.getPendingInvitations();
+    Organization.getInvitations({ status: 'pending' });
     ```
   </AccordionPanel>
 
@@ -632,9 +632,9 @@ As part of this major version, a number of previously deprecated props, arugment
   <AccordionPanel>
     The `getOrganizationMemberships` [method on the `Clerk` class](/docs/references/javascript/clerk/clerk#organization) has been removed. Instead, use `getOrganizationMemberships` on a user instance.
 
-    ```diff {{ prettier: false }}
-    - Clerk.getOrganizationMemberships();
-    + user.getOrganizationMemberships();
+    ```jsx {{ prettier: false, del: [1], ins: [2] }}
+    Clerk.getOrganizationMemberships();
+    user.getOrganizationMemberships();
     ```
   </AccordionPanel>
 
@@ -660,28 +660,28 @@ As part of this major version, a number of previously deprecated props, arugment
   <AccordionPanel>
     The `signOutCallback` prop on the [`<SignOutButton />` component](/docs/components/unstyled/sign-out-button) has been removed. Instead, you can use the `redirectUrl` prop. Example below:
 
-    ```diff {{ prettier: false }}
-      import { SignOutButton } from "@clerk/clerk-react";
+    ```jsx {{ prettier: false, del: [6], ins: [7] }}
+    import { SignOutButton } from "@clerk/clerk-react";
 
-      export const Signout = () => {
-        return (
-          <SignOutButton
-    -       signOutCallback={() => { window.location.href = "/your-path" }}
-    +       redirectUrl="/your-path"
-          >
-            <button>Sign Out</button>
-          </SignOutButton>
-        )
-      }
+    export const Signout = () => {
+      return (
+        <SignOutButton
+          signOutCallback={() => { window.location.href = "/your-path" }}
+          redirectUrl="/your-path"
+        >
+          <button>Sign Out</button>
+        </SignOutButton>
+      )
+    }
     ```
   </AccordionPanel>
 
   <AccordionPanel>
     The top level `Clerk` import was changed to a named export, like `{ Clerk }`. This is just a name change and can be treated as a text replacement, no changes to the params or return types.
 
-    ```diff {{ prettier: false }}
-    - import Clerk from '@clerk/clerk-js';
-    + import { Clerk } from '@clerk/clerk-js';
+    ```jsx {{ prettier: false, del: [1], ins: [2] }}
+    import Clerk from '@clerk/clerk-js';
+    import { Clerk } from '@clerk/clerk-js';
     ```
   </AccordionPanel>
 </Accordion>

--- a/docs/upgrade-guides/core-2/nextjs.mdx
+++ b/docs/upgrade-guides/core-2/nextjs.mdx
@@ -142,22 +142,22 @@ Clerk strongly recommends migrating to the new `clerkMiddleware()` for an improv
 
 The most basic migration will be updating the import and changing out the default export, then mirroring the previous behavior of protecting all routes except `/sign-in` or `/sign-up` by doing the following:
 
-```diff {{ prettier: false }}
-- import { authMiddleware } from "@clerk/nextjs/server"
-+ import { clerkMiddleware, createRouteMatcher } from '@clerk/nextjs/server'
+```jsx {{ prettier: false, del: [1, 6], ins: [2, 4, [7, 11]] }}
+import { authMiddleware } from "@clerk/nextjs/server"
+import { clerkMiddleware, createRouteMatcher } from '@clerk/nextjs/server'
 
-+ const isPublicRoute = createRouteMatcher(['/sign-in(.*)', '/sign-up(.*)']);
+const isPublicRoute = createRouteMatcher(['/sign-in(.*)', '/sign-up(.*)']);
 
-- export default authMiddleware()
-+ export default clerkMiddleware((auth, request) =>{
-+   if(!isPublicRoute(request)){
-+     auth().protect();
-+   }
-+ });
-
-  export const config = {
-    matcher: ["/((?!.*\\..*|_next).*)", "/", "/(api|trpc)(.*)"],
+export default authMiddleware()
+export default clerkMiddleware((auth, request) =>{
+  if(!isPublicRoute(request)){
+    auth().protect();
   }
+});
+
+export const config = {
+  matcher: ["/((?!.*\\..*|_next).*)", "/", "/(api|trpc)(.*)"],
+}
 ```
 
 Of course, in most cases you'll have a more complicated setup than this. You can find some examples below for how to migrate a few common use cases. Be sure to review the [`clerkMiddleware()` documentation](/docs/references/nextjs/clerk-middleware) if your specific use case is not mentioned.
@@ -382,46 +382,46 @@ As part of this release, some of the top-level exports of `@clerk/nextjs` have b
   <AccordionPanel>
     Previously these exports have been exported both from `@clerk/nextjs` and `@clerk/nextjs/server`. As of v5 they are only exported from the latter. Going forward, the expectation can be that any imports that are intended to run within react on the client side, will come from `@clerk/nextjs` and imports that are intended to run on the server, will come from `@clerk/nextjs/server`.
 
-    ```diff {{ prettier: false }}
-      import {
-        auth,
-        currentUser,
-        authMiddleware,
-        buildClerkProps,
-        verifyToken,
-        verifyJwt,
-        decodeJwt,
-        signJwt,
-        constants,
-        redirect,
-        createAuthenticateRequest,
-        createIsomorphicRequest,
-    - } from "@clerk/nextjs"
-    + } from "@clerk/nextjs/server"
+    ```jsx {{ prettier: false, del: [14], ins: [15] }}
+    import {
+      auth,
+      currentUser,
+      authMiddleware,
+      buildClerkProps,
+      verifyToken,
+      verifyJwt,
+      decodeJwt,
+      signJwt,
+      constants,
+      redirect,
+      createAuthenticateRequest,
+      createIsomorphicRequest,
+    } from "@clerk/nextjs"
+    } from "@clerk/nextjs/server"
     ```
   </AccordionPanel>
 
   <AccordionPanel>
     Exports related to errors are now under `@clerk/nextjs/errors`.
 
-    ```diff {{ prettier: false }}
-      import {
-        isClerkAPIResponseError,
-        isEmailLinkError,
-        isKnownError,
-        isMetamaskError,
-        EmailLinkErrorCode,
-    - } from "@clerk/nextjs"
-    + } from "@clerk/nextjs/errors"
+    ```jsx {{ prettier: false, del: [7], ins: [8] }}
+    import {
+      isClerkAPIResponseError,
+      isEmailLinkError,
+      isKnownError,
+      isMetamaskError,
+      EmailLinkErrorCode,
+    } from "@clerk/nextjs"
+    } from "@clerk/nextjs/errors"
     ```
   </AccordionPanel>
 
   <AccordionPanel>
     The `@clerk/nextjs` import will work with both the App and Pages Router.
 
-    ```diff {{ prettier: false }}
-    - import { } from "@clerk/nextjs/app-beta"
-    + import { } from "@clerk/nextjs"
+    ```jsx {{ prettier: false, del: [1], ins: [2] }}
+    import { } from "@clerk/nextjs/app-beta"
+    import { } from "@clerk/nextjs"
     ```
 
     Some behavior may have changed between Clerk's beta and the stable release. Please check on your end if behavior stayed the same.
@@ -430,42 +430,42 @@ As part of this release, some of the top-level exports of `@clerk/nextjs` have b
   <AccordionPanel>
     The top-level exports support SSR by default now.
 
-    ```diff {{ prettier: false }}
-    - import { } from "@clerk/nextjs/ssr"
-    + import { } from "@clerk/nextjs"
+    ```jsx {{ prettier: false, del: [1], ins: [2] }}
+    import { } from "@clerk/nextjs/ssr"
+    import { } from "@clerk/nextjs"
     ```
   </AccordionPanel>
 
   <AccordionPanel>
-    ```diff {{ prettier: false }}
-    - import { } from "@clerk/nextjs/edge-middleware"
-    + import { } from "@clerk/nextjs"
+    ```jsx {{ prettier: false, del: [1], ins: [2] }}
+    import { } from "@clerk/nextjs/edge-middleware"
+    import { } from "@clerk/nextjs"
     ```
   </AccordionPanel>
 
   <AccordionPanel>
-    ```diff {{ prettier: false }}
-    - import { } from "@clerk/nextjs/edge-middlewarefiles"
-    + import { } from "@clerk/nextjs"
+    ```jsx {{ prettier: false, del: [1], ins: [2] }}
+    import { } from "@clerk/nextjs/edge-middlewarefiles"
+    import { } from "@clerk/nextjs"
     ```
   </AccordionPanel>
 
   <AccordionPanel>
     The `@clerk/nextjs/api` subpath was removed completely. It re-exported helpers from `@clerk/clerk-sdk-node` and its types. If you relied on these, import from `@clerk/clerk-sdk-node` directly instead.
 
-    ```diff {{ prettier: false }}
-      import type {
-        ClerkMiddleware,
-        ClerkMiddlewareOptions,
-        LooseAuthProp,
-        RequireAuthProp,
-        StrictAuthProp,
-        WithAuthProp
-    - } from "@clerk/nextjs/api"
-    + } from "@clerk/clerk-sdk-node"
+    ```jsx {{ prettier: false, del: [8, 11], ins: [9, 12] }}
+    import type {
+      ClerkMiddleware,
+      ClerkMiddlewareOptions,
+      LooseAuthProp,
+      RequireAuthProp,
+      StrictAuthProp,
+      WithAuthProp
+    } from "@clerk/nextjs/api"
+    } from "@clerk/clerk-sdk-node"
 
-    - import { requireAuth, withAuth } from "@clerk/nextjs/api"
-    + import { requireAuth, withAuth } from "@clerk/clerk-sdk-node"
+    import { requireAuth, withAuth } from "@clerk/nextjs/api"
+    import { requireAuth, withAuth } from "@clerk/clerk-sdk-node"
     ```
   </AccordionPanel>
 </Accordion>
@@ -476,9 +476,9 @@ Defining redirect URLs for after sign up, in, and/or out via the Clerk Dashboard
 
 As part of this change, the default redirect URL for each of these props has been set to `/`, so if you are passing `/` explicitly to any one of the above props, that line is no longer necessary and can be removed.
 
-```diff {{ prettier: false }}
-- <UserButton afterSignOutUrl='/' />
-+ <UserButton />
+```jsx {{ prettier: false, del: [1], ins: [2] }}
+<UserButton afterSignOutUrl='/' />
+<UserButton />
 ```
 
 ### `afterSignXUrl` changes
@@ -498,9 +498,9 @@ In general, use the environment variables over the props.
 
 To retain the current behavior of your app without any changes, you can switch `afterSignXUrl` with `signXFallbackRedirectUrl` as such:
 
-```diff {{ prettier: false }}
-- <SignIn afterSignInUrl='/foo' />
-+ <SignIn signInFallbackRedirectUrl='/foo' />
+```jsx {{ prettier: false, del: [1], ins: [2] }}
+<SignIn afterSignInUrl='/foo' />
+<SignIn signInFallbackRedirectUrl='/foo' />
 ```
 
 ### Removed: `orgs` claim on JWT
@@ -606,14 +606,14 @@ As part of this major version, a number of previously deprecated props, arugment
   <AccordionPanel>
     If you are updating a user's password via the [`User.update` method](/docs/references/javascript/user/user#update), it must be changed to [`User.updatePassword`](/docs/references/javascript/user/password-management#update-password) instead. This method will require the current password as well as the desired new password. We made this update to improve the security of password changes. Example below:
 
-    ```diff {{ prettier: false }}
-    - user.update({ password: 'foo' });
+    ```jsx {{ prettier: false, del: [1], ins: [[3, 7]] }}
+    user.update({ password: 'foo' });
 
-    + user.updatePassword({
-    +   currentPassword: 'bar',
-    +   newPassword: 'foo',
-    +   signOutOfOtherSessions: true,
-    + });
+    user.updatePassword({
+      currentPassword: 'bar',
+      newPassword: 'foo',
+      signOutOfOtherSessions: true,
+    });
     ```
   </AccordionPanel>
 
@@ -634,53 +634,53 @@ As part of this major version, a number of previously deprecated props, arugment
   <AccordionPanel>
     The `apiKey` argument passed to `authMiddleware` must be changed to `secretKey`.
 
-    ```diff {{ prettier: false }}
+    ```jsx {{ prettier: false, del: [3], ins: [4] }}
     import { authMiddleware } from '@clerk/nextjs/server';
 
-    - authMiddleware({ apiKey: '...' });
-    + authMiddleware({ secretKey: '...' });
+    authMiddleware({ apiKey: '...' });
+    authMiddleware({ secretKey: '...' });
     ```
   </AccordionPanel>
 
   <AccordionPanel>
     The `frontendApi` argument passed to `authMiddleware` must be changed to `publishableKey`
 
-    ```diff {{ prettier: false }}
+    ```jsx {{ prettier: false, del: [3], ins: [4] }}
     import { authMiddleware } from "@clerk/nextjs/server"
 
-    - authMiddleware({ frontendApi: '...' })
-    + authMiddleware({ publishableKey: '...' })
+    authMiddleware({ frontendApi: '...' })
+    authMiddleware({ publishableKey: '...' })
     ```
   </AccordionPanel>
 
   <AccordionPanel>
     The `apiKey` argument passed to `createClerkClient` must be changed to `secretKey`.
 
-    ```diff {{ prettier: false }}
+    ```jsx {{ prettier: false, del: [3], ins: [4] }}
     import { createClerkClient } from '@clerk/nextjs/server';
 
-    - createClerkClient({ apiKey: '...' });
-    + createClerkClient({ secretKey: '...' });
+    createClerkClient({ apiKey: '...' });
+    createClerkClient({ secretKey: '...' });
     ```
   </AccordionPanel>
 
   <AccordionPanel>
     The `frontendApi` argument passed to `createClerkClient` must be changed to `publishableKey`. Note that the values of the two keys are different, so both keys and values need to be changed. You can find your application's publishable key in the Clerk dashboard.
 
-    ```diff {{ prettier: false }}
+    ```jsx {{ prettier: false, del: [3], ins: [4] }}
     import { createClerkClient } from '@clerk/nextjs/server';
 
-    - createClerkClient({ frontendApi: '...' });
-    + createClerkClient({ publishableKey: '...' });
+    createClerkClient({ frontendApi: '...' });
+    createClerkClient({ publishableKey: '...' });
     ```
   </AccordionPanel>
 
   <AccordionPanel>
     The `apiKey` argument passed to `getAuth` must be changed to `secretKey`.
 
-    ```diff {{ prettier: false }}
-    - getAuth({ apiKey: '...' })
-    + getAuth({ secretKey: '...' })
+    ```jsx {{ prettier: false, del: [1], ins: [2] }}
+    getAuth({ apiKey: '...' })
+    getAuth({ secretKey: '...' })
     ```
   </AccordionPanel>
 
@@ -773,9 +773,9 @@ As part of this major version, a number of previously deprecated props, arugment
   <AccordionPanel>
     The `MultiSessionAppSupport` import path has changed from `@clerk/nextjs` to `@clerk/nextjs/internal`. You must update your import path in order for it to work correctly. Note that internal imports are not intended for usage and are outside the scope of semver. Example below of the fix that needs to be made:
 
-    ```diff {{ prettier: false }}
-    - import { MultiSessionAppSupport } from "@clerk/nextjs"
-    + import { MultiSessionAppSupport } from "@clerk/nextjs/internal"
+    ```jsx {{ prettier: false, del: [1], ins: [2] }}
+    import { MultiSessionAppSupport } from "@clerk/nextjs"
+    import { MultiSessionAppSupport } from "@clerk/nextjs/internal"
     ```
   </AccordionPanel>
 
@@ -792,104 +792,104 @@ As part of this major version, a number of previously deprecated props, arugment
   <AccordionPanel>
     There have been a couple changes to the pagination arguments that can be passed into this function - `limit` has been renamed to `pageSize`, and `offset` has been renamed to `initialPage`. This will help to make it more clear and simple to reason about pagination control. Example of how changes might look below:
 
-    ```diff {{ prettier: false }}
-      const { data } = await organization.getRoles({
-    -   limit: 10,
-    +   pageSize: 10,
-    -   offset: 10,
-    +   initialPage: 2,
-      })
+    ```jsx {{ prettier: false, del: [2, 4], ins: [3, 5] }}
+    const { data } = await organization.getRoles({
+      limit: 10,
+      pageSize: 10,
+      offset: 10,
+      initialPage: 2,
+    })
     ```
   </AccordionPanel>
 
   <AccordionPanel>
     There have been a couple changes to the pagination arguments that can be passed into this function - `limit` has been renamed to `pageSize`, and `offset` has been renamed to `initialPage`. This will help to make it more clear and simple to reason about pagination control. Example of how changes might look below:
 
-    ```diff {{ prettier: false }}
-      const { data } = await organization.getMemberships({
-    -   limit: 10,
-    +   pageSize: 10,
-    -   offset: 10,
-    +   initialPage: 2,
-      })
+    ```jsx {{ prettier: false, del: [2, 4], ins: [3, 5] }}
+    const { data } = await organization.getMemberships({
+      limit: 10,
+      pageSize: 10,
+      offset: 10,
+      initialPage: 2,
+    })
     ```
   </AccordionPanel>
 
   <AccordionPanel>
     There have been a couple changes to the pagination arguments that can be passed into this function - `limit` has been renamed to `pageSize`, and `offset` has been renamed to `initialPage`. This will help to make it more clear and simple to reason about pagination control. Example of how changes might look below:
 
-    ```diff {{ prettier: false }}
-      const { data } = await organization.getDomains({
-    -   limit: 10,
-    +   pageSize: 10,
-    -   offset: 10,
-    +   initialPage: 2,
-      })
+    ```jsx {{ prettier: false, del: [2, 4], ins: [3, 5] }}
+    const { data } = await organization.getDomains({
+      limit: 10,
+      pageSize: 10,
+      offset: 10,
+      initialPage: 2,
+    })
     ```
   </AccordionPanel>
 
   <AccordionPanel>
     There have been a couple changes to the pagination arguments that can be passed into this function - `limit` has been renamed to `pageSize`, and `offset` has been renamed to `initialPage`. This will help to make it more clear and simple to reason about pagination control. Example of how changes might look below:
 
-    ```diff {{ prettier: false }}
-      const { data } = await organization.getInvitations({
-    -   limit: 10,
-    +   pageSize: 10,
-    -   offset: 10,
-    +   initialPage: 2,
-      })
+    ```jsx {{ prettier: false, del: [2, 4], ins: [3, 5] }}
+    const { data } = await organization.getInvitations({
+      limit: 10,
+      pageSize: 10,
+      offset: 10,
+      initialPage: 2,
+    })
     ```
   </AccordionPanel>
 
   <AccordionPanel>
     There have been a couple changes to the pagination arguments that can be passed into this function - `limit` has been renamed to `pageSize`, and `offset` has been renamed to `initialPage`. This will help to make it more clear and simple to reason about pagination control. Example of how changes might look below:
 
-    ```diff {{ prettier: false }}
-      const { data } = await organization.getMembershipRequests({
-    -   limit: 10,
-    +   pageSize: 10,
-    -   offset: 10,
-    +   initialPage: 2,
-      })
+    ```jsx {{ prettier: false, del: [2, 4], ins: [3, 5] }}
+    const { data } = await organization.getMembershipRequests({
+      limit: 10,
+      pageSize: 10,
+      offset: 10,
+      initialPage: 2,
+    })
     ```
   </AccordionPanel>
 
   <AccordionPanel>
     There have been a couple changes to the pagination arguments that can be passed into this function - `limit` has been renamed to `pageSize`, and `offset` has been renamed to `initialPage`. This will help to make it more clear and simple to reason about pagination control. Example of how changes might look below:
 
-    ```diff {{ prettier: false }}
-      const { data } = await user.getOrganizationInvitations({
-    -   limit: 10,
-    +   pageSize: 10,
-    -   offset: 10,
-    +   initialPage: 2,
-      })
+    ```jsx {{ prettier: false, del: [2, 4], ins: [3, 5] }}
+    const { data } = await user.getOrganizationInvitations({
+      limit: 10,
+      pageSize: 10,
+      offset: 10,
+      initialPage: 2,
+    })
     ```
   </AccordionPanel>
 
   <AccordionPanel>
     There have been a couple changes to the pagination arguments that can be passed into this function - `limit` has been renamed to `pageSize`, and `offset` has been renamed to `initialPage`. This will help to make it more clear and simple to reason about pagination control. Example of how changes might look below:
 
-    ```diff {{ prettier: false }}
-      const { data } = await user.getOrganizationSuggestions({
-    -   limit: 10,
-    +   pageSize: 10,
-    -   offset: 10,
-    +   initialPage: 2,
-      })
+    ```jsx {{ prettier: false, del: [2, 4], ins: [3, 5] }}
+    const { data } = await user.getOrganizationSuggestions({
+      limit: 10,
+      pageSize: 10,
+      offset: 10,
+      initialPage: 2,
+    })
     ```
   </AccordionPanel>
 
   <AccordionPanel>
     There have been a couple changes to the pagination arguments that can be passed into this function - `limit` has been renamed to `pageSize`, and `offset` has been renamed to `initialPage`. This will help to make it more clear and simple to reason about pagination control. Example of how changes might look below:
 
-    ```diff {{ prettier: false }}
-      const { data } = await user.getOrganizationMemberships({
-    -   limit: 10,
-    +   pageSize: 10,
-    -   offset: 10,
-    +   initialPage: 2,
-      })
+    ```jsx {{ prettier: false, del: [2, 4], ins: [3, 5] }}
+    const { data } = await user.getOrganizationMemberships({
+      limit: 10,
+      pageSize: 10,
+      offset: 10,
+      initialPage: 2,
+    })
     ```
   </AccordionPanel>
 
@@ -898,9 +898,9 @@ As part of this major version, a number of previously deprecated props, arugment
 
     Here's an example of how the response shape would change with this modification:
 
-    ```diff {{ prettier: false }}
-    - const data = await clerkClient.users.getOrganizationMembershipList()
-    + const { data, totalCount } = await clerkClient.users.getOrganizationMembershipList()
+    ```jsx {{ prettier: false, del: [1], ins: [2] }}
+    const data = await clerkClient.users.getOrganizationMembershipList()
+    const { data, totalCount } = await clerkClient.users.getOrganizationMembershipList()
     ```
   </AccordionPanel>
 
@@ -909,34 +909,34 @@ As part of this major version, a number of previously deprecated props, arugment
 
     Here's an example of how the response shape would change with this modification:
 
-    ```diff {{ prettier: false }}
-    - const data = await clerkClient.users.getOrganizationInvitationList()
-    + const { data, totalCount } = await clerkClient.users.getOrganizationInvitationList()
+    ```jsx {{ prettier: false, del: [1], ins: [2] }}
+    const data = await clerkClient.users.getOrganizationInvitationList()
+    const { data, totalCount } = await clerkClient.users.getOrganizationInvitationList()
     ```
   </AccordionPanel>
 
   <AccordionPanel>
     The return type for this function was previously `[Items]` but has now been updated to `{ data: [Items], totalCount: number }`. Since Clerk's API responses are paginated, the `totalCount` property is helpful in determining the total number of items in the response easily. A before/after code example can be seen below:
 
-    ```diff {{ prettier: false }}
-      const data = await clerkClient.organizations.getOrganizationInvitationList({
-        organizationId: "...",
-      })
+    ```jsx {{ prettier: false, del: [5], ins: [6] }}
+    const data = await clerkClient.organizations.getOrganizationInvitationList({
+      organizationId: "...",
+    })
 
-    - data.forEach(() => {})
-    + data.data.forEach(() => {})
+    data.forEach(() => {})
+    data.data.forEach(() => {})
     ```
   </AccordionPanel>
 
   <AccordionPanel>
     The return type for this function was previously `[Items]` but has now been updated to `{ data: [Items], totalCount: number }`. Since Clerk's API responses are paginated, the `totalCount` property is helpful in determining the total number of items in the response easily. A before/after code example can be seen below:
 
-    ```diff {{ prettier: false }}
-      const { user } = useUser()
-      const membershipList = user.getOrganizationMembershipList()
+    ```jsx {{ prettier: false, del: [4], ins: [5] }}
+    const { user } = useUser()
+    const membershipList = user.getOrganizationMembershipList()
 
-    - membershipList.forEach(() => {})
-    + membershipList.data.forEach(() => {})
+    membershipList.forEach(() => {})
+    membershipList.data.forEach(() => {})
     ```
   </AccordionPanel>
 
@@ -945,21 +945,21 @@ As part of this major version, a number of previously deprecated props, arugment
 
     Here's an example of how the response shape would change with this modification:
 
-    ```diff {{ prettier: false }}
-    - const data = await clerkClient.users.getOrganizationList()
-    + const { data, totalCount } = await clerkClient.users.getOrganizationList()
+    ```jsx {{ prettier: false, del: [1], ins: [2] }}
+    const data = await clerkClient.users.getOrganizationList()
+    const { data, totalCount } = await clerkClient.users.getOrganizationList()
     ```
   </AccordionPanel>
 
   <AccordionPanel>
     The return type for this function was previously `[Items]` but has now been updated to `{ data: [Items], totalCount: number }`. Since Clerk's API responses are paginated, the `totalCount` property is helpful in determining the total number of items in the response easily. A before/after code example can be seen below:
 
-    ```diff {{ prettier: false }}
-      const { organization } = useOrganization()
-      const orgList = organization.getOrganizationList()
+    ```jsx {{ prettier: false, del: [4], ins: [5] }}
+    const { organization } = useOrganization()
+    const orgList = organization.getOrganizationList()
 
-    - orgList.forEach(() => {})
-    + orgList.data.forEach(() => {})
+    orgList.forEach(() => {})
+    orgList.data.forEach(() => {})
     ```
   </AccordionPanel>
 
@@ -968,9 +968,9 @@ As part of this major version, a number of previously deprecated props, arugment
 
     Here's an example of how the response shape would change with this modification:
 
-    ```diff {{ prettier: false }}
-    - const data = await clerkClient.invitations.getInvitationList()
-    + const { data, totalCount } = await clerkClient.invitations.getInvitationList()
+    ```jsx {{ prettier: false, del: [1], ins: [2] }}
+    const data = await clerkClient.invitations.getInvitationList()
+    const { data, totalCount } = await clerkClient.invitations.getInvitationList()
     ```
   </AccordionPanel>
 
@@ -979,9 +979,9 @@ As part of this major version, a number of previously deprecated props, arugment
 
     Here's an example of how the response shape would change with this modification:
 
-    ```diff {{ prettier: false }}
-    - const data = await clerkClient.sessions.getSessionList()
-    + const { data, totalCount } = await clerkClient.sessions.getSessionList()
+    ```jsx {{ prettier: false, del: [1], ins: [2] }}
+    const data = await clerkClient.sessions.getSessionList()
+    const { data, totalCount } = await clerkClient.sessions.getSessionList()
     ```
   </AccordionPanel>
 
@@ -990,9 +990,9 @@ As part of this major version, a number of previously deprecated props, arugment
 
     Here's an example of how the response shape would change with this modification:
 
-    ```diff {{ prettier: false }}
-    - const data = await clerkClient.users.getUserList()
-    + const { data, totalCount } = await clerkClient.users.getUserList()
+    ```jsx {{ prettier: false, del: [1], ins: [2] }}
+    const data = await clerkClient.users.getUserList()
+    const { data, totalCount } = await clerkClient.users.getUserList()
     ```
   </AccordionPanel>
 
@@ -1001,9 +1001,9 @@ As part of this major version, a number of previously deprecated props, arugment
 
     Here's an example of how the response shape would change with this modification:
 
-    ```diff {{ prettier: false }}
-    - const data = await clerkClient.allowlistIdentifiers.getAllowlistIdentifierList()
-    + const { data, totalCount } = await clerkClient.allowlistIdentifiers.getAllowlistIdentifierList()
+    ```jsx {{ prettier: false, del: [1], ins: [2] }}
+    const data = await clerkClient.allowlistIdentifiers.getAllowlistIdentifierList()
+    const { data, totalCount } = await clerkClient.allowlistIdentifiers.getAllowlistIdentifierList()
     ```
   </AccordionPanel>
 
@@ -1012,9 +1012,9 @@ As part of this major version, a number of previously deprecated props, arugment
 
     Here's an example of how the response shape would change with this modification:
 
-    ```diff {{ prettier: false }}
-    - const data = await clerkClient.clients.getClientList()
-    + const { data, totalCount } = await clerkClient.allowlistIdentifiers.getClientList()
+    ```jsx {{ prettier: false, del: [1], ins: [2] }}
+    const data = await clerkClient.clients.getClientList()
+    const { data, totalCount } = await clerkClient.allowlistIdentifiers.getClientList()
     ```
   </AccordionPanel>
 
@@ -1023,9 +1023,9 @@ As part of this major version, a number of previously deprecated props, arugment
 
     Here's an example of how the response shape would change with this modification:
 
-    ```diff {{ prettier: false }}
-    - const data = await clerkClient.redirectUrls.getRedirectUrlList()
-    + const { data, totalCount } = await clerkClient.redirectUrls.getRedirectUrlList()
+    ```jsx {{ prettier: false, del: [1], ins: [2] }}
+    const data = await clerkClient.redirectUrls.getRedirectUrlList()
+    const { data, totalCount } = await clerkClient.redirectUrls.getRedirectUrlList()
     ```
   </AccordionPanel>
 
@@ -1034,24 +1034,24 @@ As part of this major version, a number of previously deprecated props, arugment
 
     Here's an example of how the response shape would change with this modification:
 
-    ```diff {{ prettier: false }}
-    - const data = await clerkClient.users.getUserOauthAccessToken()
-    + const { data, totalCount } = await clerkClient.users.getUserOauthAccessToken()
+    ```jsx {{ prettier: false, del: [1], ins: [2] }}
+    const data = await clerkClient.users.getUserOauthAccessToken()
+    const { data, totalCount } = await clerkClient.users.getUserOauthAccessToken()
     ```
   </AccordionPanel>
 
   <AccordionPanel>
     `setSession` should be replaced with `setActive`. The format of the parameters has changed slightly - `setActive` takes an object where `setSession` took params directly. The `setActive` function also can accept an `organization` param that is used to set the currently active organization. The return signature did not change. Read the [API documentation](/docs/references/javascript/clerk/session-methods#set-active) for more detail. This function should be expected to be returned from one of the following Clerk hooks: `useSessionList`, `useSignUp`, or `useSignIn`. Some migration examples:
 
-    ```diff {{ prettier: false }}
-    - await setSession('sessionID', () => void)
-    + await setActive({ session: 'sessionID',  beforeEmit: () => void })
+    ```jsx {{ prettier: false, del: [1, 4, 7], ins: [2, 5, 8] }}
+    await setSession('sessionID', () => void)
+    await setActive({ session: 'sessionID',  beforeEmit: () => void })
 
-    - await setSession(sessionObj)
-    + await setActive({ session: sessionObj })
+    await setSession(sessionObj)
+    await setActive({ session: sessionObj })
 
-    - await setSession(sessionObj, () => void)
-    + await setActive({ session: sessionObj,  beforeEmit: () => void })
+    await setSession(sessionObj, () => void)
+    await setActive({ session: sessionObj,  beforeEmit: () => void })
     ```
 
     `setActive` also supports setting an active organization:
@@ -1074,18 +1074,18 @@ As part of this major version, a number of previously deprecated props, arugment
   <AccordionPanel>
     Passing a string as an argument to `Organization.create` is no longer possible - instead, pass an object with the `name` property.
 
-    ```diff {{ prettier: false }}
-    - Organization.create('...');
-    + Organization.create({ name: '...' });
+    ```jsx {{ prettier: false, del: [1], ins: [2] }}
+    Organization.create('...');
+    Organization.create({ name: '...' });
     ```
   </AccordionPanel>
 
   <AccordionPanel>
     The `Organization.getPendingInvitations()` method has been removed. You can use `Organization.getInvitations` instead.
 
-    ```diff {{ prettier: false }}
-    - Organization.getPendingInvitations();
-    + Organization.getInvitations({ status: 'pending' });
+    ```jsx {{ prettier: false, del: [1], ins: [2] }}
+    Organization.getPendingInvitations();
+    Organization.getInvitations({ status: 'pending' });
     ```
   </AccordionPanel>
 
@@ -1108,9 +1108,9 @@ As part of this major version, a number of previously deprecated props, arugment
   <AccordionPanel>
     The `isMetamaskError` import path has changed from `@clerk/react` to `@clerk/react/errors`. You must update your import path in order for it to work correctly. Example below of the fix that needs to be made:
 
-    ```diff {{ prettier: false }}
-    - import { isMetamaskError } from "@clerk/react"
-    + import { isMetamaskError } from "@clerk/react/errors"
+    ```jsx {{ prettier: false, del: [1], ins: [2] }}
+    import { isMetamaskError } from "@clerk/react"
+    import { isMetamaskError } from "@clerk/react/errors"
     ```
   </AccordionPanel>
 
@@ -1234,19 +1234,19 @@ As part of this major version, a number of previously deprecated props, arugment
   <AccordionPanel>
     The `signOutCallback` prop on the [`<SignOutButton />` component](/docs/components/unstyled/sign-out-button) has been removed. Instead, you can use the `redirectUrl` prop. Example below:
 
-    ```diff {{ prettier: false }}
-      import { SignOutButton } from "@clerk/clerk-react";
+    ```jsx {{ prettier: false, del: [6], ins: [7] }}
+    import { SignOutButton } from "@clerk/clerk-react";
 
-      export const Signout = () => {
-        return (
-          <SignOutButton
-    -       signOutCallback={() => { window.location.href = "/your-path" }}
-    +       redirectUrl="/your-path"
-          >
-            <button>Sign Out</button>
-          </SignOutButton>
-        )
-      }
+    export const Signout = () => {
+      return (
+        <SignOutButton
+          signOutCallback={() => { window.location.href = "/your-path" }}
+          redirectUrl="/your-path"
+        >
+          <button>Sign Out</button>
+        </SignOutButton>
+      )
+    }
     ```
   </AccordionPanel>
 </Accordion>

--- a/docs/upgrade-guides/core-2/nextjs.mdx
+++ b/docs/upgrade-guides/core-2/nextjs.mdx
@@ -142,7 +142,7 @@ Clerk strongly recommends migrating to the new `clerkMiddleware()` for an improv
 
 The most basic migration will be updating the import and changing out the default export, then mirroring the previous behavior of protecting all routes except `/sign-in` or `/sign-up` by doing the following:
 
-```jsx {{ prettier: false, del: [1, 6], ins: [2, 4, [7, 11]] }}
+```js {{ prettier: false, del: [1, 6], ins: [2, 4, [7, 11]] }}
 import { authMiddleware } from "@clerk/nextjs/server"
 import { clerkMiddleware, createRouteMatcher } from '@clerk/nextjs/server'
 
@@ -382,7 +382,7 @@ As part of this release, some of the top-level exports of `@clerk/nextjs` have b
   <AccordionPanel>
     Previously these exports have been exported both from `@clerk/nextjs` and `@clerk/nextjs/server`. As of v5 they are only exported from the latter. Going forward, the expectation can be that any imports that are intended to run within react on the client side, will come from `@clerk/nextjs` and imports that are intended to run on the server, will come from `@clerk/nextjs/server`.
 
-    ```jsx {{ prettier: false, del: [14], ins: [15] }}
+    ```js {{ prettier: false, del: [14], ins: [15] }}
     import {
       auth,
       currentUser,
@@ -404,7 +404,7 @@ As part of this release, some of the top-level exports of `@clerk/nextjs` have b
   <AccordionPanel>
     Exports related to errors are now under `@clerk/nextjs/errors`.
 
-    ```jsx {{ prettier: false, del: [7], ins: [8] }}
+    ```js {{ prettier: false, del: [7], ins: [8] }}
     import {
       isClerkAPIResponseError,
       isEmailLinkError,
@@ -419,7 +419,7 @@ As part of this release, some of the top-level exports of `@clerk/nextjs` have b
   <AccordionPanel>
     The `@clerk/nextjs` import will work with both the App and Pages Router.
 
-    ```jsx {{ prettier: false, del: [1], ins: [2] }}
+    ```js {{ prettier: false, del: [1], ins: [2] }}
     import { } from "@clerk/nextjs/app-beta"
     import { } from "@clerk/nextjs"
     ```
@@ -430,21 +430,21 @@ As part of this release, some of the top-level exports of `@clerk/nextjs` have b
   <AccordionPanel>
     The top-level exports support SSR by default now.
 
-    ```jsx {{ prettier: false, del: [1], ins: [2] }}
+    ```js {{ prettier: false, del: [1], ins: [2] }}
     import { } from "@clerk/nextjs/ssr"
     import { } from "@clerk/nextjs"
     ```
   </AccordionPanel>
 
   <AccordionPanel>
-    ```jsx {{ prettier: false, del: [1], ins: [2] }}
+    ```js {{ prettier: false, del: [1], ins: [2] }}
     import { } from "@clerk/nextjs/edge-middleware"
     import { } from "@clerk/nextjs"
     ```
   </AccordionPanel>
 
   <AccordionPanel>
-    ```jsx {{ prettier: false, del: [1], ins: [2] }}
+    ```js {{ prettier: false, del: [1], ins: [2] }}
     import { } from "@clerk/nextjs/edge-middlewarefiles"
     import { } from "@clerk/nextjs"
     ```
@@ -453,7 +453,7 @@ As part of this release, some of the top-level exports of `@clerk/nextjs` have b
   <AccordionPanel>
     The `@clerk/nextjs/api` subpath was removed completely. It re-exported helpers from `@clerk/clerk-sdk-node` and its types. If you relied on these, import from `@clerk/clerk-sdk-node` directly instead.
 
-    ```jsx {{ prettier: false, del: [8, 11], ins: [9, 12] }}
+    ```js {{ prettier: false, del: [8, 11], ins: [9, 12] }}
     import type {
       ClerkMiddleware,
       ClerkMiddlewareOptions,
@@ -606,7 +606,7 @@ As part of this major version, a number of previously deprecated props, arugment
   <AccordionPanel>
     If you are updating a user's password via the [`User.update` method](/docs/references/javascript/user/user#update), it must be changed to [`User.updatePassword`](/docs/references/javascript/user/password-management#update-password) instead. This method will require the current password as well as the desired new password. We made this update to improve the security of password changes. Example below:
 
-    ```jsx {{ prettier: false, del: [1], ins: [[3, 7]] }}
+    ```js {{ prettier: false, del: [1], ins: [[3, 7]] }}
     user.update({ password: 'foo' });
 
     user.updatePassword({
@@ -634,7 +634,7 @@ As part of this major version, a number of previously deprecated props, arugment
   <AccordionPanel>
     The `apiKey` argument passed to `authMiddleware` must be changed to `secretKey`.
 
-    ```jsx {{ prettier: false, del: [3], ins: [4] }}
+    ```js {{ prettier: false, del: [3], ins: [4] }}
     import { authMiddleware } from '@clerk/nextjs/server';
 
     authMiddleware({ apiKey: '...' });
@@ -645,7 +645,7 @@ As part of this major version, a number of previously deprecated props, arugment
   <AccordionPanel>
     The `frontendApi` argument passed to `authMiddleware` must be changed to `publishableKey`
 
-    ```jsx {{ prettier: false, del: [3], ins: [4] }}
+    ```js {{ prettier: false, del: [3], ins: [4] }}
     import { authMiddleware } from "@clerk/nextjs/server"
 
     authMiddleware({ frontendApi: '...' })
@@ -656,7 +656,7 @@ As part of this major version, a number of previously deprecated props, arugment
   <AccordionPanel>
     The `apiKey` argument passed to `createClerkClient` must be changed to `secretKey`.
 
-    ```jsx {{ prettier: false, del: [3], ins: [4] }}
+    ```js {{ prettier: false, del: [3], ins: [4] }}
     import { createClerkClient } from '@clerk/nextjs/server';
 
     createClerkClient({ apiKey: '...' });
@@ -667,7 +667,7 @@ As part of this major version, a number of previously deprecated props, arugment
   <AccordionPanel>
     The `frontendApi` argument passed to `createClerkClient` must be changed to `publishableKey`. Note that the values of the two keys are different, so both keys and values need to be changed. You can find your application's publishable key in the Clerk dashboard.
 
-    ```jsx {{ prettier: false, del: [3], ins: [4] }}
+    ```js {{ prettier: false, del: [3], ins: [4] }}
     import { createClerkClient } from '@clerk/nextjs/server';
 
     createClerkClient({ frontendApi: '...' });
@@ -678,7 +678,7 @@ As part of this major version, a number of previously deprecated props, arugment
   <AccordionPanel>
     The `apiKey` argument passed to `getAuth` must be changed to `secretKey`.
 
-    ```jsx {{ prettier: false, del: [1], ins: [2] }}
+    ```js {{ prettier: false, del: [1], ins: [2] }}
     getAuth({ apiKey: '...' })
     getAuth({ secretKey: '...' })
     ```
@@ -773,7 +773,7 @@ As part of this major version, a number of previously deprecated props, arugment
   <AccordionPanel>
     The `MultiSessionAppSupport` import path has changed from `@clerk/nextjs` to `@clerk/nextjs/internal`. You must update your import path in order for it to work correctly. Note that internal imports are not intended for usage and are outside the scope of semver. Example below of the fix that needs to be made:
 
-    ```jsx {{ prettier: false, del: [1], ins: [2] }}
+    ```js {{ prettier: false, del: [1], ins: [2] }}
     import { MultiSessionAppSupport } from "@clerk/nextjs"
     import { MultiSessionAppSupport } from "@clerk/nextjs/internal"
     ```
@@ -792,7 +792,7 @@ As part of this major version, a number of previously deprecated props, arugment
   <AccordionPanel>
     There have been a couple changes to the pagination arguments that can be passed into this function - `limit` has been renamed to `pageSize`, and `offset` has been renamed to `initialPage`. This will help to make it more clear and simple to reason about pagination control. Example of how changes might look below:
 
-    ```jsx {{ prettier: false, del: [2, 4], ins: [3, 5] }}
+    ```js {{ prettier: false, del: [2, 4], ins: [3, 5] }}
     const { data } = await organization.getRoles({
       limit: 10,
       pageSize: 10,
@@ -805,7 +805,7 @@ As part of this major version, a number of previously deprecated props, arugment
   <AccordionPanel>
     There have been a couple changes to the pagination arguments that can be passed into this function - `limit` has been renamed to `pageSize`, and `offset` has been renamed to `initialPage`. This will help to make it more clear and simple to reason about pagination control. Example of how changes might look below:
 
-    ```jsx {{ prettier: false, del: [2, 4], ins: [3, 5] }}
+    ```js {{ prettier: false, del: [2, 4], ins: [3, 5] }}
     const { data } = await organization.getMemberships({
       limit: 10,
       pageSize: 10,
@@ -818,7 +818,7 @@ As part of this major version, a number of previously deprecated props, arugment
   <AccordionPanel>
     There have been a couple changes to the pagination arguments that can be passed into this function - `limit` has been renamed to `pageSize`, and `offset` has been renamed to `initialPage`. This will help to make it more clear and simple to reason about pagination control. Example of how changes might look below:
 
-    ```jsx {{ prettier: false, del: [2, 4], ins: [3, 5] }}
+    ```js {{ prettier: false, del: [2, 4], ins: [3, 5] }}
     const { data } = await organization.getDomains({
       limit: 10,
       pageSize: 10,
@@ -831,7 +831,7 @@ As part of this major version, a number of previously deprecated props, arugment
   <AccordionPanel>
     There have been a couple changes to the pagination arguments that can be passed into this function - `limit` has been renamed to `pageSize`, and `offset` has been renamed to `initialPage`. This will help to make it more clear and simple to reason about pagination control. Example of how changes might look below:
 
-    ```jsx {{ prettier: false, del: [2, 4], ins: [3, 5] }}
+    ```js {{ prettier: false, del: [2, 4], ins: [3, 5] }}
     const { data } = await organization.getInvitations({
       limit: 10,
       pageSize: 10,
@@ -844,7 +844,7 @@ As part of this major version, a number of previously deprecated props, arugment
   <AccordionPanel>
     There have been a couple changes to the pagination arguments that can be passed into this function - `limit` has been renamed to `pageSize`, and `offset` has been renamed to `initialPage`. This will help to make it more clear and simple to reason about pagination control. Example of how changes might look below:
 
-    ```jsx {{ prettier: false, del: [2, 4], ins: [3, 5] }}
+    ```js {{ prettier: false, del: [2, 4], ins: [3, 5] }}
     const { data } = await organization.getMembershipRequests({
       limit: 10,
       pageSize: 10,
@@ -857,7 +857,7 @@ As part of this major version, a number of previously deprecated props, arugment
   <AccordionPanel>
     There have been a couple changes to the pagination arguments that can be passed into this function - `limit` has been renamed to `pageSize`, and `offset` has been renamed to `initialPage`. This will help to make it more clear and simple to reason about pagination control. Example of how changes might look below:
 
-    ```jsx {{ prettier: false, del: [2, 4], ins: [3, 5] }}
+    ```js {{ prettier: false, del: [2, 4], ins: [3, 5] }}
     const { data } = await user.getOrganizationInvitations({
       limit: 10,
       pageSize: 10,
@@ -870,7 +870,7 @@ As part of this major version, a number of previously deprecated props, arugment
   <AccordionPanel>
     There have been a couple changes to the pagination arguments that can be passed into this function - `limit` has been renamed to `pageSize`, and `offset` has been renamed to `initialPage`. This will help to make it more clear and simple to reason about pagination control. Example of how changes might look below:
 
-    ```jsx {{ prettier: false, del: [2, 4], ins: [3, 5] }}
+    ```js {{ prettier: false, del: [2, 4], ins: [3, 5] }}
     const { data } = await user.getOrganizationSuggestions({
       limit: 10,
       pageSize: 10,
@@ -883,7 +883,7 @@ As part of this major version, a number of previously deprecated props, arugment
   <AccordionPanel>
     There have been a couple changes to the pagination arguments that can be passed into this function - `limit` has been renamed to `pageSize`, and `offset` has been renamed to `initialPage`. This will help to make it more clear and simple to reason about pagination control. Example of how changes might look below:
 
-    ```jsx {{ prettier: false, del: [2, 4], ins: [3, 5] }}
+    ```js {{ prettier: false, del: [2, 4], ins: [3, 5] }}
     const { data } = await user.getOrganizationMemberships({
       limit: 10,
       pageSize: 10,
@@ -898,7 +898,7 @@ As part of this major version, a number of previously deprecated props, arugment
 
     Here's an example of how the response shape would change with this modification:
 
-    ```jsx {{ prettier: false, del: [1], ins: [2] }}
+    ```js {{ prettier: false, del: [1], ins: [2] }}
     const data = await clerkClient.users.getOrganizationMembershipList()
     const { data, totalCount } = await clerkClient.users.getOrganizationMembershipList()
     ```
@@ -909,7 +909,7 @@ As part of this major version, a number of previously deprecated props, arugment
 
     Here's an example of how the response shape would change with this modification:
 
-    ```jsx {{ prettier: false, del: [1], ins: [2] }}
+    ```js {{ prettier: false, del: [1], ins: [2] }}
     const data = await clerkClient.users.getOrganizationInvitationList()
     const { data, totalCount } = await clerkClient.users.getOrganizationInvitationList()
     ```
@@ -918,7 +918,7 @@ As part of this major version, a number of previously deprecated props, arugment
   <AccordionPanel>
     The return type for this function was previously `[Items]` but has now been updated to `{ data: [Items], totalCount: number }`. Since Clerk's API responses are paginated, the `totalCount` property is helpful in determining the total number of items in the response easily. A before/after code example can be seen below:
 
-    ```jsx {{ prettier: false, del: [5], ins: [6] }}
+    ```js {{ prettier: false, del: [5], ins: [6] }}
     const data = await clerkClient.organizations.getOrganizationInvitationList({
       organizationId: "...",
     })
@@ -931,7 +931,7 @@ As part of this major version, a number of previously deprecated props, arugment
   <AccordionPanel>
     The return type for this function was previously `[Items]` but has now been updated to `{ data: [Items], totalCount: number }`. Since Clerk's API responses are paginated, the `totalCount` property is helpful in determining the total number of items in the response easily. A before/after code example can be seen below:
 
-    ```jsx {{ prettier: false, del: [4], ins: [5] }}
+    ```js {{ prettier: false, del: [4], ins: [5] }}
     const { user } = useUser()
     const membershipList = user.getOrganizationMembershipList()
 
@@ -945,7 +945,7 @@ As part of this major version, a number of previously deprecated props, arugment
 
     Here's an example of how the response shape would change with this modification:
 
-    ```jsx {{ prettier: false, del: [1], ins: [2] }}
+    ```js {{ prettier: false, del: [1], ins: [2] }}
     const data = await clerkClient.users.getOrganizationList()
     const { data, totalCount } = await clerkClient.users.getOrganizationList()
     ```
@@ -954,7 +954,7 @@ As part of this major version, a number of previously deprecated props, arugment
   <AccordionPanel>
     The return type for this function was previously `[Items]` but has now been updated to `{ data: [Items], totalCount: number }`. Since Clerk's API responses are paginated, the `totalCount` property is helpful in determining the total number of items in the response easily. A before/after code example can be seen below:
 
-    ```jsx {{ prettier: false, del: [4], ins: [5] }}
+    ```js {{ prettier: false, del: [4], ins: [5] }}
     const { organization } = useOrganization()
     const orgList = organization.getOrganizationList()
 
@@ -968,7 +968,7 @@ As part of this major version, a number of previously deprecated props, arugment
 
     Here's an example of how the response shape would change with this modification:
 
-    ```jsx {{ prettier: false, del: [1], ins: [2] }}
+    ```js {{ prettier: false, del: [1], ins: [2] }}
     const data = await clerkClient.invitations.getInvitationList()
     const { data, totalCount } = await clerkClient.invitations.getInvitationList()
     ```
@@ -979,7 +979,7 @@ As part of this major version, a number of previously deprecated props, arugment
 
     Here's an example of how the response shape would change with this modification:
 
-    ```jsx {{ prettier: false, del: [1], ins: [2] }}
+    ```js {{ prettier: false, del: [1], ins: [2] }}
     const data = await clerkClient.sessions.getSessionList()
     const { data, totalCount } = await clerkClient.sessions.getSessionList()
     ```
@@ -990,7 +990,7 @@ As part of this major version, a number of previously deprecated props, arugment
 
     Here's an example of how the response shape would change with this modification:
 
-    ```jsx {{ prettier: false, del: [1], ins: [2] }}
+    ```js {{ prettier: false, del: [1], ins: [2] }}
     const data = await clerkClient.users.getUserList()
     const { data, totalCount } = await clerkClient.users.getUserList()
     ```
@@ -1001,7 +1001,7 @@ As part of this major version, a number of previously deprecated props, arugment
 
     Here's an example of how the response shape would change with this modification:
 
-    ```jsx {{ prettier: false, del: [1], ins: [2] }}
+    ```js {{ prettier: false, del: [1], ins: [2] }}
     const data = await clerkClient.allowlistIdentifiers.getAllowlistIdentifierList()
     const { data, totalCount } = await clerkClient.allowlistIdentifiers.getAllowlistIdentifierList()
     ```
@@ -1012,7 +1012,7 @@ As part of this major version, a number of previously deprecated props, arugment
 
     Here's an example of how the response shape would change with this modification:
 
-    ```jsx {{ prettier: false, del: [1], ins: [2] }}
+    ```js {{ prettier: false, del: [1], ins: [2] }}
     const data = await clerkClient.clients.getClientList()
     const { data, totalCount } = await clerkClient.allowlistIdentifiers.getClientList()
     ```
@@ -1023,7 +1023,7 @@ As part of this major version, a number of previously deprecated props, arugment
 
     Here's an example of how the response shape would change with this modification:
 
-    ```jsx {{ prettier: false, del: [1], ins: [2] }}
+    ```js {{ prettier: false, del: [1], ins: [2] }}
     const data = await clerkClient.redirectUrls.getRedirectUrlList()
     const { data, totalCount } = await clerkClient.redirectUrls.getRedirectUrlList()
     ```
@@ -1034,7 +1034,7 @@ As part of this major version, a number of previously deprecated props, arugment
 
     Here's an example of how the response shape would change with this modification:
 
-    ```jsx {{ prettier: false, del: [1], ins: [2] }}
+    ```js {{ prettier: false, del: [1], ins: [2] }}
     const data = await clerkClient.users.getUserOauthAccessToken()
     const { data, totalCount } = await clerkClient.users.getUserOauthAccessToken()
     ```
@@ -1043,7 +1043,7 @@ As part of this major version, a number of previously deprecated props, arugment
   <AccordionPanel>
     `setSession` should be replaced with `setActive`. The format of the parameters has changed slightly - `setActive` takes an object where `setSession` took params directly. The `setActive` function also can accept an `organization` param that is used to set the currently active organization. The return signature did not change. Read the [API documentation](/docs/references/javascript/clerk/session-methods#set-active) for more detail. This function should be expected to be returned from one of the following Clerk hooks: `useSessionList`, `useSignUp`, or `useSignIn`. Some migration examples:
 
-    ```jsx {{ prettier: false, del: [1, 4, 7], ins: [2, 5, 8] }}
+    ```js {{ prettier: false, del: [1, 4, 7], ins: [2, 5, 8] }}
     await setSession('sessionID', () => void)
     await setActive({ session: 'sessionID',  beforeEmit: () => void })
 
@@ -1074,7 +1074,7 @@ As part of this major version, a number of previously deprecated props, arugment
   <AccordionPanel>
     Passing a string as an argument to `Organization.create` is no longer possible - instead, pass an object with the `name` property.
 
-    ```jsx {{ prettier: false, del: [1], ins: [2] }}
+    ```js {{ prettier: false, del: [1], ins: [2] }}
     Organization.create('...');
     Organization.create({ name: '...' });
     ```
@@ -1083,7 +1083,7 @@ As part of this major version, a number of previously deprecated props, arugment
   <AccordionPanel>
     The `Organization.getPendingInvitations()` method has been removed. You can use `Organization.getInvitations` instead.
 
-    ```jsx {{ prettier: false, del: [1], ins: [2] }}
+    ```js {{ prettier: false, del: [1], ins: [2] }}
     Organization.getPendingInvitations();
     Organization.getInvitations({ status: 'pending' });
     ```
@@ -1108,7 +1108,7 @@ As part of this major version, a number of previously deprecated props, arugment
   <AccordionPanel>
     The `isMetamaskError` import path has changed from `@clerk/react` to `@clerk/react/errors`. You must update your import path in order for it to work correctly. Example below of the fix that needs to be made:
 
-    ```jsx {{ prettier: false, del: [1], ins: [2] }}
+    ```js {{ prettier: false, del: [1], ins: [2] }}
     import { isMetamaskError } from "@clerk/react"
     import { isMetamaskError } from "@clerk/react/errors"
     ```

--- a/docs/upgrade-guides/core-2/node.mdx
+++ b/docs/upgrade-guides/core-2/node.mdx
@@ -67,7 +67,7 @@ If you are having trouble with `npx`, it's also possible to install directly wit
 
 If you are using either of these import paths, they are no longer necessary and you can import directly from the top level `@clerk/express` path.
 
-```jsx {{ prettier: false, del: [1, 2], ins: [3] }}
+```js {{ prettier: false, del: [1, 2], ins: [3] }}
 import { ... } from "@clerk/clerk-sdk-node/esm/instance";
 import { ... } from "@clerk/clerk-sdk-node/cjs/instance";
 import { ... } from "@clerk/clerk-sdk-node";
@@ -84,7 +84,7 @@ The following setter methods have been removed in the lastest version. If you we
 
 Code example:
 
-```jsx {{ prettier: false, del: [[3, 6], [9, 12]], ins: [[15, 18]] }}
+```js {{ prettier: false, del: [[3, 6], [9, 12]], ins: [[15, 18]] }}
 import {
    clerkClient,
    setClerkApiKey,
@@ -200,7 +200,7 @@ As part of this major version, a number of previously deprecated props, arugment
   <AccordionPanel>
     If you are updating a user's password via the [`User.update` method](/docs/references/javascript/user/user#update), it must be changed to [`User.updatePassword`](/docs/references/javascript/user/password-management#update-password) instead. This method will require the current password as well as the desired new password. We made this update to improve the security of password changes. Example below:
 
-    ```jsx {{ prettier: false, del: [1], ins: [[3, 7]] }}
+    ```js {{ prettier: false, del: [1], ins: [[3, 7]] }}
     user.update({ password: 'foo' });
 
     user.updatePassword({
@@ -222,7 +222,7 @@ As part of this major version, a number of previously deprecated props, arugment
   <AccordionPanel>
     The `apiKey` argument passed to `ClerkExpressRequireAuth` must be changed to `secretKey`.
 
-    ```jsx {{ prettier: false, del: [3], ins: [4] }}
+    ```js {{ prettier: false, del: [3], ins: [4] }}
     import { ClerkExpressRequireAuth } from '@clerk/clerk-sdk-node';
 
     ClerkExpressRequireAuth({ apiKey: '...' });
@@ -233,7 +233,7 @@ As part of this major version, a number of previously deprecated props, arugment
   <AccordionPanel>
     The `apiKey` argument passed to `ClerkExpressWithAuth` must be changed to `secretKey`.
 
-    ```jsx {{ prettier: false, del: [3], ins: [4] }}
+    ```js {{ prettier: false, del: [3], ins: [4] }}
     import { ClerkExpressWithAuth } from '@clerk/clerk-sdk-node';
 
     ClerkExpressWithAuth({ apiKey: '...' });
@@ -244,7 +244,7 @@ As part of this major version, a number of previously deprecated props, arugment
   <AccordionPanel>
     The `apiKey` argument passed to `createClerkClient` must be changed to `secretKey`.
 
-    ```jsx {{ prettier: false, del: [3], ins: [4] }}
+    ```js {{ prettier: false, del: [3], ins: [4] }}
     import { createClerkClient } from '@clerk/clerk-sdk-node';
 
     createClerkClient({ apiKey: '...' });
@@ -255,7 +255,7 @@ As part of this major version, a number of previously deprecated props, arugment
   <AccordionPanel>
     The `apiKey` argument passed to `createClerkExpressRequireAuth` must be changed to `secretKey`.
 
-    ```jsx {{ prettier: false, del: [3], ins: [4] }}
+    ```js {{ prettier: false, del: [3], ins: [4] }}
     import { createClerkExpressRequireAuth } from '@clerk/clerk-sdk-node';
 
     createClerkExpressRequireAuth({ apiKey: '...' });
@@ -266,7 +266,7 @@ As part of this major version, a number of previously deprecated props, arugment
   <AccordionPanel>
     The `apiKey` argument passed to `createClerkExpressWithAuth` must be changed to `secretKey`.
 
-    ```jsx {{ prettier: false, del: [3], ins: [4] }}
+    ```js {{ prettier: false, del: [3], ins: [4] }}
     import { createClerkExpressWithAuth } from '@clerk/clerk-sdk-node';
 
     createClerkExpressWithAuth({ apiKey: '...' });
@@ -277,7 +277,7 @@ As part of this major version, a number of previously deprecated props, arugment
   <AccordionPanel>
     The `frontendApi` argument passed to `createClerkClient` must be changed to `publishableKey`. Note that the values of the two keys are different, so both keys and values need to be changed. You can find your application's publishable key in the Clerk dashboard.
 
-    ```jsx {{ prettier: false, del: [3], ins: [4] }}
+    ```js {{ prettier: false, del: [3], ins: [4] }}
     import { createClerkClient } from '@clerk/clerk-sdk-node';
 
     createClerkClient({ frontendApi: '...' });
@@ -288,7 +288,7 @@ As part of this major version, a number of previously deprecated props, arugment
   <AccordionPanel>
     The `frontendApi` argument passed to `createClerkExpressRequireAuth` must be changed to `publishableKey`. Note that the values of the two keys are different, so both keys and values need to be changed. You can find your application's publishable key in the Clerk dashboard.
 
-    ```jsx {{ prettier: false, del: [3], ins: [4] }}
+    ```js {{ prettier: false, del: [3], ins: [4] }}
     import { createClerkExpressRequireAuth } from '@clerk/clerk-sdk-node';
 
     createClerkExpressRequireAuth({ frontendApi: '...' });
@@ -299,7 +299,7 @@ As part of this major version, a number of previously deprecated props, arugment
   <AccordionPanel>
     The `frontendApi` argument passed to `ClerkExpressRequireAuth` must be changed to `publishableKey`. Note that the values of the two keys are different, so both keys and values need to be changed. You can find your application's publishable key in the Clerk dashboard.
 
-    ```jsx {{ prettier: false, del: [3], ins: [4] }}
+    ```js {{ prettier: false, del: [3], ins: [4] }}
     import { ClerkExpressRequireAuth } from '@clerk/clerk-sdk-node';
 
     ClerkExpressRequireAuth({ frontendApi: '...' });
@@ -310,7 +310,7 @@ As part of this major version, a number of previously deprecated props, arugment
   <AccordionPanel>
     The `frontendApi` argument passed to `createClerkExpressWithAuth` must be changed to `publishableKey`. Note that the values of the two keys are different, so both keys and values need to be changed. You can find your application's publishable key in the Clerk dashboard.
 
-    ```jsx {{ prettier: false, del: [3], ins: [4] }}
+    ```js {{ prettier: false, del: [3], ins: [4] }}
     import { createClerkExpressWithAuth } from '@clerk/clerk-sdk-node';
 
     createClerkExpressWithAuth({ frontendApi: '...' });
@@ -321,7 +321,7 @@ As part of this major version, a number of previously deprecated props, arugment
   <AccordionPanel>
     The `frontendApi` argument passed to `ClerkExpressWithAuth` must be changed to `publishableKey`. Note that the values of the two keys are different, so both keys and values need to be changed. You can find your application's publishable key in the Clerk dashboard.
 
-    ```jsx {{ prettier: false, del: [3], ins: [4] }}
+    ```js {{ prettier: false, del: [3], ins: [4] }}
     import { ClerkExpressWithAuth } from '@clerk/clerk-sdk-node';
 
     ClerkExpressWithAuth({ frontendApi: '...' });
@@ -338,7 +338,7 @@ As part of this major version, a number of previously deprecated props, arugment
   <AccordionPanel>
     There have been a couple changes to the pagination arguments that can be passed into this function - `limit` has been renamed to `pageSize`, and `offset` has been renamed to `initialPage`. This will help to make it more clear and simple to reason about pagination control. Example of how changes might look below:
 
-    ```jsx {{ prettier: false, del: [2, 4], ins: [3, 5] }}
+    ```js {{ prettier: false, del: [2, 4], ins: [3, 5] }}
     const { data } = await organization.getRoles({
       limit: 10,
       pageSize: 10,
@@ -351,7 +351,7 @@ As part of this major version, a number of previously deprecated props, arugment
   <AccordionPanel>
     There have been a couple changes to the pagination arguments that can be passed into this function - `limit` has been renamed to `pageSize`, and `offset` has been renamed to `initialPage`. This will help to make it more clear and simple to reason about pagination control. Example of how changes might look below:
 
-    ```jsx {{ prettier: false, del: [2, 4], ins: [3, 5] }}
+    ```js {{ prettier: false, del: [2, 4], ins: [3, 5] }}
     const { data } = await organization.getMemberships({
       limit: 10,
       pageSize: 10,
@@ -364,7 +364,7 @@ As part of this major version, a number of previously deprecated props, arugment
   <AccordionPanel>
     There have been a couple changes to the pagination arguments that can be passed into this function - `limit` has been renamed to `pageSize`, and `offset` has been renamed to `initialPage`. This will help to make it more clear and simple to reason about pagination control. Example of how changes might look below:
 
-    ```jsx {{ prettier: false, del: [2, 4], ins: [3, 5] }}
+    ```js {{ prettier: false, del: [2, 4], ins: [3, 5] }}
     const { data } = await organization.getDomains({
       limit: 10,
       pageSize: 10,
@@ -377,7 +377,7 @@ As part of this major version, a number of previously deprecated props, arugment
   <AccordionPanel>
     There have been a couple changes to the pagination arguments that can be passed into this function - `limit` has been renamed to `pageSize`, and `offset` has been renamed to `initialPage`. This will help to make it more clear and simple to reason about pagination control. Example of how changes might look below:
 
-    ```jsx {{ prettier: false, del: [2, 4], ins: [3, 5] }}
+    ```js {{ prettier: false, del: [2, 4], ins: [3, 5] }}
     const { data } = await organization.getInvitations({
       limit: 10,
       pageSize: 10,
@@ -390,7 +390,7 @@ As part of this major version, a number of previously deprecated props, arugment
   <AccordionPanel>
     There have been a couple changes to the pagination arguments that can be passed into this function - `limit` has been renamed to `pageSize`, and `offset` has been renamed to `initialPage`. This will help to make it more clear and simple to reason about pagination control. Example of how changes might look below:
 
-    ```jsx {{ prettier: false, del: [2, 4], ins: [3, 5] }}
+    ```js {{ prettier: false, del: [2, 4], ins: [3, 5] }}
     const { data } = await organization.getMembershipRequests({
       limit: 10,
       pageSize: 10,
@@ -403,7 +403,7 @@ As part of this major version, a number of previously deprecated props, arugment
   <AccordionPanel>
     There have been a couple changes to the pagination arguments that can be passed into this function - `limit` has been renamed to `pageSize`, and `offset` has been renamed to `initialPage`. This will help to make it more clear and simple to reason about pagination control. Example of how changes might look below:
 
-    ```jsx {{ prettier: false, del: [2, 4], ins: [3, 5] }}
+    ```js {{ prettier: false, del: [2, 4], ins: [3, 5] }}
     const { data } = await user.getOrganizationInvitations({
       limit: 10,
       pageSize: 10,
@@ -416,7 +416,7 @@ As part of this major version, a number of previously deprecated props, arugment
   <AccordionPanel>
     There have been a couple changes to the pagination arguments that can be passed into this function - `limit` has been renamed to `pageSize`, and `offset` has been renamed to `initialPage`. This will help to make it more clear and simple to reason about pagination control. Example of how changes might look below:
 
-    ```jsx {{ prettier: false, del: [2, 4], ins: [3, 5] }}
+    ```js {{ prettier: false, del: [2, 4], ins: [3, 5] }}
     const { data } = await user.getOrganizationSuggestions({
       limit: 10,
       pageSize: 10,
@@ -429,7 +429,7 @@ As part of this major version, a number of previously deprecated props, arugment
   <AccordionPanel>
     There have been a couple changes to the pagination arguments that can be passed into this function - `limit` has been renamed to `pageSize`, and `offset` has been renamed to `initialPage`. This will help to make it more clear and simple to reason about pagination control. Example of how changes might look below:
 
-    ```jsx {{ prettier: false, del: [2, 4], ins: [3, 5] }}
+    ```js {{ prettier: false, del: [2, 4], ins: [3, 5] }}
     const { data } = await user.getOrganizationMemberships({
       limit: 10,
       pageSize: 10,
@@ -444,7 +444,7 @@ As part of this major version, a number of previously deprecated props, arugment
 
     Here's an example of how the response shape would change with this modification:
 
-    ```jsx {{ prettier: false, del: [1], ins: [2] }}
+    ```js {{ prettier: false, del: [1], ins: [2] }}
     const data = await clerkClient.users.getOrganizationMembershipList()
     const { data, totalCount } = await clerkClient.users.getOrganizationMembershipList()
     ```
@@ -455,7 +455,7 @@ As part of this major version, a number of previously deprecated props, arugment
 
     Here's an example of how the response shape would change with this modification:
 
-    ```jsx {{ prettier: false, del: [1], ins: [2] }}
+    ```js {{ prettier: false, del: [1], ins: [2] }}
     const data = await clerkClient.users.getOrganizationInvitationList()
     const { data, totalCount } = await clerkClient.users.getOrganizationInvitationList()
     ```
@@ -464,7 +464,7 @@ As part of this major version, a number of previously deprecated props, arugment
   <AccordionPanel>
     The return type for this function was previously `[Items]` but has now been updated to `{ data: [Items], totalCount: number }`. Since Clerk's API responses are paginated, the `totalCount` property is helpful in determining the total number of items in the response easily. A before/after code example can be seen below:
 
-    ```jsx {{ prettier: false, del: [5], ins: [6] }}
+    ```js {{ prettier: false, del: [5], ins: [6] }}
     const data = await clerkClient.organizations.getOrganizationInvitationList({
       organizationId: "...",
     })
@@ -477,7 +477,7 @@ As part of this major version, a number of previously deprecated props, arugment
   <AccordionPanel>
     The return type for this function was previously `[Items]` but has now been updated to `{ data: [Items], totalCount: number }`. Since Clerk's API responses are paginated, the `totalCount` property is helpful in determining the total number of items in the response easily. A before/after code example can be seen below:
 
-    ```jsx {{ prettier: false, del: [4], ins: [5] }}
+    ```js {{ prettier: false, del: [4], ins: [5] }}
     const { user } = useUser()
     const membershipList = user.getOrganizationMembershipList()
 
@@ -491,7 +491,7 @@ As part of this major version, a number of previously deprecated props, arugment
 
     Here's an example of how the response shape would change with this modification:
 
-    ```jsx {{ prettier: false, del: [1], ins: [2] }}
+    ```js {{ prettier: false, del: [1], ins: [2] }}
     const data = await clerkClient.users.getOrganizationList()
     const { data, totalCount } = await clerkClient.users.getOrganizationList()
     ```
@@ -500,7 +500,7 @@ As part of this major version, a number of previously deprecated props, arugment
   <AccordionPanel>
     The return type for this function was previously `[Items]` but has now been updated to `{ data: [Items], totalCount: number }`. Since Clerk's API responses are paginated, the `totalCount` property is helpful in determining the total number of items in the response easily. A before/after code example can be seen below:
 
-    ```jsx {{ prettier: false, del: [4], ins: [5] }}
+    ```js {{ prettier: false, del: [4], ins: [5] }}
     const { organization } = useOrganization()
     const orgList = organization.getOrganizationList()
 
@@ -514,7 +514,7 @@ As part of this major version, a number of previously deprecated props, arugment
 
     Here's an example of how the response shape would change with this modification:
 
-    ```jsx {{ prettier: false, del: [1], ins: [2] }}
+    ```js {{ prettier: false, del: [1], ins: [2] }}
     const data = await clerkClient.invitations.getInvitationList()
     const { data, totalCount } = await clerkClient.invitations.getInvitationList()
     ```
@@ -525,7 +525,7 @@ As part of this major version, a number of previously deprecated props, arugment
 
     Here's an example of how the response shape would change with this modification:
 
-    ```jsx {{ prettier: false, del: [1], ins: [2] }}
+    ```js {{ prettier: false, del: [1], ins: [2] }}
     const data = await clerkClient.sessions.getSessionList()
     const { data, totalCount } = await clerkClient.sessions.getSessionList()
     ```
@@ -536,7 +536,7 @@ As part of this major version, a number of previously deprecated props, arugment
 
     Here's an example of how the response shape would change with this modification:
 
-    ```jsx {{ prettier: false, del: [1], ins: [2] }}
+    ```js {{ prettier: false, del: [1], ins: [2] }}
     const data = await clerkClient.users.getUserList()
     const { data, totalCount } = await clerkClient.users.getUserList()
     ```
@@ -547,7 +547,7 @@ As part of this major version, a number of previously deprecated props, arugment
 
     Here's an example of how the response shape would change with this modification:
 
-    ```jsx {{ prettier: false, del: [1], ins: [2] }}
+    ```js {{ prettier: false, del: [1], ins: [2] }}
     const data = await clerkClient.allowlistIdentifiers.getAllowlistIdentifierList()
     const { data, totalCount } = await clerkClient.allowlistIdentifiers.getAllowlistIdentifierList()
     ```
@@ -558,7 +558,7 @@ As part of this major version, a number of previously deprecated props, arugment
 
     Here's an example of how the response shape would change with this modification:
 
-    ```jsx {{ prettier: false, del: [1], ins: [2] }}
+    ```js {{ prettier: false, del: [1], ins: [2] }}
     const data = await clerkClient.clients.getClientList()
     const { data, totalCount } = await clerkClient.allowlistIdentifiers.getClientList()
     ```
@@ -569,7 +569,7 @@ As part of this major version, a number of previously deprecated props, arugment
 
     Here's an example of how the response shape would change with this modification:
 
-    ```jsx {{ prettier: false, del: [1], ins: [2] }}
+    ```js {{ prettier: false, del: [1], ins: [2] }}
     const data = await clerkClient.redirectUrls.getRedirectUrlList()
     const { data, totalCount } = await clerkClient.redirectUrls.getRedirectUrlList()
     ```
@@ -580,7 +580,7 @@ As part of this major version, a number of previously deprecated props, arugment
 
     Here's an example of how the response shape would change with this modification:
 
-    ```jsx {{ prettier: false, del: [1], ins: [2] }}
+    ```js {{ prettier: false, del: [1], ins: [2] }}
     const data = await clerkClient.users.getUserOauthAccessToken()
     const { data, totalCount } = await clerkClient.users.getUserOauthAccessToken()
     ```
@@ -593,7 +593,7 @@ As part of this major version, a number of previously deprecated props, arugment
   <AccordionPanel>
     We changed the values that our middleware adds to the `request` object after running. Previously it returned a `LegacyAuthObject` type, and now it returns an `AuthObject` type, the difference between the two types is as such:
 
-    ```jsx {{ prettier: false, del: [1, 8], ins: [2, [9, 14]] }}
+    ```ts {{ prettier: false, del: [1, 8], ins: [2, [9, 14]] }}
     type LegacyAuthObject = {
     type AuthObject = {
       sessionId: string | null;
@@ -617,7 +617,7 @@ As part of this major version, a number of previously deprecated props, arugment
   <AccordionPanel>
     The `Clerk` default import has changed to `createClerkClient` and been moved to a named import rather than default. You must update your import path in order for it to work correctly. Example below of the fix that needs to be made:
 
-    ```jsx {{ prettier: false, del: [1], ins: [2] }}
+    ```js {{ prettier: false, del: [1], ins: [2] }}
     import Clerk from "@clerk/clerk-sdk-node"
     import { createClerkClient } from "@clerk/clerk-sdk-node"
     ```

--- a/docs/upgrade-guides/core-2/node.mdx
+++ b/docs/upgrade-guides/core-2/node.mdx
@@ -67,10 +67,10 @@ If you are having trouble with `npx`, it's also possible to install directly wit
 
 If you are using either of these import paths, they are no longer necessary and you can import directly from the top level `@clerk/express` path.
 
-```diff {{ prettier: false }}
-- import { ... } from "@clerk/clerk-sdk-node/esm/instance";
-- import { ... } from "@clerk/clerk-sdk-node/cjs/instance";
-+ import { ... } from "@clerk/clerk-sdk-node";
+```jsx {{ prettier: false, del: [1, 2], ins: [3] }}
+import { ... } from "@clerk/clerk-sdk-node/esm/instance";
+import { ... } from "@clerk/clerk-sdk-node/cjs/instance";
+import { ... } from "@clerk/clerk-sdk-node";
 ```
 
 ### Clerk client setters removed in favor of `createClerkClient` options
@@ -84,28 +84,28 @@ The following setter methods have been removed in the lastest version. If you we
 
 Code example:
 
-```diff {{ prettier: false }}
-  import {
-     clerkClient,
--    setClerkApiKey,
--    setClerkApiVersion,
--    setClerkHttpOptions,
--    setClerkServerApiUrl
+```jsx {{ prettier: false, del: [[3, 6], [9, 12]], ins: [[15, 18]] }}
+import {
+   clerkClient,
+   setClerkApiKey,
+   setClerkApiVersion,
+   setClerkHttpOptions,
+   setClerkServerApiUrl
 } from "@clerk/clerk-sdk-node"
 
-- setClerkApiKey("...")
-- setClerkApiVersion("...")
-- setClerkHttpOptions("...")
-- setClerkServerApiUrl("...")
+setClerkApiKey("...")
+setClerkApiVersion("...")
+setClerkHttpOptions("...")
+setClerkServerApiUrl("...")
 
-  const clerkClient = createClerkClient({
-+     secretKey: "..."
-+     apiVersion: "..."
-+     httpOptions: "..."
-+     serverApiUrl: "..."
-  })
+const clerkClient = createClerkClient({
+    secretKey: "..."
+    apiVersion: "..."
+    httpOptions: "..."
+    serverApiUrl: "..."
+})
 
-  await clerkClient.users.getUser(userId);
+await clerkClient.users.getUser(userId);
 ```
 
 ### Removed: `orgs` claim on JWT
@@ -200,14 +200,14 @@ As part of this major version, a number of previously deprecated props, arugment
   <AccordionPanel>
     If you are updating a user's password via the [`User.update` method](/docs/references/javascript/user/user#update), it must be changed to [`User.updatePassword`](/docs/references/javascript/user/password-management#update-password) instead. This method will require the current password as well as the desired new password. We made this update to improve the security of password changes. Example below:
 
-    ```diff {{ prettier: false }}
-    - user.update({ password: 'foo' });
+    ```jsx {{ prettier: false, del: [1], ins: [[3, 7]] }}
+    user.update({ password: 'foo' });
 
-    + user.updatePassword({
-    +   currentPassword: 'bar',
-    +   newPassword: 'foo',
-    +   signOutOfOtherSessions: true,
-    + });
+    user.updatePassword({
+      currentPassword: 'bar',
+      newPassword: 'foo',
+      signOutOfOtherSessions: true,
+    });
     ```
   </AccordionPanel>
 
@@ -222,110 +222,110 @@ As part of this major version, a number of previously deprecated props, arugment
   <AccordionPanel>
     The `apiKey` argument passed to `ClerkExpressRequireAuth` must be changed to `secretKey`.
 
-    ```diff {{ prettier: false }}
+    ```jsx {{ prettier: false, del: [3], ins: [4] }}
     import { ClerkExpressRequireAuth } from '@clerk/clerk-sdk-node';
 
-    - ClerkExpressRequireAuth({ apiKey: '...' });
-    + ClerkExpressRequireAuth({ secretKey: '...' });
+    ClerkExpressRequireAuth({ apiKey: '...' });
+    ClerkExpressRequireAuth({ secretKey: '...' });
     ```
   </AccordionPanel>
 
   <AccordionPanel>
     The `apiKey` argument passed to `ClerkExpressWithAuth` must be changed to `secretKey`.
 
-    ```diff {{ prettier: false }}
+    ```jsx {{ prettier: false, del: [3], ins: [4] }}
     import { ClerkExpressWithAuth } from '@clerk/clerk-sdk-node';
 
-    - ClerkExpressWithAuth({ apiKey: '...' });
-    + ClerkExpressWithAuth({ secretKey: '...' });
+    ClerkExpressWithAuth({ apiKey: '...' });
+    ClerkExpressWithAuth({ secretKey: '...' });
     ```
   </AccordionPanel>
 
   <AccordionPanel>
     The `apiKey` argument passed to `createClerkClient` must be changed to `secretKey`.
 
-    ```diff {{ prettier: false }}
+    ```jsx {{ prettier: false, del: [3], ins: [4] }}
     import { createClerkClient } from '@clerk/clerk-sdk-node';
 
-    - createClerkClient({ apiKey: '...' });
-    + createClerkClient({ secretKey: '...' });
+    createClerkClient({ apiKey: '...' });
+    createClerkClient({ secretKey: '...' });
     ```
   </AccordionPanel>
 
   <AccordionPanel>
     The `apiKey` argument passed to `createClerkExpressRequireAuth` must be changed to `secretKey`.
 
-    ```diff {{ prettier: false }}
+    ```jsx {{ prettier: false, del: [3], ins: [4] }}
     import { createClerkExpressRequireAuth } from '@clerk/clerk-sdk-node';
 
-    - createClerkExpressRequireAuth({ apiKey: '...' });
-    + createClerkExpressRequireAuth({ secretKey: '...' });
+    createClerkExpressRequireAuth({ apiKey: '...' });
+    createClerkExpressRequireAuth({ secretKey: '...' });
     ```
   </AccordionPanel>
 
   <AccordionPanel>
     The `apiKey` argument passed to `createClerkExpressWithAuth` must be changed to `secretKey`.
 
-    ```diff {{ prettier: false }}
+    ```jsx {{ prettier: false, del: [3], ins: [4] }}
     import { createClerkExpressWithAuth } from '@clerk/clerk-sdk-node';
 
-    - createClerkExpressWithAuth({ apiKey: '...' });
-    + createClerkExpressWithAuth({ secretKey: '...' });
+    createClerkExpressWithAuth({ apiKey: '...' });
+    createClerkExpressWithAuth({ secretKey: '...' });
     ```
   </AccordionPanel>
 
   <AccordionPanel>
     The `frontendApi` argument passed to `createClerkClient` must be changed to `publishableKey`. Note that the values of the two keys are different, so both keys and values need to be changed. You can find your application's publishable key in the Clerk dashboard.
 
-    ```diff {{ prettier: false }}
+    ```jsx {{ prettier: false, del: [3], ins: [4] }}
     import { createClerkClient } from '@clerk/clerk-sdk-node';
 
-    - createClerkClient({ frontendApi: '...' });
-    + createClerkClient({ publishableKey: '...' });
+    createClerkClient({ frontendApi: '...' });
+    createClerkClient({ publishableKey: '...' });
     ```
   </AccordionPanel>
 
   <AccordionPanel>
     The `frontendApi` argument passed to `createClerkExpressRequireAuth` must be changed to `publishableKey`. Note that the values of the two keys are different, so both keys and values need to be changed. You can find your application's publishable key in the Clerk dashboard.
 
-    ```diff {{ prettier: false }}
+    ```jsx {{ prettier: false, del: [3], ins: [4] }}
     import { createClerkExpressRequireAuth } from '@clerk/clerk-sdk-node';
 
-    - createClerkExpressRequireAuth({ frontendApi: '...' });
-    + createClerkExpressRequireAuth({ publishableKey: '...' });
+    createClerkExpressRequireAuth({ frontendApi: '...' });
+    createClerkExpressRequireAuth({ publishableKey: '...' });
     ```
   </AccordionPanel>
 
   <AccordionPanel>
     The `frontendApi` argument passed to `ClerkExpressRequireAuth` must be changed to `publishableKey`. Note that the values of the two keys are different, so both keys and values need to be changed. You can find your application's publishable key in the Clerk dashboard.
 
-    ```diff {{ prettier: false }}
+    ```jsx {{ prettier: false, del: [3], ins: [4] }}
     import { ClerkExpressRequireAuth } from '@clerk/clerk-sdk-node';
 
-    - ClerkExpressRequireAuth({ frontendApi: '...' });
-    + ClerkExpressRequireAuth({ publishableKey: '...' });
+    ClerkExpressRequireAuth({ frontendApi: '...' });
+    ClerkExpressRequireAuth({ publishableKey: '...' });
     ```
   </AccordionPanel>
 
   <AccordionPanel>
     The `frontendApi` argument passed to `createClerkExpressWithAuth` must be changed to `publishableKey`. Note that the values of the two keys are different, so both keys and values need to be changed. You can find your application's publishable key in the Clerk dashboard.
 
-    ```diff {{ prettier: false }}
+    ```jsx {{ prettier: false, del: [3], ins: [4] }}
     import { createClerkExpressWithAuth } from '@clerk/clerk-sdk-node';
 
-    - createClerkExpressWithAuth({ frontendApi: '...' });
-    + createClerkExpressWithAuth({ publishableKey: '...' });
+    createClerkExpressWithAuth({ frontendApi: '...' });
+    createClerkExpressWithAuth({ publishableKey: '...' });
     ```
   </AccordionPanel>
 
   <AccordionPanel>
     The `frontendApi` argument passed to `ClerkExpressWithAuth` must be changed to `publishableKey`. Note that the values of the two keys are different, so both keys and values need to be changed. You can find your application's publishable key in the Clerk dashboard.
 
-    ```diff {{ prettier: false }}
+    ```jsx {{ prettier: false, del: [3], ins: [4] }}
     import { ClerkExpressWithAuth } from '@clerk/clerk-sdk-node';
 
-    - ClerkExpressWithAuth({ frontendApi: '...' });
-    + ClerkExpressWithAuth({ publishableKey: '...' });
+    ClerkExpressWithAuth({ frontendApi: '...' });
+    ClerkExpressWithAuth({ publishableKey: '...' });
     ```
   </AccordionPanel>
 </Accordion>
@@ -338,104 +338,104 @@ As part of this major version, a number of previously deprecated props, arugment
   <AccordionPanel>
     There have been a couple changes to the pagination arguments that can be passed into this function - `limit` has been renamed to `pageSize`, and `offset` has been renamed to `initialPage`. This will help to make it more clear and simple to reason about pagination control. Example of how changes might look below:
 
-    ```diff {{ prettier: false }}
-      const { data } = await organization.getRoles({
-    -   limit: 10,
-    +   pageSize: 10,
-    -   offset: 10,
-    +   initialPage: 2,
-      })
+    ```jsx {{ prettier: false, del: [2, 4], ins: [3, 5] }}
+    const { data } = await organization.getRoles({
+      limit: 10,
+      pageSize: 10,
+      offset: 10,
+      initialPage: 2,
+    })
     ```
   </AccordionPanel>
 
   <AccordionPanel>
     There have been a couple changes to the pagination arguments that can be passed into this function - `limit` has been renamed to `pageSize`, and `offset` has been renamed to `initialPage`. This will help to make it more clear and simple to reason about pagination control. Example of how changes might look below:
 
-    ```diff {{ prettier: false }}
-      const { data } = await organization.getMemberships({
-    -   limit: 10,
-    +   pageSize: 10,
-    -   offset: 10,
-    +   initialPage: 2,
-      })
+    ```jsx {{ prettier: false, del: [2, 4], ins: [3, 5] }}
+    const { data } = await organization.getMemberships({
+      limit: 10,
+      pageSize: 10,
+      offset: 10,
+      initialPage: 2,
+    })
     ```
   </AccordionPanel>
 
   <AccordionPanel>
     There have been a couple changes to the pagination arguments that can be passed into this function - `limit` has been renamed to `pageSize`, and `offset` has been renamed to `initialPage`. This will help to make it more clear and simple to reason about pagination control. Example of how changes might look below:
 
-    ```diff {{ prettier: false }}
-      const { data } = await organization.getDomains({
-    -   limit: 10,
-    +   pageSize: 10,
-    -   offset: 10,
-    +   initialPage: 2,
-      })
+    ```jsx {{ prettier: false, del: [2, 4], ins: [3, 5] }}
+    const { data } = await organization.getDomains({
+      limit: 10,
+      pageSize: 10,
+      offset: 10,
+      initialPage: 2,
+    })
     ```
   </AccordionPanel>
 
   <AccordionPanel>
     There have been a couple changes to the pagination arguments that can be passed into this function - `limit` has been renamed to `pageSize`, and `offset` has been renamed to `initialPage`. This will help to make it more clear and simple to reason about pagination control. Example of how changes might look below:
 
-    ```diff {{ prettier: false }}
-      const { data } = await organization.getInvitations({
-    -   limit: 10,
-    +   pageSize: 10,
-    -   offset: 10,
-    +   initialPage: 2,
-      })
+    ```jsx {{ prettier: false, del: [2, 4], ins: [3, 5] }}
+    const { data } = await organization.getInvitations({
+      limit: 10,
+      pageSize: 10,
+      offset: 10,
+      initialPage: 2,
+    })
     ```
   </AccordionPanel>
 
   <AccordionPanel>
     There have been a couple changes to the pagination arguments that can be passed into this function - `limit` has been renamed to `pageSize`, and `offset` has been renamed to `initialPage`. This will help to make it more clear and simple to reason about pagination control. Example of how changes might look below:
 
-    ```diff {{ prettier: false }}
-      const { data } = await organization.getMembershipRequests({
-    -   limit: 10,
-    +   pageSize: 10,
-    -   offset: 10,
-    +   initialPage: 2,
-      })
+    ```jsx {{ prettier: false, del: [2, 4], ins: [3, 5] }}
+    const { data } = await organization.getMembershipRequests({
+      limit: 10,
+      pageSize: 10,
+      offset: 10,
+      initialPage: 2,
+    })
     ```
   </AccordionPanel>
 
   <AccordionPanel>
     There have been a couple changes to the pagination arguments that can be passed into this function - `limit` has been renamed to `pageSize`, and `offset` has been renamed to `initialPage`. This will help to make it more clear and simple to reason about pagination control. Example of how changes might look below:
 
-    ```diff {{ prettier: false }}
-      const { data } = await user.getOrganizationInvitations({
-    -   limit: 10,
-    +   pageSize: 10,
-    -   offset: 10,
-    +   initialPage: 2,
-      })
+    ```jsx {{ prettier: false, del: [2, 4], ins: [3, 5] }}
+    const { data } = await user.getOrganizationInvitations({
+      limit: 10,
+      pageSize: 10,
+      offset: 10,
+      initialPage: 2,
+    })
     ```
   </AccordionPanel>
 
   <AccordionPanel>
     There have been a couple changes to the pagination arguments that can be passed into this function - `limit` has been renamed to `pageSize`, and `offset` has been renamed to `initialPage`. This will help to make it more clear and simple to reason about pagination control. Example of how changes might look below:
 
-    ```diff {{ prettier: false }}
-      const { data } = await user.getOrganizationSuggestions({
-    -   limit: 10,
-    +   pageSize: 10,
-    -   offset: 10,
-    +   initialPage: 2,
-      })
+    ```jsx {{ prettier: false, del: [2, 4], ins: [3, 5] }}
+    const { data } = await user.getOrganizationSuggestions({
+      limit: 10,
+      pageSize: 10,
+      offset: 10,
+      initialPage: 2,
+    })
     ```
   </AccordionPanel>
 
   <AccordionPanel>
     There have been a couple changes to the pagination arguments that can be passed into this function - `limit` has been renamed to `pageSize`, and `offset` has been renamed to `initialPage`. This will help to make it more clear and simple to reason about pagination control. Example of how changes might look below:
 
-    ```diff {{ prettier: false }}
-      const { data } = await user.getOrganizationMemberships({
-    -   limit: 10,
-    +   pageSize: 10,
-    -   offset: 10,
-    +   initialPage: 2,
-      })
+    ```jsx {{ prettier: false, del: [2, 4], ins: [3, 5] }}
+    const { data } = await user.getOrganizationMemberships({
+      limit: 10,
+      pageSize: 10,
+      offset: 10,
+      initialPage: 2,
+    })
     ```
   </AccordionPanel>
 
@@ -444,9 +444,9 @@ As part of this major version, a number of previously deprecated props, arugment
 
     Here's an example of how the response shape would change with this modification:
 
-    ```diff {{ prettier: false }}
-    - const data = await clerkClient.users.getOrganizationMembershipList()
-    + const { data, totalCount } = await clerkClient.users.getOrganizationMembershipList()
+    ```jsx {{ prettier: false, del: [1], ins: [2] }}
+    const data = await clerkClient.users.getOrganizationMembershipList()
+    const { data, totalCount } = await clerkClient.users.getOrganizationMembershipList()
     ```
   </AccordionPanel>
 
@@ -455,34 +455,34 @@ As part of this major version, a number of previously deprecated props, arugment
 
     Here's an example of how the response shape would change with this modification:
 
-    ```diff {{ prettier: false }}
-    - const data = await clerkClient.users.getOrganizationInvitationList()
-    + const { data, totalCount } = await clerkClient.users.getOrganizationInvitationList()
+    ```jsx {{ prettier: false, del: [1], ins: [2] }}
+    const data = await clerkClient.users.getOrganizationInvitationList()
+    const { data, totalCount } = await clerkClient.users.getOrganizationInvitationList()
     ```
   </AccordionPanel>
 
   <AccordionPanel>
     The return type for this function was previously `[Items]` but has now been updated to `{ data: [Items], totalCount: number }`. Since Clerk's API responses are paginated, the `totalCount` property is helpful in determining the total number of items in the response easily. A before/after code example can be seen below:
 
-    ```diff {{ prettier: false }}
-      const data = await clerkClient.organizations.getOrganizationInvitationList({
-        organizationId: "...",
-      })
+    ```jsx {{ prettier: false, del: [5], ins: [6] }}
+    const data = await clerkClient.organizations.getOrganizationInvitationList({
+      organizationId: "...",
+    })
 
-    - data.forEach(() => {})
-    + data.data.forEach(() => {})
+    data.forEach(() => {})
+    data.data.forEach(() => {})
     ```
   </AccordionPanel>
 
   <AccordionPanel>
     The return type for this function was previously `[Items]` but has now been updated to `{ data: [Items], totalCount: number }`. Since Clerk's API responses are paginated, the `totalCount` property is helpful in determining the total number of items in the response easily. A before/after code example can be seen below:
 
-    ```diff {{ prettier: false }}
-      const { user } = useUser()
-      const membershipList = user.getOrganizationMembershipList()
+    ```jsx {{ prettier: false, del: [4], ins: [5] }}
+    const { user } = useUser()
+    const membershipList = user.getOrganizationMembershipList()
 
-    - membershipList.forEach(() => {})
-    + membershipList.data.forEach(() => {})
+    membershipList.forEach(() => {})
+    membershipList.data.forEach(() => {})
     ```
   </AccordionPanel>
 
@@ -491,21 +491,21 @@ As part of this major version, a number of previously deprecated props, arugment
 
     Here's an example of how the response shape would change with this modification:
 
-    ```diff {{ prettier: false }}
-    - const data = await clerkClient.users.getOrganizationList()
-    + const { data, totalCount } = await clerkClient.users.getOrganizationList()
+    ```jsx {{ prettier: false, del: [1], ins: [2] }}
+    const data = await clerkClient.users.getOrganizationList()
+    const { data, totalCount } = await clerkClient.users.getOrganizationList()
     ```
   </AccordionPanel>
 
   <AccordionPanel>
     The return type for this function was previously `[Items]` but has now been updated to `{ data: [Items], totalCount: number }`. Since Clerk's API responses are paginated, the `totalCount` property is helpful in determining the total number of items in the response easily. A before/after code example can be seen below:
 
-    ```diff {{ prettier: false }}
-      const { organization } = useOrganization()
-      const orgList = organization.getOrganizationList()
+    ```jsx {{ prettier: false, del: [4], ins: [5] }}
+    const { organization } = useOrganization()
+    const orgList = organization.getOrganizationList()
 
-    - orgList.forEach(() => {})
-    + orgList.data.forEach(() => {})
+    orgList.forEach(() => {})
+    orgList.data.forEach(() => {})
     ```
   </AccordionPanel>
 
@@ -514,9 +514,9 @@ As part of this major version, a number of previously deprecated props, arugment
 
     Here's an example of how the response shape would change with this modification:
 
-    ```diff {{ prettier: false }}
-    - const data = await clerkClient.invitations.getInvitationList()
-    + const { data, totalCount } = await clerkClient.invitations.getInvitationList()
+    ```jsx {{ prettier: false, del: [1], ins: [2] }}
+    const data = await clerkClient.invitations.getInvitationList()
+    const { data, totalCount } = await clerkClient.invitations.getInvitationList()
     ```
   </AccordionPanel>
 
@@ -525,9 +525,9 @@ As part of this major version, a number of previously deprecated props, arugment
 
     Here's an example of how the response shape would change with this modification:
 
-    ```diff {{ prettier: false }}
-    - const data = await clerkClient.sessions.getSessionList()
-    + const { data, totalCount } = await clerkClient.sessions.getSessionList()
+    ```jsx {{ prettier: false, del: [1], ins: [2] }}
+    const data = await clerkClient.sessions.getSessionList()
+    const { data, totalCount } = await clerkClient.sessions.getSessionList()
     ```
   </AccordionPanel>
 
@@ -536,9 +536,9 @@ As part of this major version, a number of previously deprecated props, arugment
 
     Here's an example of how the response shape would change with this modification:
 
-    ```diff {{ prettier: false }}
-    - const data = await clerkClient.users.getUserList()
-    + const { data, totalCount } = await clerkClient.users.getUserList()
+    ```jsx {{ prettier: false, del: [1], ins: [2] }}
+    const data = await clerkClient.users.getUserList()
+    const { data, totalCount } = await clerkClient.users.getUserList()
     ```
   </AccordionPanel>
 
@@ -547,9 +547,9 @@ As part of this major version, a number of previously deprecated props, arugment
 
     Here's an example of how the response shape would change with this modification:
 
-    ```diff {{ prettier: false }}
-    - const data = await clerkClient.allowlistIdentifiers.getAllowlistIdentifierList()
-    + const { data, totalCount } = await clerkClient.allowlistIdentifiers.getAllowlistIdentifierList()
+    ```jsx {{ prettier: false, del: [1], ins: [2] }}
+    const data = await clerkClient.allowlistIdentifiers.getAllowlistIdentifierList()
+    const { data, totalCount } = await clerkClient.allowlistIdentifiers.getAllowlistIdentifierList()
     ```
   </AccordionPanel>
 
@@ -558,9 +558,9 @@ As part of this major version, a number of previously deprecated props, arugment
 
     Here's an example of how the response shape would change with this modification:
 
-    ```diff {{ prettier: false }}
-    - const data = await clerkClient.clients.getClientList()
-    + const { data, totalCount } = await clerkClient.allowlistIdentifiers.getClientList()
+    ```jsx {{ prettier: false, del: [1], ins: [2] }}
+    const data = await clerkClient.clients.getClientList()
+    const { data, totalCount } = await clerkClient.allowlistIdentifiers.getClientList()
     ```
   </AccordionPanel>
 
@@ -569,9 +569,9 @@ As part of this major version, a number of previously deprecated props, arugment
 
     Here's an example of how the response shape would change with this modification:
 
-    ```diff {{ prettier: false }}
-    - const data = await clerkClient.redirectUrls.getRedirectUrlList()
-    + const { data, totalCount } = await clerkClient.redirectUrls.getRedirectUrlList()
+    ```jsx {{ prettier: false, del: [1], ins: [2] }}
+    const data = await clerkClient.redirectUrls.getRedirectUrlList()
+    const { data, totalCount } = await clerkClient.redirectUrls.getRedirectUrlList()
     ```
   </AccordionPanel>
 
@@ -580,9 +580,9 @@ As part of this major version, a number of previously deprecated props, arugment
 
     Here's an example of how the response shape would change with this modification:
 
-    ```diff {{ prettier: false }}
-    - const data = await clerkClient.users.getUserOauthAccessToken()
-    + const { data, totalCount } = await clerkClient.users.getUserOauthAccessToken()
+    ```jsx {{ prettier: false, del: [1], ins: [2] }}
+    const data = await clerkClient.users.getUserOauthAccessToken()
+    const { data, totalCount } = await clerkClient.users.getUserOauthAccessToken()
     ```
   </AccordionPanel>
 
@@ -593,22 +593,22 @@ As part of this major version, a number of previously deprecated props, arugment
   <AccordionPanel>
     We changed the values that our middleware adds to the `request` object after running. Previously it returned a `LegacyAuthObject` type, and now it returns an `AuthObject` type, the difference between the two types is as such:
 
-    ```diff {{ prettier: false }}
-    - type LegacyAuthObject = {
-    + type AuthObject = {
-        sessionId: string | null;
-        actor: ActClaim | undefined | null;
-        userId: string | null;
-        getToken: ServerGetToken | null;
-        debug: AuthObjectDebug | null;
-    -   claims: JwtPayload | null;
-    +   sessionClaims: JwtPayload | null;
-    +   orgId: string | undefined | null;
-    +   orgRole: OrganizationCustomRoleKey | undefined | null;
-    +   orgSlug: string | undefined | null;
-    +   orgPermissions: OrganizationCustomPermissionKey[] | undefined | null;
-    +   has: CheckAuthorizationWithCustomPermissions | null;
-      }
+    ```jsx {{ prettier: false, del: [1, 8], ins: [2, [9, 14]] }}
+    type LegacyAuthObject = {
+    type AuthObject = {
+      sessionId: string | null;
+      actor: ActClaim | undefined | null;
+      userId: string | null;
+      getToken: ServerGetToken | null;
+      debug: AuthObjectDebug | null;
+      claims: JwtPayload | null;
+      sessionClaims: JwtPayload | null;
+      orgId: string | undefined | null;
+      orgRole: OrganizationCustomRoleKey | undefined | null;
+      orgSlug: string | undefined | null;
+      orgPermissions: OrganizationCustomPermissionKey[] | undefined | null;
+      has: CheckAuthorizationWithCustomPermissions | null;
+    }
     ```
 
     If you were using the `claims` key on the request after running middleware, you will need to instead use `sessionClaims`. Additionally, if you were using the `LooseAuthProp` or `StrictAuthProp` exported types anywhere, note that these have been adjusted to fit the shape of the new middleware response typing.
@@ -617,9 +617,9 @@ As part of this major version, a number of previously deprecated props, arugment
   <AccordionPanel>
     The `Clerk` default import has changed to `createClerkClient` and been moved to a named import rather than default. You must update your import path in order for it to work correctly. Example below of the fix that needs to be made:
 
-    ```diff {{ prettier: false }}
-    - import Clerk from "@clerk/clerk-sdk-node"
-    + import { createClerkClient } from "@clerk/clerk-sdk-node"
+    ```jsx {{ prettier: false, del: [1], ins: [2] }}
+    import Clerk from "@clerk/clerk-sdk-node"
+    import { createClerkClient } from "@clerk/clerk-sdk-node"
     ```
   </AccordionPanel>
 

--- a/docs/upgrade-guides/core-2/react.mdx
+++ b/docs/upgrade-guides/core-2/react.mdx
@@ -258,7 +258,7 @@ As part of this major version, a number of previously deprecated props, arugment
   <AccordionPanel>
     If you are updating a user's password via the [`User.update` method](/docs/references/javascript/user/user#update), it must be changed to [`User.updatePassword`](/docs/references/javascript/user/password-management#update-password) instead. This method will require the current password as well as the desired new password. We made this update to improve the security of password changes. Example below:
 
-    ```jsx {{ prettier: false, del: [1], ins: [[3, 7]] }}
+    ```js {{ prettier: false, del: [1], ins: [[3, 7]] }}
     user.update({ password: 'foo' });
 
     user.updatePassword({
@@ -295,7 +295,7 @@ As part of this major version, a number of previously deprecated props, arugment
   <AccordionPanel>
     There have been a couple changes to the pagination arguments that can be passed into this function - `limit` has been renamed to `pageSize`, and `offset` has been renamed to `initialPage`. This will help to make it more clear and simple to reason about pagination control. Example of how changes might look below:
 
-    ```jsx {{ prettier: false, del: [2, 4], ins: [3, 5] }}
+    ```js {{ prettier: false, del: [2, 4], ins: [3, 5] }}
     const { data } = await organization.getRoles({
       limit: 10,
       pageSize: 10,
@@ -308,7 +308,7 @@ As part of this major version, a number of previously deprecated props, arugment
   <AccordionPanel>
     There have been a couple changes to the pagination arguments that can be passed into this function - `limit` has been renamed to `pageSize`, and `offset` has been renamed to `initialPage`. This will help to make it more clear and simple to reason about pagination control. Example of how changes might look below:
 
-    ```jsx {{ prettier: false, del: [2, 4], ins: [3, 5] }}
+    ```js {{ prettier: false, del: [2, 4], ins: [3, 5] }}
     const { data } = await organization.getMemberships({
       limit: 10,
       pageSize: 10,
@@ -321,7 +321,7 @@ As part of this major version, a number of previously deprecated props, arugment
   <AccordionPanel>
     There have been a couple changes to the pagination arguments that can be passed into this function - `limit` has been renamed to `pageSize`, and `offset` has been renamed to `initialPage`. This will help to make it more clear and simple to reason about pagination control. Example of how changes might look below:
 
-    ```jsx {{ prettier: false, del: [2, 4], ins: [3, 5] }}
+    ```js {{ prettier: false, del: [2, 4], ins: [3, 5] }}
     const { data } = await organization.getDomains({
       limit: 10,
       pageSize: 10,
@@ -334,7 +334,7 @@ As part of this major version, a number of previously deprecated props, arugment
   <AccordionPanel>
     There have been a couple changes to the pagination arguments that can be passed into this function - `limit` has been renamed to `pageSize`, and `offset` has been renamed to `initialPage`. This will help to make it more clear and simple to reason about pagination control. Example of how changes might look below:
 
-    ```jsx {{ prettier: false, del: [2, 4], ins: [3, 5] }}
+    ```js {{ prettier: false, del: [2, 4], ins: [3, 5] }}
     const { data } = await organization.getInvitations({
       limit: 10,
       pageSize: 10,
@@ -347,7 +347,7 @@ As part of this major version, a number of previously deprecated props, arugment
   <AccordionPanel>
     There have been a couple changes to the pagination arguments that can be passed into this function - `limit` has been renamed to `pageSize`, and `offset` has been renamed to `initialPage`. This will help to make it more clear and simple to reason about pagination control. Example of how changes might look below:
 
-    ```jsx {{ prettier: false, del: [2, 4], ins: [3, 5] }}
+    ```js {{ prettier: false, del: [2, 4], ins: [3, 5] }}
     const { data } = await organization.getMembershipRequests({
       limit: 10,
       pageSize: 10,
@@ -360,7 +360,7 @@ As part of this major version, a number of previously deprecated props, arugment
   <AccordionPanel>
     There have been a couple changes to the pagination arguments that can be passed into this function - `limit` has been renamed to `pageSize`, and `offset` has been renamed to `initialPage`. This will help to make it more clear and simple to reason about pagination control. Example of how changes might look below:
 
-    ```jsx {{ prettier: false, del: [2, 4], ins: [3, 5] }}
+    ```js {{ prettier: false, del: [2, 4], ins: [3, 5] }}
     const { data } = await user.getOrganizationInvitations({
       limit: 10,
       pageSize: 10,
@@ -373,7 +373,7 @@ As part of this major version, a number of previously deprecated props, arugment
   <AccordionPanel>
     There have been a couple changes to the pagination arguments that can be passed into this function - `limit` has been renamed to `pageSize`, and `offset` has been renamed to `initialPage`. This will help to make it more clear and simple to reason about pagination control. Example of how changes might look below:
 
-    ```jsx {{ prettier: false, del: [2, 4], ins: [3, 5] }}
+    ```js {{ prettier: false, del: [2, 4], ins: [3, 5] }}
     const { data } = await user.getOrganizationSuggestions({
       limit: 10,
       pageSize: 10,
@@ -386,7 +386,7 @@ As part of this major version, a number of previously deprecated props, arugment
   <AccordionPanel>
     There have been a couple changes to the pagination arguments that can be passed into this function - `limit` has been renamed to `pageSize`, and `offset` has been renamed to `initialPage`. This will help to make it more clear and simple to reason about pagination control. Example of how changes might look below:
 
-    ```jsx {{ prettier: false, del: [2, 4], ins: [3, 5] }}
+    ```js {{ prettier: false, del: [2, 4], ins: [3, 5] }}
     const { data } = await user.getOrganizationMemberships({
       limit: 10,
       pageSize: 10,
@@ -401,7 +401,7 @@ As part of this major version, a number of previously deprecated props, arugment
 
     Here's an example of how the response shape would change with this modification:
 
-    ```jsx {{ prettier: false, del: [1], ins: [2] }}
+    ```js {{ prettier: false, del: [1], ins: [2] }}
     const data = await clerkClient.users.getOrganizationMembershipList()
     const { data, totalCount } = await clerkClient.users.getOrganizationMembershipList()
     ```
@@ -412,7 +412,7 @@ As part of this major version, a number of previously deprecated props, arugment
 
     Here's an example of how the response shape would change with this modification:
 
-    ```jsx {{ prettier: false, del: [1], ins: [2] }}
+    ```js {{ prettier: false, del: [1], ins: [2] }}
     const data = await clerkClient.users.getOrganizationInvitationList()
     const { data, totalCount } = await clerkClient.users.getOrganizationInvitationList()
     ```
@@ -421,7 +421,7 @@ As part of this major version, a number of previously deprecated props, arugment
   <AccordionPanel>
     The return type for this function was previously `[Items]` but has now been updated to `{ data: [Items], totalCount: number }`. Since Clerk's API responses are paginated, the `totalCount` property is helpful in determining the total number of items in the response easily. A before/after code example can be seen below:
 
-    ```jsx {{ prettier: false, del: [5], ins: [6] }}
+    ```js {{ prettier: false, del: [5], ins: [6] }}
     const data = await clerkClient.organizations.getOrganizationInvitationList({
       organizationId: "...",
     })
@@ -434,7 +434,7 @@ As part of this major version, a number of previously deprecated props, arugment
   <AccordionPanel>
     The return type for this function was previously `[Items]` but has now been updated to `{ data: [Items], totalCount: number }`. Since Clerk's API responses are paginated, the `totalCount` property is helpful in determining the total number of items in the response easily. A before/after code example can be seen below:
 
-    ```jsx {{ prettier: false, del: [4], ins: [5] }}
+    ```js {{ prettier: false, del: [4], ins: [5] }}
     const { user } = useUser()
     const membershipList = user.getOrganizationMembershipList()
 
@@ -448,7 +448,7 @@ As part of this major version, a number of previously deprecated props, arugment
 
     Here's an example of how the response shape would change with this modification:
 
-    ```jsx {{ prettier: false, del: [1], ins: [2] }}
+    ```js {{ prettier: false, del: [1], ins: [2] }}
     const data = await clerkClient.users.getOrganizationList()
     const { data, totalCount } = await clerkClient.users.getOrganizationList()
     ```
@@ -457,7 +457,7 @@ As part of this major version, a number of previously deprecated props, arugment
   <AccordionPanel>
     The return type for this function was previously `[Items]` but has now been updated to `{ data: [Items], totalCount: number }`. Since Clerk's API responses are paginated, the `totalCount` property is helpful in determining the total number of items in the response easily. A before/after code example can be seen below:
 
-    ```jsx {{ prettier: false, del: [4], ins: [5] }}
+    ```js {{ prettier: false, del: [4], ins: [5] }}
     const { organization } = useOrganization()
     const orgList = organization.getOrganizationList()
 
@@ -471,7 +471,7 @@ As part of this major version, a number of previously deprecated props, arugment
 
     Here's an example of how the response shape would change with this modification:
 
-    ```jsx {{ prettier: false, del: [1], ins: [2] }}
+    ```js {{ prettier: false, del: [1], ins: [2] }}
     const data = await clerkClient.invitations.getInvitationList()
     const { data, totalCount } = await clerkClient.invitations.getInvitationList()
     ```
@@ -482,7 +482,7 @@ As part of this major version, a number of previously deprecated props, arugment
 
     Here's an example of how the response shape would change with this modification:
 
-    ```jsx {{ prettier: false, del: [1], ins: [2] }}
+    ```js {{ prettier: false, del: [1], ins: [2] }}
     const data = await clerkClient.sessions.getSessionList()
     const { data, totalCount } = await clerkClient.sessions.getSessionList()
     ```
@@ -493,7 +493,7 @@ As part of this major version, a number of previously deprecated props, arugment
 
     Here's an example of how the response shape would change with this modification:
 
-    ```jsx {{ prettier: false, del: [1], ins: [2] }}
+    ```js {{ prettier: false, del: [1], ins: [2] }}
     const data = await clerkClient.users.getUserList()
     const { data, totalCount } = await clerkClient.users.getUserList()
     ```
@@ -504,7 +504,7 @@ As part of this major version, a number of previously deprecated props, arugment
 
     Here's an example of how the response shape would change with this modification:
 
-    ```jsx {{ prettier: false, del: [1], ins: [2] }}
+    ```js {{ prettier: false, del: [1], ins: [2] }}
     const data = await clerkClient.allowlistIdentifiers.getAllowlistIdentifierList()
     const { data, totalCount } = await clerkClient.allowlistIdentifiers.getAllowlistIdentifierList()
     ```
@@ -515,7 +515,7 @@ As part of this major version, a number of previously deprecated props, arugment
 
     Here's an example of how the response shape would change with this modification:
 
-    ```jsx {{ prettier: false, del: [1], ins: [2] }}
+    ```js {{ prettier: false, del: [1], ins: [2] }}
     const data = await clerkClient.clients.getClientList()
     const { data, totalCount } = await clerkClient.allowlistIdentifiers.getClientList()
     ```
@@ -526,7 +526,7 @@ As part of this major version, a number of previously deprecated props, arugment
 
     Here's an example of how the response shape would change with this modification:
 
-    ```jsx {{ prettier: false, del: [1], ins: [2] }}
+    ```js {{ prettier: false, del: [1], ins: [2] }}
     const data = await clerkClient.redirectUrls.getRedirectUrlList()
     const { data, totalCount } = await clerkClient.redirectUrls.getRedirectUrlList()
     ```
@@ -537,7 +537,7 @@ As part of this major version, a number of previously deprecated props, arugment
 
     Here's an example of how the response shape would change with this modification:
 
-    ```jsx {{ prettier: false, del: [1], ins: [2] }}
+    ```js {{ prettier: false, del: [1], ins: [2] }}
     const data = await clerkClient.users.getUserOauthAccessToken()
     const { data, totalCount } = await clerkClient.users.getUserOauthAccessToken()
     ```
@@ -760,7 +760,7 @@ As part of this major version, a number of previously deprecated props, arugment
   <AccordionPanel>
     `MultiSessionAppSupport` is a component that handles the intermediate “undefined” state for multisession apps by unmounting and remounting the components during the session switch (`setActive` call) in order to solve theoretical edge-cases that can arise while switching sessions. It is undocumented and intended only for internal use, so it has been moved to an `/internal` import path. Please note that internal imports are not intended for public use, and are outside the scope of semver.
 
-    ```jsx {{ prettier: false, del: [1], ins: [2] }}
+    ```js {{ prettier: false, del: [1], ins: [2] }}
     import { MultiSessionAppSupport } from '@clerk/clerk-react'
     import { MultiSessionAppSupport } from '@clerk/clerk-react/internal'
     ```
@@ -788,7 +788,7 @@ As part of this major version, a number of previously deprecated props, arugment
   <AccordionPanel>
     `setSession` should be replaced with `setActive`. The format of the parameters has changed slightly - `setActive` takes an object where `setSession` took params directly. The `setActive` function also can accept an `organization` param that is used to set the currently active organization. The return signature did not change. Read the [API documentation](/docs/references/javascript/clerk/session-methods#set-active) for more detail. This function should be expected to be returned from one of the following Clerk hooks: `useSessionList`, `useSignUp`, or `useSignIn`. Some migration examples:
 
-    ```jsx {{ prettier: false, del: [1, 4, 7], ins: [2, 5, 8] }}
+    ```js {{ prettier: false, del: [1, 4, 7], ins: [2, 5, 8] }}
     await setSession('sessionID', () => void)
     await setActive({ session: 'sessionID',  beforeEmit: () => void })
 
@@ -818,7 +818,7 @@ As part of this major version, a number of previously deprecated props, arugment
   <AccordionPanel>
     Passing a string as an argument to `Organization.create` is no longer possible - instead, pass an object with the `name` property.
 
-    ```jsx {{ prettier: false, del: [1], ins: [2] }}
+    ```js {{ prettier: false, del: [1], ins: [2] }}
     Organization.create('...');
     Organization.create({ name: '...' });
     ```
@@ -827,7 +827,7 @@ As part of this major version, a number of previously deprecated props, arugment
   <AccordionPanel>
     The `Organization.getPendingInvitations()` method has been removed. You can use `Organization.getInvitations` instead.
 
-    ```jsx {{ prettier: false, del: [1], ins: [2] }}
+    ```js {{ prettier: false, del: [1], ins: [2] }}
     Organization.getPendingInvitations();
     Organization.getInvitations({ status: 'pending' });
     ```

--- a/docs/upgrade-guides/core-2/react.mdx
+++ b/docs/upgrade-guides/core-2/react.mdx
@@ -95,9 +95,9 @@ Defining redirect URLs for after sign up, in, and/or out via the Clerk dashboard
 
 As part of this change, the default URL for each of these props has been set to `/`, so if you are passing `/` explicitly to any one of the above props, that line is no longer necessary and can be removed.
 
-```diff {{ prettier: false }}
-- <UserButton afterSignOutUrl='/' />
-+ <UserButton />
+```jsx {{ prettier: false, del: [1], ins: [2] }}
+<UserButton afterSignOutUrl='/' />
+<UserButton />
 ```
 
 ### `afterSignXUrl` changes
@@ -117,9 +117,9 @@ In general, use the environment variables over the props.
 
 To retain the current behavior of your app without any changes, you can switch `afterSignXUrl` with `signXFallbackRedirectUrl` as such:
 
-```diff {{ prettier: false }}
-- <SignIn afterSignInUrl='/foo' />
-+ <SignIn signInFallbackRedirectUrl='/foo' />
+```jsx {{ prettier: false, del: [1], ins: [2] }}
+<SignIn afterSignInUrl='/foo' />
+<SignIn signInFallbackRedirectUrl='/foo' />
 ```
 
 ### `navigate` prop to `ClerkProvider` replaced by `routerPush` and `routerReplace`
@@ -130,9 +130,9 @@ Two new props have been added to `ClerkProvider` that replace the single `naviga
 
 If you’d like to keep the same behavior as you had with the single `navigate` prop, pass the exact same function to both `routerPush` and `routerReplace` and the behavior will be identical. For example:
 
-```diff {{ prettier: false }}
-- <ClerkProvider navigate={ x => x } />
-+ <ClerkProvider routerPush={ x => x } routerReplace={ x => x } />
+```jsx {{ prettier: false, del: [1], ins: [2] }}
+<ClerkProvider navigate={ x => x } />
+<ClerkProvider routerPush={ x => x } routerReplace={ x => x } />
 ```
 
 However, you now have the option to differentiate behavior based on whether the navigation will be a push or replace.
@@ -258,14 +258,14 @@ As part of this major version, a number of previously deprecated props, arugment
   <AccordionPanel>
     If you are updating a user's password via the [`User.update` method](/docs/references/javascript/user/user#update), it must be changed to [`User.updatePassword`](/docs/references/javascript/user/password-management#update-password) instead. This method will require the current password as well as the desired new password. We made this update to improve the security of password changes. Example below:
 
-    ```diff {{ prettier: false }}
-    - user.update({ password: 'foo' });
+    ```jsx {{ prettier: false, del: [1], ins: [[3, 7]] }}
+    user.update({ password: 'foo' });
 
-    + user.updatePassword({
-    +   currentPassword: 'bar',
-    +   newPassword: 'foo',
-    +   signOutOfOtherSessions: true,
-    + });
+    user.updatePassword({
+      currentPassword: 'bar',
+      newPassword: 'foo',
+      signOutOfOtherSessions: true,
+    });
     ```
   </AccordionPanel>
 
@@ -276,9 +276,9 @@ As part of this major version, a number of previously deprecated props, arugment
   <AccordionPanel>
     The `afterSwitchOrganizationUrl` prop on the `<OrganizationSwitcher />` component has been renamed to `afterSelectOrganizationUrl`. This is a quick and simple rename.
 
-    ```diff {{ prettier: false }}
-    - <OrganizationSwitcher afterSwitchOrganizationUrl='...' />
-    + <OrganizationSwitcher afterSelectOrganizationUrl='...' />
+    ```jsx {{ prettier: false, del: [1], ins: [2] }}
+    <OrganizationSwitcher afterSwitchOrganizationUrl='...' />
+    <OrganizationSwitcher afterSelectOrganizationUrl='...' />
     ```
   </AccordionPanel>
 
@@ -295,104 +295,104 @@ As part of this major version, a number of previously deprecated props, arugment
   <AccordionPanel>
     There have been a couple changes to the pagination arguments that can be passed into this function - `limit` has been renamed to `pageSize`, and `offset` has been renamed to `initialPage`. This will help to make it more clear and simple to reason about pagination control. Example of how changes might look below:
 
-    ```diff {{ prettier: false }}
-      const { data } = await organization.getRoles({
-    -   limit: 10,
-    +   pageSize: 10,
-    -   offset: 10,
-    +   initialPage: 2,
-      })
+    ```jsx {{ prettier: false, del: [2, 4], ins: [3, 5] }}
+    const { data } = await organization.getRoles({
+      limit: 10,
+      pageSize: 10,
+      offset: 10,
+      initialPage: 2,
+    })
     ```
   </AccordionPanel>
 
   <AccordionPanel>
     There have been a couple changes to the pagination arguments that can be passed into this function - `limit` has been renamed to `pageSize`, and `offset` has been renamed to `initialPage`. This will help to make it more clear and simple to reason about pagination control. Example of how changes might look below:
 
-    ```diff {{ prettier: false }}
-      const { data } = await organization.getMemberships({
-    -   limit: 10,
-    +   pageSize: 10,
-    -   offset: 10,
-    +   initialPage: 2,
-      })
+    ```jsx {{ prettier: false, del: [2, 4], ins: [3, 5] }}
+    const { data } = await organization.getMemberships({
+      limit: 10,
+      pageSize: 10,
+      offset: 10,
+      initialPage: 2,
+    })
     ```
   </AccordionPanel>
 
   <AccordionPanel>
     There have been a couple changes to the pagination arguments that can be passed into this function - `limit` has been renamed to `pageSize`, and `offset` has been renamed to `initialPage`. This will help to make it more clear and simple to reason about pagination control. Example of how changes might look below:
 
-    ```diff {{ prettier: false }}
-      const { data } = await organization.getDomains({
-    -   limit: 10,
-    +   pageSize: 10,
-    -   offset: 10,
-    +   initialPage: 2,
-      })
+    ```jsx {{ prettier: false, del: [2, 4], ins: [3, 5] }}
+    const { data } = await organization.getDomains({
+      limit: 10,
+      pageSize: 10,
+      offset: 10,
+      initialPage: 2,
+    })
     ```
   </AccordionPanel>
 
   <AccordionPanel>
     There have been a couple changes to the pagination arguments that can be passed into this function - `limit` has been renamed to `pageSize`, and `offset` has been renamed to `initialPage`. This will help to make it more clear and simple to reason about pagination control. Example of how changes might look below:
 
-    ```diff {{ prettier: false }}
-      const { data } = await organization.getInvitations({
-    -   limit: 10,
-    +   pageSize: 10,
-    -   offset: 10,
-    +   initialPage: 2,
-      })
+    ```jsx {{ prettier: false, del: [2, 4], ins: [3, 5] }}
+    const { data } = await organization.getInvitations({
+      limit: 10,
+      pageSize: 10,
+      offset: 10,
+      initialPage: 2,
+    })
     ```
   </AccordionPanel>
 
   <AccordionPanel>
     There have been a couple changes to the pagination arguments that can be passed into this function - `limit` has been renamed to `pageSize`, and `offset` has been renamed to `initialPage`. This will help to make it more clear and simple to reason about pagination control. Example of how changes might look below:
 
-    ```diff {{ prettier: false }}
-      const { data } = await organization.getMembershipRequests({
-    -   limit: 10,
-    +   pageSize: 10,
-    -   offset: 10,
-    +   initialPage: 2,
-      })
+    ```jsx {{ prettier: false, del: [2, 4], ins: [3, 5] }}
+    const { data } = await organization.getMembershipRequests({
+      limit: 10,
+      pageSize: 10,
+      offset: 10,
+      initialPage: 2,
+    })
     ```
   </AccordionPanel>
 
   <AccordionPanel>
     There have been a couple changes to the pagination arguments that can be passed into this function - `limit` has been renamed to `pageSize`, and `offset` has been renamed to `initialPage`. This will help to make it more clear and simple to reason about pagination control. Example of how changes might look below:
 
-    ```diff {{ prettier: false }}
-      const { data } = await user.getOrganizationInvitations({
-    -   limit: 10,
-    +   pageSize: 10,
-    -   offset: 10,
-    +   initialPage: 2,
-      })
+    ```jsx {{ prettier: false, del: [2, 4], ins: [3, 5] }}
+    const { data } = await user.getOrganizationInvitations({
+      limit: 10,
+      pageSize: 10,
+      offset: 10,
+      initialPage: 2,
+    })
     ```
   </AccordionPanel>
 
   <AccordionPanel>
     There have been a couple changes to the pagination arguments that can be passed into this function - `limit` has been renamed to `pageSize`, and `offset` has been renamed to `initialPage`. This will help to make it more clear and simple to reason about pagination control. Example of how changes might look below:
 
-    ```diff {{ prettier: false }}
-      const { data } = await user.getOrganizationSuggestions({
-    -   limit: 10,
-    +   pageSize: 10,
-    -   offset: 10,
-    +   initialPage: 2,
-      })
+    ```jsx {{ prettier: false, del: [2, 4], ins: [3, 5] }}
+    const { data } = await user.getOrganizationSuggestions({
+      limit: 10,
+      pageSize: 10,
+      offset: 10,
+      initialPage: 2,
+    })
     ```
   </AccordionPanel>
 
   <AccordionPanel>
     There have been a couple changes to the pagination arguments that can be passed into this function - `limit` has been renamed to `pageSize`, and `offset` has been renamed to `initialPage`. This will help to make it more clear and simple to reason about pagination control. Example of how changes might look below:
 
-    ```diff {{ prettier: false }}
-      const { data } = await user.getOrganizationMemberships({
-    -   limit: 10,
-    +   pageSize: 10,
-    -   offset: 10,
-    +   initialPage: 2,
-      })
+    ```jsx {{ prettier: false, del: [2, 4], ins: [3, 5] }}
+    const { data } = await user.getOrganizationMemberships({
+      limit: 10,
+      pageSize: 10,
+      offset: 10,
+      initialPage: 2,
+    })
     ```
   </AccordionPanel>
 
@@ -401,9 +401,9 @@ As part of this major version, a number of previously deprecated props, arugment
 
     Here's an example of how the response shape would change with this modification:
 
-    ```diff {{ prettier: false }}
-    - const data = await clerkClient.users.getOrganizationMembershipList()
-    + const { data, totalCount } = await clerkClient.users.getOrganizationMembershipList()
+    ```jsx {{ prettier: false, del: [1], ins: [2] }}
+    const data = await clerkClient.users.getOrganizationMembershipList()
+    const { data, totalCount } = await clerkClient.users.getOrganizationMembershipList()
     ```
   </AccordionPanel>
 
@@ -412,34 +412,34 @@ As part of this major version, a number of previously deprecated props, arugment
 
     Here's an example of how the response shape would change with this modification:
 
-    ```diff {{ prettier: false }}
-    - const data = await clerkClient.users.getOrganizationInvitationList()
-    + const { data, totalCount } = await clerkClient.users.getOrganizationInvitationList()
+    ```jsx {{ prettier: false, del: [1], ins: [2] }}
+    const data = await clerkClient.users.getOrganizationInvitationList()
+    const { data, totalCount } = await clerkClient.users.getOrganizationInvitationList()
     ```
   </AccordionPanel>
 
   <AccordionPanel>
     The return type for this function was previously `[Items]` but has now been updated to `{ data: [Items], totalCount: number }`. Since Clerk's API responses are paginated, the `totalCount` property is helpful in determining the total number of items in the response easily. A before/after code example can be seen below:
 
-    ```diff {{ prettier: false }}
-      const data = await clerkClient.organizations.getOrganizationInvitationList({
-        organizationId: "...",
-      })
+    ```jsx {{ prettier: false, del: [5], ins: [6] }}
+    const data = await clerkClient.organizations.getOrganizationInvitationList({
+      organizationId: "...",
+    })
 
-    - data.forEach(() => {})
-    + data.data.forEach(() => {})
+    data.forEach(() => {})
+    data.data.forEach(() => {})
     ```
   </AccordionPanel>
 
   <AccordionPanel>
     The return type for this function was previously `[Items]` but has now been updated to `{ data: [Items], totalCount: number }`. Since Clerk's API responses are paginated, the `totalCount` property is helpful in determining the total number of items in the response easily. A before/after code example can be seen below:
 
-    ```diff {{ prettier: false }}
-      const { user } = useUser()
-      const membershipList = user.getOrganizationMembershipList()
+    ```jsx {{ prettier: false, del: [4], ins: [5] }}
+    const { user } = useUser()
+    const membershipList = user.getOrganizationMembershipList()
 
-    - membershipList.forEach(() => {})
-    + membershipList.data.forEach(() => {})
+    membershipList.forEach(() => {})
+    membershipList.data.forEach(() => {})
     ```
   </AccordionPanel>
 
@@ -448,21 +448,21 @@ As part of this major version, a number of previously deprecated props, arugment
 
     Here's an example of how the response shape would change with this modification:
 
-    ```diff {{ prettier: false }}
-    - const data = await clerkClient.users.getOrganizationList()
-    + const { data, totalCount } = await clerkClient.users.getOrganizationList()
+    ```jsx {{ prettier: false, del: [1], ins: [2] }}
+    const data = await clerkClient.users.getOrganizationList()
+    const { data, totalCount } = await clerkClient.users.getOrganizationList()
     ```
   </AccordionPanel>
 
   <AccordionPanel>
     The return type for this function was previously `[Items]` but has now been updated to `{ data: [Items], totalCount: number }`. Since Clerk's API responses are paginated, the `totalCount` property is helpful in determining the total number of items in the response easily. A before/after code example can be seen below:
 
-    ```diff {{ prettier: false }}
-      const { organization } = useOrganization()
-      const orgList = organization.getOrganizationList()
+    ```jsx {{ prettier: false, del: [4], ins: [5] }}
+    const { organization } = useOrganization()
+    const orgList = organization.getOrganizationList()
 
-    - orgList.forEach(() => {})
-    + orgList.data.forEach(() => {})
+    orgList.forEach(() => {})
+    orgList.data.forEach(() => {})
     ```
   </AccordionPanel>
 
@@ -471,9 +471,9 @@ As part of this major version, a number of previously deprecated props, arugment
 
     Here's an example of how the response shape would change with this modification:
 
-    ```diff {{ prettier: false }}
-    - const data = await clerkClient.invitations.getInvitationList()
-    + const { data, totalCount } = await clerkClient.invitations.getInvitationList()
+    ```jsx {{ prettier: false, del: [1], ins: [2] }}
+    const data = await clerkClient.invitations.getInvitationList()
+    const { data, totalCount } = await clerkClient.invitations.getInvitationList()
     ```
   </AccordionPanel>
 
@@ -482,9 +482,9 @@ As part of this major version, a number of previously deprecated props, arugment
 
     Here's an example of how the response shape would change with this modification:
 
-    ```diff {{ prettier: false }}
-    - const data = await clerkClient.sessions.getSessionList()
-    + const { data, totalCount } = await clerkClient.sessions.getSessionList()
+    ```jsx {{ prettier: false, del: [1], ins: [2] }}
+    const data = await clerkClient.sessions.getSessionList()
+    const { data, totalCount } = await clerkClient.sessions.getSessionList()
     ```
   </AccordionPanel>
 
@@ -493,9 +493,9 @@ As part of this major version, a number of previously deprecated props, arugment
 
     Here's an example of how the response shape would change with this modification:
 
-    ```diff {{ prettier: false }}
-    - const data = await clerkClient.users.getUserList()
-    + const { data, totalCount } = await clerkClient.users.getUserList()
+    ```jsx {{ prettier: false, del: [1], ins: [2] }}
+    const data = await clerkClient.users.getUserList()
+    const { data, totalCount } = await clerkClient.users.getUserList()
     ```
   </AccordionPanel>
 
@@ -504,9 +504,9 @@ As part of this major version, a number of previously deprecated props, arugment
 
     Here's an example of how the response shape would change with this modification:
 
-    ```diff {{ prettier: false }}
-    - const data = await clerkClient.allowlistIdentifiers.getAllowlistIdentifierList()
-    + const { data, totalCount } = await clerkClient.allowlistIdentifiers.getAllowlistIdentifierList()
+    ```jsx {{ prettier: false, del: [1], ins: [2] }}
+    const data = await clerkClient.allowlistIdentifiers.getAllowlistIdentifierList()
+    const { data, totalCount } = await clerkClient.allowlistIdentifiers.getAllowlistIdentifierList()
     ```
   </AccordionPanel>
 
@@ -515,9 +515,9 @@ As part of this major version, a number of previously deprecated props, arugment
 
     Here's an example of how the response shape would change with this modification:
 
-    ```diff {{ prettier: false }}
-    - const data = await clerkClient.clients.getClientList()
-    + const { data, totalCount } = await clerkClient.allowlistIdentifiers.getClientList()
+    ```jsx {{ prettier: false, del: [1], ins: [2] }}
+    const data = await clerkClient.clients.getClientList()
+    const { data, totalCount } = await clerkClient.allowlistIdentifiers.getClientList()
     ```
   </AccordionPanel>
 
@@ -526,9 +526,9 @@ As part of this major version, a number of previously deprecated props, arugment
 
     Here's an example of how the response shape would change with this modification:
 
-    ```diff {{ prettier: false }}
-    - const data = await clerkClient.redirectUrls.getRedirectUrlList()
-    + const { data, totalCount } = await clerkClient.redirectUrls.getRedirectUrlList()
+    ```jsx {{ prettier: false, del: [1], ins: [2] }}
+    const data = await clerkClient.redirectUrls.getRedirectUrlList()
+    const { data, totalCount } = await clerkClient.redirectUrls.getRedirectUrlList()
     ```
   </AccordionPanel>
 
@@ -537,9 +537,9 @@ As part of this major version, a number of previously deprecated props, arugment
 
     Here's an example of how the response shape would change with this modification:
 
-    ```diff {{ prettier: false }}
-    - const data = await clerkClient.users.getUserOauthAccessToken()
-    + const { data, totalCount } = await clerkClient.users.getUserOauthAccessToken()
+    ```jsx {{ prettier: false, del: [1], ins: [2] }}
+    const data = await clerkClient.users.getUserOauthAccessToken()
+    const { data, totalCount } = await clerkClient.users.getUserOauthAccessToken()
     ```
   </AccordionPanel>
 
@@ -634,9 +634,9 @@ As part of this major version, a number of previously deprecated props, arugment
   <AccordionPanel>
     The `userProfile` prop on [the `UserButton` component](/docs/components/user/user-button) has been changed to `userProfileProps`. This is purely a name change, none of the values need to be updated.
 
-    ```diff {{ prettier: false }}
-    - <UserButton userProfile={} />
-    + <UserButton userProfileProps={} />
+    ```jsx {{ prettier: false, del: [1], ins: [2] }}
+    <UserButton userProfile={} />
+    <UserButton userProfileProps={} />
     ```
   </AccordionPanel>
 
@@ -760,43 +760,43 @@ As part of this major version, a number of previously deprecated props, arugment
   <AccordionPanel>
     `MultiSessionAppSupport` is a component that handles the intermediate “undefined” state for multisession apps by unmounting and remounting the components during the session switch (`setActive` call) in order to solve theoretical edge-cases that can arise while switching sessions. It is undocumented and intended only for internal use, so it has been moved to an `/internal` import path. Please note that internal imports are not intended for public use, and are outside the scope of semver.
 
-    ```diff {{ prettier: false }}
-    - import { MultiSessionAppSupport } from '@clerk/clerk-react'
-    + import { MultiSessionAppSupport } from '@clerk/clerk-react/internal'
+    ```jsx {{ prettier: false, del: [1], ins: [2] }}
+    import { MultiSessionAppSupport } from '@clerk/clerk-react'
+    import { MultiSessionAppSupport } from '@clerk/clerk-react/internal'
     ```
   </AccordionPanel>
 
   <AccordionPanel>
     The `signOutCallback` prop on the [`<SignOutButton />` component](/docs/components/unstyled/sign-out-button) has been removed. Instead, you can use the `redirectUrl` prop. Example below:
 
-    ```diff {{ prettier: false }}
-      import { SignOutButton } from "@clerk/clerk-react";
+    ```jsx {{ prettier: false, del: [6], ins: [7] }}
+    import { SignOutButton } from "@clerk/clerk-react";
 
-      export const Signout = () => {
-        return (
-          <SignOutButton
-    -       signOutCallback={() => { window.location.href = "/your-path" }}
-    +       redirectUrl="/your-path"
-          >
-            <button>Sign Out</button>
-          </SignOutButton>
-        )
-      }
+    export const Signout = () => {
+      return (
+        <SignOutButton
+          signOutCallback={() => { window.location.href = "/your-path" }}
+          redirectUrl="/your-path"
+        >
+          <button>Sign Out</button>
+        </SignOutButton>
+      )
+    }
     ```
   </AccordionPanel>
 
   <AccordionPanel>
     `setSession` should be replaced with `setActive`. The format of the parameters has changed slightly - `setActive` takes an object where `setSession` took params directly. The `setActive` function also can accept an `organization` param that is used to set the currently active organization. The return signature did not change. Read the [API documentation](/docs/references/javascript/clerk/session-methods#set-active) for more detail. This function should be expected to be returned from one of the following Clerk hooks: `useSessionList`, `useSignUp`, or `useSignIn`. Some migration examples:
 
-    ```diff {{ prettier: false }}
-    - await setSession('sessionID', () => void)
-    + await setActive({ session: 'sessionID',  beforeEmit: () => void })
+    ```jsx {{ prettier: false, del: [1, 4, 7], ins: [2, 5, 8] }}
+    await setSession('sessionID', () => void)
+    await setActive({ session: 'sessionID',  beforeEmit: () => void })
 
-    - await setSession(sessionObj)
-    + await setActive({ session: sessionObj })
+    await setSession(sessionObj)
+    await setActive({ session: sessionObj })
 
-    - await setSession(sessionObj, () => void)
-    + await setActive({ session: sessionObj,  beforeEmit: () => void })
+    await setSession(sessionObj, () => void)
+    await setActive({ session: sessionObj,  beforeEmit: () => void })
     ```
 
     `setActive` also supports setting an active organization:
@@ -818,18 +818,18 @@ As part of this major version, a number of previously deprecated props, arugment
   <AccordionPanel>
     Passing a string as an argument to `Organization.create` is no longer possible - instead, pass an object with the `name` property.
 
-    ```diff {{ prettier: false }}
-    - Organization.create('...');
-    + Organization.create({ name: '...' });
+    ```jsx {{ prettier: false, del: [1], ins: [2] }}
+    Organization.create('...');
+    Organization.create({ name: '...' });
     ```
   </AccordionPanel>
 
   <AccordionPanel>
     The `Organization.getPendingInvitations()` method has been removed. You can use `Organization.getInvitations` instead.
 
-    ```diff {{ prettier: false }}
-    - Organization.getPendingInvitations();
-    + Organization.getInvitations({ status: 'pending' });
+    ```jsx {{ prettier: false, del: [1], ins: [2] }}
+    Organization.getPendingInvitations();
+    Organization.getInvitations({ status: 'pending' });
     ```
   </AccordionPanel>
 </Accordion>

--- a/docs/upgrade-guides/core-2/remix.mdx
+++ b/docs/upgrade-guides/core-2/remix.mdx
@@ -87,20 +87,20 @@ If you are having trouble with `npx`, it's also possible to install directly wit
 
 `ClerkErrorBoundary` is no longer needed for correct error handling in remix, so we have removed this function from the remix SDK, and it can be removed from your code as well. Example below:
 
-```diff {{ prettier: false }}
- import { rootAuthLoader } from '@clerk/remix/ssr.server';
- import {
-     ClerkApp,
--    ClerkErrorBoundary
- } from '@clerk/remix';
+```tsx {{ prettier: false, del: [4, 13] }}
+import { rootAuthLoader } from '@clerk/remix/ssr.server';
+import {
+  ClerkApp,
+  ClerkErrorBoundary
+} from '@clerk/remix';
 
- export const loader = (args: DataFunctionArgs) => {
-   return rootAuthLoader(args);
- };
+export const loader = (args: DataFunctionArgs) => {
+  return rootAuthLoader(args);
+};
 
- export default ClerkApp(App);
+export default ClerkApp(App);
 
-- export const ErrorBoundary = ClerkErrorBoundary();
+export const ErrorBoundary = ClerkErrorBoundary();
 ```
 
 ### Component design adjustments
@@ -115,9 +115,9 @@ Defining redirect URLs for after sign up, in, and/or out via the Clerk dashboard
 
 As part of this change, the default URL for each of these props has been set to `/`, so if you are passing `/` explicitly to any one of the above props, that line is no longer necessary and can be removed.
 
-```diff {{ prettier: false }}
-- <UserButton afterSignOutUrl='/' />
-+ <UserButton />
+```jsx {{ prettier: false, del: [1], ins: [2] }}
+<UserButton afterSignOutUrl='/' />
+<UserButton />
 ```
 
 ### `afterSignXUrl` changes
@@ -137,9 +137,9 @@ In general, use the environment variables over the props.
 
 To retain the current behavior of your app without any changes, you can switch `afterSignXUrl` with `signXFallbackRedirectUrl` as such:
 
-```diff {{ prettier: false }}
-- <SignIn afterSignInUrl='/foo' />
-+ <SignIn signInFallbackRedirectUrl='/foo' />
+```jsx {{ prettier: false, del: [1], ins: [2] }}
+<SignIn afterSignInUrl='/foo' />
+<SignIn signInFallbackRedirectUrl='/foo' />
 ```
 
 ### Removed: `orgs` claim on JWT
@@ -245,48 +245,48 @@ As part of this major version, a number of previously deprecated props, arugment
   <AccordionPanel>
     If you are updating a user's password via the [`User.update` method](/docs/references/javascript/user/user#update), it must be changed to [`User.updatePassword`](/docs/references/javascript/user/password-management#update-password) instead. This method will require the current password as well as the desired new password. We made this update to improve the security of password changes. Example below:
 
-    ```diff {{ prettier: false }}
-    - user.update({ password: 'foo' });
+    ```jsx {{ prettier: false, del: [1], ins: [[3, 7]] }}
+    user.update({ password: 'foo' });
 
-    + user.updatePassword({
-    +   currentPassword: 'bar',
-    +   newPassword: 'foo',
-    +   signOutOfOtherSessions: true,
-    + });
+    user.updatePassword({
+      currentPassword: 'bar',
+      newPassword: 'foo',
+      signOutOfOtherSessions: true,
+    });
     ```
   </AccordionPanel>
 
   <AccordionPanel>
     The `apiKey` argument passed to `createClerkClient` must be changed to `secretKey`.
 
-    ```diff {{ prettier: false }}
+    ```jsx {{ prettier: false, del: [3], ins: [4] }}
     import { createClerkClient } from '@clerk/remix/api.server';
 
-    - createClerkClient({ apiKey: '...' });
-    + createClerkClient({ secretKey: '...' });
+    createClerkClient({ apiKey: '...' });
+    createClerkClient({ secretKey: '...' });
     ```
   </AccordionPanel>
 
   <AccordionPanel>
     The `apiKey` argument passed to `rootAuthLoader` must be changed to `secretKey`.
 
-    ```diff {{ prettier: false }}
+    ```jsx {{ prettier: false, del: [3], ins: [4] }}
     import { rootAuthLoader } from '@clerk/remix/ssr.server';
 
-    - export const loader = args => rootAuthLoader(args, { apiKey: '...' });
-    + export const loader = args => rootAuthLoader(args, { secretKey: '...' });
+    export const loader = args => rootAuthLoader(args, { apiKey: '...' });
+    export const loader = args => rootAuthLoader(args, { secretKey: '...' });
     ```
   </AccordionPanel>
 
   <AccordionPanel>
     The `apiKey` argument passed to `getAuth` must be changed to `secretKey`.
 
-    ```diff {{ prettier: false }}
+    ```jsx {{ prettier: false, del: [4], ins: [5] }}
     import { getAuth } from '@clerk/remix/ssr.server';
 
     export const loader: LoaderFunction = async args => {
-    -  return getAuth(args, { apiKey: '...' });
-    +  return getAuth(args, { secretKey: '...' });
+     return getAuth(args, { apiKey: '...' });
+     return getAuth(args, { secretKey: '...' });
     };
     ```
   </AccordionPanel>
@@ -298,11 +298,11 @@ As part of this major version, a number of previously deprecated props, arugment
   <AccordionPanel>
     The `frontendApi` argument passed to `rootAuthLoader` must be changed to `publishableKey`.
 
-    ```diff {{ prettier: false }}
+    ```jsx {{ prettier: false, del: [3], ins: [4] }}
     import { rootAuthLoader } from '@clerk/remix/ssr.server';
 
-    - export const loader = args => rootAuthLoader(args, { frontendApi: '...' });
-    + export const loader = args => rootAuthLoader(args, { publishableKey: '...' });
+    export const loader = args => rootAuthLoader(args, { frontendApi: '...' });
+    export const loader = args => rootAuthLoader(args, { publishableKey: '...' });
     ```
   </AccordionPanel>
 
@@ -317,9 +317,9 @@ As part of this major version, a number of previously deprecated props, arugment
   <AccordionPanel>
     The `Clerk` default import has changed to `createClerkClient` and been moved to a named import rather than default. You must update your import path in order for it to work correctly. Example below of the fix that needs to be made:
 
-    ```diff {{ prettier: false }}
-    - import Clerk from "@clerk/remix"
-    + import { createClerkClient } from "@clerk/remix"
+    ```jsx {{ prettier: false, del: [1], ins: [2] }}
+    import Clerk from "@clerk/remix"
+    import { createClerkClient } from "@clerk/remix"
     ```
   </AccordionPanel>
 </Accordion>
@@ -332,15 +332,15 @@ As part of this major version, a number of previously deprecated props, arugment
   <AccordionPanel>
     `setSession` should be replaced with `setActive`. The format of the parameters has changed slightly - `setActive` takes an object where `setSession` took params directly. The `setActive` function also can accept an `organization` param that is used to set the currently active organization. The return signature did not change. Read the [API documentation](/docs/references/javascript/clerk/session-methods#set-active) for more detail. This function should be expected to be returned from one of the following Clerk hooks: `useSessionList`, `useSignUp`, or `useSignIn`. Some migration examples:
 
-    ```diff {{ prettier: false }}
-    - await setSession('sessionID', () => void)
-    + await setActive({ session: 'sessionID',  beforeEmit: () => void })
+    ```jsx {{ prettier: false, del: [1, 4, 7], ins: [2, 5, 8] }}
+    await setSession('sessionID', () => void)
+    await setActive({ session: 'sessionID',  beforeEmit: () => void })
 
-    - await setSession(sessionObj)
-    + await setActive({ session: sessionObj })
+    await setSession(sessionObj)
+    await setActive({ session: sessionObj })
 
-    - await setSession(sessionObj, () => void)
-    + await setActive({ session: sessionObj,  beforeEmit: () => void })
+    await setSession(sessionObj, () => void)
+    await setActive({ session: sessionObj,  beforeEmit: () => void })
     ```
 
     `setActive` also supports setting an active organization:
@@ -363,18 +363,18 @@ As part of this major version, a number of previously deprecated props, arugment
   <AccordionPanel>
     Passing a string as an argument to `Organization.create` is no longer possible - instead, pass an object with the `name` property.
 
-    ```diff {{ prettier: false }}
-    - Organization.create('...');
-    + Organization.create({ name: '...' });
+    ```jsx {{ prettier: false, del: [1], ins: [2] }}
+    Organization.create('...');
+    Organization.create({ name: '...' });
     ```
   </AccordionPanel>
 
   <AccordionPanel>
     The `Organization.getPendingInvitations()` method has been removed. You can use `Organization.getInvitations` instead.
 
-    ```diff {{ prettier: false }}
-    - Organization.getPendingInvitations();
-    + Organization.getInvitations({ status: 'pending' });
+    ```jsx {{ prettier: false, del: [1], ins: [2] }}
+    Organization.getPendingInvitations();
+    Organization.getInvitations({ status: 'pending' });
     ```
   </AccordionPanel>
 
@@ -393,19 +393,19 @@ As part of this major version, a number of previously deprecated props, arugment
   <AccordionPanel>
     The `signOutCallback` prop on the [`<SignOutButton />` component](/docs/components/unstyled/sign-out-button) has been removed. Instead, you can use the `redirectUrl` prop. Example below:
 
-    ```diff {{ prettier: false }}
-      import { SignOutButton } from "@clerk/clerk-react";
+    ```jsx {{ prettier: false, del: [6], ins: [7] }}
+    import { SignOutButton } from "@clerk/clerk-react";
 
-      export const Signout = () => {
-        return (
-          <SignOutButton
-    -       signOutCallback={() => { window.location.href = "/your-path" }}
-    +       redirectUrl="/your-path"
-          >
-            <button>Sign Out</button>
-          </SignOutButton>
-        )
-      }
+    export const Signout = () => {
+      return (
+        <SignOutButton
+          signOutCallback={() => { window.location.href = "/your-path" }}
+          redirectUrl="/your-path"
+        >
+          <button>Sign Out</button>
+        </SignOutButton>
+      )
+    }
     ```
   </AccordionPanel>
 </Accordion>

--- a/docs/upgrade-guides/core-2/remix.mdx
+++ b/docs/upgrade-guides/core-2/remix.mdx
@@ -87,7 +87,7 @@ If you are having trouble with `npx`, it's also possible to install directly wit
 
 `ClerkErrorBoundary` is no longer needed for correct error handling in remix, so we have removed this function from the remix SDK, and it can be removed from your code as well. Example below:
 
-```tsx {{ prettier: false, del: [4, 13] }}
+```ts {{ prettier: false, del: [4, 13] }}
 import { rootAuthLoader } from '@clerk/remix/ssr.server';
 import {
   ClerkApp,
@@ -245,7 +245,7 @@ As part of this major version, a number of previously deprecated props, arugment
   <AccordionPanel>
     If you are updating a user's password via the [`User.update` method](/docs/references/javascript/user/user#update), it must be changed to [`User.updatePassword`](/docs/references/javascript/user/password-management#update-password) instead. This method will require the current password as well as the desired new password. We made this update to improve the security of password changes. Example below:
 
-    ```jsx {{ prettier: false, del: [1], ins: [[3, 7]] }}
+    ```js {{ prettier: false, del: [1], ins: [[3, 7]] }}
     user.update({ password: 'foo' });
 
     user.updatePassword({
@@ -259,7 +259,7 @@ As part of this major version, a number of previously deprecated props, arugment
   <AccordionPanel>
     The `apiKey` argument passed to `createClerkClient` must be changed to `secretKey`.
 
-    ```jsx {{ prettier: false, del: [3], ins: [4] }}
+    ```js {{ prettier: false, del: [3], ins: [4] }}
     import { createClerkClient } from '@clerk/remix/api.server';
 
     createClerkClient({ apiKey: '...' });
@@ -270,7 +270,7 @@ As part of this major version, a number of previously deprecated props, arugment
   <AccordionPanel>
     The `apiKey` argument passed to `rootAuthLoader` must be changed to `secretKey`.
 
-    ```jsx {{ prettier: false, del: [3], ins: [4] }}
+    ```js {{ prettier: false, del: [3], ins: [4] }}
     import { rootAuthLoader } from '@clerk/remix/ssr.server';
 
     export const loader = args => rootAuthLoader(args, { apiKey: '...' });
@@ -281,7 +281,7 @@ As part of this major version, a number of previously deprecated props, arugment
   <AccordionPanel>
     The `apiKey` argument passed to `getAuth` must be changed to `secretKey`.
 
-    ```jsx {{ prettier: false, del: [4], ins: [5] }}
+    ```ts {{ prettier: false, del: [4], ins: [5] }}
     import { getAuth } from '@clerk/remix/ssr.server';
 
     export const loader: LoaderFunction = async args => {
@@ -298,7 +298,7 @@ As part of this major version, a number of previously deprecated props, arugment
   <AccordionPanel>
     The `frontendApi` argument passed to `rootAuthLoader` must be changed to `publishableKey`.
 
-    ```jsx {{ prettier: false, del: [3], ins: [4] }}
+    ```js {{ prettier: false, del: [3], ins: [4] }}
     import { rootAuthLoader } from '@clerk/remix/ssr.server';
 
     export const loader = args => rootAuthLoader(args, { frontendApi: '...' });
@@ -317,7 +317,7 @@ As part of this major version, a number of previously deprecated props, arugment
   <AccordionPanel>
     The `Clerk` default import has changed to `createClerkClient` and been moved to a named import rather than default. You must update your import path in order for it to work correctly. Example below of the fix that needs to be made:
 
-    ```jsx {{ prettier: false, del: [1], ins: [2] }}
+    ```js {{ prettier: false, del: [1], ins: [2] }}
     import Clerk from "@clerk/remix"
     import { createClerkClient } from "@clerk/remix"
     ```
@@ -332,7 +332,7 @@ As part of this major version, a number of previously deprecated props, arugment
   <AccordionPanel>
     `setSession` should be replaced with `setActive`. The format of the parameters has changed slightly - `setActive` takes an object where `setSession` took params directly. The `setActive` function also can accept an `organization` param that is used to set the currently active organization. The return signature did not change. Read the [API documentation](/docs/references/javascript/clerk/session-methods#set-active) for more detail. This function should be expected to be returned from one of the following Clerk hooks: `useSessionList`, `useSignUp`, or `useSignIn`. Some migration examples:
 
-    ```jsx {{ prettier: false, del: [1, 4, 7], ins: [2, 5, 8] }}
+    ```js {{ prettier: false, del: [1, 4, 7], ins: [2, 5, 8] }}
     await setSession('sessionID', () => void)
     await setActive({ session: 'sessionID',  beforeEmit: () => void })
 
@@ -363,7 +363,7 @@ As part of this major version, a number of previously deprecated props, arugment
   <AccordionPanel>
     Passing a string as an argument to `Organization.create` is no longer possible - instead, pass an object with the `name` property.
 
-    ```jsx {{ prettier: false, del: [1], ins: [2] }}
+    ```js {{ prettier: false, del: [1], ins: [2] }}
     Organization.create('...');
     Organization.create({ name: '...' });
     ```
@@ -372,7 +372,7 @@ As part of this major version, a number of previously deprecated props, arugment
   <AccordionPanel>
     The `Organization.getPendingInvitations()` method has been removed. You can use `Organization.getInvitations` instead.
 
-    ```jsx {{ prettier: false, del: [1], ins: [2] }}
+    ```js {{ prettier: false, del: [1], ins: [2] }}
     Organization.getPendingInvitations();
     Organization.getInvitations({ status: 'pending' });
     ```

--- a/prettier-mdx.mjs
+++ b/prettier-mdx.mjs
@@ -19,6 +19,20 @@ const processor = remark()
   .use(remarkFrontmatter)
   .use(remarkGfm, { tablePipeAlign: false })
   .use(remarkMdx, { printWidth: 120 })
+  .use(remarkDisallowDiffLang)
+
+function remarkDisallowDiffLang() {
+  return function traverse(tree) {
+    visit(tree, 'code', (node) => {
+      if (node.lang === 'diff') {
+        let position = `${node.position.start.line}:${node.position.start.column}`
+        throw new Error(
+          `The \`diff\` language is not supported (${position}). Please use the \`del\` and \`ins\` props instead. https://github.com/clerk/clerk-docs/blob/main/CONTRIBUTING.md#highlighting`,
+        )
+      }
+    })
+  }
+}
 
 function formatAnnotation(annotation, prettierOptions) {
   let prefix = 'let _ = '


### PR DESCRIPTION
This PR replaces uses of the `diff` code block language with the `del` and `ins` props ([documentation](https://github.com/clerk/clerk-docs/blob/main/CONTRIBUTING.md#highlighting)).

This format allows for code within code blocks to be formatted, and syntax highlighted in code editors.

**Before**

````markdown
```diff
- console.log('hi')
+ console.log('yo')
```
````

**After**

````markdown
```js {{ del: [1], ins: [2] }}
console.log('hi')
console.log('yo')
```
````