### PR TITLE
Add Elements video to docs

### DIFF
--- a/docs/elements/overview.mdx
+++ b/docs/elements/overview.mdx
@@ -4,6 +4,8 @@ description: Learn how to use Clerk Elements to build custom UIs on top of Clerk
 
 # Clerk Elements (Beta)
 
+<YouTube videoid="K46GF72Hnzw" />
+
 > [!WARNING]
 > Clerk Elements is currently in beta with support for Next.js App Router. It is **not yet recommended for production use**.
 >


### PR DESCRIPTION
Adds a 3 minute video introducing Elements to the top of the Cler Elements (Beta) overview documentation page

Slack convo for more context: https://clerkinc.slack.com/archives/C05ST2R2HM3/p1722505083043519