### PR TITLE
Remove /nodejs/token-verification from sidenav

### DIFF
--- a/docs/manifest.json
+++ b/docs/manifest.json
@@ -1774,10 +1774,6 @@
                   {
                     "title": "Connect/Express Middleware",
                     "href": "/docs/backend-requests/handling/nodejs"
-                  },
-                  {
-                    "title": "Networkless token verification",
-                    "href": "/docs/references/nodejs/token-verification"
                   }
                 ]
               ]


### PR DESCRIPTION
Page is coming up as 404 because it was removed, but wasn't removed from sidenav