### PR TITLE
Use `env` lang for environment variable code blocks

### DIFF
--- a/docs/guides/add-onboarding-flow.mdx
+++ b/docs/guides/add-onboarding-flow.mdx
@@ -139,7 +139,7 @@ export default function RootLayout({
 
 To ensure a smooth onboarding flow, add redirect URL's to your environment variables. The fallback redirect URL is used when there is no `redirect_url` in the path. The force redirect URL will always be used after a successful sign up.
 
-```sh {{ prettier: false, filename: '.env.local' }}
+```env {{ prettier: false, filename: '.env.local' }}
 NEXT_PUBLIC_CLERK_SIGN_IN_FALLBACK_REDIRECT_URL=/dashboard
 NEXT_PUBLIC_CLERK_SIGN_UP_FORCE_REDIRECT_URL=/onboarding
 ```

--- a/docs/guides/authjs-migration.mdx
+++ b/docs/guides/authjs-migration.mdx
@@ -65,7 +65,7 @@ This guide shows how to migrate an application using Auth.js (formerly NextAuth.
   **Pro tip!** If you are signed into your [Clerk Dashboard](https://dashboard.clerk.com/last-active?path=api-keys), your secret key should become visible by clicking on the eye icon.
 
   <InjectKeys>
-    ```sh {{ prettier: false, filename: '.env.local' }}
+    ```env {{ prettier: false, filename: '.env.local' }}
     NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY={{pub_key}}
     CLERK_SECRET_KEY={{secret}}
     ```

--- a/docs/guides/custom-redirects.mdx
+++ b/docs/guides/custom-redirects.mdx
@@ -29,12 +29,12 @@ You can define a fallback redirect URL in the case that there is no `redirect_ur
 The following example shows how to define a fallback redirect URL for both sign-in and sign-up pages:
 
 <CodeBlockTabs type="framework" options={["Next.js", "Remix"]}>
-  ```sh {{ prettier: false, filename: '.env.local' }}
+  ```env {{ prettier: false, filename: '.env.local' }}
   NEXT_PUBLIC_CLERK_SIGN_IN_FALLBACK_REDIRECT_URL=/dashboard
   NEXT_PUBLIC_CLERK_SIGN_UP_FALLBACK_REDIRECT_URL=/onboarding
   ```
 
-  ```sh {{ prettier: false, filename: '.env' }}
+  ```env {{ prettier: false, filename: '.env' }}
   CLERK_SIGN_IN_FALLBACK_REDIRECT_URL=/dashboard
   CLERK_SIGN_UP_FALLBACK_REDIRECT_URL=/onboarding
   ```
@@ -45,12 +45,12 @@ The following example shows how to define a fallback redirect URL for both sign-
 If you would like to override the `redirect_url` value and supply a custom redirect URL after sign-in or sign-up, you can use the following environment variables:
 
 <CodeBlockTabs type="framework" options={["Next.js", "Remix"]}>
-  ```sh {{ prettier: false, filename: '.env.local' }}
+  ```env {{ prettier: false, filename: '.env.local' }}
   NEXT_PUBLIC_CLERK_SIGN_IN_FORCE_REDIRECT_URL=/dashboard
   NEXT_PUBLIC_CLERK_SIGN_UP_FORCE_REDIRECT_URL=/onboarding
   ```
 
-  ```sh {{ prettier: false, filename: '.env' }}
+  ```env {{ prettier: false, filename: '.env' }}
   CLERK_SIGN_IN_FORCE_REDIRECT_URL=/dashboard
   CLERK_SIGN_UP_FORCE_REDIRECT_URL=/onboarding
   ```

--- a/docs/integrations/databases/convex.mdx
+++ b/docs/integrations/databases/convex.mdx
@@ -121,7 +121,7 @@ This tutorial assumes that you have already [set up a Clerk application](https:/
   **Pro tip!** If you are signed into your Clerk Dashboard, you can copy your publishable key below. Otherwise, you can find it in the Clerk Dashboard on the [API Keys](https://dashboard.clerk.com/last-active?path=api-keys) page.
 
   <InjectKeys>
-    ```sh {{ prettier: false, filename: '.env.local' }}
+    ```env {{ prettier: false, filename: '.env.local' }}
     VITE_CLERK_PUBLISHABLE_KEY={{pub_key}}
     ```
   </InjectKeys>

--- a/docs/integrations/databases/neon.mdx
+++ b/docs/integrations/databases/neon.mdx
@@ -68,7 +68,7 @@ This tutorial demonstrates how to integrate Neon Postgres with Clerk in a Next.j
 
   Your environment variable file should have the following values:
 
-  ```sh {{ prettier: false, filename: '.env.local' }}
+  ```env {{ prettier: false, filename: '.env.local' }}
   DATABASE_URL=NEON_DB_CONNECTION_STRING
   NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY={{pub_key}}
   CLERK_SECRET_KEY={{secret}}

--- a/docs/integrations/webhooks/sync-data.mdx
+++ b/docs/integrations/webhooks/sync-data.mdx
@@ -61,7 +61,7 @@ This guide can be adapted to listen for any Clerk event.
   1. In your project's root directory, you should have an `.env.local` file that includes your Clerk API keys. Here, assign your signing secret to `WEBHOOK_SECRET`. Your file should look something like this:
 
   <InjectKeys>
-    ```sh {{ prettier: false, filename: '.env.local' }}
+    ```env {{ prettier: false, filename: '.env.local' }}
     NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY={{pub_key}}
     CLERK_SECRET_KEY={{secret}}
     WEBHOOK_SECRET=whsec_123

--- a/docs/quickstarts/astro.mdx
+++ b/docs/quickstarts/astro.mdx
@@ -71,7 +71,7 @@ Clerk's [Astro SDK](/docs/references/astro/overview) provides a set of component
   </SignedOut>
 
   <InjectKeys>
-    ```sh {{ prettier: false, filename: '.env' }}
+    ```env {{ prettier: false, filename: '.env' }}
     PUBLIC_CLERK_PUBLISHABLE_KEY={{pub_key}}
     CLERK_SECRET_KEY={{secret}}
     ```

--- a/docs/quickstarts/expo.mdx
+++ b/docs/quickstarts/expo.mdx
@@ -85,7 +85,7 @@ description: Add authentication and user management to your Expo app with Clerk.
     The final result should resemble the following:
   </SignedOut>
 
-  ```sh filename=".env"
+  ```env {{ filename: '.env' }}
   EXPO_PUBLIC_CLERK_PUBLISHABLE_KEY={{pub_key}}
   ```
 

--- a/docs/quickstarts/gatsby.mdx
+++ b/docs/quickstarts/gatsby.mdx
@@ -35,7 +35,7 @@ Learn how to use Clerk to quickly and easily add secure authentication and user 
   **Pro tip!** If you are signed into your Clerk Dashboard, your secret key should become visible by clicking on the eye icon. Otherwise, you can find your keys in the Clerk Dashboard on the [API Keys](https://dashboard.clerk.com/last-active?path=api-keys) page.
 
   <InjectKeys>
-    ```sh {{ prettier: false, filename: '.env.development' }}
+    ```env {{ prettier: false, filename: '.env.development' }}
     GATSBY_CLERK_PUBLISHABLE_KEY={{pub_key}}
     CLERK_SECRET_KEY={{secret}}
     ```

--- a/docs/quickstarts/nextjs.mdx
+++ b/docs/quickstarts/nextjs.mdx
@@ -64,7 +64,7 @@ description: Add authentication and user management to your Next.js app with Cle
   </SignedOut>
 
   <InjectKeys>
-    ```sh {{ prettier: false, filename: '.env.local' }}
+    ```env {{ prettier: false, filename: '.env.local' }}
     NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY={{pub_key}}
     CLERK_SECRET_KEY={{secret}}
     ```

--- a/docs/quickstarts/react.mdx
+++ b/docs/quickstarts/react.mdx
@@ -92,7 +92,7 @@ description: Add authentication and user management to your React app with Clerk
   The final result should look as follows:
 
   <InjectKeys>
-    ```sh {{ prettier: false, filename: '.env.local' }}
+    ```env {{ prettier: false, filename: '.env.local' }}
     VITE_CLERK_PUBLISHABLE_KEY={{pub_key}}
     ```
   </InjectKeys>

--- a/docs/quickstarts/remix.mdx
+++ b/docs/quickstarts/remix.mdx
@@ -60,7 +60,7 @@ Learn how to use Clerk to quickly and easily add secure authentication and user 
   **Pro tip!** If you are signed into your Clerk Dashboard, your secret key should become visible by clicking on the eye icon. Otherwise, you can find your keys in the Clerk Dashboard on the [API Keys](https://dashboard.clerk.com/last-active?path=api-keys) page.
 
   <InjectKeys>
-    ```sh {{ prettier: false, filename: '.env' }}
+    ```env {{ prettier: false, filename: '.env' }}
     CLERK_PUBLISHABLE_KEY={{pub_key}}
     CLERK_SECRET_KEY={{secret}}
     ```

--- a/docs/references/nextjs/custom-signup-signin-pages.mdx
+++ b/docs/references/nextjs/custom-signup-signin-pages.mdx
@@ -68,7 +68,7 @@ If Clerk's prebuilt components don't meet your specific needs or if you require 
 
   In Next.js applications, you can either pass the `path` prop, _or_ you can define the `NEXT_PUBLIC_CLERK_SIGN_IN_URL` and `NEXT_PUBLIC_CLERK_SIGN_UP_URL` environment variables, like so:
 
-  ```sh {{ prettier: false, filename: '.env.local' }}
+  ```env {{ prettier: false, filename: '.env.local' }}
   NEXT_PUBLIC_CLERK_SIGN_IN_URL=/sign-in
   NEXT_PUBLIC_CLERK_SIGN_UP_URL=/sign-up
   ```

--- a/docs/references/redwood/overview.mdx
+++ b/docs/references/redwood/overview.mdx
@@ -31,7 +31,7 @@ Learn how to use Clerk to quickly and easily add secure authentication and user 
   **Pro tip!** If you are signed into your Clerk Dashboard, your secret key should become visible by clicking on the eye icon. Otherwise, you can find your keys in the Clerk Dashboard on the [API Keys](https://dashboard.clerk.com/last-active?path=api-keys) page.
 
   <InjectKeys>
-    ```sh {{ prettier: false, filename: '.env.local' }}
+    ```env {{ prettier: false, filename: '.env.local' }}
     CLERK_PUBLISHABLE_KEY={{pub_key}}
     CLERK_SECRET_KEY={{secret}}
     ```

--- a/docs/references/remix/custom-signup-signin-pages.mdx
+++ b/docs/references/remix/custom-signup-signin-pages.mdx
@@ -53,7 +53,7 @@ The functionality of the components are controlled by the instance settings you 
     <Tab>
       For SSR Mode, add environment variables for the `signIn`, `signUp`, `afterSignUp`, and `afterSignIn` paths:
 
-      ```sh {{ prettier: false, filename: '.env' }}
+      ```env {{ prettier: false, filename: '.env' }}
       CLERK_SIGN_IN_URL=/sign-in
       CLERK_SIGN_UP_URL=/sign-up
       CLERK_SIGN_IN_FALLBACK_URL=/

--- a/docs/references/remix/spa-mode.mdx
+++ b/docs/references/remix/spa-mode.mdx
@@ -62,7 +62,7 @@ description: Clerk supports Remix SPA mode out-of-the-box.
   The final result should look as follows:
 
   <InjectKeys>
-    ```sh {{ prettier: false, filename: '.env' }}
+    ```env {{ prettier: false, filename: '.env' }}
     VITE_CLERK_PUBLISHABLE_KEY={{pub_key}}
     ```
   </InjectKeys>


### PR DESCRIPTION
This PR replaces usage of the `sh` language for environment variable file (`.env`) snippets. The `env` language is an alias for `shell`/`sh` (see https://github.com/clerk/clerk/pull/538), but using `env` where appropriate allows us to differentiate between `.env` snippets and command line snippets.