### PR TITLE
Rename Expo read-session-user-data doc; remove unused import

### DIFF
--- a/docs/manifest.json
+++ b/docs/manifest.json
@@ -1728,7 +1728,7 @@
                   },
                   {
                     "title": "Read session and user data",
-                    "href": "/docs/references/expo/expo-read-session-user-data"
+                    "href": "/docs/references/expo/read-session-user-data"
                   },
                   {
                     "title": "Web support",

--- a/docs/quickstarts/expo.mdx
+++ b/docs/quickstarts/expo.mdx
@@ -455,7 +455,7 @@ See the following guides to take the next steps toward fleshing out your Expo ap
 
   ---
 
-  - [Read session and user data](/docs/references/expo/expo-read-session-user-data)
+  - [Read session and user data](/docs/references/expo/read-session-user-data)
   - Learn how to read session and user data with Expo.
 
   ---

--- a/docs/references/expo/read-session-user-data.mdx
+++ b/docs/references/expo/read-session-user-data.mdx
@@ -19,7 +19,7 @@ import { useAuth } from "@clerk/clerk-expo";
 import { Text } from "react-native";
 
 export default function UseAuthExample() {
-  const { isLoaded, userId, sessionId, getToken } = useAuth();
+  const { isLoaded, userId, sessionId } = useAuth();
 
   // In case the user signs out while on the page.
   if (!isLoaded || !userId) {


### PR DESCRIPTION
<!--- Add the "deploy-preview" label and add your page previews here -->

> [!WARNING]
> Need [clerk/clerk#549](https://github.com/clerk/clerk/pull/549) merged for redirects

<!--- Describe your changes in detail. Why does this change need to happen? Include any links to Slack discussions, Linear comments, etc. -->

### Explanation:

<!--- How does this PR solve the problem? -->

Needed to remove an unused import from an expo doc. Also found that the /expo/expo-read-session-user-data doc doesn't /expo twice.
