### PR TITLE
ORGS-111: Add docs for the new `createOrganizationsLimit` field

### DIFF
--- a/docs/organizations/overview.mdx
+++ b/docs/organizations/overview.mdx
@@ -116,9 +116,9 @@ If you need more organizations or custom pricing, please contact [our sales team
 By default, users can create organizations within your application. To disable this permission for all users:
 
 1. Navigate to the [Clerk Dashboard](https://dashboard.clerk.com/last-active?path=organizations-settings).
-2. In the navigation sidebar, select **Organization Settings**.
-3. At the bottom of the page, in the **Limit creation** section, toggle **Allow new users to create organizations** off.
-4. You can also configure the number of organizations that can be created by each user. By default, unlimited organizations can be created by each user.
+1. In the navigation sidebar, select **Organization Settings**.
+1. At the bottom of the page, in the **Limit creation** section, toggle **Allow new users to create organizations** off.
+1. You can also configure the number of organizations that can be created by each user. By default, unlimited organizations can be created by each user.
 
 If you want to only disable this permission for certain users, you can override it on a per-user basis on the user's profile page in the Clerk Dashboard:
 

--- a/docs/organizations/overview.mdx
+++ b/docs/organizations/overview.mdx
@@ -116,8 +116,9 @@ If you need more organizations or custom pricing, please contact [our sales team
 By default, users can create organizations within your application. To disable this permission for all users:
 
 1. Navigate to the [Clerk Dashboard](https://dashboard.clerk.com/last-active?path=organizations-settings).
-1. In the navigation sidebar, select **Organization Settings**.
-1. At the bottom of the page, in the **Limit creation** section, toggle **Allow new users to create organizations** off.
+2. In the navigation sidebar, select **Organization Settings**.
+3. At the bottom of the page, in the **Limit creation** section, toggle **Allow new users to create organizations** off.
+4. You can also configure the number of organizations that can be created by each user. By default, unlimited organizations can be created by each user.
 
 If you want to only disable this permission for certain users, you can override it on a per-user basis on the user's profile page in the Clerk Dashboard:
 

--- a/docs/references/backend/types/backend-user.mdx
+++ b/docs/references/backend/types/backend-user.mdx
@@ -203,6 +203,13 @@ The Backend `User` object is similar to the `User` object as it holds informatio
   - `boolean`
 
   A boolean indicating whether the organization creation is enabled for the user or not.
+
+  ---
+
+  - `createOrganizationsLimit?`
+  - `number`
+
+  An integer indicating the number of organizations that can be created by the user. If the value is `0`, then the user can create unlimited organizations. Default is `null`.
 </Properties>
 
 [web3-ref]: /docs/references/javascript/web3-wallet/web3-wallet

--- a/docs/references/backend/user/update-user.mdx
+++ b/docs/references/backend/user/update-user.mdx
@@ -181,6 +181,13 @@ function updateUser: (userId: string, params: UpdateUserParams) => Promise<User>
 
   ---
 
+  - `createOrganizationsLimit?`
+  - `number`
+
+  An integer indicating the number of organizations that can be created by the user. If the value is `0`, then the user can create unlimited organizations. Default is `null`.
+
+  ---
+
   - `createdAt?`
   - `Date`
 

--- a/docs/references/backend/user/update-user.mdx
+++ b/docs/references/backend/user/update-user.mdx
@@ -15,6 +15,7 @@ function updateUser: (userId: string, params: UpdateUserParams) => Promise<User>
 
 ## `UpdateUserParams`
 
+<<<<<<< HEAD
 <Properties>
   - `userId`
   - `string`
@@ -186,6 +187,36 @@ function updateUser: (userId: string, params: UpdateUserParams) => Promise<User>
 
   A custom date/time denoting when the user signed up to the application, specified in RFC3339 format<br /><br />For example: `2012-10-20T07:15:20.902Z`.
 </Properties>
+=======
+| Name | Type | Description |
+| - | - | - |
+| `userId` | `string` | The ID of the user to update. |
+| `externalId?` | `string` | The ID of the user as used in your external systems or your previous authentication solution. Must be unique across your instance. |
+| `firstName?` | `string` | The user's first name. |
+| `lastName?` | `string` | The user's last name. |
+| `primaryEmailAddressID?` | `string` | The ID of the email address to set as primary. It must be verified, and present on the current user. |
+| `notifyPrimaryEmailAddressChanged?` | `boolean` | If set to `true`, the user will be notified that their primary email address has changed. By default, no notification is sent. Defaults to `false`. |
+| `primaryPhoneNumberID?` | `string` | The ID of the phone number to set as primary. It must be verified, and present on the current user. |
+| `primaryWeb3WalletID?` | `string` | The ID of the web3 wallets to set as primary. It must be verified, and present on the current user. |
+| `username?` | `string` | The user's username. It must be unique across your instance. |
+| be used when providing a `password`. | | |
+| `profileImageID?` | `string` | The ID of the image to set as the user's profile image. |
+| `password?` | `string` | The plaintext password to give the user. Must be at least 8 characters long, and can not be in any list of hacked passwords. |
+| `passwordDigest?` | `string` | In case you already have the password digests and not the passwords, you can use them for the newly created user via this property. The digests should be generated with one of the supported algorithms. The hashing algorithm can be specified using the `password_hasher` property. |
+| `passwordHasher?` | `'argon2i' \| 'argon2id' \| 'bcrypt' \| 'bcrypt_sha256_django' \| 'md5' \| 'pbkdf2_sha256' \| 'pbkdf2_sha256_django' \| 'pbkdf2_sha1' \| 'phpass' \| 'scrypt_firebase' \| 'scrypt_werkzeug' \| 'sha256'` | The hashing algorithm that was used to generate the password digest. Each of the supported hashers expects the incoming digest to be in a particular format. See the [Clerk Backend API reference](https://clerk.com/docs/reference/backend-api/tag/Users#operation/CreateUser) for more information. |
+| `skipPasswordChecks?` | `boolean` | When set to `true`, all password checks are skipped. It is recommended to use this method only when migrating plaintext passwords to Clerk. Upon migration the user base should be prompted to pick stronger password. |
+| `skipPasswordRequirement?` | `boolean` | When set to `true`, password is not required anymore when creating the user and can be omitted. This is useful when you are trying to create a user that doesn't have a password, in an instance that is using passwords. Please note that you cannot use this flag if password is the only way for a user to sign into your instance. |
+| `signOutOfOtherSessions?` | `boolean` | Set to `true` to sign out the user from all their active sessions once their password is updated. This parameter can only be used when providing a `password`. |
+| `totpSecret?` | `string` | In case TOTP is configured on the instance, you can provide the secret to enable it on the newly created user without the need to reset it. Please note that currently the supported options are: <ul><li>Period: 30 seconds</li><li>Code length: 6 digits</li><li>Algorithm: SHA1</li></ul> |
+| `backupCodes?` | `string[]` | If backup codes are configured on the instance, you can provide them to enable it on the newly created user without the need to reset them. You must provide the backup codes in plain format or the corresponding bcrypt digest. |
+| `publicMetadata?` | `Record<string, unknown>` | Metadata saved on the user, that is visible to both your Frontend and Backend APIs. |
+| `privateMetadata?` | `Record<string, unknown>` | Metadata saved on the user that is only visible to your Backend API. |
+| `unsafeMetadata?` | `Record<string, unknown>` | Metadata saved on the user, that can be updated from both the Frontend and Backend APIs. **Note:** Since this data can be modified from the frontend, it is not guaranteed to be safe. |
+| `deleteSelfEnabled?` | `boolean` | If `true`, the user can delete themselves with the Frontend API. |
+| `createOrganizationEnabled?` | `boolean` | If `true`, the user can create organizations with the Frontend API. |
+| `createOrganizationsLimit` | `number` | An integer indicating the number of organizations that can be created by the user. If the value is `0`, then the user can create unlimited organizations. |
+| `createdAt?` | `Date` | A custom date/time denoting when the user signed up to the application, specified in RFC3339 format<br /><br />For example: `2012-10-20T07:15:20.902Z`. |
+>>>>>>> 05004066 (lint)
 
 ## Example
 

--- a/docs/references/backend/user/update-user.mdx
+++ b/docs/references/backend/user/update-user.mdx
@@ -15,7 +15,6 @@ function updateUser: (userId: string, params: UpdateUserParams) => Promise<User>
 
 ## `UpdateUserParams`
 
-<<<<<<< HEAD
 <Properties>
   - `userId`
   - `string`
@@ -187,36 +186,6 @@ function updateUser: (userId: string, params: UpdateUserParams) => Promise<User>
 
   A custom date/time denoting when the user signed up to the application, specified in RFC3339 format<br /><br />For example: `2012-10-20T07:15:20.902Z`.
 </Properties>
-=======
-| Name | Type | Description |
-| - | - | - |
-| `userId` | `string` | The ID of the user to update. |
-| `externalId?` | `string` | The ID of the user as used in your external systems or your previous authentication solution. Must be unique across your instance. |
-| `firstName?` | `string` | The user's first name. |
-| `lastName?` | `string` | The user's last name. |
-| `primaryEmailAddressID?` | `string` | The ID of the email address to set as primary. It must be verified, and present on the current user. |
-| `notifyPrimaryEmailAddressChanged?` | `boolean` | If set to `true`, the user will be notified that their primary email address has changed. By default, no notification is sent. Defaults to `false`. |
-| `primaryPhoneNumberID?` | `string` | The ID of the phone number to set as primary. It must be verified, and present on the current user. |
-| `primaryWeb3WalletID?` | `string` | The ID of the web3 wallets to set as primary. It must be verified, and present on the current user. |
-| `username?` | `string` | The user's username. It must be unique across your instance. |
-| be used when providing a `password`. | | |
-| `profileImageID?` | `string` | The ID of the image to set as the user's profile image. |
-| `password?` | `string` | The plaintext password to give the user. Must be at least 8 characters long, and can not be in any list of hacked passwords. |
-| `passwordDigest?` | `string` | In case you already have the password digests and not the passwords, you can use them for the newly created user via this property. The digests should be generated with one of the supported algorithms. The hashing algorithm can be specified using the `password_hasher` property. |
-| `passwordHasher?` | `'argon2i' \| 'argon2id' \| 'bcrypt' \| 'bcrypt_sha256_django' \| 'md5' \| 'pbkdf2_sha256' \| 'pbkdf2_sha256_django' \| 'pbkdf2_sha1' \| 'phpass' \| 'scrypt_firebase' \| 'scrypt_werkzeug' \| 'sha256'` | The hashing algorithm that was used to generate the password digest. Each of the supported hashers expects the incoming digest to be in a particular format. See the [Clerk Backend API reference](https://clerk.com/docs/reference/backend-api/tag/Users#operation/CreateUser) for more information. |
-| `skipPasswordChecks?` | `boolean` | When set to `true`, all password checks are skipped. It is recommended to use this method only when migrating plaintext passwords to Clerk. Upon migration the user base should be prompted to pick stronger password. |
-| `skipPasswordRequirement?` | `boolean` | When set to `true`, password is not required anymore when creating the user and can be omitted. This is useful when you are trying to create a user that doesn't have a password, in an instance that is using passwords. Please note that you cannot use this flag if password is the only way for a user to sign into your instance. |
-| `signOutOfOtherSessions?` | `boolean` | Set to `true` to sign out the user from all their active sessions once their password is updated. This parameter can only be used when providing a `password`. |
-| `totpSecret?` | `string` | In case TOTP is configured on the instance, you can provide the secret to enable it on the newly created user without the need to reset it. Please note that currently the supported options are: <ul><li>Period: 30 seconds</li><li>Code length: 6 digits</li><li>Algorithm: SHA1</li></ul> |
-| `backupCodes?` | `string[]` | If backup codes are configured on the instance, you can provide them to enable it on the newly created user without the need to reset them. You must provide the backup codes in plain format or the corresponding bcrypt digest. |
-| `publicMetadata?` | `Record<string, unknown>` | Metadata saved on the user, that is visible to both your Frontend and Backend APIs. |
-| `privateMetadata?` | `Record<string, unknown>` | Metadata saved on the user that is only visible to your Backend API. |
-| `unsafeMetadata?` | `Record<string, unknown>` | Metadata saved on the user, that can be updated from both the Frontend and Backend APIs. **Note:** Since this data can be modified from the frontend, it is not guaranteed to be safe. |
-| `deleteSelfEnabled?` | `boolean` | If `true`, the user can delete themselves with the Frontend API. |
-| `createOrganizationEnabled?` | `boolean` | If `true`, the user can create organizations with the Frontend API. |
-| `createOrganizationsLimit` | `number` | An integer indicating the number of organizations that can be created by the user. If the value is `0`, then the user can create unlimited organizations. |
-| `createdAt?` | `Date` | A custom date/time denoting when the user signed up to the application, specified in RFC3339 format<br /><br />For example: `2012-10-20T07:15:20.902Z`. |
->>>>>>> 05004066 (lint)
 
 ## Example
 

--- a/docs/references/javascript/user/user.mdx
+++ b/docs/references/javascript/user/user.mdx
@@ -219,6 +219,13 @@ The ClerkJS SDK provides some helper [methods](#methods) on the `User` object to
 
   ---
 
+  - `createOrganizationsLimit?`
+  - `number`
+
+  An integer indicating the number of organizations that can be created by the user. If the value is `0`, then the user can create unlimited organizations. Default is `null`.
+
+  ---
+
   - `deleteSelfEnabled`
   - `boolean`
 


### PR DESCRIPTION
<!--- Add the "deploy-preview" label and add your page previews here -->


> [!CAUTION]
> ❌ Blocked by:
> https://github.com/clerk/javascript/pull/3823

> [!IMPORTANT]
> 🔎 Previews:
>
> - https://clerk.com/docs/pr/1364
> - https://clerk.com/docs/pr/1364/organizations/overview
> - https://clerk.com/docs/pr/1364/references/backend/types/backend-user
> - https://clerk.com/docs/pr/1364/references/backend/user/update-user
> - https://clerk.com/docs/pr/1364/references/javascript/user/user

<!--- Describe your changes in detail. Why does this change need to happen? Include any links to Slack discussions, Linear comments, etc. -->

### Explanation:
This PR adds descriptions and indicates the new section of the dashboard to manage create organization limits.

