### PR TITLE
fix: remove errant slash

### DIFF
--- a/docs/quickstarts/expo.mdx
+++ b/docs/quickstarts/expo.mdx
@@ -54,7 +54,7 @@ description: Add authentication and user management to your Expo app with Clerk.
 
   ### Install `@clerk/clerk-expo`
 
-  Add Clerk's \[Expo SDK] (/docs/expo/overview) to your project:
+  Add Clerk's [Expo SDK] (/docs/expo/overview) to your project:
 
   <CodeBlockTabs type="installer" options={["npm", "yarn", "pnpm"]}>
     ```bash filename="terminal"


### PR DESCRIPTION
<!--- Add the "deploy-preview" label and add your page previews here -->

> [!IMPORTANT]
> 🔎 Previews:
>
> -

### This PR:

- Removes a stray `\` that was causing a malformed markdown link
