### PR TITLE
Fix Firebase guide; add demo repo

### DIFF
--- a/docs/integrations/databases/firebase.mdx
+++ b/docs/integrations/databases/firebase.mdx
@@ -30,6 +30,9 @@ description: Learn how to integrate Clerk into your Firebase application.
 
 Integrating Firebase with Clerk gives you the benefits of using Firebase's features while leveraging Clerk's authentication, prebuilt components, and webhooks.
 
+> [!TIP]
+> Check out the [demo repo](https://github.com/clerk/clerk-firebase-nextjs) for a full example of how to integrate Firebase with Clerk in a Next.js app.
+
 <Steps>
   ### Configure the integration
 
@@ -99,7 +102,7 @@ Integrating Firebase with Clerk gives you the benefits of using Firebase's featu
 
   1. Visit [your Firebase project settings](https://console.firebase.google.com/project/_/settings/general/).
   1. In the **Your apps** section, there should be a code snippet that includes the `firebaseConfig` object. Copy this object. It should look similar to the following:
-     ```typescript {{ prettier: false }}
+     ```ts {{ prettier: false }}
      const firebaseConfig = {
        apiKey: "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
        authDomain: "clerk-example-xxxxx.firebaseapp.com",
@@ -121,68 +124,78 @@ Integrating Firebase with Clerk gives you the benefits of using Firebase's featu
 
   The following example:
 
-  - Uses Clerk to generate an authentication token for Firebase's API.
-  - Creates a button for signing into your Firebase app.
+  - Expects the user to be signed into the app with Clerk.
+  - Creates a button for signing into your Firebase app, which uses Clerk to generate an authentication token for Firebase's API.
   - Creates a button for fetching example data from your Firestore database.
 
   This example is written for Next.js App Router, but is supported by any React meta framework, such as Remix or Gatsby.
 
-  ```tsx {{ prettier: false, filename: 'app/firebase/page.tsx' }}
-  "use client";
-  import { useAuth } from "@clerk/nextjs";
-  import { initializeApp } from "firebase/app";
-  import { getAuth, signInWithCustomToken } from "firebase/auth";
-  import { getFirestore } from "firebase/firestore";
-  import { doc, getDoc } from "firebase/firestore";
+  ```tsx {{ filename: 'app/firebase/page.tsx' }}
+  'use client'
+  import { useAuth } from '@clerk/nextjs'
+  import { initializeApp } from 'firebase/app'
+  import { getAuth, signInWithCustomToken } from 'firebase/auth'
+  import { getFirestore } from 'firebase/firestore'
+  import { doc, getDoc } from 'firebase/firestore'
 
+  // Add your Firebase config object
   const firebaseConfig = {
-    apiKey: "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
-    authDomain: "clerk-example-xxxxx.firebaseapp.com",
-    databaseURL: "https://clerk-example-xxxxx-default-xxxx.firebaseio.com",
-    projectId: "clerk-test-xxxx",
-    storageBucket: "clerk-test-xxxx.appspot.com",
-    messagingSenderId: "012345678910",
-    appId: "1:012345678:web:abcdef123456hijklm",
-    measurementId: "G-ABC123DEF",
-  };
+    apiKey: 'xxxxxxxxxxxxxxxxxxxxxxxxxxxxxx',
+    authDomain: 'clerk-example-xxxxx.firebaseapp.com',
+    databaseURL: 'https://clerk-example-xxxxx-default-xxxx.firebaseio.com',
+    projectId: 'clerk-test-xxxx',
+    storageBucket: 'clerk-test-xxxx.appspot.com',
+    messagingSenderId: '012345678910',
+    appId: '1:012345678:web:abcdef123456hijklm',
+    measurementId: 'G-ABC123DEF',
+  }
 
   // Connect to your Firebase app
-  const app = initializeApp(firebaseConfig);
+  const app = initializeApp(firebaseConfig)
   // Connect to your Firestore database
-  const db = getFirestore(app);
+  const db = getFirestore(app)
   // Connect to Firebase auth
-  const auth = getAuth(app);
+  const auth = getAuth(app)
 
   // Remove this if you do not have Firestore set up
   // for your Firebase app
   const getFirestoreData = async () => {
-    const docRef = doc(db, "example", "example-document");
-    const docSnap = await getDoc(docRef);
+    const docRef = doc(db, 'example', 'example-document')
+    const docSnap = await getDoc(docRef)
     if (docSnap.exists()) {
-      console.log("Document data:", docSnap.data());
+      console.log('Document data:', docSnap.data())
     } else {
       // docSnap.data() will be undefined in this case
-      console.log("No such document!");
+      console.log('No such document!')
     }
-  };
+  }
 
   export default function FirebaseUI() {
-    const { getToken } = useAuth();
-    const signInWithClerk = async () => {
-      console.log("Sign in with clerk");
-      const token = await getToken({ template: "integration_firebase" });
-      const userCredentials = await signInWithCustomToken(auth, token || "");
-       // The userCredentials.user object can call the methods of
-       // the Firebase platform as an authenticated user.
-      console.log("User:", userCredentials.user);
-    };
+    const { getToken, userId } = useAuth()
+
+    // Handle if the user is not signed in
+    // You could display content, or redirect them to a sign-in page
+    if (!userId) {
+      return <p>You need to sign in with Clerk to access this page.</p>
+    }
+
+    const signIntoFirebaseWithClerk = async () => {
+      const token = await getToken({ template: 'integration_firebase' })
+
+      const userCredentials = await signInWithCustomToken(auth, token || '')
+      // The userCredentials.user object can call the methods of
+      // the Firebase platform as an authenticated user.
+      console.log('User:', userCredentials.user)
+    }
 
     return (
-      <main style={{ display: "flex", flexDirection: "column", rowGap: "1rem" }}>
-        <button onClick={signInWithClerk}>Sign in</button>
+      <main style={{ display: 'flex', flexDirection: 'column', rowGap: '1rem' }}>
+        <button onClick={signIntoFirebaseWithClerk}>Sign in</button>
+
+        {/* Remove this button if you do not have Firestore set up */}
         <button onClick={getFirestoreData}>Get document</button>
       </main>
-    );
+    )
   }
   ```
 </Steps>
@@ -200,7 +213,7 @@ Integrating Firebase with Clerk gives you the benefits of using Firebase's featu
 
   ---
 
-  - [Deploy to Production](/docs/deployments/overview)
+  - [Deploy to production](/docs/deployments/overview)
   - Learn how to deploy your Clerk app to production.
 
   ---


### PR DESCRIPTION
<!--- Add the "deploy-preview" label and add your page previews here -->

> [!IMPORTANT]
> 🔎 Previews:
>
> -

<!--- Describe your changes in detail. Why does this change need to happen? Include any links to Slack discussions, Linear comments, etc. -->

### Explanation:

<!--- How does this PR solve the problem? -->

Firebase guide was unclear of how it was working - "Sign in with Clerk" was incorrect as the user should already be signed in with Clerk in order to sign in to Firebase. 

### This PR:

- Adds demo repo
- Uses function naming that represents the function more clearly
