### PR TITLE
Remove `<InjectKeys>`

### DIFF
--- a/docs/advanced-usage/using-proxies.mdx
+++ b/docs/advanced-usage/using-proxies.mdx
@@ -146,38 +146,36 @@ When using a proxy, all requests to the Frontend API will be made through your d
 
   To configure your proxy setup using environment variables, your `.env.local` file should look like this:
 
-  <InjectKeys>
-    <Tabs type="framework" items={["Next.js", "Remix", "JavaScript"]}>
-      <Tab>
-        ```env {{ prettier: false, filename: '.env.local' }}
-        NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY={{pub_key}}
-        CLERK_SECRET_KEY={{secret}}
+  <Tabs type="framework" items={["Next.js", "Remix", "JavaScript"]}>
+    <Tab>
+      ```env {{ prettier: false, filename: '.env.local' }}
+      NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY={{pub_key}}
+      CLERK_SECRET_KEY={{secret}}
 
-        NEXT_PUBLIC_CLERK_PROXY_URL=https://app.dev/__clerk
-        ```
-      </Tab>
+      NEXT_PUBLIC_CLERK_PROXY_URL=https://app.dev/__clerk
+      ```
+    </Tab>
 
-      <Tab>
-        ```env {{ prettier: false, filename: '.env.local' }}
-        CLERK_PUBLISHABLE_KEY={{pub_key}}
-        CLERK_SECRET_KEY={{secret}}
+    <Tab>
+      ```env {{ prettier: false, filename: '.env.local' }}
+      CLERK_PUBLISHABLE_KEY={{pub_key}}
+      CLERK_SECRET_KEY={{secret}}
 
-        CLERK_PROXY_URL=https://app.dev/__clerk
-        ```
-      </Tab>
+      CLERK_PROXY_URL=https://app.dev/__clerk
+      ```
+    </Tab>
 
-      <Tab>
-        You will only need to set environment variables in your JavaScript application if you are using a bundler (the `NPM module` method for ClerkJS installation). If you are using the `<script>` method, configure your proxy setup using [properties in your application](#properties-in-your-application) instead.
+    <Tab>
+      You will only need to set environment variables in your JavaScript application if you are using a bundler (the `NPM module` method for ClerkJS installation). If you are using the `<script>` method, configure your proxy setup using [properties in your application](#properties-in-your-application) instead.
 
-        ```env {{ prettier: false, filename: '.env.local' }}
-        CLERK_PUBLISHABLE_KEY={{pub_key}}
-        CLERK_SECRET_KEY={{secret}}
+      ```env {{ prettier: false, filename: '.env.local' }}
+      CLERK_PUBLISHABLE_KEY={{pub_key}}
+      CLERK_SECRET_KEY={{secret}}
 
-        CLERK_PROXY_URL=https://app.dev/__clerk
-        ```
-      </Tab>
-    </Tabs>
-  </InjectKeys>
+      CLERK_PROXY_URL=https://app.dev/__clerk
+      ```
+    </Tab>
+  </Tabs>
 
   #### Properties in your application
 
@@ -250,40 +248,38 @@ When using a proxy, all requests to the Frontend API will be made through your d
     <Tab>
       To configure your proxy setup using properties in your JavaScript application, pass the `proxyUrl` option to the [`load()`](/docs/references/javascript/clerk/clerk#load) method.
 
-      <InjectKeys>
-        <CodeBlockTabs type="npm-script" options={["NPM module", "<script>"]}>
-          ```js {{ prettier: false, filename: 'main.js' }}
-            import { Clerk } from '@clerk/clerk-js';
+      <CodeBlockTabs type="npm-script" options={["NPM module", "<script>"]}>
+        ```js {{ prettier: false, filename: 'main.js' }}
+          import { Clerk } from '@clerk/clerk-js';
 
-            // Initialize Clerk with your Clerk publishable key
-            const clerk = new Clerk('{{pub_key}}');
+          // Initialize Clerk with your Clerk publishable key
+          const clerk = new Clerk('{{pub_key}}');
 
-            await clerk.load({
-              proxyUrl: 'https://app.dev/__clerk',
-            });
-          ```
+          await clerk.load({
+            proxyUrl: 'https://app.dev/__clerk',
+          });
+        ```
 
-          ```html {{ prettier: false, filename: 'index.html' }}
-            <!-- Initialize Clerk with your
-            Clerk Publishable key and Frontend API URL -->
-            <script
-              async
-              crossorigin="anonymous"
-              data-clerk-publishable-key="{{pub_key}}"
-              src="https://{{fapi_url}}/npm/@clerk/clerk-js@latest/dist/clerk.browser.js"
-              type="text/javascript"
-            ></script>
+        ```html {{ prettier: false, filename: 'index.html' }}
+          <!-- Initialize Clerk with your
+          Clerk Publishable key and Frontend API URL -->
+          <script
+            async
+            crossorigin="anonymous"
+            data-clerk-publishable-key="{{pub_key}}"
+            src="https://{{fapi_url}}/npm/@clerk/clerk-js@latest/dist/clerk.browser.js"
+            type="text/javascript"
+          ></script>
 
-            <script>
-              window.addEventListener("load", async function () {
-                await Clerk.load({
-                  proxyUrl: 'https://app.dev/__clerk',
-                });
+          <script>
+            window.addEventListener("load", async function () {
+              await Clerk.load({
+                proxyUrl: 'https://app.dev/__clerk',
               });
-            </script>
-          ```
-        </CodeBlockTabs>
-      </InjectKeys>
+            });
+          </script>
+        ```
+      </CodeBlockTabs>
     </Tab>
   </Tabs>
 

--- a/docs/backend-requests/handling/go.mdx
+++ b/docs/backend-requests/handling/go.mdx
@@ -11,47 +11,45 @@ The Clerk Go SDK provides an easy-to-use middleware that adds the active session
 
 **Pro tip!** If you are signed into your Clerk Dashboard, your secret key should become visible by clicking on the eye icon. Otherwise, you can find your keys in the Clerk Dashboard on the [API Keys](https://dashboard.clerk.com/last-active?path=api-keys) page.
 
-<InjectKeys>
-  ```go {{ prettier: false, filename: 'main.go' }}
-  package main
+```go {{ prettier: false, filename: 'main.go' }}
+package main
 
-  import (
-  	"net/http"
+import (
+	"net/http"
 
-  	"github.com/clerk/clerk-sdk-go/v2"
-  	clerkhttp "github.com/clerk/clerk-sdk-go/v2/http"
-  	"github.com/clerk/clerk-sdk-go/v2/user"
-  )
+	"github.com/clerk/clerk-sdk-go/v2"
+	clerkhttp "github.com/clerk/clerk-sdk-go/v2/http"
+	"github.com/clerk/clerk-sdk-go/v2/user"
+)
 
-  func main() {
-  	clerk.SetKey(`{{secret}}`)
+func main() {
+	clerk.SetKey(`{{secret}}`)
 
-  	mux := http.NewServeMux()
-  	mux.Handle("/hello", clerkhttp.WithHeaderAuthorization()(hello()))
-  	http.ListenAndServe(":8080", mux)
-  }
+	mux := http.NewServeMux()
+	mux.Handle("/hello", clerkhttp.WithHeaderAuthorization()(hello()))
+	http.ListenAndServe(":8080", mux)
+}
 
-  func hello() http.HandlerFunc {
-  	return func(w http.ResponseWriter, r *http.Request) {
-  		ctx := r.Context()
-  		claims, ok := clerk.SessionClaimsFromContext(ctx)
-  		if !ok {
-  			w.WriteHeader(http.StatusUnauthorized)
-  			w.Write([]byte(`{"access": "unauthorized"}`))
-  			return
-  		}
+func hello() http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		ctx := r.Context()
+		claims, ok := clerk.SessionClaimsFromContext(ctx)
+		if !ok {
+			w.WriteHeader(http.StatusUnauthorized)
+			w.Write([]byte(`{"access": "unauthorized"}`))
+			return
+		}
 
-  		usr, err := user.Get(ctx, claims.Subject)
-  		if err != nil {
-  			panic(err)
-  		}
-  		if usr == nil {
-  			w.Write([]byte("User does not exist"))
-  			return
-  		}
+		usr, err := user.Get(ctx, claims.Subject)
+		if err != nil {
+			panic(err)
+		}
+		if usr == nil {
+			w.Write([]byte("User does not exist"))
+			return
+		}
 
-  		w.Write([]byte("Hello " + *usr.FirstName))
-  	}
-  }
-  ```
-</InjectKeys>
+		w.Write([]byte("Hello " + *usr.FirstName))
+	}
+}
+```

--- a/docs/components/authentication/sign-in.mdx
+++ b/docs/components/authentication/sign-in.mdx
@@ -129,52 +129,50 @@ function mountSignIn(node: HTMLDivElement, props?: SignInProps): void;
 
 #### `mountSignIn()` usage
 
-<InjectKeys>
-  <CodeBlockTabs type="npm-script" options={['NPM module', '<script>']}>
-    ```js {{ prettier: false, filename: 'index.js', mark: [14] }}
-    import { Clerk } from '@clerk/clerk-js';
+<CodeBlockTabs type="npm-script" options={['NPM module', '<script>']}>
+  ```js {{ prettier: false, filename: 'index.js', mark: [14] }}
+  import { Clerk } from '@clerk/clerk-js';
 
-    // Initialize Clerk with your Clerk publishable key
-    const clerk = new Clerk('{{pub_key}}');
-    await clerk.load();
+  // Initialize Clerk with your Clerk publishable key
+  const clerk = new Clerk('{{pub_key}}');
+  await clerk.load();
 
-    document.getElementById("app").innerHTML = `
-      <div id="sign-in"></div>
-    `;
-
-    const signInDiv =
-      document.getElementById("sign-in");
-
-    clerk.mountSignIn(signInDiv);
-    ```
-
-    ```html {{ prettier: false, filename: 'index.html', mark: [21] }}
-    <!-- Add a <div id="sign-in"> element to your HTML -->
+  document.getElementById("app").innerHTML = `
     <div id="sign-in"></div>
+  `;
 
-    <!-- Initialize Clerk with your
-    Clerk Publishable key and Frontend API URL -->
-    <script
-      async
-      crossorigin="anonymous"
-      data-clerk-publishable-key="{{pub_key}}"
-      src="https://{{fapi_url}}/npm/@clerk/clerk-js@latest/dist/clerk.browser.js"
-      type="text/javascript"
-    ></script>
+  const signInDiv =
+    document.getElementById("sign-in");
 
-    <script>
-      window.addEventListener("load", async function () {
-        await Clerk.load();
+  clerk.mountSignIn(signInDiv);
+  ```
 
-        const signInDiv =
-          document.getElementById('sign-in');
+  ```html {{ prettier: false, filename: 'index.html', mark: [21] }}
+  <!-- Add a <div id="sign-in"> element to your HTML -->
+  <div id="sign-in"></div>
 
-        Clerk.mountSignIn(signInDiv);
-      });
-    </script>
-    ```
-  </CodeBlockTabs>
-</InjectKeys>
+  <!-- Initialize Clerk with your
+  Clerk Publishable key and Frontend API URL -->
+  <script
+    async
+    crossorigin="anonymous"
+    data-clerk-publishable-key="{{pub_key}}"
+    src="https://{{fapi_url}}/npm/@clerk/clerk-js@latest/dist/clerk.browser.js"
+    type="text/javascript"
+  ></script>
+
+  <script>
+    window.addEventListener("load", async function () {
+      await Clerk.load();
+
+      const signInDiv =
+        document.getElementById('sign-in');
+
+      Clerk.mountSignIn(signInDiv);
+    });
+  </script>
+  ```
+</CodeBlockTabs>
 
 ### `unmountSignIn()`
 
@@ -192,60 +190,58 @@ function unmountSignIn(node: HTMLDivElement): void;
 
 #### `unmountSignIn()` usage
 
-<InjectKeys>
-  <CodeBlockTabs type="npm-script" options={['NPM module', '<script>']}>
-    ```js {{ prettier: false, filename: 'index.js', mark: [18] }}
-    import { Clerk } from '@clerk/clerk-js';
+<CodeBlockTabs type="npm-script" options={['NPM module', '<script>']}>
+  ```js {{ prettier: false, filename: 'index.js', mark: [18] }}
+  import { Clerk } from '@clerk/clerk-js';
 
-    // Initialize Clerk with your Clerk publishable key
-    const clerk = new Clerk('{{pub_key}}');
-    await clerk.load();
+  // Initialize Clerk with your Clerk publishable key
+  const clerk = new Clerk('{{pub_key}}');
+  await clerk.load();
 
-    document.getElementById('app').innerHTML = `
-      <div id="sign-in"></div>
-    `
-
-    const signInDiv =
-      document.getElementById('sign-in');
-
-    clerk.mountSignIn(signInDiv);
-
-    // ...
-
-    clerk.unmountSignIn(signInDiv);
-    ```
-
-    ```html {{ prettier: false, filename: 'index.html', mark: [25] }}
-    <!-- Add a <div id="sign-in"> element to your HTML -->
+  document.getElementById('app').innerHTML = `
     <div id="sign-in"></div>
+  `
 
-    <!-- Initialize Clerk with your
-    Clerk Publishable key and Frontend API URL -->
-    <script
-      async
-      crossorigin="anonymous"
-      data-clerk-publishable-key="{{pub_key}}"
-      src="https://{{fapi_url}}/npm/@clerk/clerk-js@latest/dist/clerk.browser.js"
-      type="text/javascript"
-    ></script>
+  const signInDiv =
+    document.getElementById('sign-in');
 
-    <script>
-      window.addEventListener("load", async function () {
-        await Clerk.load();
+  clerk.mountSignIn(signInDiv);
 
-        const signInDiv =
-          document.getElementById('sign-in');
+  // ...
 
-        Clerk.mountSignIn(signInDiv);
+  clerk.unmountSignIn(signInDiv);
+  ```
 
-        // ...
+  ```html {{ prettier: false, filename: 'index.html', mark: [25] }}
+  <!-- Add a <div id="sign-in"> element to your HTML -->
+  <div id="sign-in"></div>
 
-        Clerk.unmountSignIn(signInDiv);
-      });
-    </script>
-    ```
-  </CodeBlockTabs>
-</InjectKeys>
+  <!-- Initialize Clerk with your
+  Clerk Publishable key and Frontend API URL -->
+  <script
+    async
+    crossorigin="anonymous"
+    data-clerk-publishable-key="{{pub_key}}"
+    src="https://{{fapi_url}}/npm/@clerk/clerk-js@latest/dist/clerk.browser.js"
+    type="text/javascript"
+  ></script>
+
+  <script>
+    window.addEventListener("load", async function () {
+      await Clerk.load();
+
+      const signInDiv =
+        document.getElementById('sign-in');
+
+      Clerk.mountSignIn(signInDiv);
+
+      // ...
+
+      Clerk.unmountSignIn(signInDiv);
+    });
+  </script>
+  ```
+</CodeBlockTabs>
 
 ### `openSignIn()`
 
@@ -263,39 +259,37 @@ function openSignIn(props?: SignInProps): void;
 
 #### `openSignIn()` usage
 
-<InjectKeys>
-  <CodeBlockTabs type="npm-script" options={['NPM module', '<script>']}>
-    ```js {{ prettier: false, filename: 'index.js', mark: [7] }}
-    import { Clerk } from '@clerk/clerk-js';
+<CodeBlockTabs type="npm-script" options={['NPM module', '<script>']}>
+  ```js {{ prettier: false, filename: 'index.js', mark: [7] }}
+  import { Clerk } from '@clerk/clerk-js';
 
-    // Initialize Clerk with your Clerk publishable key
-    const clerk = new Clerk('{{pub_key}}');
-    await clerk.load();
+  // Initialize Clerk with your Clerk publishable key
+  const clerk = new Clerk('{{pub_key}}');
+  await clerk.load();
 
-    clerk.openSignIn();
-    ```
+  clerk.openSignIn();
+  ```
 
-    ```html {{ prettier: false, filename: 'index.html', mark: [15] }}
-    <!-- Initialize Clerk with your
-    Clerk Publishable key and Frontend API URL -->
-    <script
-      async
-      crossorigin="anonymous"
-      data-clerk-publishable-key="{{pub_key}}"
-      src="https://{{fapi_url}}/npm/@clerk/clerk-js@latest/dist/clerk.browser.js"
-      type="text/javascript"
-    ></script>
+  ```html {{ prettier: false, filename: 'index.html', mark: [15] }}
+  <!-- Initialize Clerk with your
+  Clerk Publishable key and Frontend API URL -->
+  <script
+    async
+    crossorigin="anonymous"
+    data-clerk-publishable-key="{{pub_key}}"
+    src="https://{{fapi_url}}/npm/@clerk/clerk-js@latest/dist/clerk.browser.js"
+    type="text/javascript"
+  ></script>
 
-    <script>
-      window.addEventListener("load", async function () {
-        await Clerk.load();
+  <script>
+    window.addEventListener("load", async function () {
+      await Clerk.load();
 
-        Clerk.openSignIn();
-      });
-    </script>
-    ```
-  </CodeBlockTabs>
-</InjectKeys>
+      Clerk.openSignIn();
+    });
+  </script>
+  ```
+</CodeBlockTabs>
 
 ### `closeSignIn()`
 
@@ -307,47 +301,45 @@ function closeSignIn(): void;
 
 #### `closeSignIn()` usage
 
-<InjectKeys>
-  <CodeBlockTabs type="npm-script" options={['NPM module', '<script>']}>
-    ```js {{ prettier: false, filename: 'index.js', mark: [11] }}
-    import { Clerk } from '@clerk/clerk-js';
+<CodeBlockTabs type="npm-script" options={['NPM module', '<script>']}>
+  ```js {{ prettier: false, filename: 'index.js', mark: [11] }}
+  import { Clerk } from '@clerk/clerk-js';
 
-    // Initialize Clerk with your Clerk publishable key
-    const clerk = new Clerk('{{pub_key}}');
-    await clerk.load();
+  // Initialize Clerk with your Clerk publishable key
+  const clerk = new Clerk('{{pub_key}}');
+  await clerk.load();
 
-    clerk.openSignIn();
+  clerk.openSignIn();
 
-    // ...
+  // ...
 
-    clerk.closeSignIn();
-    ```
+  clerk.closeSignIn();
+  ```
 
-    ```html {{ prettier: false, filename: 'index.html', mark: [19] }}
-    <!-- Initialize Clerk with your
-    Clerk Publishable key and Frontend API URL -->
-    <script
-      async
-      crossorigin="anonymous"
-      data-clerk-publishable-key="{{pub_key}}"
-      src="https://{{fapi_url}}/npm/@clerk/clerk-js@latest/dist/clerk.browser.js"
-      type="text/javascript"
-    ></script>
+  ```html {{ prettier: false, filename: 'index.html', mark: [19] }}
+  <!-- Initialize Clerk with your
+  Clerk Publishable key and Frontend API URL -->
+  <script
+    async
+    crossorigin="anonymous"
+    data-clerk-publishable-key="{{pub_key}}"
+    src="https://{{fapi_url}}/npm/@clerk/clerk-js@latest/dist/clerk.browser.js"
+    type="text/javascript"
+  ></script>
 
-    <script>
-      window.addEventListener("load", async function () {
-        await Clerk.load();
+  <script>
+    window.addEventListener("load", async function () {
+      await Clerk.load();
 
-        Clerk.openSignIn();
+      Clerk.openSignIn();
 
-        // ...
+      // ...
 
-        Clerk.closeSignIn();
-      });
-    </script>
-    ```
-  </CodeBlockTabs>
-</InjectKeys>
+      Clerk.closeSignIn();
+    });
+  </script>
+  ```
+</CodeBlockTabs>
 
 ## Customization
 

--- a/docs/components/authentication/sign-up.mdx
+++ b/docs/components/authentication/sign-up.mdx
@@ -129,52 +129,50 @@ function mountSignUp(node: HTMLDivElement, props?: SignUpProps): void;
 
 #### `mountSignUp()` usage
 
-<InjectKeys>
-  <CodeBlockTabs type="npm-script" options={['NPM module', '<script>']}>
-    ```typescript {{ prettier: false, filename: 'index.ts', mark: [14] }}
-    import { Clerk } from '@clerk/clerk-js';
+<CodeBlockTabs type="npm-script" options={['NPM module', '<script>']}>
+  ```typescript {{ prettier: false, filename: 'index.ts', mark: [14] }}
+  import { Clerk } from '@clerk/clerk-js';
 
-    // Initialize Clerk with your Clerk publishable key
-    const clerk = new Clerk('{{pub_key}}');
-    await clerk.load();
+  // Initialize Clerk with your Clerk publishable key
+  const clerk = new Clerk('{{pub_key}}');
+  await clerk.load();
 
-    document.getElementById("app").innerHTML = `
-      <div id="sign-up"></div>
-    `;
-
-    const signUpDiv =
-      document.getElementById("sign-up");
-
-    clerk.mountSignUp(signUpDiv);
-    ```
-
-    ```html {{ prettier: false, filename: 'index.js', mark: [21] }}
-    <!-- Add a <div id="sign-up"> element to your HTML -->
+  document.getElementById("app").innerHTML = `
     <div id="sign-up"></div>
+  `;
 
-    <!-- Initialize Clerk with your
-    Clerk Publishable key and Frontend API URL -->
-    <script
-      async
-      crossorigin="anonymous"
-      data-clerk-publishable-key="{{pub_key}}"
-      src="https://{{fapi_url}}/npm/@clerk/clerk-js@latest/dist/clerk.browser.js"
-      type="text/javascript"
-    ></script>
+  const signUpDiv =
+    document.getElementById("sign-up");
 
-    <script>
-      window.addEventListener("load", async function () {
-        await Clerk.load();
+  clerk.mountSignUp(signUpDiv);
+  ```
 
-        const signUpDiv =
-          document.getElementById('sign-up');
+  ```html {{ prettier: false, filename: 'index.js', mark: [21] }}
+  <!-- Add a <div id="sign-up"> element to your HTML -->
+  <div id="sign-up"></div>
 
-        Clerk.mountSignUp(signUpDiv);
-      });
-    </script>
-    ```
-  </CodeBlockTabs>
-</InjectKeys>
+  <!-- Initialize Clerk with your
+  Clerk Publishable key and Frontend API URL -->
+  <script
+    async
+    crossorigin="anonymous"
+    data-clerk-publishable-key="{{pub_key}}"
+    src="https://{{fapi_url}}/npm/@clerk/clerk-js@latest/dist/clerk.browser.js"
+    type="text/javascript"
+  ></script>
+
+  <script>
+    window.addEventListener("load", async function () {
+      await Clerk.load();
+
+      const signUpDiv =
+        document.getElementById('sign-up');
+
+      Clerk.mountSignUp(signUpDiv);
+    });
+  </script>
+  ```
+</CodeBlockTabs>
 
 ### `unmountSignUp()`
 
@@ -192,60 +190,58 @@ function unmountSignUp(node: HTMLDivElement): void;
 
 #### `unmountSignUp()` usage
 
-<InjectKeys>
-  <CodeBlockTabs type="npm-script" options={['NPM module', '<script>']}>
-    ```typescript {{ prettier: false, filename: 'index.ts', mark: [18] }}
-    import { Clerk } from '@clerk/clerk-js';
+<CodeBlockTabs type="npm-script" options={['NPM module', '<script>']}>
+  ```typescript {{ prettier: false, filename: 'index.ts', mark: [18] }}
+  import { Clerk } from '@clerk/clerk-js';
 
-    // Initialize Clerk with your Clerk publishable key
-    const clerk = new Clerk('{{pub_key}}');
-    await clerk.load();
+  // Initialize Clerk with your Clerk publishable key
+  const clerk = new Clerk('{{pub_key}}');
+  await clerk.load();
 
-    document.getElementById("app").innerHTML = `
-      <div id="sign-up"></div>
-    `;
-
-    const signUpDiv =
-      document.getElementById("sign-up");
-
-    clerk.mountSignUp(signUpDiv);
-
-    // ...
-
-    clerk.unmountSignUp(signUpDiv);
-    ```
-
-    ```html {{ prettier: false, filename: 'index.js', mark: [25] }}
-    <!-- Add a <div id="sign-up"> element to your HTML -->
+  document.getElementById("app").innerHTML = `
     <div id="sign-up"></div>
+  `;
 
-    <!-- Initialize Clerk with your
-    Clerk Publishable key and Frontend API URL -->
-    <script
-      async
-      crossorigin="anonymous"
-      data-clerk-publishable-key="{{pub_key}}"
-      src="https://{{fapi_url}}/npm/@clerk/clerk-js@latest/dist/clerk.browser.js"
-      type="text/javascript"
-    ></script>
+  const signUpDiv =
+    document.getElementById("sign-up");
 
-    <script>
-      window.addEventListener("load", async function () {
-        await Clerk.load();
+  clerk.mountSignUp(signUpDiv);
 
-        const signUpDiv =
-          document.getElementById('sign-up');
+  // ...
 
-        Clerk.mountSignUp(signUpDiv);
+  clerk.unmountSignUp(signUpDiv);
+  ```
 
-        // ...
+  ```html {{ prettier: false, filename: 'index.js', mark: [25] }}
+  <!-- Add a <div id="sign-up"> element to your HTML -->
+  <div id="sign-up"></div>
 
-        Clerk.unmountSignUp(signUpDiv);
-      });
-    </script>
-    ```
-  </CodeBlockTabs>
-</InjectKeys>
+  <!-- Initialize Clerk with your
+  Clerk Publishable key and Frontend API URL -->
+  <script
+    async
+    crossorigin="anonymous"
+    data-clerk-publishable-key="{{pub_key}}"
+    src="https://{{fapi_url}}/npm/@clerk/clerk-js@latest/dist/clerk.browser.js"
+    type="text/javascript"
+  ></script>
+
+  <script>
+    window.addEventListener("load", async function () {
+      await Clerk.load();
+
+      const signUpDiv =
+        document.getElementById('sign-up');
+
+      Clerk.mountSignUp(signUpDiv);
+
+      // ...
+
+      Clerk.unmountSignUp(signUpDiv);
+    });
+  </script>
+  ```
+</CodeBlockTabs>
 
 ### `openSignUp()`
 
@@ -263,39 +259,37 @@ function openSignUp(props?: SignUpProps): void;
 
 #### `openSignUp()` usage
 
-<InjectKeys>
-  <CodeBlockTabs type="npm-script" options={['NPM module', '<script>']}>
-    ```js {{ prettier: false, filename: 'index.ts', mark: [7] }}
-    import { Clerk } from '@clerk/clerk-js';
+<CodeBlockTabs type="npm-script" options={['NPM module', '<script>']}>
+  ```js {{ prettier: false, filename: 'index.ts', mark: [7] }}
+  import { Clerk } from '@clerk/clerk-js';
 
-    // Initialize Clerk with your Clerk publishable key
-    const clerk = new Clerk('{{pub_key}}');
-    await clerk.load();
+  // Initialize Clerk with your Clerk publishable key
+  const clerk = new Clerk('{{pub_key}}');
+  await clerk.load();
 
-    clerk.openSignUp();
-    ```
+  clerk.openSignUp();
+  ```
 
-    ```html {{ prettier: false, filename: 'index.html', mark: [15] }}
-    <!-- Initialize Clerk with your
-    Clerk Publishable key and Frontend API URL -->
-    <script
-      async
-      crossorigin="anonymous"
-      data-clerk-publishable-key="{{pub_key}}"
-      src="https://{{fapi_url}}/npm/@clerk/clerk-js@latest/dist/clerk.browser.js"
-      type="text/javascript"
-    ></script>
+  ```html {{ prettier: false, filename: 'index.html', mark: [15] }}
+  <!-- Initialize Clerk with your
+  Clerk Publishable key and Frontend API URL -->
+  <script
+    async
+    crossorigin="anonymous"
+    data-clerk-publishable-key="{{pub_key}}"
+    src="https://{{fapi_url}}/npm/@clerk/clerk-js@latest/dist/clerk.browser.js"
+    type="text/javascript"
+  ></script>
 
-    <script>
-      window.addEventListener("load", async function () {
-        await Clerk.load();
+  <script>
+    window.addEventListener("load", async function () {
+      await Clerk.load();
 
-        Clerk.openSignUp();
-      });
-    </script>
-    ```
-  </CodeBlockTabs>
-</InjectKeys>
+      Clerk.openSignUp();
+    });
+  </script>
+  ```
+</CodeBlockTabs>
 
 ### `closeSignUp()`
 
@@ -307,47 +301,45 @@ function closeSignUp(): void;
 
 #### `closeSignUp()` usage
 
-<InjectKeys>
-  <CodeBlockTabs type="npm-script" options={['NPM module', '<script>']}>
-    ```js {{ prettier: false, filename: 'index.ts', mark: [11] }}
-    import { Clerk } from '@clerk/clerk-js';
+<CodeBlockTabs type="npm-script" options={['NPM module', '<script>']}>
+  ```js {{ prettier: false, filename: 'index.ts', mark: [11] }}
+  import { Clerk } from '@clerk/clerk-js';
 
-    // Initialize Clerk with your Clerk publishable key
-    const clerk = new Clerk('{{pub_key}}');
-    await clerk.load();
+  // Initialize Clerk with your Clerk publishable key
+  const clerk = new Clerk('{{pub_key}}');
+  await clerk.load();
 
-    clerk.openSignUp();
+  clerk.openSignUp();
 
-    // ...
+  // ...
 
-    clerk.closeSignUp();
-    ```
+  clerk.closeSignUp();
+  ```
 
-    ```html {{ prettier: false, filename: 'index.html', mark: [19] }}
-    <!-- Initialize Clerk with your
-    Clerk Publishable key and Frontend API URL -->
-    <script
-      async
-      crossorigin="anonymous"
-      data-clerk-publishable-key="{{pub_key}}"
-      src="https://{{fapi_url}}/npm/@clerk/clerk-js@latest/dist/clerk.browser.js"
-      type="text/javascript"
-    ></script>
+  ```html {{ prettier: false, filename: 'index.html', mark: [19] }}
+  <!-- Initialize Clerk with your
+  Clerk Publishable key and Frontend API URL -->
+  <script
+    async
+    crossorigin="anonymous"
+    data-clerk-publishable-key="{{pub_key}}"
+    src="https://{{fapi_url}}/npm/@clerk/clerk-js@latest/dist/clerk.browser.js"
+    type="text/javascript"
+  ></script>
 
-    <script>
-      window.addEventListener("load", async function () {
-        await Clerk.load();
+  <script>
+    window.addEventListener("load", async function () {
+      await Clerk.load();
 
-        Clerk.openSignUp();
+      Clerk.openSignUp();
 
-        // ...
+      // ...
 
-        Clerk.closeSignUp();
-      });
-    </script>
-    ```
-  </CodeBlockTabs>
-</InjectKeys>
+      Clerk.closeSignUp();
+    });
+  </script>
+  ```
+</CodeBlockTabs>
 
 ## Customization
 

--- a/docs/components/control/authenticate-with-callback.mdx
+++ b/docs/components/control/authenticate-with-callback.mdx
@@ -9,130 +9,128 @@ The `<AuthenticateWithRedirectCallback />` is used to complete a custom OAuth fl
 
 ## Usage
 
-<InjectKeys>
-  <Tabs type="framework" items={["Next.js", "React"]}>
-    <Tab>
-      This example below uses built in Next.js pages, but you could use any routing library you want.
+<Tabs type="framework" items={["Next.js", "React"]}>
+  <Tab>
+    This example below uses built in Next.js pages, but you could use any routing library you want.
 
-      ```tsx {{ prettier: false, filename: 'app.tsx' }}
-      import '@/styles/globals.css';
-      import { ClerkProvider, SignedIn, SignedOut, useSignIn } from '@clerk/nextjs';
-      import { AppProps } from 'next/app';
-      import { useRouter } from 'next/router';
+    ```tsx {{ prettier: false, filename: 'app.tsx' }}
+    import '@/styles/globals.css';
+    import { ClerkProvider, SignedIn, SignedOut, useSignIn } from '@clerk/nextjs';
+    import { AppProps } from 'next/app';
+    import { useRouter } from 'next/router';
 
-      const publicPages: Array<string> = [];
+    const publicPages: Array<string> = [];
 
-      const SignInOAuthButtons = () => {
-        const { signIn, isLoaded } = useSignIn();
-        if (!isLoaded) {
-          return null;
-        }
-        const signInWithGoogle = () =>
-          signIn.authenticateWithRedirect({
-            strategy: 'oauth_google',
-            redirectUrl: '/sso-callback',
-            redirectUrlComplete: '/'
-          });
-        return <button onClick={signInWithGoogle}>Sign in with Google</button>;
-      };
-      function MyApp({ Component, pageProps }: AppProps) {
-        const { pathname } = useRouter();
-        const isPublicPage = publicPages.includes(pathname);
-
-        return (
-          <ClerkProvider {...pageProps}>
-            {isPublicPage ? (
-              <Component {...pageProps} />
-            ) : (
-              <>
-                <SignedIn>
-                  <Component {...pageProps} />
-                </SignedIn>
-                <SignedOut>
-                  <SignInOAuthButtons />
-                </SignedOut>
-              </>
-            )}
-          </ClerkProvider>
-        );
+    const SignInOAuthButtons = () => {
+      const { signIn, isLoaded } = useSignIn();
+      if (!isLoaded) {
+        return null;
       }
+      const signInWithGoogle = () =>
+        signIn.authenticateWithRedirect({
+          strategy: 'oauth_google',
+          redirectUrl: '/sso-callback',
+          redirectUrlComplete: '/'
+        });
+      return <button onClick={signInWithGoogle}>Sign in with Google</button>;
+    };
+    function MyApp({ Component, pageProps }: AppProps) {
+      const { pathname } = useRouter();
+      const isPublicPage = publicPages.includes(pathname);
 
-      export default MyApp;
-      ```
+      return (
+        <ClerkProvider {...pageProps}>
+          {isPublicPage ? (
+            <Component {...pageProps} />
+          ) : (
+            <>
+              <SignedIn>
+                <Component {...pageProps} />
+              </SignedIn>
+              <SignedOut>
+                <SignInOAuthButtons />
+              </SignedOut>
+            </>
+          )}
+        </ClerkProvider>
+      );
+    }
 
-      Once you have implemented your sign in flow, you can implement the callback page.
+    export default MyApp;
+    ```
 
-      ```tsx {{ prettier: false, filename: '/pages/sso-callback.tsx' }}
-      import { AuthenticateWithRedirectCallback } from '@clerk/nextjs';
+    Once you have implemented your sign in flow, you can implement the callback page.
 
-      export default function SSOCallBack() {
-        return <AuthenticateWithRedirectCallback />;
+    ```tsx {{ prettier: false, filename: '/pages/sso-callback.tsx' }}
+    import { AuthenticateWithRedirectCallback } from '@clerk/nextjs';
+
+    export default function SSOCallBack() {
+      return <AuthenticateWithRedirectCallback />;
+    }
+    ```
+  </Tab>
+
+  <Tab>
+    This example below is using the `react-router-dom` library. You can use any routing library you want.
+
+    ```tsx {{ prettier: false, filename: 'app.tsx' }}
+    import {
+      ClerkProvider,
+      AuthenticateWithRedirectCallback,
+      SignedOut,
+      useSignIn,
+      SignedIn
+    } from '@clerk/clerk-react';
+
+    import { Route, Routes } from 'react-router-dom';
+
+    function App() {
+      return (
+        <ClerkProvider publishableKey={`{{pub_key}}`}>
+          {/* Define a / route that displays the OAuth button */}
+          <Routes>
+            <Route path="/" element={<HomePages />} />
+
+            <Route
+              path="/sso-callback"
+              element={<AuthenticateWithRedirectCallback />}
+            />
+          </Routes>
+        </ClerkProvider>
+      );
+    }
+
+    function HomePages() {
+      return (
+        <>
+          <SignedOut>
+            <SignInOAuthButtons />
+          </SignedOut>
+          <SignedIn>
+            <div>Hello! You are Signed In!</div>
+          </SignedIn>
+        </>
+      );
+    }
+
+    function SignInOAuthButtons() {
+      const { signIn, isLoaded } = useSignIn();
+      if (!isLoaded) {
+        return null;
       }
-      ```
-    </Tab>
+      const signInWithGoogle = () =>
+        signIn.authenticateWithRedirect({
+          strategy: 'oauth_google',
+          redirectUrl: '/sso-callback',
+          redirectUrlComplete: '/'
+        });
+      return <button onClick={signInWithGoogle}>Sign in with Google</button>;
+    }
 
-    <Tab>
-      This example below is using the `react-router-dom` library. You can use any routing library you want.
-
-      ```tsx {{ prettier: false, filename: 'app.tsx' }}
-      import {
-        ClerkProvider,
-        AuthenticateWithRedirectCallback,
-        SignedOut,
-        useSignIn,
-        SignedIn
-      } from '@clerk/clerk-react';
-
-      import { Route, Routes } from 'react-router-dom';
-
-      function App() {
-        return (
-          <ClerkProvider publishableKey={`{{pub_key}}`}>
-            {/* Define a / route that displays the OAuth button */}
-            <Routes>
-              <Route path="/" element={<HomePages />} />
-
-              <Route
-                path="/sso-callback"
-                element={<AuthenticateWithRedirectCallback />}
-              />
-            </Routes>
-          </ClerkProvider>
-        );
-      }
-
-      function HomePages() {
-        return (
-          <>
-            <SignedOut>
-              <SignInOAuthButtons />
-            </SignedOut>
-            <SignedIn>
-              <div>Hello! You are Signed In!</div>
-            </SignedIn>
-          </>
-        );
-      }
-
-      function SignInOAuthButtons() {
-        const { signIn, isLoaded } = useSignIn();
-        if (!isLoaded) {
-          return null;
-        }
-        const signInWithGoogle = () =>
-          signIn.authenticateWithRedirect({
-            strategy: 'oauth_google',
-            redirectUrl: '/sso-callback',
-            redirectUrlComplete: '/'
-          });
-        return <button onClick={signInWithGoogle}>Sign in with Google</button>;
-      }
-
-      export default App;
-      ```
-    </Tab>
-  </Tabs>
-</InjectKeys>
+    export default App;
+    ```
+  </Tab>
+</Tabs>
 
 ## Properties
 

--- a/docs/components/control/clerk-loaded.mdx
+++ b/docs/components/control/clerk-loaded.mdx
@@ -9,138 +9,136 @@ The `<ClerkLoaded>` component guarantees that the Clerk object has loaded and wi
 
 ## Usage
 
-<InjectKeys>
-  <Tabs type="framework" items={["Next.js", "React", "Remix"]}>
-    <Tab>
-      <Tabs type="router" items={["App Router", "Pages Router"]}>
-        <Tab>
-          ```tsx {{ prettier: false, filename: 'app/layout.tsx' }}
-            import { ClerkProvider, ClerkLoaded, ClerkLoading } from '@clerk/nextjs'
-            import './globals.css';
+<Tabs type="framework" items={["Next.js", "React", "Remix"]}>
+  <Tab>
+    <Tabs type="router" items={["App Router", "Pages Router"]}>
+      <Tab>
+        ```tsx {{ prettier: false, filename: 'app/layout.tsx' }}
+          import { ClerkProvider, ClerkLoaded, ClerkLoading } from '@clerk/nextjs'
+          import './globals.css';
 
-            export default function RootLayout({
-              children,
-            }: {
-              children: React.ReactNode
-            }) {
-              return (
-                <ClerkProvider>
-                  <html lang="en">
-                    <body>
-                      <ClerkLoaded>
-                        {children}
-                      </ClerkLoaded>
-                    </body>
-                  </html>
-                </ClerkProvider>
-              )
-            }
-          ```
-
-          Once you have wrapped your app with `<ClerkLoaded>`, you can access the `Clerk` object without the need to check if it exists.
-
-          ```tsx {{ prettier: false, filename: 'app/page.tsx' }}
-          declare global {
-            interface Window {
-              Clerk: any;
-            }
-          }
-
-          export default function Home() {
-            return <div>This page uses Clerk {window.Clerk.version}; </div>;
-          }
-          ```
-        </Tab>
-
-        <Tab>
-          ```tsx {{ prettier: false, filename: 'pages/_app.tsx' }}
-          import "@/styles/globals.css";
-          import { ClerkLoaded, ClerkProvider } from "@clerk/nextjs";
-          import { AppProps } from "next/app";
-
-          function MyApp({ Component, pageProps }: AppProps) {
+          export default function RootLayout({
+            children,
+          }: {
+            children: React.ReactNode
+          }) {
             return (
-
-            <ClerkProvider {...pageProps}>
-              <ClerkLoaded>
-                <Component {...pageProps} />
-              </ClerkLoaded>
-            </ClerkProvider>
-            );
+              <ClerkProvider>
+                <html lang="en">
+                  <body>
+                    <ClerkLoaded>
+                      {children}
+                    </ClerkLoaded>
+                  </body>
+                </html>
+              </ClerkProvider>
+            )
           }
+        ```
 
-          export default MyApp;
-          ```
+        Once you have wrapped your app with `<ClerkLoaded>`, you can access the `Clerk` object without the need to check if it exists.
 
-          Once you have wrapped your app with `<ClerkLoaded>`, you can access the `Clerk` object without the need to check if it exists.
-
-          ```tsx {{ prettier: false, filename: 'pages/index.tsx' }}
-          declare global {
-            interface Window {
-              Clerk: any;
-            }
+        ```tsx {{ prettier: false, filename: 'app/page.tsx' }}
+        declare global {
+          interface Window {
+            Clerk: any;
           }
-
-          export default function Home() {
-            return <div>This page uses Clerk {window.Clerk.version}; </div>;
-          }
-          ```
-        </Tab>
-      </Tabs>
-    </Tab>
-
-    <Tab>
-      ```tsx {{ prettier: false, filename: 'app.tsx' }}
-      import { useEffect } from "react";
-      import { ClerkLoaded, ClerkProvider } from "@clerk/clerk-react";
-
-      declare global {
-        interface Window {
-          Clerk: any;
         }
-      }
 
-      function App() {
-        return (
-          <ClerkProvider publishableKey={`{{pub_key}}`}>
+        export default function Home() {
+          return <div>This page uses Clerk {window.Clerk.version}; </div>;
+        }
+        ```
+      </Tab>
+
+      <Tab>
+        ```tsx {{ prettier: false, filename: 'pages/_app.tsx' }}
+        import "@/styles/globals.css";
+        import { ClerkLoaded, ClerkProvider } from "@clerk/nextjs";
+        import { AppProps } from "next/app";
+
+        function MyApp({ Component, pageProps }: AppProps) {
+          return (
+
+          <ClerkProvider {...pageProps}>
             <ClerkLoaded>
-              <Page />
+              <Component {...pageProps} />
             </ClerkLoaded>
           </ClerkProvider>
-        );
+          );
+        }
+
+        export default MyApp;
+        ```
+
+        Once you have wrapped your app with `<ClerkLoaded>`, you can access the `Clerk` object without the need to check if it exists.
+
+        ```tsx {{ prettier: false, filename: 'pages/index.tsx' }}
+        declare global {
+          interface Window {
+            Clerk: any;
+          }
+        }
+
+        export default function Home() {
+          return <div>This page uses Clerk {window.Clerk.version}; </div>;
+        }
+        ```
+      </Tab>
+    </Tabs>
+  </Tab>
+
+  <Tab>
+    ```tsx {{ prettier: false, filename: 'app.tsx' }}
+    import { useEffect } from "react";
+    import { ClerkLoaded, ClerkProvider } from "@clerk/clerk-react";
+
+    declare global {
+      interface Window {
+        Clerk: any;
       }
+    }
 
-      function Page() {
-        useEffect(() => {
-          // no need to check if window.Clerk exists
-          document.title = "This page uses Clerk " +
-          window.Clerk.version;
-        }, []);
+    function App() {
+      return (
+        <ClerkProvider publishableKey={`{{pub_key}}`}>
+          <ClerkLoaded>
+            <Page />
+          </ClerkLoaded>
+        </ClerkProvider>
+      );
+    }
 
-        return (
-          <div>The content </div>
-        );
-      }
+    function Page() {
+      useEffect(() => {
+        // no need to check if window.Clerk exists
+        document.title = "This page uses Clerk " +
+        window.Clerk.version;
+      }, []);
 
-      export default App;
-      ```
-    </Tab>
+      return (
+        <div>The content </div>
+      );
+    }
 
-    <Tab>
-      ```tsx {{ prettier: false, filename: 'routes/index.tsx' }}
-      import { ClerkLoaded } from "@clerk/remix";
+    export default App;
+    ```
+  </Tab>
 
-      export default function Index() {
-        return (
-          <div>
-            <ClerkLoaded>
-              <div>Clerk is loaded</div>
-              <p>window.Clerk.version</p>
-            </ClerkLoaded>
-          </div>
-        );
-      }
-      ```
-    </Tab>
-  </Tabs>
-</InjectKeys>
+  <Tab>
+    ```tsx {{ prettier: false, filename: 'routes/index.tsx' }}
+    import { ClerkLoaded } from "@clerk/remix";
+
+    export default function Index() {
+      return (
+        <div>
+          <ClerkLoaded>
+            <div>Clerk is loaded</div>
+            <p>window.Clerk.version</p>
+          </ClerkLoaded>
+        </div>
+      );
+    }
+    ```
+  </Tab>
+</Tabs>

--- a/docs/components/control/clerk-loading.mdx
+++ b/docs/components/control/clerk-loading.mdx
@@ -9,100 +9,98 @@ The `<ClerkLoading>` renders its children while Clerk is loading, and is helpful
 
 ## Usage
 
-<InjectKeys>
-  <Tabs type="framework" items={["Next.js", "React", "Remix"]}>
-    <Tab>
-      <CodeBlockTabs type="router" options={["App Router", "Pages Router"]}>
-        ```tsx {{ prettier: false, filename: 'app/layout.tsx' }}
-          import { ClerkProvider, ClerkLoaded, ClerkLoading } from '@clerk/nextjs'
-          import './globals.css';
+<Tabs type="framework" items={["Next.js", "React", "Remix"]}>
+  <Tab>
+    <CodeBlockTabs type="router" options={["App Router", "Pages Router"]}>
+      ```tsx {{ prettier: false, filename: 'app/layout.tsx' }}
+        import { ClerkProvider, ClerkLoaded, ClerkLoading } from '@clerk/nextjs'
+        import './globals.css';
 
-          export default function RootLayout({
-            children,
-          }: {
-            children: React.ReactNode
-          }) {
-            return (
-              <ClerkProvider>
-                <html lang="en">
-                  <body>
-                    <ClerkLoading>
-                      <div>Clerk is loading...</div>
-                    </ClerkLoading>
-                    <ClerkLoaded>
-                      {children}
-                    </ClerkLoaded>
-                  </body>
-                </html>
-              </ClerkProvider>
-            )
-          }
-        ```
-
-        ```tsx {{ prettier: false, filename: 'pages/_app.tsx' }}
-        import "@/styles/globals.css";
-        import { ClerkLoaded, ClerkLoading, ClerkProvider } from "@clerk/nextjs";
-        import { AppProps } from "next/app";
-
-        function MyApp({ Component, pageProps }: AppProps) {
+        export default function RootLayout({
+          children,
+        }: {
+          children: React.ReactNode
+        }) {
           return (
-
-          <ClerkProvider {...pageProps}>
-            <ClerkLoading>
-              <div>Clerk is loading</div>
-            </ClerkLoading>
-            <ClerkLoaded>
-              <Component {...pageProps} />
-            </ClerkLoaded>
-          </ClerkProvider>
-          );
+            <ClerkProvider>
+              <html lang="en">
+                <body>
+                  <ClerkLoading>
+                    <div>Clerk is loading...</div>
+                  </ClerkLoading>
+                  <ClerkLoaded>
+                    {children}
+                  </ClerkLoaded>
+                </body>
+              </html>
+            </ClerkProvider>
+          )
         }
+      ```
 
-        export default MyApp;
-        ```
-      </CodeBlockTabs>
-    </Tab>
+      ```tsx {{ prettier: false, filename: 'pages/_app.tsx' }}
+      import "@/styles/globals.css";
+      import { ClerkLoaded, ClerkLoading, ClerkProvider } from "@clerk/nextjs";
+      import { AppProps } from "next/app";
 
-    <Tab>
-      ```tsx {{ prettier: false, filename: 'app.tsx' }}
-      import { ClerkLoaded, ClerkLoading, ClerkProvider } from '@clerk/clerk-react';
-
-      function App() {
+      function MyApp({ Component, pageProps }: AppProps) {
         return (
-          <ClerkProvider publishableKey={`{{pub_key}}`}>
-            <ClerkLoading>
-              <div>Clerk is loading</div>
-            </ClerkLoading>
-            <ClerkLoaded>
-              <Page />
-            </ClerkLoaded>
-            <div>This div is always visible</div>
-          </ClerkProvider>
+
+        <ClerkProvider {...pageProps}>
+          <ClerkLoading>
+            <div>Clerk is loading</div>
+          </ClerkLoading>
+          <ClerkLoaded>
+            <Component {...pageProps} />
+          </ClerkLoaded>
+        </ClerkProvider>
         );
       }
 
-      function Page() {
-        return <div>The content</div>;
-      }
-
-      export default App;
+      export default MyApp;
       ```
-    </Tab>
+    </CodeBlockTabs>
+  </Tab>
 
-    <Tab>
-      ```tsx {{ prettier: false, filename: 'routes/index.tsx' }}
-      import { ClerkLoading } from "@clerk/remix";
+  <Tab>
+    ```tsx {{ prettier: false, filename: 'app.tsx' }}
+    import { ClerkLoaded, ClerkLoading, ClerkProvider } from '@clerk/clerk-react';
 
-      export default function Index() {
-        return (
-          <div>
-            <ClerkLoading>
-              <div>Clerk is loading</div>
-            </ClerkLoading>
-          </div>
-        );
-      }
-      ```
-    </Tab>
-  </Tabs>
-</InjectKeys>
+    function App() {
+      return (
+        <ClerkProvider publishableKey={`{{pub_key}}`}>
+          <ClerkLoading>
+            <div>Clerk is loading</div>
+          </ClerkLoading>
+          <ClerkLoaded>
+            <Page />
+          </ClerkLoaded>
+          <div>This div is always visible</div>
+        </ClerkProvider>
+      );
+    }
+
+    function Page() {
+      return <div>The content</div>;
+    }
+
+    export default App;
+    ```
+  </Tab>
+
+  <Tab>
+    ```tsx {{ prettier: false, filename: 'routes/index.tsx' }}
+    import { ClerkLoading } from "@clerk/remix";
+
+    export default function Index() {
+      return (
+        <div>
+          <ClerkLoading>
+            <div>Clerk is loading</div>
+          </ClerkLoading>
+        </div>
+      );
+    }
+    ```
+  </Tab>
+</Tabs>

--- a/docs/components/control/multi-session.mdx
+++ b/docs/components/control/multi-session.mdx
@@ -9,49 +9,47 @@ The `<MultisessionAppSupport>` provides a wrapper for your React application tha
 
 ## Usage
 
-<InjectKeys>
-  <Tabs type="framework" items={["Next.js", "React"]}>
-    <Tab>
-      ```tsx {{ prettier: false, filename: 'pages/_app.tsx' }}
-      import "@/styles/globals.css";
-      import { MultisessionAppSupport,ClerkProvider } from "@clerk/nextjs/internal";
-      import { AppProps } from "next/app";
+<Tabs type="framework" items={["Next.js", "React"]}>
+  <Tab>
+    ```tsx {{ prettier: false, filename: 'pages/_app.tsx' }}
+    import "@/styles/globals.css";
+    import { MultisessionAppSupport,ClerkProvider } from "@clerk/nextjs/internal";
+    import { AppProps } from "next/app";
 
-      function MyApp({ Component, pageProps }: AppProps) {
-        return (
-          <ClerkProvider {...pageProps}>
-            <MultisessionAppSupport>
-              <Component {...pageProps} />
-            </MultisessionAppSupport>
-          </ClerkProvider>
-        );
-      }
+    function MyApp({ Component, pageProps }: AppProps) {
+      return (
+        <ClerkProvider {...pageProps}>
+          <MultisessionAppSupport>
+            <Component {...pageProps} />
+          </MultisessionAppSupport>
+        </ClerkProvider>
+      );
+    }
 
-      export default MyApp;
-      ```
-    </Tab>
+    export default MyApp;
+    ```
+  </Tab>
 
-    <Tab>
-      ```tsx {{ prettier: false, filename: 'app.tsx' }}
-      import { ClerkProvider, MultisessionAppSupport } from "@clerk/clerk-react/internal";
+  <Tab>
+    ```tsx {{ prettier: false, filename: 'app.tsx' }}
+    import { ClerkProvider, MultisessionAppSupport } from "@clerk/clerk-react/internal";
 
-      function App() {
-        return (
-          <ClerkProvider publishableKey={`{{pub_key}}`}>
-            <MultisessionAppSupport>
-              <Page />
-            </MultisessionAppSupport>
-          </ClerkProvider>
-        );
-      }
+    function App() {
+      return (
+        <ClerkProvider publishableKey={`{{pub_key}}`}>
+          <MultisessionAppSupport>
+            <Page />
+          </MultisessionAppSupport>
+        </ClerkProvider>
+      );
+    }
 
-      function Page() {
-        return (
-          <div>The content</div>
-        );
-      }
+    function Page() {
+      return (
+        <div>The content</div>
+      );
+    }
 
-      ```
-    </Tab>
-  </Tabs>
-</InjectKeys>
+    ```
+  </Tab>
+</Tabs>

--- a/docs/components/control/redirect-to-createorganization.mdx
+++ b/docs/components/control/redirect-to-createorganization.mdx
@@ -9,81 +9,79 @@ The `<RedirectToCreateOrganization />` component will navigate to the create org
 
 ## Usage
 
-<InjectKeys>
-  <Tabs type="framework" items={["Next.js", "React", "Remix"]}>
-    <Tab>
-      ```tsx {{ prettier: false, filename: 'pages/_app.tsx' }}
-      import {
-        ClerkProvider,
-        SignedIn,
-        SignedOut,
-        RedirectToCreateOrganization,
-      } from "@clerk/nextjs";
-      import { AppProps } from "next/app";
+<Tabs type="framework" items={["Next.js", "React", "Remix"]}>
+  <Tab>
+    ```tsx {{ prettier: false, filename: 'pages/_app.tsx' }}
+    import {
+      ClerkProvider,
+      SignedIn,
+      SignedOut,
+      RedirectToCreateOrganization,
+    } from "@clerk/nextjs";
+    import { AppProps } from "next/app";
 
 
-      function MyApp({ Component, pageProps } : AppProps) {
-        return (
-          <ClerkProvider {...pageProps}>
-            <SignedIn>
-              <RedirectToCreateOrganization/>
-            </SignedIn>
-            <SignedOut>
-              Please Sign In
-            </SignedOut>
-          </ClerkProvider>
-        );
-      }
+    function MyApp({ Component, pageProps } : AppProps) {
+      return (
+        <ClerkProvider {...pageProps}>
+          <SignedIn>
+            <RedirectToCreateOrganization/>
+          </SignedIn>
+          <SignedOut>
+            Please Sign In
+          </SignedOut>
+        </ClerkProvider>
+      );
+    }
 
-      export default MyApp;
-      ```
-    </Tab>
+    export default MyApp;
+    ```
+  </Tab>
 
-    <Tab>
-      ```tsx {{ prettier: false, filename: 'pages/privatepage.tsx' }}
-      import {
-        ClerkProvider,
-        SignedIn,
-        SignedOut,
-        RedirectToCreateOrganization
-      } from "@clerk/clerk-react";
+  <Tab>
+    ```tsx {{ prettier: false, filename: 'pages/privatepage.tsx' }}
+    import {
+      ClerkProvider,
+      SignedIn,
+      SignedOut,
+      RedirectToCreateOrganization
+    } from "@clerk/clerk-react";
 
-      function PrivatePage() {
-        return (
-          <ClerkProvider publishableKey={`{{pub_key}}`}>
-            <SignedIn>
-              <RedirectToCreateOrganization/>
-            </SignedIn>
-            <SignedOut>
-              Please Sign In
-            </SignedOut>
-          </ClerkProvider>
-        );
-      }
-      ```
-    </Tab>
+    function PrivatePage() {
+      return (
+        <ClerkProvider publishableKey={`{{pub_key}}`}>
+          <SignedIn>
+            <RedirectToCreateOrganization/>
+          </SignedIn>
+          <SignedOut>
+            Please Sign In
+          </SignedOut>
+        </ClerkProvider>
+      );
+    }
+    ```
+  </Tab>
 
-    <Tab>
-      ```tsx {{ prettier: false, filename: 'routes/index.tsx' }}
-      import {
-        SignedIn,
-        SignedOut,
-        RedirectToCreateOrganization
-      } from "@clerk/remix";
+  <Tab>
+    ```tsx {{ prettier: false, filename: 'routes/index.tsx' }}
+    import {
+      SignedIn,
+      SignedOut,
+      RedirectToCreateOrganization
+    } from "@clerk/remix";
 
-      export default function Index() {
-        return (
-          <div>
-            <SignedIn>
-              <RedirectToCreateOrganization/>
-            </SignedIn>
-            <SignedOut>
-              <p>Please sign in </p>
-            </SignedOut>
-          </div>
-        );
-      }
-      ```
-    </Tab>
-  </Tabs>
-</InjectKeys>
+    export default function Index() {
+      return (
+        <div>
+          <SignedIn>
+            <RedirectToCreateOrganization/>
+          </SignedIn>
+          <SignedOut>
+            <p>Please sign in </p>
+          </SignedOut>
+        </div>
+      );
+    }
+    ```
+  </Tab>
+</Tabs>

--- a/docs/components/control/redirect-to-organizationprofile.mdx
+++ b/docs/components/control/redirect-to-organizationprofile.mdx
@@ -9,81 +9,79 @@ The `<RedirectToOrganizationProfile />` component will navigate to the organizat
 
 ## Usage
 
-<InjectKeys>
-  <Tabs type="framework" items={["Next.js", "React", "Remix"]}>
-    <Tab>
-      ```tsx {{ prettier: false, filename: 'pages/_app.tsx' }}
-      import {
-        ClerkProvider,
-        SignedIn,
-        SignedOut,
-        RedirectToOrganizationProfile,
-      } from "@clerk/nextjs";
-      import { AppProps } from "next/app";
+<Tabs type="framework" items={["Next.js", "React", "Remix"]}>
+  <Tab>
+    ```tsx {{ prettier: false, filename: 'pages/_app.tsx' }}
+    import {
+      ClerkProvider,
+      SignedIn,
+      SignedOut,
+      RedirectToOrganizationProfile,
+    } from "@clerk/nextjs";
+    import { AppProps } from "next/app";
 
 
-      function MyApp({ Component, pageProps } : AppProps) {
-        return (
-          <ClerkProvider {...pageProps}>
-            <SignedIn>
-              <RedirectToOrganizationProfile/>
-            </SignedIn>
-            <SignedOut>
-              Please Sign In
-            </SignedOut>
-          </ClerkProvider>
-        );
-      }
+    function MyApp({ Component, pageProps } : AppProps) {
+      return (
+        <ClerkProvider {...pageProps}>
+          <SignedIn>
+            <RedirectToOrganizationProfile/>
+          </SignedIn>
+          <SignedOut>
+            Please Sign In
+          </SignedOut>
+        </ClerkProvider>
+      );
+    }
 
-      export default MyApp;
-      ```
-    </Tab>
+    export default MyApp;
+    ```
+  </Tab>
 
-    <Tab>
-      ```tsx {{ prettier: false, filename: 'pages/privatepage.tsx' }}
-      import {
-        ClerkProvider,
-        SignedIn,
-        SignedOut,
-        RedirectToOrganizationProfile
-      } from "@clerk/clerk-react";
+  <Tab>
+    ```tsx {{ prettier: false, filename: 'pages/privatepage.tsx' }}
+    import {
+      ClerkProvider,
+      SignedIn,
+      SignedOut,
+      RedirectToOrganizationProfile
+    } from "@clerk/clerk-react";
 
-      function PrivatePage() {
-        return (
-          <ClerkProvider publishableKey={`{{pub_key}}`}>
-            <SignedIn>
-              <RedirectToOrganizationProfile/>
-            </SignedIn>
-            <SignedOut>
-              Please Sign In
-            </SignedOut>
-          </div>
-        );
-      }
-      ```
-    </Tab>
+    function PrivatePage() {
+      return (
+        <ClerkProvider publishableKey={`{{pub_key}}`}>
+          <SignedIn>
+            <RedirectToOrganizationProfile/>
+          </SignedIn>
+          <SignedOut>
+            Please Sign In
+          </SignedOut>
+        </div>
+      );
+    }
+    ```
+  </Tab>
 
-    <Tab>
-      ```tsx {{ prettier: false, filename: 'routes/index.tsx' }}
-      import {
-        SignedIn,
-        SignedOut,
-        RedirectToOrganizationProfile
-      } from "@clerk/remix";
+  <Tab>
+    ```tsx {{ prettier: false, filename: 'routes/index.tsx' }}
+    import {
+      SignedIn,
+      SignedOut,
+      RedirectToOrganizationProfile
+    } from "@clerk/remix";
 
-      export default function Index() {
-        return (
-          <div>
-            <SignedIn>
-              <RedirectToOrganizationProfile/>
-            </SignedIn>
-            <SignedOut>
-              <p>Please sign in </p>
-            </SignedOut>
-          </div>
-        );
-      }
-      ```
-    </Tab>
-  </Tabs>
-</InjectKeys>
+    export default function Index() {
+      return (
+        <div>
+          <SignedIn>
+            <RedirectToOrganizationProfile/>
+          </SignedIn>
+          <SignedOut>
+            <p>Please sign in </p>
+          </SignedOut>
+        </div>
+      );
+    }
+    ```
+  </Tab>
+</Tabs>

--- a/docs/components/control/redirect-to-signin.mdx
+++ b/docs/components/control/redirect-to-signin.mdx
@@ -9,122 +9,120 @@ The `<RedirectToSignIn />` component will navigate to the sign in URL which has 
 
 ## Usage
 
-<InjectKeys>
-  <Tabs items={["Next.js", "React", "Remix"]}>
-    <CodeBlockTabs options={["App Router", "Pages Router"]}>
-      <Tab>
-        ```tsx {{ prettier: false, filename: 'app/layout.tsx' }}
-        import {
-          ClerkProvider,
-          SignedIn,
-          SignedOut,
-          RedirectToSignIn,
-        } from "@clerk/nextjs";
-
-        export default function RootLayout({
-          children,
-        }: {
-          children: React.ReactNode;
-        }) {
-          return (
-            <html>
-              <body>
-                <ClerkProvider>
-                  <SignedIn>
-                    {children}
-                  </SignedIn>
-                  <SignedOut>
-                    <RedirectToSignIn />
-                  </SignedOut>
-                </ClerkProvider>
-              </body>
-            </html>
-          );
-        }
-        ```
-      </Tab>
-
-      <Tab>
-        ```tsx {{ prettier: false, filename: 'pages/_app.tsx' }}
-        import {
-          ClerkProvider,
-          SignedIn,
-          SignedOut,
-          RedirectToSignIn,
-        } from "@clerk/nextjs";
-        import { AppProps } from "next/app";
-
-        function MyApp({ Component, pageProps } : AppProps) {
-          return (
-            <ClerkProvider>
-              <SignedIn>
-                <Component {...pageProps} />
-              </SignedIn>
-              <SignedOut>
-                <RedirectToSignIn />
-              </SignedOut>
-            </ClerkProvider>
-          );
-        }
-
-        export default MyApp;
-        ```
-      </Tab>
-    </CodeBlockTabs>
-
+<Tabs items={["Next.js", "React", "Remix"]}>
+  <CodeBlockTabs options={["App Router", "Pages Router"]}>
     <Tab>
-      ```tsx {{ prettier: false, filename: 'pages/privatepage.tsx' }}
+      ```tsx {{ prettier: false, filename: 'app/layout.tsx' }}
       import {
         ClerkProvider,
         SignedIn,
         SignedOut,
-        RedirectToSignIn
-      } from "@clerk/clerk-react";
+        RedirectToSignIn,
+      } from "@clerk/nextjs";
 
-      function PrivatePage() {
+      export default function RootLayout({
+        children,
+      }: {
+        children: React.ReactNode;
+      }) {
         return (
-          <ClerkProvider publishableKey={`{{pub_key}}`}>
-            <SignedIn>
-              Content that is displayed to signed in
-              users.
-            </SignedIn>
-            <SignedOut>
-              <RedirectToSignIn />
-            </SignedOut>
-          </div>
+          <html>
+            <body>
+              <ClerkProvider>
+                <SignedIn>
+                  {children}
+                </SignedIn>
+                <SignedOut>
+                  <RedirectToSignIn />
+                </SignedOut>
+              </ClerkProvider>
+            </body>
+          </html>
         );
       }
-
       ```
     </Tab>
 
     <Tab>
-      ```tsx {{ prettier: false, filename: 'routes/index.tsx' }}
+      ```tsx {{ prettier: false, filename: 'pages/_app.tsx' }}
       import {
+        ClerkProvider,
         SignedIn,
         SignedOut,
         RedirectToSignIn,
-        UserButton,
-      } from "@clerk/remix";
+      } from "@clerk/nextjs";
+      import { AppProps } from "next/app";
 
-      export default function Index() {
+      function MyApp({ Component, pageProps } : AppProps) {
         return (
-          <div>
+          <ClerkProvider>
             <SignedIn>
-              <h1>Index route</h1>
-              <p>You are signed in!</p>
-              <UserButton />
+              <Component {...pageProps} />
             </SignedIn>
             <SignedOut>
               <RedirectToSignIn />
             </SignedOut>
-          </div>
+          </ClerkProvider>
         );
       }
+
+      export default MyApp;
       ```
     </Tab>
-  </Tabs>
-</InjectKeys>
+  </CodeBlockTabs>
+
+  <Tab>
+    ```tsx {{ prettier: false, filename: 'pages/privatepage.tsx' }}
+    import {
+      ClerkProvider,
+      SignedIn,
+      SignedOut,
+      RedirectToSignIn
+    } from "@clerk/clerk-react";
+
+    function PrivatePage() {
+      return (
+        <ClerkProvider publishableKey={`{{pub_key}}`}>
+          <SignedIn>
+            Content that is displayed to signed in
+            users.
+          </SignedIn>
+          <SignedOut>
+            <RedirectToSignIn />
+          </SignedOut>
+        </div>
+      );
+    }
+
+    ```
+  </Tab>
+
+  <Tab>
+    ```tsx {{ prettier: false, filename: 'routes/index.tsx' }}
+    import {
+      SignedIn,
+      SignedOut,
+      RedirectToSignIn,
+      UserButton,
+    } from "@clerk/remix";
+
+    export default function Index() {
+      return (
+        <div>
+          <SignedIn>
+            <h1>Index route</h1>
+            <p>You are signed in!</p>
+            <UserButton />
+          </SignedIn>
+          <SignedOut>
+            <RedirectToSignIn />
+          </SignedOut>
+        </div>
+      );
+    }
+    ```
+  </Tab>
+</Tabs>
 
 ## Properties
 

--- a/docs/components/control/redirect-to-signup.mdx
+++ b/docs/components/control/redirect-to-signup.mdx
@@ -9,121 +9,119 @@ The `<RedirectToSignUp />` component will navigate to the sign up URL which has 
 
 ## Usage
 
-<InjectKeys>
-  <Tabs type="framework" items={["Next.js", "React", "Remix"]}>
-    <CodeBlockTabs options={["App Router", "Pages Router"]}>
-      <Tab>
-        ```tsx {{ prettier: false, filename: 'app/layout.tsx' }}
-        import {
-          ClerkProvider,
-          SignedIn,
-          SignedOut,
-          RedirectToSignUp,
-        } from "@clerk/nextjs";
-
-        export default function RootLayout({
-          children,
-        }: {
-          children: React.ReactNode;
-        }) {
-          return (
-            <html>
-              <body>
-                <ClerkProvider>
-                  <SignedIn>
-                    {children}
-                  </SignedIn>
-                  <SignedOut>
-                    <RedirectToSignUp />
-                  </SignedOut>
-                </ClerkProvider>
-              </body>
-            </html>
-          );
-        }
-        ```
-      </Tab>
-
-      <Tab>
-        ```tsx {{ prettier: false, filename: 'pages/_app.tsx' }}
-        import {
-          ClerkProvider,
-          SignedIn,
-          SignedOut,
-          RedirectToSignUp,
-        } from "@clerk/nextjs";
-        import { AppProps } from "next/app";
-
-        function MyApp({ Component, pageProps } : AppProps) {
-          return (
-            <ClerkProvider>
-              <SignedIn>
-                <Component {...pageProps />
-              </SignedIn>
-              <SignedOut>
-                <RedirectToSignUp />
-              </SignedOut>
-            </ClerkProvider>
-          );
-        }
-
-        export default MyApp;
-        ```
-      </Tab>
-    </CodeBlockTabs>
-
+<Tabs type="framework" items={["Next.js", "React", "Remix"]}>
+  <CodeBlockTabs options={["App Router", "Pages Router"]}>
     <Tab>
-      ```tsx {{ prettier: false, filename: 'pages/privatepage.tsx' }}
+      ```tsx {{ prettier: false, filename: 'app/layout.tsx' }}
       import {
         ClerkProvider,
         SignedIn,
         SignedOut,
-        RedirectToSignUp
-      } from "@clerk/clerk-react";
+        RedirectToSignUp,
+      } from "@clerk/nextjs";
 
-      function PrivatePage() {
+      export default function RootLayout({
+        children,
+      }: {
+        children: React.ReactNode;
+      }) {
         return (
-          <ClerkProvider publishableKey={`{{pub_key}}`}>
-            <SignedIn>
-              Content that is displayed to signed in
-              users.
-            </SignedIn>
-            <SignedOut>
-              <RedirectToSignUp />
-            </SignedOut>
-          </div>
+          <html>
+            <body>
+              <ClerkProvider>
+                <SignedIn>
+                  {children}
+                </SignedIn>
+                <SignedOut>
+                  <RedirectToSignUp />
+                </SignedOut>
+              </ClerkProvider>
+            </body>
+          </html>
         );
       }
       ```
     </Tab>
 
     <Tab>
-      ```tsx {{ prettier: false, filename: 'routes/index.tsx' }}
+      ```tsx {{ prettier: false, filename: 'pages/_app.tsx' }}
       import {
+        ClerkProvider,
         SignedIn,
         SignedOut,
         RedirectToSignUp,
-        UserButton,
-      } from "@clerk/remix";
+      } from "@clerk/nextjs";
+      import { AppProps } from "next/app";
 
-      export default function Index() {
+      function MyApp({ Component, pageProps } : AppProps) {
         return (
-          <div>
+          <ClerkProvider>
             <SignedIn>
-              <h1>Index route</h1>
-              <p>You are signed in!</p>
-              <UserButton />
+              <Component {...pageProps />
             </SignedIn>
             <SignedOut>
               <RedirectToSignUp />
             </SignedOut>
-          </div>
+          </ClerkProvider>
         );
       }
+
+      export default MyApp;
       ```
     </Tab>
-  </Tabs>
-</InjectKeys>
+  </CodeBlockTabs>
+
+  <Tab>
+    ```tsx {{ prettier: false, filename: 'pages/privatepage.tsx' }}
+    import {
+      ClerkProvider,
+      SignedIn,
+      SignedOut,
+      RedirectToSignUp
+    } from "@clerk/clerk-react";
+
+    function PrivatePage() {
+      return (
+        <ClerkProvider publishableKey={`{{pub_key}}`}>
+          <SignedIn>
+            Content that is displayed to signed in
+            users.
+          </SignedIn>
+          <SignedOut>
+            <RedirectToSignUp />
+          </SignedOut>
+        </div>
+      );
+    }
+    ```
+  </Tab>
+
+  <Tab>
+    ```tsx {{ prettier: false, filename: 'routes/index.tsx' }}
+    import {
+      SignedIn,
+      SignedOut,
+      RedirectToSignUp,
+      UserButton,
+    } from "@clerk/remix";
+
+    export default function Index() {
+      return (
+        <div>
+          <SignedIn>
+            <h1>Index route</h1>
+            <p>You are signed in!</p>
+            <UserButton />
+          </SignedIn>
+          <SignedOut>
+            <RedirectToSignUp />
+          </SignedOut>
+        </div>
+      );
+    }
+    ```
+  </Tab>
+</Tabs>
 
 ## Properties
 

--- a/docs/components/control/redirect-to-userprofile.mdx
+++ b/docs/components/control/redirect-to-userprofile.mdx
@@ -9,81 +9,79 @@ The `<RedirectToUserProfile />` component will navigate to the user profile URL 
 
 ## Usage
 
-<InjectKeys>
-  <Tabs type="framework" items={["Next.js", "React", "Remix"]}>
-    <Tab>
-      ```tsx {{ prettier: false, filename: 'pages/_app.tsx' }}
-      import {
-        ClerkProvider,
-        SignedIn,
-        SignedOut,
-        RedirectToUserProfile,
-      } from "@clerk/nextjs";
-      import { AppProps } from "next/app";
+<Tabs type="framework" items={["Next.js", "React", "Remix"]}>
+  <Tab>
+    ```tsx {{ prettier: false, filename: 'pages/_app.tsx' }}
+    import {
+      ClerkProvider,
+      SignedIn,
+      SignedOut,
+      RedirectToUserProfile,
+    } from "@clerk/nextjs";
+    import { AppProps } from "next/app";
 
 
-      function MyApp({ Component, pageProps } : AppProps) {
-        return (
-          <ClerkProvider {...pageProps}>
-            <SignedIn>
-              <RedirectToUserProfile/>
-            </SignedIn>
-            <SignedOut>
-              Please Sign In
-            </SignedOut>
-          </ClerkProvider>
-        );
-      }
+    function MyApp({ Component, pageProps } : AppProps) {
+      return (
+        <ClerkProvider {...pageProps}>
+          <SignedIn>
+            <RedirectToUserProfile/>
+          </SignedIn>
+          <SignedOut>
+            Please Sign In
+          </SignedOut>
+        </ClerkProvider>
+      );
+    }
 
-      export default MyApp;
-      ```
-    </Tab>
+    export default MyApp;
+    ```
+  </Tab>
 
-    <Tab>
-      ```tsx {{ prettier: false, filename: 'pages/privatepage.tsx' }}
-      import {
-        ClerkProvider,
-        SignedIn,
-        SignedOut,
-        RedirectToUserProfile
-      } from "@clerk/clerk-react";
+  <Tab>
+    ```tsx {{ prettier: false, filename: 'pages/privatepage.tsx' }}
+    import {
+      ClerkProvider,
+      SignedIn,
+      SignedOut,
+      RedirectToUserProfile
+    } from "@clerk/clerk-react";
 
-      function PrivatePage() {
-        return (
-          <ClerkProvider publishableKey={`{{pub_key}}`}>
-            <SignedIn>
-              <RedirectToUserProfile/>
-            </SignedIn>
-            <SignedOut>
-              Please Sign In
-            </SignedOut>
-          </div>
-        );
-      }
-      ```
-    </Tab>
+    function PrivatePage() {
+      return (
+        <ClerkProvider publishableKey={`{{pub_key}}`}>
+          <SignedIn>
+            <RedirectToUserProfile/>
+          </SignedIn>
+          <SignedOut>
+            Please Sign In
+          </SignedOut>
+        </div>
+      );
+    }
+    ```
+  </Tab>
 
-    <Tab>
-      ```tsx {{ prettier: false, filename: 'routes/index.tsx' }}
-      import {
-        SignedIn,
-        SignedOut,
-        RedirectToUserProfile
-      } from "@clerk/remix";
+  <Tab>
+    ```tsx {{ prettier: false, filename: 'routes/index.tsx' }}
+    import {
+      SignedIn,
+      SignedOut,
+      RedirectToUserProfile
+    } from "@clerk/remix";
 
-      export default function Index() {
-        return (
-          <div>
-            <SignedIn>
-              <RedirectToUserProfile/>
-            </SignedIn>
-            <SignedOut>
-              <p>Please sign in </p>
-            </SignedOut>
-          </div>
-        );
-      }
-      ```
-    </Tab>
-  </Tabs>
-</InjectKeys>
+    export default function Index() {
+      return (
+        <div>
+          <SignedIn>
+            <RedirectToUserProfile/>
+          </SignedIn>
+          <SignedOut>
+            <p>Please sign in </p>
+          </SignedOut>
+        </div>
+      );
+    }
+    ```
+  </Tab>
+</Tabs>

--- a/docs/components/control/signed-in.mdx
+++ b/docs/components/control/signed-in.mdx
@@ -11,80 +11,78 @@ The `<SignedIn>` component offers authentication checks as a cross-cutting conce
 
 ## Usage
 
-<InjectKeys>
-  <Tabs type="framework" items={["Next.js", "React", "Remix"]}>
-    <Tab>
-      ```tsx {{ prettier: false, filename: 'app.tsx' }}
-      import "@/styles/globals.css";
-      import {
-        ClerkProvider,
-        RedirectToSignIn,
-        SignedIn,
-      } from "@clerk/nextjs";
-      import { AppProps } from "next/app";
+<Tabs type="framework" items={["Next.js", "React", "Remix"]}>
+  <Tab>
+    ```tsx {{ prettier: false, filename: 'app.tsx' }}
+    import "@/styles/globals.css";
+    import {
+      ClerkProvider,
+      RedirectToSignIn,
+      SignedIn,
+    } from "@clerk/nextjs";
+    import { AppProps } from "next/app";
 
-      function MyApp({ Component, pageProps }: AppProps) {
-        return (
-          <ClerkProvider {...pageProps}>
+    function MyApp({ Component, pageProps }: AppProps) {
+      return (
+        <ClerkProvider {...pageProps}>
+          <SignedIn>
+            <div>You are signed in</div>
+          </SignedIn>
+          <div>Always visible</div>
+        </ClerkProvider>
+      );
+    }
+
+    export default MyApp;
+
+    ```
+  </Tab>
+
+  <Tab>
+    ```tsx {{ prettier: false, filename: 'app.tsx' }}
+    import { SignedIn, ClerkProvider } from "@clerk/clerk-react";
+
+    function Page() {
+      return (
+        <ClerkProvider publishableKey={`{{pub_key}}`}>
+          <section>
+            <div>
+              This content is always visible.
+            </div>
             <SignedIn>
-              <div>You are signed in</div>
-            </SignedIn>
-            <div>Always visible</div>
-          </ClerkProvider>
-        );
-      }
-
-      export default MyApp;
-
-      ```
-    </Tab>
-
-    <Tab>
-      ```tsx {{ prettier: false, filename: 'app.tsx' }}
-      import { SignedIn, ClerkProvider } from "@clerk/clerk-react";
-
-      function Page() {
-        return (
-          <ClerkProvider publishableKey={`{{pub_key}}`}>
-            <section>
               <div>
-                This content is always visible.
+                This content is visible only to
+                signed in users.
               </div>
-              <SignedIn>
-                <div>
-                  This content is visible only to
-                  signed in users.
-                </div>
-              </SignedIn>
-            </section>
-          </ClerkProvider>
-        );
-      }
-      ```
-    </Tab>
-
-    <Tab>
-      ```tsx {{ prettier: false, filename: 'routes/index.tsx' }}
-      import {
-        SignedIn,
-        UserButton,
-      } from "@clerk/remix";
-
-      export default function Index() {
-        return (
-          <div>
-            <SignedIn>
-              <h1>Index route</h1>
-              <p>You are signed in!</p>
-              <UserButton />
             </SignedIn>
-          </div>
-        );
-      }
-      ```
-    </Tab>
-  </Tabs>
-</InjectKeys>
+          </section>
+        </ClerkProvider>
+      );
+    }
+    ```
+  </Tab>
+
+  <Tab>
+    ```tsx {{ prettier: false, filename: 'routes/index.tsx' }}
+    import {
+      SignedIn,
+      UserButton,
+    } from "@clerk/remix";
+
+    export default function Index() {
+      return (
+        <div>
+          <SignedIn>
+            <h1>Index route</h1>
+            <p>You are signed in!</p>
+            <UserButton />
+          </SignedIn>
+        </div>
+      );
+    }
+    ```
+  </Tab>
+</Tabs>
 
 ### Usage with React Router
 

--- a/docs/components/control/signed-out.mdx
+++ b/docs/components/control/signed-out.mdx
@@ -9,113 +9,111 @@ The `<SignedOut>` component offers authentication checks as a cross-cutting conc
 
 ## Usage
 
-<InjectKeys>
-  <Tabs type="framework" items={["Next.js", "React", "Remix"]}>
-    <Tab>
-      ```tsx {{ prettier: false, filename: 'app.tsx' }}
-      import "@/styles/globals.css";
-      import {
-        ClerkProvider,
-        RedirectToSignIn,
-        SignedOut,
-      } from "@clerk/nextjs";
-      import { AppProps } from "next/app";
+<Tabs type="framework" items={["Next.js", "React", "Remix"]}>
+  <Tab>
+    ```tsx {{ prettier: false, filename: 'app.tsx' }}
+    import "@/styles/globals.css";
+    import {
+      ClerkProvider,
+      RedirectToSignIn,
+      SignedOut,
+    } from "@clerk/nextjs";
+    import { AppProps } from "next/app";
 
-      function MyApp({ Component, pageProps }: AppProps) {
-        return (
-          <ClerkProvider {...pageProps}>
+    function MyApp({ Component, pageProps }: AppProps) {
+      return (
+        <ClerkProvider {...pageProps}>
+          <SignedOut>
+            <div>You are signed Out</div>
+          </SignedOut>
+          <div>Always visible</div>
+        </ClerkProvider>
+      );
+    }
+
+    export default MyApp;
+    ```
+  </Tab>
+
+  <Tab>
+    ```tsx {{ prettier: false, filename: 'app.tsx' }}
+    import { SignedOut, ClerkProvider } from "@clerk/clerk-react";
+
+    function Page() {
+      return (
+        <ClerkProvider publishableKey={`{{pub_key}}`}>
+          <section>
+            <div>
+              This content is always visible.
+            </div>
             <SignedOut>
-              <div>You are signed Out</div>
-            </SignedOut>
-            <div>Always visible</div>
-          </ClerkProvider>
-        );
-      }
-
-      export default MyApp;
-      ```
-    </Tab>
-
-    <Tab>
-      ```tsx {{ prettier: false, filename: 'app.tsx' }}
-      import { SignedOut, ClerkProvider } from "@clerk/clerk-react";
-
-      function Page() {
-        return (
-          <ClerkProvider publishableKey={`{{pub_key}}`}>
-            <section>
               <div>
-                This content is always visible.
+                This content is visible only to signed out users.
               </div>
-              <SignedOut>
-                <div>
-                  This content is visible only to signed out users.
-                </div>
-              </SignedOut>
-            </section>
-          </ClerkProvider>
-        );
-      }
-      ```
-
-      ### Usage with React Router
-
-      Below is an example of how to use `<SignedOut>` with React Router. The `<SignedOut>` component can be used as a child of a `<Route />` component to render content only to signed in users.
-
-      ```tsx {{ prettier: false, filename: 'app.tsx' }}
-      import { Routes, Route } from 'react-router-dom';
-      import {
-        ClerkProvider,
-        SignedOut,
-        RedirectToSignIn
-      } from "@clerk/clerk-react";
-
-      function App() {
-        return (
-          <ClerkProvider publishableKey={`{{pub_key}}`}>
-            <Routes>
-            <Route
-              path="/"
-              element={<div>This page is publicly accessible.</div>}
-            />
-            <Route
-              path="/public"
-              element={
-                <SignedOut>
-                  <div>This content is accessible only to users that are signed out.</div>
-                </SignedOut>
-              }
-            />
-          </Routes>
-          </ClerkProvider>
-        );
-      }
-      ```
-    </Tab>
-
-    <Tab>
-      ```tsx {{ prettier: false, filename: 'routes/index.tsx' }}
-      import {
-        SignedIn,
-        SignedOut,
-        UserButton,
-      } from "@clerk/remix";
-
-      export default function Index() {
-        return (
-          <div>
-            <SignedIn>
-              <h1>Index route</h1>
-              <p>You are signed in!</p>
-              <UserButton />
-            </SignedIn>
-            <SignedOut>
-            <p> You are signed out </p>
             </SignedOut>
-          </div>
-        );
-      }
-      ```
-    </Tab>
-  </Tabs>
-</InjectKeys>
+          </section>
+        </ClerkProvider>
+      );
+    }
+    ```
+
+    ### Usage with React Router
+
+    Below is an example of how to use `<SignedOut>` with React Router. The `<SignedOut>` component can be used as a child of a `<Route />` component to render content only to signed in users.
+
+    ```tsx {{ prettier: false, filename: 'app.tsx' }}
+    import { Routes, Route } from 'react-router-dom';
+    import {
+      ClerkProvider,
+      SignedOut,
+      RedirectToSignIn
+    } from "@clerk/clerk-react";
+
+    function App() {
+      return (
+        <ClerkProvider publishableKey={`{{pub_key}}`}>
+          <Routes>
+          <Route
+            path="/"
+            element={<div>This page is publicly accessible.</div>}
+          />
+          <Route
+            path="/public"
+            element={
+              <SignedOut>
+                <div>This content is accessible only to users that are signed out.</div>
+              </SignedOut>
+            }
+          />
+        </Routes>
+        </ClerkProvider>
+      );
+    }
+    ```
+  </Tab>
+
+  <Tab>
+    ```tsx {{ prettier: false, filename: 'routes/index.tsx' }}
+    import {
+      SignedIn,
+      SignedOut,
+      UserButton,
+    } from "@clerk/remix";
+
+    export default function Index() {
+      return (
+        <div>
+          <SignedIn>
+            <h1>Index route</h1>
+            <p>You are signed in!</p>
+            <UserButton />
+          </SignedIn>
+          <SignedOut>
+          <p> You are signed out </p>
+          </SignedOut>
+        </div>
+      );
+    }
+    ```
+  </Tab>
+</Tabs>

--- a/docs/components/organization/create-organization.mdx
+++ b/docs/components/organization/create-organization.mdx
@@ -102,52 +102,50 @@ function mountCreateOrganization(node: HTMLDivElement, props?: CreateOrganizatio
 
 #### `mountCreateOrganization()` usage
 
-<InjectKeys>
-  <CodeBlockTabs type="npm-script" options={['NPM module', '<script>']}>
-    ```js {{ prettier: false, filename: 'main.js', mark: [14] }}
-    import { Clerk } from '@clerk/clerk-js';
+<CodeBlockTabs type="npm-script" options={['NPM module', '<script>']}>
+  ```js {{ prettier: false, filename: 'main.js', mark: [14] }}
+  import { Clerk } from '@clerk/clerk-js';
 
-    // Initialize Clerk with your Clerk publishable key
-    const clerk = new Clerk('{{pub_key}}');
-    await clerk.load();
+  // Initialize Clerk with your Clerk publishable key
+  const clerk = new Clerk('{{pub_key}}');
+  await clerk.load();
 
-    document.getElementById("app").innerHTML = `
-      <div id="create-organization"></div>
-    `;
-
-    const createOrgDiv =
-      document.getElementById("create-organization");
-
-    clerk.mountCreateOrganization(createOrgDiv);
-    ```
-
-    ```html {{ prettier: false, filename: 'index.html', mark: [21] }}
-    <!-- Add a <div id="create-organization"> element to your HTML -->
+  document.getElementById("app").innerHTML = `
     <div id="create-organization"></div>
+  `;
 
-    <!-- Initialize Clerk with your
-    Clerk Publishable key and Frontend API URL -->
-    <script
-      async
-      crossorigin="anonymous"
-      data-clerk-publishable-key="{{pub_key}}"
-      src="https://{{fapi_url}}/npm/@clerk/clerk-js@latest/dist/clerk.browser.js"
-      type="text/javascript"
-    ></script>
+  const createOrgDiv =
+    document.getElementById("create-organization");
 
-    <script>
-      window.addEventListener("load", async function () {
-        await Clerk.load();
+  clerk.mountCreateOrganization(createOrgDiv);
+  ```
 
-        const createOrgDiv =
-          document.getElementById("create-organization");
+  ```html {{ prettier: false, filename: 'index.html', mark: [21] }}
+  <!-- Add a <div id="create-organization"> element to your HTML -->
+  <div id="create-organization"></div>
 
-        Clerk.mountCreateOrganization(createOrgDiv);
-      });
-    </script>
-    ```
-  </CodeBlockTabs>
-</InjectKeys>
+  <!-- Initialize Clerk with your
+  Clerk Publishable key and Frontend API URL -->
+  <script
+    async
+    crossorigin="anonymous"
+    data-clerk-publishable-key="{{pub_key}}"
+    src="https://{{fapi_url}}/npm/@clerk/clerk-js@latest/dist/clerk.browser.js"
+    type="text/javascript"
+  ></script>
+
+  <script>
+    window.addEventListener("load", async function () {
+      await Clerk.load();
+
+      const createOrgDiv =
+        document.getElementById("create-organization");
+
+      Clerk.mountCreateOrganization(createOrgDiv);
+    });
+  </script>
+  ```
+</CodeBlockTabs>
 
 ### <code>unmountCreate<wbr />Organization()</code>
 
@@ -165,60 +163,58 @@ function unmountCreateOrganization(node: HTMLDivElement): void;
 
 #### `unmountCreateOrganization()` usage
 
-<InjectKeys>
-  <CodeBlockTabs type="npm-script" options={['NPM module', '<script>']}>
-    ```js {{ prettier: false, filename: 'main.js', mark: [18] }}
-    import { Clerk } from '@clerk/clerk-js';
+<CodeBlockTabs type="npm-script" options={['NPM module', '<script>']}>
+  ```js {{ prettier: false, filename: 'main.js', mark: [18] }}
+  import { Clerk } from '@clerk/clerk-js';
 
-    // Initialize Clerk with your Clerk publishable key
-    const clerk = new Clerk('{{pub_key}}');
-    await clerk.load();
+  // Initialize Clerk with your Clerk publishable key
+  const clerk = new Clerk('{{pub_key}}');
+  await clerk.load();
 
-    document.getElementById('app').innerHTML = `
-      <div id="create-organization"></div>
-    `
-
-    const createOrgDiv =
-      document.getElementById('create-organization');
-
-    clerk.mountCreateOrganization(createOrgDiv);
-
-    // ...
-
-    clerk.unmountCreateOrganization(createOrgDiv);
-    ```
-
-    ```html {{ prettier: false, filename: 'index.html', mark: [25] }}
-    <!-- Add a <div id="create-organization"> element to your HTML -->
+  document.getElementById('app').innerHTML = `
     <div id="create-organization"></div>
+  `
 
-    <!-- Initialize Clerk with your
-    Clerk Publishable key and Frontend API URL -->
-    <script
-      async
-      crossorigin="anonymous"
-      data-clerk-publishable-key="{{pub_key}}"
-      src="https://{{fapi_url}}/npm/@clerk/clerk-js@latest/dist/clerk.browser.js"
-      type="text/javascript"
-    ></script>
+  const createOrgDiv =
+    document.getElementById('create-organization');
 
-    <script>
-      window.addEventListener("load", async function () {
-        await Clerk.load();
+  clerk.mountCreateOrganization(createOrgDiv);
 
-        const createOrgDiv =
-          document.getElementById('create-organization');
+  // ...
 
-        Clerk.mountCreateOrganization(createOrgDiv);
+  clerk.unmountCreateOrganization(createOrgDiv);
+  ```
 
-        // ...
+  ```html {{ prettier: false, filename: 'index.html', mark: [25] }}
+  <!-- Add a <div id="create-organization"> element to your HTML -->
+  <div id="create-organization"></div>
 
-        Clerk.unmountCreateOrganization(createOrgDiv);
-      });
-    </script>
-    ```
-  </CodeBlockTabs>
-</InjectKeys>
+  <!-- Initialize Clerk with your
+  Clerk Publishable key and Frontend API URL -->
+  <script
+    async
+    crossorigin="anonymous"
+    data-clerk-publishable-key="{{pub_key}}"
+    src="https://{{fapi_url}}/npm/@clerk/clerk-js@latest/dist/clerk.browser.js"
+    type="text/javascript"
+  ></script>
+
+  <script>
+    window.addEventListener("load", async function () {
+      await Clerk.load();
+
+      const createOrgDiv =
+        document.getElementById('create-organization');
+
+      Clerk.mountCreateOrganization(createOrgDiv);
+
+      // ...
+
+      Clerk.unmountCreateOrganization(createOrgDiv);
+    });
+  </script>
+  ```
+</CodeBlockTabs>
 
 ### `openCreateOrganization()`
 
@@ -236,52 +232,50 @@ function openCreateOrganization(props?: CreateOrganizationProps): void;
 
 #### `openCreateOrganization()` usage
 
-<InjectKeys>
-  <CodeBlockTabs type="npm-script" options={['NPM module', '<script>']}>
-    ```js {{ prettier: false, filename: 'main.js', mark: [18] }}
-    import { Clerk } from '@clerk/clerk-js';
+<CodeBlockTabs type="npm-script" options={['NPM module', '<script>']}>
+  ```js {{ prettier: false, filename: 'main.js', mark: [18] }}
+  import { Clerk } from '@clerk/clerk-js';
 
-    // Initialize Clerk with your Clerk publishable key
-    const clerk = new Clerk('{{pub_key}}');
-    await clerk.load();
+  // Initialize Clerk with your Clerk publishable key
+  const clerk = new Clerk('{{pub_key}}');
+  await clerk.load();
 
-    document.getElementById('app').innerHTML = `
-      <div id="create-organization"></div>
-    `
-
-    const createOrgDiv =
-      document.getElementById('create-organization');
-
-    clerk.openCreateOrganization(createOrgDiv);
-    ```
-
-    ```html {{ prettier: false, filename: 'index.html', mark: [21] }}
-    <!-- Add a <div id="create-organization"> element to your HTML -->
+  document.getElementById('app').innerHTML = `
     <div id="create-organization"></div>
+  `
 
-    <!-- Initialize Clerk with your
-    Clerk Publishable key and Frontend API URL -->
-    <script
-      async
-      crossorigin="anonymous"
-      data-clerk-publishable-key="{{pub_key}}"
-      src="https://{{fapi_url}}/npm/@clerk/clerk-js@latest/dist/clerk.browser.js"
-      type="text/javascript"
-    ></script>
+  const createOrgDiv =
+    document.getElementById('create-organization');
 
-    <script>
-      window.addEventListener("load", async function () {
-        await Clerk.load();
+  clerk.openCreateOrganization(createOrgDiv);
+  ```
 
-        const createOrgDiv =
-          document.getElementById('create-organization');
+  ```html {{ prettier: false, filename: 'index.html', mark: [21] }}
+  <!-- Add a <div id="create-organization"> element to your HTML -->
+  <div id="create-organization"></div>
 
-        Clerk.openCreateOrganization(createOrgDiv);
-      });
-    </script>
-    ```
-  </CodeBlockTabs>
-</InjectKeys>
+  <!-- Initialize Clerk with your
+  Clerk Publishable key and Frontend API URL -->
+  <script
+    async
+    crossorigin="anonymous"
+    data-clerk-publishable-key="{{pub_key}}"
+    src="https://{{fapi_url}}/npm/@clerk/clerk-js@latest/dist/clerk.browser.js"
+    type="text/javascript"
+  ></script>
+
+  <script>
+    window.addEventListener("load", async function () {
+      await Clerk.load();
+
+      const createOrgDiv =
+        document.getElementById('create-organization');
+
+      Clerk.openCreateOrganization(createOrgDiv);
+    });
+  </script>
+  ```
+</CodeBlockTabs>
 
 ### `closeCreateOrganization()`
 
@@ -293,60 +287,58 @@ function closeCreateOrganization(): void;
 
 #### `closeCreateOrganization()` usage
 
-<InjectKeys>
-  <CodeBlockTabs type="npm-script" options={['NPM module', '<script>']}>
-    ```js {{ prettier: false, filename: 'main.js', mark: [18] }}
-    import { Clerk } from '@clerk/clerk-js';
+<CodeBlockTabs type="npm-script" options={['NPM module', '<script>']}>
+  ```js {{ prettier: false, filename: 'main.js', mark: [18] }}
+  import { Clerk } from '@clerk/clerk-js';
 
-    // Initialize Clerk with your Clerk publishable key
-    const clerk = new Clerk('{{pub_key}}');
-    await clerk.load();
+  // Initialize Clerk with your Clerk publishable key
+  const clerk = new Clerk('{{pub_key}}');
+  await clerk.load();
 
-    document.getElementById('app').innerHTML = `
-      <div id="create-organization"></div>
-    `
-
-    const createOrgDiv =
-      document.getElementById('create-organization');
-
-    clerk.openCreateOrganization(createOrgDiv);
-
-    // ...
-
-    clerk.closeCreateOrganization(createOrgDiv);
-    ```
-
-    ```html {{ prettier: false, filename: 'index.html', mark: [25] }}
-    <!-- Add a <div id="create-organization"> element to your HTML -->
+  document.getElementById('app').innerHTML = `
     <div id="create-organization"></div>
+  `
 
-    <!-- Initialize Clerk with your
-    Clerk Publishable key and Frontend API URL -->
-    <script
-      async
-      crossorigin="anonymous"
-      data-clerk-publishable-key="{{pub_key}}"
-      src="https://{{fapi_url}}/npm/@clerk/clerk-js@latest/dist/clerk.browser.js"
-      type="text/javascript"
-    ></script>
+  const createOrgDiv =
+    document.getElementById('create-organization');
 
-    <script>
-      window.addEventListener("load", async function () {
-        await Clerk.load();
+  clerk.openCreateOrganization(createOrgDiv);
 
-        const createOrgDiv =
-          document.getElementById('create-organization');
+  // ...
 
-        Clerk.openCreateOrganization(createOrgDiv);
+  clerk.closeCreateOrganization(createOrgDiv);
+  ```
 
-        // ...
+  ```html {{ prettier: false, filename: 'index.html', mark: [25] }}
+  <!-- Add a <div id="create-organization"> element to your HTML -->
+  <div id="create-organization"></div>
 
-        Clerk.closeCreateOrganization(createOrgDiv);
-      });
-    </script>
-    ```
-  </CodeBlockTabs>
-</InjectKeys>
+  <!-- Initialize Clerk with your
+  Clerk Publishable key and Frontend API URL -->
+  <script
+    async
+    crossorigin="anonymous"
+    data-clerk-publishable-key="{{pub_key}}"
+    src="https://{{fapi_url}}/npm/@clerk/clerk-js@latest/dist/clerk.browser.js"
+    type="text/javascript"
+  ></script>
+
+  <script>
+    window.addEventListener("load", async function () {
+      await Clerk.load();
+
+      const createOrgDiv =
+        document.getElementById('create-organization');
+
+      Clerk.openCreateOrganization(createOrgDiv);
+
+      // ...
+
+      Clerk.closeCreateOrganization(createOrgDiv);
+    });
+  </script>
+  ```
+</CodeBlockTabs>
 
 ## Customization
 

--- a/docs/components/organization/organization-list.mdx
+++ b/docs/components/organization/organization-list.mdx
@@ -121,52 +121,50 @@ function mountOrganizationList(node: HTMLDivElement, props?: OrganizationListPro
 
 ### `mountOrganizationList()` usage
 
-<InjectKeys>
-  <CodeBlockTabs type="npm-script" options={['NPM module', '<script>']}>
-    ```js {{ prettier: false, filename: 'main.js', mark: [14] }}
-    import { Clerk } from '@clerk/clerk-js';
+<CodeBlockTabs type="npm-script" options={['NPM module', '<script>']}>
+  ```js {{ prettier: false, filename: 'main.js', mark: [14] }}
+  import { Clerk } from '@clerk/clerk-js';
 
-    // Initialize Clerk with your Clerk publishable key
-    const clerk = new Clerk('{{pub_key}}');
-    await clerk.load();
+  // Initialize Clerk with your Clerk publishable key
+  const clerk = new Clerk('{{pub_key}}');
+  await clerk.load();
 
-    document.getElementById("app").innerHTML = `
-      <div id="organization-list"></div>
-    `;
-
-    const orgListDiv =
-      document.getElementById("organization-list");
-
-    clerk.mountOrganizationList(orgListDiv);
-    ```
-
-    ```html {{ prettier: false, filename: 'index.html', mark: [21] }}
-    <!-- Add a <div id="organization-list"> element to your HTML -->
+  document.getElementById("app").innerHTML = `
     <div id="organization-list"></div>
+  `;
 
-    <!-- Initialize Clerk with your
-    Clerk Publishable key and Frontend API URL -->
-    <script
-      async
-      crossorigin="anonymous"
-      data-clerk-publishable-key="{{pub_key}}"
-      src="https://{{fapi_url}}/npm/@clerk/clerk-js@latest/dist/clerk.browser.js"
-      type="text/javascript"
-    ></script>
+  const orgListDiv =
+    document.getElementById("organization-list");
 
-    <script>
-      window.addEventListener("load", async function () {
-        await Clerk.load();
+  clerk.mountOrganizationList(orgListDiv);
+  ```
 
-        const orgListDiv =
-          document.getElementById('organization-list');
+  ```html {{ prettier: false, filename: 'index.html', mark: [21] }}
+  <!-- Add a <div id="organization-list"> element to your HTML -->
+  <div id="organization-list"></div>
 
-        Clerk.mountOrganizationList(orgListDiv);
-      });
-    </script>
-    ```
-  </CodeBlockTabs>
-</InjectKeys>
+  <!-- Initialize Clerk with your
+  Clerk Publishable key and Frontend API URL -->
+  <script
+    async
+    crossorigin="anonymous"
+    data-clerk-publishable-key="{{pub_key}}"
+    src="https://{{fapi_url}}/npm/@clerk/clerk-js@latest/dist/clerk.browser.js"
+    type="text/javascript"
+  ></script>
+
+  <script>
+    window.addEventListener("load", async function () {
+      await Clerk.load();
+
+      const orgListDiv =
+        document.getElementById('organization-list');
+
+      Clerk.mountOrganizationList(orgListDiv);
+    });
+  </script>
+  ```
+</CodeBlockTabs>
 
 ## `unmountOrganizationList()`
 
@@ -184,60 +182,58 @@ function unmountOrganizationList(node: HTMLDivElement): void;
 
 ### `unmountOrganizationList()` usage
 
-<InjectKeys>
-  <CodeBlockTabs type="npm-script" options={['NPM module', '<script>']}>
-    ```js {{ prettier: false, filename: 'main.js', mark: [18] }}
-    import { Clerk } from '@clerk/clerk-js';
+<CodeBlockTabs type="npm-script" options={['NPM module', '<script>']}>
+  ```js {{ prettier: false, filename: 'main.js', mark: [18] }}
+  import { Clerk } from '@clerk/clerk-js';
 
-    // Initialize Clerk with your Clerk publishable key
-    const clerk = new Clerk('{{pub_key}}');
-    await clerk.load();
+  // Initialize Clerk with your Clerk publishable key
+  const clerk = new Clerk('{{pub_key}}');
+  await clerk.load();
 
-    document.getElementById('app').innerHTML = `
-      <div id="organization-list"></div>
-    `
-
-    const orgListDiv =
-      document.getElementById('organization-list');
-
-    clerk.mountOrganizationList(orgListDiv);
-
-    // ...
-
-    clerk.unmountOrganizationList(orgListDiv);
-    ```
-
-    ```html {{ prettier: false, filename: 'index.html', mark: [25] }}
-    <!-- Add a <div id="organization-list"> element to your HTML -->
+  document.getElementById('app').innerHTML = `
     <div id="organization-list"></div>
+  `
 
-    <!-- Initialize Clerk with your
-    Clerk Publishable key and Frontend API URL -->
-    <script
-      async
-      crossorigin="anonymous"
-      data-clerk-publishable-key="{{pub_key}}"
-      src="https://{{fapi_url}}/npm/@clerk/clerk-js@latest/dist/clerk.browser.js"
-      type="text/javascript"
-    ></script>
+  const orgListDiv =
+    document.getElementById('organization-list');
 
-    <script>
-      window.addEventListener("load", async function () {
-        await Clerk.load();
+  clerk.mountOrganizationList(orgListDiv);
 
-        const orgListDiv =
-          document.getElementById('organization-list');
+  // ...
 
-        Clerk.mountOrganizationList(orgListDiv);
+  clerk.unmountOrganizationList(orgListDiv);
+  ```
 
-        // ...
+  ```html {{ prettier: false, filename: 'index.html', mark: [25] }}
+  <!-- Add a <div id="organization-list"> element to your HTML -->
+  <div id="organization-list"></div>
 
-        Clerk.unmountOrganizationList(orgListDiv);
-      });
-    </script>
-    ```
-  </CodeBlockTabs>
-</InjectKeys>
+  <!-- Initialize Clerk with your
+  Clerk Publishable key and Frontend API URL -->
+  <script
+    async
+    crossorigin="anonymous"
+    data-clerk-publishable-key="{{pub_key}}"
+    src="https://{{fapi_url}}/npm/@clerk/clerk-js@latest/dist/clerk.browser.js"
+    type="text/javascript"
+  ></script>
+
+  <script>
+    window.addEventListener("load", async function () {
+      await Clerk.load();
+
+      const orgListDiv =
+        document.getElementById('organization-list');
+
+      Clerk.mountOrganizationList(orgListDiv);
+
+      // ...
+
+      Clerk.unmountOrganizationList(orgListDiv);
+    });
+  </script>
+  ```
+</CodeBlockTabs>
 
 ## Force organizations
 

--- a/docs/components/organization/organization-profile.mdx
+++ b/docs/components/organization/organization-profile.mdx
@@ -108,52 +108,50 @@ function mountOrganizationProfile(node: HTMLDivElement, props?: OrganizationProf
 
 #### `mountOrganizationProfile()` usage
 
-<InjectKeys>
-  <CodeBlockTabs type="npm-script" options={['NPM module', '<script>']}>
-    ```js {{ prettier: false, filename: 'main.js', mark: [14] }}
-    import { Clerk } from '@clerk/clerk-js';
+<CodeBlockTabs type="npm-script" options={['NPM module', '<script>']}>
+  ```js {{ prettier: false, filename: 'main.js', mark: [14] }}
+  import { Clerk } from '@clerk/clerk-js';
 
-    // Initialize Clerk with your Clerk publishable key
-    const clerk = new Clerk('{{pub_key}}');
-    await clerk.load();
+  // Initialize Clerk with your Clerk publishable key
+  const clerk = new Clerk('{{pub_key}}');
+  await clerk.load();
 
-    document.getElementById("app").innerHTML = `
-      <div id="organization-profile"></div>
-    `;
-
-    const orgProfileDiv =
-      document.getElementById("organization-profile");
-
-    clerk.mountOrganizationProfile(orgProfileDiv);
-    ```
-
-    ```html {{ prettier: false, filename: 'index.html', mark: [21] }}
-    <!-- Add a <div id="organization-profile"> element to your HTML -->
+  document.getElementById("app").innerHTML = `
     <div id="organization-profile"></div>
+  `;
 
-    <!-- Initialize Clerk with your
-    Clerk Publishable key and Frontend API URL -->
-    <script
-      async
-      crossorigin="anonymous"
-      data-clerk-publishable-key="{{pub_key}}"
-      src="https://{{fapi_url}}/npm/@clerk/clerk-js@latest/dist/clerk.browser.js"
-      type="text/javascript"
-    ></script>
+  const orgProfileDiv =
+    document.getElementById("organization-profile");
 
-    <script>
-      window.addEventListener("load", async function () {
-        await Clerk.load();
+  clerk.mountOrganizationProfile(orgProfileDiv);
+  ```
 
-        const orgProfileDiv =
-          document.getElementById('organization-profile');
+  ```html {{ prettier: false, filename: 'index.html', mark: [21] }}
+  <!-- Add a <div id="organization-profile"> element to your HTML -->
+  <div id="organization-profile"></div>
 
-        Clerk.mountOrganizationProfile(orgProfileDiv);
-      });
-    </script>
-    ```
-  </CodeBlockTabs>
-</InjectKeys>
+  <!-- Initialize Clerk with your
+  Clerk Publishable key and Frontend API URL -->
+  <script
+    async
+    crossorigin="anonymous"
+    data-clerk-publishable-key="{{pub_key}}"
+    src="https://{{fapi_url}}/npm/@clerk/clerk-js@latest/dist/clerk.browser.js"
+    type="text/javascript"
+  ></script>
+
+  <script>
+    window.addEventListener("load", async function () {
+      await Clerk.load();
+
+      const orgProfileDiv =
+        document.getElementById('organization-profile');
+
+      Clerk.mountOrganizationProfile(orgProfileDiv);
+    });
+  </script>
+  ```
+</CodeBlockTabs>
 
 ### <code>unmountOrganization<wbr />Profile()</code>
 
@@ -171,60 +169,58 @@ function unmountOrganizationProfile(node: HTMLDivElement): void;
 
 #### `unmountOrganizationProfile()` usage
 
-<InjectKeys>
-  <CodeBlockTabs type="npm-script" options={['NPM module', '<script>']}>
-    ```js {{ prettier: false, filename: 'main.js', mark: [18] }}
-    import { Clerk } from '@clerk/clerk-js';
+<CodeBlockTabs type="npm-script" options={['NPM module', '<script>']}>
+  ```js {{ prettier: false, filename: 'main.js', mark: [18] }}
+  import { Clerk } from '@clerk/clerk-js';
 
-    // Initialize Clerk with your Clerk publishable key
-    const clerk = new Clerk('{{pub_key}}');
-    await clerk.load();
+  // Initialize Clerk with your Clerk publishable key
+  const clerk = new Clerk('{{pub_key}}');
+  await clerk.load();
 
-    document.getElementById('app').innerHTML = `
-      <div id="organization-profile"></div>
-    `
-
-    const orgProfileDiv =
-      document.getElementById('organization-profile');
-
-    clerk.mountOrganizationProfile(orgProfileDiv);
-
-    // ...
-
-    clerk.unmountOrganizationProfile(orgProfileDiv);
-    ```
-
-    ```html {{ prettier: false, filename: 'index.html', mark: [25] }}
-    <!-- Add a <div id="organization-profile"> element to your HTML -->
+  document.getElementById('app').innerHTML = `
     <div id="organization-profile"></div>
+  `
 
-    <!-- Initialize Clerk with your
-    Clerk Publishable key and Frontend API URL -->
-    <script
-      async
-      crossorigin="anonymous"
-      data-clerk-publishable-key="{{pub_key}}"
-      src="https://{{fapi_url}}/npm/@clerk/clerk-js@latest/dist/clerk.browser.js"
-      type="text/javascript"
-    ></script>
+  const orgProfileDiv =
+    document.getElementById('organization-profile');
 
-    <script>
-      window.addEventListener("load", async function () {
-        await Clerk.load();
+  clerk.mountOrganizationProfile(orgProfileDiv);
 
-        const orgProfileDiv =
-          document.getElementById('organization-profile');
+  // ...
 
-        Clerk.mountOrganizationProfile(orgProfileDiv);
+  clerk.unmountOrganizationProfile(orgProfileDiv);
+  ```
 
-        // ...
+  ```html {{ prettier: false, filename: 'index.html', mark: [25] }}
+  <!-- Add a <div id="organization-profile"> element to your HTML -->
+  <div id="organization-profile"></div>
 
-        Clerk.unmountOrganizationProfile(orgProfileDiv);
-      });
-    </script>
-    ```
-  </CodeBlockTabs>
-</InjectKeys>
+  <!-- Initialize Clerk with your
+  Clerk Publishable key and Frontend API URL -->
+  <script
+    async
+    crossorigin="anonymous"
+    data-clerk-publishable-key="{{pub_key}}"
+    src="https://{{fapi_url}}/npm/@clerk/clerk-js@latest/dist/clerk.browser.js"
+    type="text/javascript"
+  ></script>
+
+  <script>
+    window.addEventListener("load", async function () {
+      await Clerk.load();
+
+      const orgProfileDiv =
+        document.getElementById('organization-profile');
+
+      Clerk.mountOrganizationProfile(orgProfileDiv);
+
+      // ...
+
+      Clerk.unmountOrganizationProfile(orgProfileDiv);
+    });
+  </script>
+  ```
+</CodeBlockTabs>
 
 ### `openOrganizationProfile()`
 
@@ -242,52 +238,50 @@ function openOrganizationProfile(props?: OrganizationProfileProps): void;
 
 #### `openOrganizationProfile()` usage
 
-<InjectKeys>
-  <CodeBlockTabs type="npm-script" options={['NPM module', '<script>']}>
-    ```js {{ prettier: false, filename: 'main.js', mark: [14] }}
-    import { Clerk } from '@clerk/clerk-js';
+<CodeBlockTabs type="npm-script" options={['NPM module', '<script>']}>
+  ```js {{ prettier: false, filename: 'main.js', mark: [14] }}
+  import { Clerk } from '@clerk/clerk-js';
 
-    // Initialize Clerk with your Clerk publishable key
-    const clerk = new Clerk('{{pub_key}}');
-    await clerk.load();
+  // Initialize Clerk with your Clerk publishable key
+  const clerk = new Clerk('{{pub_key}}');
+  await clerk.load();
 
-    document.getElementById('app').innerHTML = `
-      <div id="organization-profile"></div>
-    `
-
-    const orgProfileDiv =
-      document.getElementById('organization-profile');
-
-    clerk.openOrganizationProfile(orgProfileDiv);
-    ```
-
-    ```html {{ prettier: false, filename: 'index.html', mark: [21] }}
-    <!-- Add a <div id="organization-profile"> element to your HTML -->
+  document.getElementById('app').innerHTML = `
     <div id="organization-profile"></div>
+  `
 
-    <!-- Initialize Clerk with your
-    Clerk Publishable key and Frontend API URL -->
-    <script
-      async
-      crossorigin="anonymous"
-      data-clerk-publishable-key="{{pub_key}}"
-      src="https://{{fapi_url}}/npm/@clerk/clerk-js@latest/dist/clerk.browser.js"
-      type="text/javascript"
-    ></script>
+  const orgProfileDiv =
+    document.getElementById('organization-profile');
 
-    <script>
-      window.addEventListener("load", async function () {
-        await Clerk.load();
+  clerk.openOrganizationProfile(orgProfileDiv);
+  ```
 
-        const orgProfileDiv =
-          document.getElementById('organization-profile');
+  ```html {{ prettier: false, filename: 'index.html', mark: [21] }}
+  <!-- Add a <div id="organization-profile"> element to your HTML -->
+  <div id="organization-profile"></div>
 
-        Clerk.openOrganizationProfile(orgProfileDiv);
-      });
-    </script>
-    ```
-  </CodeBlockTabs>
-</InjectKeys>
+  <!-- Initialize Clerk with your
+  Clerk Publishable key and Frontend API URL -->
+  <script
+    async
+    crossorigin="anonymous"
+    data-clerk-publishable-key="{{pub_key}}"
+    src="https://{{fapi_url}}/npm/@clerk/clerk-js@latest/dist/clerk.browser.js"
+    type="text/javascript"
+  ></script>
+
+  <script>
+    window.addEventListener("load", async function () {
+      await Clerk.load();
+
+      const orgProfileDiv =
+        document.getElementById('organization-profile');
+
+      Clerk.openOrganizationProfile(orgProfileDiv);
+    });
+  </script>
+  ```
+</CodeBlockTabs>
 
 ### `closeOrganizationProfile()`
 
@@ -299,52 +293,50 @@ function closeOrganizationProfile(): void;
 
 #### `closeOrganizationProfile()` usage
 
-<InjectKeys>
-  <CodeBlockTabs type="npm-script" options={['NPM module', '<script>']}>
-    ```js {{ prettier: false, filename: 'main.js', mark: [14] }}
-    import { Clerk } from '@clerk/clerk-js';
+<CodeBlockTabs type="npm-script" options={['NPM module', '<script>']}>
+  ```js {{ prettier: false, filename: 'main.js', mark: [14] }}
+  import { Clerk } from '@clerk/clerk-js';
 
-    // Initialize Clerk with your Clerk publishable key
-    const clerk = new Clerk('{{pub_key}}');
-    await clerk.load();
+  // Initialize Clerk with your Clerk publishable key
+  const clerk = new Clerk('{{pub_key}}');
+  await clerk.load();
 
-    document.getElementById('app').innerHTML = `
-      <div id="organization-profile"></div>
-    `
-
-    const orgProfileDiv =
-      document.getElementById('organization-profile');
-
-    clerk.closeOrganizationProfile(orgProfileDiv);
-    ```
-
-    ```html {{ prettier: false, filename: 'index.html', mark: [21] }}
-    <!-- Add a <div id="organization-profile"> element to your HTML -->
+  document.getElementById('app').innerHTML = `
     <div id="organization-profile"></div>
+  `
 
-    <!-- Initialize Clerk with your
-    Clerk Publishable key and Frontend API URL -->
-    <script
-      async
-      crossorigin="anonymous"
-      data-clerk-publishable-key="{{pub_key}}"
-      src="https://{{fapi_url}}/npm/@clerk/clerk-js@latest/dist/clerk.browser.js"
-      type="text/javascript"
-    ></script>
+  const orgProfileDiv =
+    document.getElementById('organization-profile');
 
-    <script>
-      window.addEventListener("load", async function () {
-        await Clerk.load();
+  clerk.closeOrganizationProfile(orgProfileDiv);
+  ```
 
-        const orgProfileDiv =
-          document.getElementById('organization-profile');
+  ```html {{ prettier: false, filename: 'index.html', mark: [21] }}
+  <!-- Add a <div id="organization-profile"> element to your HTML -->
+  <div id="organization-profile"></div>
 
-        Clerk.closeOrganizationProfile(orgProfileDiv);
-      });
-    </script>
-    ```
-  </CodeBlockTabs>
-</InjectKeys>
+  <!-- Initialize Clerk with your
+  Clerk Publishable key and Frontend API URL -->
+  <script
+    async
+    crossorigin="anonymous"
+    data-clerk-publishable-key="{{pub_key}}"
+    src="https://{{fapi_url}}/npm/@clerk/clerk-js@latest/dist/clerk.browser.js"
+    type="text/javascript"
+  ></script>
+
+  <script>
+    window.addEventListener("load", async function () {
+      await Clerk.load();
+
+      const orgProfileDiv =
+        document.getElementById('organization-profile');
+
+      Clerk.closeOrganizationProfile(orgProfileDiv);
+    });
+  </script>
+  ```
+</CodeBlockTabs>
 
 ## Customization
 

--- a/docs/components/organization/organization-switcher.mdx
+++ b/docs/components/organization/organization-switcher.mdx
@@ -122,52 +122,50 @@ function mountOrganizationSwitcher(node: HTMLDivElement, props?: OrganizationSwi
 
 ### <code>mountOrganization<wbr />Switcher()</code> usage
 
-<InjectKeys>
-  <CodeBlockTabs type="npm-script" options={['NPM module', '<script>']}>
-    ```js {{ prettier: false, filename: 'main.js', mark: [14] }}
-    import { Clerk } from '@clerk/clerk-js';
+<CodeBlockTabs type="npm-script" options={['NPM module', '<script>']}>
+  ```js {{ prettier: false, filename: 'main.js', mark: [14] }}
+  import { Clerk } from '@clerk/clerk-js';
 
-    // Initialize Clerk with your Clerk publishable key
-    const clerk = new Clerk('{{pub_key}}');
-    await clerk.load();
+  // Initialize Clerk with your Clerk publishable key
+  const clerk = new Clerk('{{pub_key}}');
+  await clerk.load();
 
-    document.getElementById("app").innerHTML = `
-      <div id="organization-switcher"></div>
-    `;
-
-    const orgSwitcherDiv =
-      document.getElementById("organization-switcher");
-
-    clerk.mountOrganizationSwitcher(orgSwitcherDiv);
-    ```
-
-    ```html {{ prettier: false, filename: 'index.html', mark: [21] }}
-    <!-- Add a <div id="organization-switcher"> element to your HTML -->
+  document.getElementById("app").innerHTML = `
     <div id="organization-switcher"></div>
+  `;
 
-    <!-- Initialize Clerk with your
-    Clerk Publishable key and Frontend API URL -->
-    <script
-      async
-      crossorigin="anonymous"
-      data-clerk-publishable-key="{{pub_key}}"
-      src="https://{{fapi_url}}/npm/@clerk/clerk-js@latest/dist/clerk.browser.js"
-      type="text/javascript"
-    ></script>
+  const orgSwitcherDiv =
+    document.getElementById("organization-switcher");
 
-    <script>
-      window.addEventListener("load", async function () {
-        await Clerk.load();
+  clerk.mountOrganizationSwitcher(orgSwitcherDiv);
+  ```
 
-        const orgSwitcherDiv =
-          document.getElementById('organization-switcher');
+  ```html {{ prettier: false, filename: 'index.html', mark: [21] }}
+  <!-- Add a <div id="organization-switcher"> element to your HTML -->
+  <div id="organization-switcher"></div>
 
-        Clerk.mountOrganizationSwitcher(orgSwitcherDiv);
-      });
-    </script>
-    ```
-  </CodeBlockTabs>
-</InjectKeys>
+  <!-- Initialize Clerk with your
+  Clerk Publishable key and Frontend API URL -->
+  <script
+    async
+    crossorigin="anonymous"
+    data-clerk-publishable-key="{{pub_key}}"
+    src="https://{{fapi_url}}/npm/@clerk/clerk-js@latest/dist/clerk.browser.js"
+    type="text/javascript"
+  ></script>
+
+  <script>
+    window.addEventListener("load", async function () {
+      await Clerk.load();
+
+      const orgSwitcherDiv =
+        document.getElementById('organization-switcher');
+
+      Clerk.mountOrganizationSwitcher(orgSwitcherDiv);
+    });
+  </script>
+  ```
+</CodeBlockTabs>
 
 ## <code>unmountOrganization<wbr />Switcher()</code>
 
@@ -185,60 +183,58 @@ function unmountOrganizationSwitcher(node: HTMLDivElement): void;
 
 ### <code>unmountOrganization<wbr />Switcher()</code> usage
 
-<InjectKeys>
-  <CodeBlockTabs type="npm-script" options={['NPM module', '<script>']}>
-    ```js {{ prettier: false, filename: 'main.js', mark: [18] }}
-    import { Clerk } from '@clerk/clerk-js';
+<CodeBlockTabs type="npm-script" options={['NPM module', '<script>']}>
+  ```js {{ prettier: false, filename: 'main.js', mark: [18] }}
+  import { Clerk } from '@clerk/clerk-js';
 
-    // Initialize Clerk with your Clerk publishable key
-    const clerk = new Clerk('{{pub_key}}');
-    await clerk.load();
+  // Initialize Clerk with your Clerk publishable key
+  const clerk = new Clerk('{{pub_key}}');
+  await clerk.load();
 
-    document.getElementById('app').innerHTML = `
-      <div id="organization-switcher"></div>
-    `
-
-    const orgSwitcherDiv =
-      document.getElementById('organization-switcher');
-
-    clerk.mountOrganizationSwitcher(orgSwitcherDiv);
-
-    // ...
-
-    clerk.unmountOrganizationSwitcher(orgSwitcherDiv);
-    ```
-
-    ```html {{ prettier: false, filename: 'index.html', mark: [25] }}
-    <!-- Add a <div id="organization-switcher"> element to your HTML -->
+  document.getElementById('app').innerHTML = `
     <div id="organization-switcher"></div>
+  `
 
-    <!-- Initialize Clerk with your
-    Clerk Publishable key and Frontend API URL -->
-    <script
-      async
-      crossorigin="anonymous"
-      data-clerk-publishable-key="{{pub_key}}"
-      src="https://{{fapi_url}}/npm/@clerk/clerk-js@latest/dist/clerk.browser.js"
-      type="text/javascript"
-    ></script>
+  const orgSwitcherDiv =
+    document.getElementById('organization-switcher');
 
-    <script>
-      window.addEventListener("load", async function () {
-        await Clerk.load();
+  clerk.mountOrganizationSwitcher(orgSwitcherDiv);
 
-        const orgSwitcherDiv =
-          document.getElementById('organization-switcher');
+  // ...
 
-        Clerk.mountOrganizationSwitcher(orgSwitcherDiv);
+  clerk.unmountOrganizationSwitcher(orgSwitcherDiv);
+  ```
 
-        // ...
+  ```html {{ prettier: false, filename: 'index.html', mark: [25] }}
+  <!-- Add a <div id="organization-switcher"> element to your HTML -->
+  <div id="organization-switcher"></div>
 
-        Clerk.unmountOrganizationSwitcher(orgSwitcherDiv);
-      });
-    </script>
-    ```
-  </CodeBlockTabs>
-</InjectKeys>
+  <!-- Initialize Clerk with your
+  Clerk Publishable key and Frontend API URL -->
+  <script
+    async
+    crossorigin="anonymous"
+    data-clerk-publishable-key="{{pub_key}}"
+    src="https://{{fapi_url}}/npm/@clerk/clerk-js@latest/dist/clerk.browser.js"
+    type="text/javascript"
+  ></script>
+
+  <script>
+    window.addEventListener("load", async function () {
+      await Clerk.load();
+
+      const orgSwitcherDiv =
+        document.getElementById('organization-switcher');
+
+      Clerk.mountOrganizationSwitcher(orgSwitcherDiv);
+
+      // ...
+
+      Clerk.unmountOrganizationSwitcher(orgSwitcherDiv);
+    });
+  </script>
+  ```
+</CodeBlockTabs>
 
 ## Customization
 

--- a/docs/components/user/user-button.mdx
+++ b/docs/components/user/user-button.mdx
@@ -241,52 +241,50 @@ function mountUserButton(node: HTMLDivElement, props?: UserButtonProps): void;
 
 #### `mountUserButton()` usage
 
-<InjectKeys>
-  <CodeBlockTabs type="npm-script" options={['NPM module', '<script>']}>
-    ```js {{ prettier: false, filename: 'main.js', mark: [14] }}
-    import { Clerk } from '@clerk/clerk-js';
+<CodeBlockTabs type="npm-script" options={['NPM module', '<script>']}>
+  ```js {{ prettier: false, filename: 'main.js', mark: [14] }}
+  import { Clerk } from '@clerk/clerk-js';
 
-    // Initialize Clerk with your Clerk publishable key
-    const clerk = new Clerk('{{pub_key}}');
-    await clerk.load();
+  // Initialize Clerk with your Clerk publishable key
+  const clerk = new Clerk('{{pub_key}}');
+  await clerk.load();
 
-    document.getElementById("app").innerHTML = `
-      <div id="user-button"></div>
-    `;
-
-    const userbuttonDiv =
-      document.getElementById("user-button");
-
-    clerk.mountUserButton(userbuttonDiv);
-    ```
-
-    ```html {{ prettier: false, filename: 'index.html', mark: [21] }}
-    <!-- Add a <div id="user-button"> element to your HTML -->
+  document.getElementById("app").innerHTML = `
     <div id="user-button"></div>
+  `;
 
-    <!-- Initialize Clerk with your
-    Clerk Publishable key and Frontend API URL -->
-    <script
-      async
-      crossorigin="anonymous"
-      data-clerk-publishable-key="{{pub_key}}"
-      src="https://{{fapi_url}}/npm/@clerk/clerk-js@latest/dist/clerk.browser.js"
-      type="text/javascript"
-    ></script>
+  const userbuttonDiv =
+    document.getElementById("user-button");
 
-    <script>
-      window.addEventListener("load", async function () {
-        await Clerk.load();
+  clerk.mountUserButton(userbuttonDiv);
+  ```
 
-        const userbuttonDiv =
-          document.getElementById('user-button');
+  ```html {{ prettier: false, filename: 'index.html', mark: [21] }}
+  <!-- Add a <div id="user-button"> element to your HTML -->
+  <div id="user-button"></div>
 
-        Clerk.mountUserButton(userbuttonDiv);
-      });
-    </script>
-    ```
-  </CodeBlockTabs>
-</InjectKeys>
+  <!-- Initialize Clerk with your
+  Clerk Publishable key and Frontend API URL -->
+  <script
+    async
+    crossorigin="anonymous"
+    data-clerk-publishable-key="{{pub_key}}"
+    src="https://{{fapi_url}}/npm/@clerk/clerk-js@latest/dist/clerk.browser.js"
+    type="text/javascript"
+  ></script>
+
+  <script>
+    window.addEventListener("load", async function () {
+      await Clerk.load();
+
+      const userbuttonDiv =
+        document.getElementById('user-button');
+
+      Clerk.mountUserButton(userbuttonDiv);
+    });
+  </script>
+  ```
+</CodeBlockTabs>
 
 ### `unmountUserButton()`
 
@@ -304,60 +302,58 @@ function unmountUserButton(node: HTMLDivElement): void;
 
 #### `unmountUserButton()` usage
 
-<InjectKeys>
-  <CodeBlockTabs type="npm-script" options={['NPM module', '<script>']}>
-    ```js {{ prettier: false, filename: 'main.js', mark: [18] }}
-    import { Clerk } from '@clerk/clerk-js';
+<CodeBlockTabs type="npm-script" options={['NPM module', '<script>']}>
+  ```js {{ prettier: false, filename: 'main.js', mark: [18] }}
+  import { Clerk } from '@clerk/clerk-js';
 
-    // Initialize Clerk with your Clerk publishable key
-    const clerk = new Clerk('{{pub_key}}');
-    await clerk.load();
+  // Initialize Clerk with your Clerk publishable key
+  const clerk = new Clerk('{{pub_key}}');
+  await clerk.load();
 
-    document.getElementById('app').innerHTML = `
-      <div id="user-button"></div>
-    `
-
-    const userButtonDiv =
-      document.getElementById('user-button');
-
-    clerk.mountUserButton(userButtonDiv);
-
-    // ...
-
-    clerk.unmountUserButton(userButtonDiv);
-    ```
-
-    ```html {{ prettier: false, filename: 'index.html', mark: [25] }}
-    <!-- Add a <div id="user-button"> element to your HTML -->
+  document.getElementById('app').innerHTML = `
     <div id="user-button"></div>
+  `
 
-    <!-- Initialize Clerk with your
-    Clerk Publishable key and Frontend API URL -->
-    <script
-      async
-      crossorigin="anonymous"
-      data-clerk-publishable-key="{{pub_key}}"
-      src="https://{{fapi_url}}/npm/@clerk/clerk-js@latest/dist/clerk.browser.js"
-      type="text/javascript"
-    ></script>
+  const userButtonDiv =
+    document.getElementById('user-button');
 
-    <script>
-      window.addEventListener("load", async function () {
-        await Clerk.load();
+  clerk.mountUserButton(userButtonDiv);
 
-        const userButtonDiv =
-          document.getElementById('user-button');
+  // ...
 
-        Clerk.mountUserButton(userButtonDiv);
+  clerk.unmountUserButton(userButtonDiv);
+  ```
 
-        // ...
+  ```html {{ prettier: false, filename: 'index.html', mark: [25] }}
+  <!-- Add a <div id="user-button"> element to your HTML -->
+  <div id="user-button"></div>
 
-        Clerk.unmountUserButton(userButtonDiv);
-      });
-    </script>
-    ```
-  </CodeBlockTabs>
-</InjectKeys>
+  <!-- Initialize Clerk with your
+  Clerk Publishable key and Frontend API URL -->
+  <script
+    async
+    crossorigin="anonymous"
+    data-clerk-publishable-key="{{pub_key}}"
+    src="https://{{fapi_url}}/npm/@clerk/clerk-js@latest/dist/clerk.browser.js"
+    type="text/javascript"
+  ></script>
+
+  <script>
+    window.addEventListener("load", async function () {
+      await Clerk.load();
+
+      const userButtonDiv =
+        document.getElementById('user-button');
+
+      Clerk.mountUserButton(userButtonDiv);
+
+      // ...
+
+      Clerk.unmountUserButton(userButtonDiv);
+    });
+  </script>
+  ```
+</CodeBlockTabs>
 
 ## Customization
 

--- a/docs/components/user/user-profile.mdx
+++ b/docs/components/user/user-profile.mdx
@@ -106,52 +106,50 @@ function mountUserProfile(node: HTMLDivElement, props?: UserProfileProps): void;
 
 #### `mountUserProfile()` usage
 
-<InjectKeys>
-  <CodeBlockTabs type="npm-script" options={['NPM module', '<script>']}>
-    ```js {{ prettier: false, filename: 'main.js', mark: [14] }}
-    import { Clerk } from '@clerk/clerk-js';
+<CodeBlockTabs type="npm-script" options={['NPM module', '<script>']}>
+  ```js {{ prettier: false, filename: 'main.js', mark: [14] }}
+  import { Clerk } from '@clerk/clerk-js';
 
-    // Initialize Clerk with your Clerk publishable key
-    const clerk = new Clerk('{{pub_key}}');
-    await clerk.load();
+  // Initialize Clerk with your Clerk publishable key
+  const clerk = new Clerk('{{pub_key}}');
+  await clerk.load();
 
-    document.getElementById("app").innerHTML = `
-      <div id="user-profile"></div>
-    `;
-
-    const userProfileDiv =
-      document.getElementById("user-profile");
-
-    clerk.mountUserProfile(userProfileDiv);
-    ```
-
-    ```html {{ prettier: false, filename: 'index.html', mark: [21] }}
-    <!-- Add a <div id="user-profile"> element to your HTML -->
+  document.getElementById("app").innerHTML = `
     <div id="user-profile"></div>
+  `;
 
-    <!-- Initialize Clerk with your
-    Clerk Publishable key and Frontend API URL -->
-    <script
-      async
-      crossorigin="anonymous"
-      data-clerk-publishable-key="{{pub_key}}"
-      src="https://{{fapi_url}}/npm/@clerk/clerk-js@latest/dist/clerk.browser.js"
-      type="text/javascript"
-    ></script>
+  const userProfileDiv =
+    document.getElementById("user-profile");
 
-    <script>
-      window.addEventListener("load", async function () {
-        await Clerk.load();
+  clerk.mountUserProfile(userProfileDiv);
+  ```
 
-        const userProfileDiv =
-          document.getElementById('user-profile');
+  ```html {{ prettier: false, filename: 'index.html', mark: [21] }}
+  <!-- Add a <div id="user-profile"> element to your HTML -->
+  <div id="user-profile"></div>
 
-        Clerk.mountUserProfile(userProfileDiv);
-      });
-    </script>
-    ```
-  </CodeBlockTabs>
-</InjectKeys>
+  <!-- Initialize Clerk with your
+  Clerk Publishable key and Frontend API URL -->
+  <script
+    async
+    crossorigin="anonymous"
+    data-clerk-publishable-key="{{pub_key}}"
+    src="https://{{fapi_url}}/npm/@clerk/clerk-js@latest/dist/clerk.browser.js"
+    type="text/javascript"
+  ></script>
+
+  <script>
+    window.addEventListener("load", async function () {
+      await Clerk.load();
+
+      const userProfileDiv =
+        document.getElementById('user-profile');
+
+      Clerk.mountUserProfile(userProfileDiv);
+    });
+  </script>
+  ```
+</CodeBlockTabs>
 
 ### `unmountUserProfile()`
 
@@ -169,60 +167,58 @@ function unmountUserProfile(node: HTMLDivElement): void;
 
 #### `unmountUserProfile()` usage
 
-<InjectKeys>
-  <CodeBlockTabs type="npm-script" options={['NPM module', '<script>']}>
-    ```js {{ prettier: false, filename: 'main.js', mark: [18] }}
-    import { Clerk } from '@clerk/clerk-js';
+<CodeBlockTabs type="npm-script" options={['NPM module', '<script>']}>
+  ```js {{ prettier: false, filename: 'main.js', mark: [18] }}
+  import { Clerk } from '@clerk/clerk-js';
 
-    // Initialize Clerk with your Clerk publishable key
-    const clerk = new Clerk('{{pub_key}}');
-    await clerk.load();
+  // Initialize Clerk with your Clerk publishable key
+  const clerk = new Clerk('{{pub_key}}');
+  await clerk.load();
 
-    document.getElementById('app').innerHTML = `
-      <div id="user-profile"></div>
-    `
-
-    const userProfileDiv =
-      document.getElementById('user-profile');
-
-    clerk.mountUserProfile(userProfileDiv);
-
-    // ...
-
-    clerk.unmountUserProfile(userProfileDiv);
-    ```
-
-    ```html {{ prettier: false, filename: 'index.html', mark: [25] }}
-    <!-- Add a <div id="user-profile"> element to your HTML -->
+  document.getElementById('app').innerHTML = `
     <div id="user-profile"></div>
+  `
 
-    <!-- Initialize Clerk with your
-    Clerk Publishable key and Frontend API URL -->
-    <script
-      async
-      crossorigin="anonymous"
-      data-clerk-publishable-key="{{pub_key}}"
-      src="https://{{fapi_url}}/npm/@clerk/clerk-js@latest/dist/clerk.browser.js"
-      type="text/javascript"
-    ></script>
+  const userProfileDiv =
+    document.getElementById('user-profile');
 
-    <script>
-      window.addEventListener("load", async function () {
-        await Clerk.load();
+  clerk.mountUserProfile(userProfileDiv);
 
-        const userProfileDiv =
-          document.getElementById('user-profile');
+  // ...
 
-        Clerk.mountUserProfile(userProfileDiv);
+  clerk.unmountUserProfile(userProfileDiv);
+  ```
 
-        // ...
+  ```html {{ prettier: false, filename: 'index.html', mark: [25] }}
+  <!-- Add a <div id="user-profile"> element to your HTML -->
+  <div id="user-profile"></div>
 
-        Clerk.unmountUserProfile(userProfileDiv);
-      });
-    </script>
-    ```
-  </CodeBlockTabs>
-</InjectKeys>
+  <!-- Initialize Clerk with your
+  Clerk Publishable key and Frontend API URL -->
+  <script
+    async
+    crossorigin="anonymous"
+    data-clerk-publishable-key="{{pub_key}}"
+    src="https://{{fapi_url}}/npm/@clerk/clerk-js@latest/dist/clerk.browser.js"
+    type="text/javascript"
+  ></script>
+
+  <script>
+    window.addEventListener("load", async function () {
+      await Clerk.load();
+
+      const userProfileDiv =
+        document.getElementById('user-profile');
+
+      Clerk.mountUserProfile(userProfileDiv);
+
+      // ...
+
+      Clerk.unmountUserProfile(userProfileDiv);
+    });
+  </script>
+  ```
+</CodeBlockTabs>
 
 ### `openUserProfile()`
 
@@ -240,52 +236,50 @@ function openUserProfile(props?: UserProfileProps): void;
 
 #### `openUserProfile()` usage
 
-<InjectKeys>
-  <CodeBlockTabs type="npm-script" options={['NPM module', '<script>']}>
-    ```js {{ prettier: false, filename: 'main.js', mark: [14] }}
-    import { Clerk } from '@clerk/clerk-js';
+<CodeBlockTabs type="npm-script" options={['NPM module', '<script>']}>
+  ```js {{ prettier: false, filename: 'main.js', mark: [14] }}
+  import { Clerk } from '@clerk/clerk-js';
 
-    // Initialize Clerk with your Clerk publishable key
-    const clerk = new Clerk('{{pub_key}}');
-    await clerk.load();
+  // Initialize Clerk with your Clerk publishable key
+  const clerk = new Clerk('{{pub_key}}');
+  await clerk.load();
 
-    document.getElementById('app').innerHTML = `
-      <div id="user-profile"></div>
-    `
-
-    const userProfileDiv =
-      document.getElementById('user-profile');
-
-    clerk.openUserProfile(userProfileDiv);
-    ```
-
-    ```html {{ prettier: false, filename: 'index.html', mark: [21] }}
-    <!-- Add a <div id="user-profile"> element to your HTML -->
+  document.getElementById('app').innerHTML = `
     <div id="user-profile"></div>
+  `
 
-    <!-- Initialize Clerk with your
-    Clerk Publishable key and Frontend API URL -->
-    <script
-      async
-      crossorigin="anonymous"
-      data-clerk-publishable-key="{{pub_key}}"
-      src="https://{{fapi_url}}/npm/@clerk/clerk-js@latest/dist/clerk.browser.js"
-      type="text/javascript"
-    ></script>
+  const userProfileDiv =
+    document.getElementById('user-profile');
 
-    <script>
-      window.addEventListener("load", async function () {
-        await Clerk.load();
+  clerk.openUserProfile(userProfileDiv);
+  ```
 
-        const userProfileDiv =
-          document.getElementById('user-profile');
+  ```html {{ prettier: false, filename: 'index.html', mark: [21] }}
+  <!-- Add a <div id="user-profile"> element to your HTML -->
+  <div id="user-profile"></div>
 
-        Clerk.openUserProfile(userProfileDiv);
-      });
-    </script>
-    ```
-  </CodeBlockTabs>
-</InjectKeys>
+  <!-- Initialize Clerk with your
+  Clerk Publishable key and Frontend API URL -->
+  <script
+    async
+    crossorigin="anonymous"
+    data-clerk-publishable-key="{{pub_key}}"
+    src="https://{{fapi_url}}/npm/@clerk/clerk-js@latest/dist/clerk.browser.js"
+    type="text/javascript"
+  ></script>
+
+  <script>
+    window.addEventListener("load", async function () {
+      await Clerk.load();
+
+      const userProfileDiv =
+        document.getElementById('user-profile');
+
+      Clerk.openUserProfile(userProfileDiv);
+    });
+  </script>
+  ```
+</CodeBlockTabs>
 
 ### `closeUserProfile()`
 
@@ -297,52 +291,50 @@ function closeUserProfile(): void;
 
 #### `closeUserProfile()` usage
 
-<InjectKeys>
-  <CodeBlockTabs type="npm-script" options={['NPM module', '<script>']}>
-    ```js {{ prettier: false, filename: 'main.js', mark: [14] }}
-    import { Clerk } from '@clerk/clerk-js';
+<CodeBlockTabs type="npm-script" options={['NPM module', '<script>']}>
+  ```js {{ prettier: false, filename: 'main.js', mark: [14] }}
+  import { Clerk } from '@clerk/clerk-js';
 
-    // Initialize Clerk with your Clerk publishable key
-    const clerk = new Clerk('{{pub_key}}');
-    await clerk.load();
+  // Initialize Clerk with your Clerk publishable key
+  const clerk = new Clerk('{{pub_key}}');
+  await clerk.load();
 
-    document.getElementById('app').innerHTML = `
-      <div id="user-profile"></div>
-    `
-
-    const userProfileDiv =
-      document.getElementById('user-profile');
-
-    clerk.closeUserProfile(userProfileDiv);
-    ```
-
-    ```html {{ prettier: false, filename: 'index.html', mark: [21] }}
-    <!-- Add a <div id="user-profile"> element to your HTML -->
+  document.getElementById('app').innerHTML = `
     <div id="user-profile"></div>
+  `
 
-    <!-- Initialize Clerk with your
-    Clerk Publishable key and Frontend API URL -->
-    <script
-      async
-      crossorigin="anonymous"
-      data-clerk-publishable-key="{{pub_key}}"
-      src="https://{{fapi_url}}/npm/@clerk/clerk-js@latest/dist/clerk.browser.js"
-      type="text/javascript"
-    ></script>
+  const userProfileDiv =
+    document.getElementById('user-profile');
 
-    <script>
-      window.addEventListener("load", async function () {
-        await Clerk.load();
+  clerk.closeUserProfile(userProfileDiv);
+  ```
 
-        const userProfileDiv =
-          document.getElementById('user-profile');
+  ```html {{ prettier: false, filename: 'index.html', mark: [21] }}
+  <!-- Add a <div id="user-profile"> element to your HTML -->
+  <div id="user-profile"></div>
 
-        Clerk.closeUserProfile(userProfileDiv);
-      });
-    </script>
-    ```
-  </CodeBlockTabs>
-</InjectKeys>
+  <!-- Initialize Clerk with your
+  Clerk Publishable key and Frontend API URL -->
+  <script
+    async
+    crossorigin="anonymous"
+    data-clerk-publishable-key="{{pub_key}}"
+    src="https://{{fapi_url}}/npm/@clerk/clerk-js@latest/dist/clerk.browser.js"
+    type="text/javascript"
+  ></script>
+
+  <script>
+    window.addEventListener("load", async function () {
+      await Clerk.load();
+
+      const userProfileDiv =
+        document.getElementById('user-profile');
+
+      Clerk.closeUserProfile(userProfileDiv);
+    });
+  </script>
+  ```
+</CodeBlockTabs>
 
 ## Customization
 

--- a/docs/custom-flows/email-sms-otp.mdx
+++ b/docs/custom-flows/email-sms-otp.mdx
@@ -145,218 +145,216 @@ This guide will walk you through how to build a custom SMS OTP sign-up and sign-
     </Tab>
 
     <Tab>
-      <InjectKeys>
-        <Tabs type="npm-script" items={["NPM module", "<script>"]}>
-          <Tab>
-            For the following example, your HTML file should look like this:
+      <Tabs type="npm-script" items={["NPM module", "<script>"]}>
+        <Tab>
+          For the following example, your HTML file should look like this:
 
-            ```html {{ prettier: false, filename: 'index.html' }}
-            <!DOCTYPE html>
-            <html lang="en">
-              <head>
-                <meta charset="UTF-8" />
-                <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-                <title>Clerk + JavaScript App</title>
-              </head>
-              <body>
-                <div id="signed-in"></div>
+          ```html {{ prettier: false, filename: 'index.html' }}
+          <!DOCTYPE html>
+          <html lang="en">
+            <head>
+              <meta charset="UTF-8" />
+              <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+              <title>Clerk + JavaScript App</title>
+            </head>
+            <body>
+              <div id="signed-in"></div>
 
-                <div id="sign-up">
-                  <h2>Sign up</h2>
-                  <form id="sign-up-form">
-                    <label for="phone">Enter phone number</label>
-                    <input type="tel" name="phone" id="sign-up-phone" />
-                    <button type="submit">Continue</button>
-                  </form>
-                </div>
-
-                <form id="verifying" hidden>
-                  <h2>Verify your phone number</h2>
-                  <label for="code">Enter your verification code</label>
-                  <input id="code" name="code" />
-                  <button type="submit" id="verify-button">Verify</button>
+              <div id="sign-up">
+                <h2>Sign up</h2>
+                <form id="sign-up-form">
+                  <label for="phone">Enter phone number</label>
+                  <input type="tel" name="phone" id="sign-up-phone" />
+                  <button type="submit">Continue</button>
                 </form>
+              </div>
 
-                <script
-                  type="module"
-                  src="/src/main.js"
-                  async
-                  crossorigin="anonymous"
-                ></script>
-              </body>
-            </html>
-            ```
+              <form id="verifying" hidden>
+                <h2>Verify your phone number</h2>
+                <label for="code">Enter your verification code</label>
+                <input id="code" name="code" />
+                <button type="submit" id="verify-button">Verify</button>
+              </form>
 
-            And your JavaScript file should look like this:
+              <script
+                type="module"
+                src="/src/main.js"
+                async
+                crossorigin="anonymous"
+              ></script>
+            </body>
+          </html>
+          ```
 
-            ```js {{ prettier: false, filename: 'main.js' }}
-            import { Clerk } from '@clerk/clerk-js';
+          And your JavaScript file should look like this:
 
-            // Initialize Clerk with your Clerk publishable key
-            const clerk = new Clerk('{{pub_key}}');
-            await clerk.load();
+          ```js {{ prettier: false, filename: 'main.js' }}
+          import { Clerk } from '@clerk/clerk-js';
 
-            if (clerk.user) {
-              // Mount user button component
-              document.getElementById("signed-in").innerHTML = `
-                <div id="user-button"></div>
-              `;
+          // Initialize Clerk with your Clerk publishable key
+          const clerk = new Clerk('{{pub_key}}');
+          await clerk.load();
 
-              const userbuttonDiv = document.getElementById("user-button");
+          if (clerk.user) {
+            // Mount user button component
+            document.getElementById("signed-in").innerHTML = `
+              <div id="user-button"></div>
+            `;
 
-              clerk.mountUserButton(userbuttonDiv);
-            } else {
-              // Handle the sign-up form
-              document.getElementById("sign-up-form")
-                .addEventListener("submit", async (e) => {
-                  e.preventDefault();
+            const userbuttonDiv = document.getElementById("user-button");
 
-                  const formData = new FormData(e.target);
-                  const phoneNumber = formData.get("phone");
+            clerk.mountUserButton(userbuttonDiv);
+          } else {
+            // Handle the sign-up form
+            document.getElementById("sign-up-form")
+              .addEventListener("submit", async (e) => {
+                e.preventDefault();
 
-                  try {
-                    // Start the sign-up process using the phone number method
-                    await clerk.client.signUp.create({ phoneNumber });
-                    await clerk.client.signUp.preparePhoneNumberVerification();
-                    // Hide sign-up form
-                    document.getElementById("sign-up").setAttribute("hidden", "");
-                    // Show verification form
-                    document.getElementById("verifying").removeAttribute("hidden");
-                  } catch (error) {
-                    // See https://clerk.com/docs/custom-flows/error-handling
-                    // for more info on error handling
-                    console.error(error);
-                  }
-                });
-
-              // Handle the verification form
-              document.getElementById("verifying").addEventListener("submit", async (e) => {
                 const formData = new FormData(e.target);
-                const code = formData.get("code");
+                const phoneNumber = formData.get("phone");
 
                 try {
-                  // Verify the phone number
-                  const verify = await clerk.client.signUp.attemptPhoneNumberVerification({
-                    code,
-                  });
-
-                  // Now that the user is created, set the session to active.
-                  await clerk.setActive({ session: verify.createdSessionId });
+                  // Start the sign-up process using the phone number method
+                  await clerk.client.signUp.create({ phoneNumber });
+                  await clerk.client.signUp.preparePhoneNumberVerification();
+                  // Hide sign-up form
+                  document.getElementById("sign-up").setAttribute("hidden", "");
+                  // Show verification form
+                  document.getElementById("verifying").removeAttribute("hidden");
                 } catch (error) {
                   // See https://clerk.com/docs/custom-flows/error-handling
                   // for more info on error handling
                   console.error(error);
                 }
               });
-            }
-            ```
-          </Tab>
 
-          <Tab>
-            ```html {{ prettier: false, filename: 'index.html' }}
-            <!DOCTYPE html>
-            <html lang="en">
-              <head>
-                <meta charset="UTF-8" />
-                <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-                <title>Clerk + JavaScript App</title>
-              </head>
-              <body>
-                <div id="signed-in"></div>
+            // Handle the verification form
+            document.getElementById("verifying").addEventListener("submit", async (e) => {
+              const formData = new FormData(e.target);
+              const code = formData.get("code");
 
-                <div id="sign-up">
-                  <h2>Sign up</h2>
-                  <form id="sign-up-form">
-                    <label for="phone">Enter phone number</label>
-                    <input type="tel" name="phone" id="sign-up-phone" />
-                    <button type="submit">Continue</button>
-                  </form>
-                </div>
+              try {
+                // Verify the phone number
+                const verify = await clerk.client.signUp.attemptPhoneNumberVerification({
+                  code,
+                });
 
-                <form id="verifying" hidden>
-                  <h2>Verify your phone number</h2>
-                  <label for="code">Enter your verification code</label>
-                  <input id="code" name="code" />
-                  <button type="submit" id="verify-button">Verify</button>
+                // Now that the user is created, set the session to active.
+                await clerk.setActive({ session: verify.createdSessionId });
+              } catch (error) {
+                // See https://clerk.com/docs/custom-flows/error-handling
+                // for more info on error handling
+                console.error(error);
+              }
+            });
+          }
+          ```
+        </Tab>
+
+        <Tab>
+          ```html {{ prettier: false, filename: 'index.html' }}
+          <!DOCTYPE html>
+          <html lang="en">
+            <head>
+              <meta charset="UTF-8" />
+              <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+              <title>Clerk + JavaScript App</title>
+            </head>
+            <body>
+              <div id="signed-in"></div>
+
+              <div id="sign-up">
+                <h2>Sign up</h2>
+                <form id="sign-up-form">
+                  <label for="phone">Enter phone number</label>
+                  <input type="tel" name="phone" id="sign-up-phone" />
+                  <button type="submit">Continue</button>
                 </form>
+              </div>
 
-                <script
-                  async
-                  crossorigin="anonymous"
-                  data-clerk-publishable-key="{{pub_key}}"
-                  src="https://{{fapi_url}}/npm/@clerk/clerk-js@latest/dist/clerk.browser.js"
-                  type="text/javascript"
-                ></script>
+              <form id="verifying" hidden>
+                <h2>Verify your phone number</h2>
+                <label for="code">Enter your verification code</label>
+                <input id="code" name="code" />
+                <button type="submit" id="verify-button">Verify</button>
+              </form>
 
-                <script>
-                  window.addEventListener("load", async function () {
-                    await Clerk.load();
+              <script
+                async
+                crossorigin="anonymous"
+                data-clerk-publishable-key="{{pub_key}}"
+                src="https://{{fapi_url}}/npm/@clerk/clerk-js@latest/dist/clerk.browser.js"
+                type="text/javascript"
+              ></script>
 
-                    if (Clerk.user) {
-                      // Mount user button component
-                      document.getElementById("signed-in").innerHTML = `
-                      <div id="user-button"></div>
-                    `;
+              <script>
+                window.addEventListener("load", async function () {
+                  await Clerk.load();
 
-                      const userbuttonDiv = document.getElementById("user-button");
+                  if (Clerk.user) {
+                    // Mount user button component
+                    document.getElementById("signed-in").innerHTML = `
+                    <div id="user-button"></div>
+                  `;
 
-                      Clerk.mountUserButton(userbuttonDiv);
-                    } else {
-                      // Handle the sign-up form
-                      document
-                        .getElementById("sign-up-form")
-                        .addEventListener("submit", async (e) => {
-                          e.preventDefault();
+                    const userbuttonDiv = document.getElementById("user-button");
 
-                          const formData = new FormData(e.target);
-                          const phoneNumber = formData.get("phone");
+                    Clerk.mountUserButton(userbuttonDiv);
+                  } else {
+                    // Handle the sign-up form
+                    document
+                      .getElementById("sign-up-form")
+                      .addEventListener("submit", async (e) => {
+                        e.preventDefault();
 
-                          try {
-                            // Start the sign-up process using the phone number method
-                            await Clerk.client.signUp.create({ phoneNumber });
-                            await Clerk.client.signUp.preparePhoneNumberVerification();
-                            // Hide sign-up form
-                            document.getElementById("sign-up").setAttribute("hidden", "");
-                            // Show verification form
-                            document.getElementById("verifying").removeAttribute("hidden");
-                          } catch (error) {
-                            // See https://clerk.com/docs/custom-flows/error-handling
-                            // for more info on error handling
-                            console.error(error);
-                          }
-                        });
+                        const formData = new FormData(e.target);
+                        const phoneNumber = formData.get("phone");
 
-                      // Handle the verification form
-                      document
-                        .getElementById("verifying")
-                        .addEventListener("submit", async (e) => {
-                          const formData = new FormData(e.target);
-                          const code = formData.get("code");
+                        try {
+                          // Start the sign-up process using the phone number method
+                          await Clerk.client.signUp.create({ phoneNumber });
+                          await Clerk.client.signUp.preparePhoneNumberVerification();
+                          // Hide sign-up form
+                          document.getElementById("sign-up").setAttribute("hidden", "");
+                          // Show verification form
+                          document.getElementById("verifying").removeAttribute("hidden");
+                        } catch (error) {
+                          // See https://clerk.com/docs/custom-flows/error-handling
+                          // for more info on error handling
+                          console.error(error);
+                        }
+                      });
 
-                          try {
-                            // Verify the phone number
-                            const verify =
-                              await Clerk.client.signUp.attemptPhoneNumberVerification({
-                                code,
-                              });
+                    // Handle the verification form
+                    document
+                      .getElementById("verifying")
+                      .addEventListener("submit", async (e) => {
+                        const formData = new FormData(e.target);
+                        const code = formData.get("code");
 
-                            // Now that the user is created, set the session to active.
-                            await Clerk.setActive({ session: verify.createdSessionId });
-                          } catch (error) {
-                            // See https://clerk.com/docs/custom-flows/error-handling
-                            // for more info on error handling
-                            console.error(error);
-                          }
-                        });
-                    }
-                  });
-                </script>
-              </body>
-            </html>
-            ```
-          </Tab>
-        </Tabs>
-      </InjectKeys>
+                        try {
+                          // Verify the phone number
+                          const verify =
+                            await Clerk.client.signUp.attemptPhoneNumberVerification({
+                              code,
+                            });
+
+                          // Now that the user is created, set the session to active.
+                          await Clerk.setActive({ session: verify.createdSessionId });
+                        } catch (error) {
+                          // See https://clerk.com/docs/custom-flows/error-handling
+                          // for more info on error handling
+                          console.error(error);
+                        }
+                      });
+                  }
+                });
+              </script>
+            </body>
+          </html>
+          ```
+        </Tab>
+      </Tabs>
     </Tab>
 
     <Tab>
@@ -571,256 +569,254 @@ This guide will walk you through how to build a custom SMS OTP sign-up and sign-
     </Tab>
 
     <Tab>
-      <InjectKeys>
-        <Tabs type="npm-script" items={["NPM module", "<script>"]}>
-          <Tab>
-            For the following example, your HTML file should look like this:
+      <Tabs type="npm-script" items={["NPM module", "<script>"]}>
+        <Tab>
+          For the following example, your HTML file should look like this:
 
-            ```html {{ prettier: false, filename: 'index.html' }}
-            <!DOCTYPE html>
-            <html lang="en">
-              <head>
-                <meta charset="UTF-8" />
-                <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-                <title>Clerk + JavaScript App</title>
-              </head>
-              <body>
-                <div id="signed-in"></div>
+          ```html {{ prettier: false, filename: 'index.html' }}
+          <!DOCTYPE html>
+          <html lang="en">
+            <head>
+              <meta charset="UTF-8" />
+              <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+              <title>Clerk + JavaScript App</title>
+            </head>
+            <body>
+              <div id="signed-in"></div>
 
-                <div id="sign-in">
-                  <h2>Sign in</h2>
-                  <form id="sign-in-form">
-                    <label for="phone">Enter phone number</label>
-                    <input type="tel" name="phone" id="sign-in-phone" />
-                    <button type="submit">Continue</button>
-                  </form>
-                </div>
-
-                <form id="verifying" hidden>
-                  <h2>Verify your phone number</h2>
-                  <label for="code">Enter your verification code</label>
-                  <input id="code" name="code" />
-                  <button type="submit" id="verify-button">Verify</button>
+              <div id="sign-in">
+                <h2>Sign in</h2>
+                <form id="sign-in-form">
+                  <label for="phone">Enter phone number</label>
+                  <input type="tel" name="phone" id="sign-in-phone" />
+                  <button type="submit">Continue</button>
                 </form>
+              </div>
 
-                <script
-                  type="module"
-                  src="/src/main.js"
-                  async
-                  crossorigin="anonymous"
-                ></script>
-              </body>
-            </html>
-            ```
+              <form id="verifying" hidden>
+                <h2>Verify your phone number</h2>
+                <label for="code">Enter your verification code</label>
+                <input id="code" name="code" />
+                <button type="submit" id="verify-button">Verify</button>
+              </form>
 
-            And your JavaScript file should look like this:
+              <script
+                type="module"
+                src="/src/main.js"
+                async
+                crossorigin="anonymous"
+              ></script>
+            </body>
+          </html>
+          ```
 
-            ```js {{ prettier: false, filename: 'main.js' }}
-            import { Clerk } from '@clerk/clerk-js';
+          And your JavaScript file should look like this:
 
-            // Initialize Clerk with your Clerk publishable key
-            const clerk = new Clerk('{{pub_key}}');
-            await clerk.load();
+          ```js {{ prettier: false, filename: 'main.js' }}
+          import { Clerk } from '@clerk/clerk-js';
 
-            if (clerk.user) {
-              // Mount user button component
-              document.getElementById('signed-in').innerHTML = `
-                <div id="user-button"></div>
-              `;
+          // Initialize Clerk with your Clerk publishable key
+          const clerk = new Clerk('{{pub_key}}');
+          await clerk.load();
 
-              const userbuttonDiv = document.getElementById('user-button');
+          if (clerk.user) {
+            // Mount user button component
+            document.getElementById('signed-in').innerHTML = `
+              <div id="user-button"></div>
+            `;
 
-              clerk.mountUserButton(userbuttonDiv);
-            } else {
-              // Handle the sign-in form
-              document
-                .getElementById('sign-in-form')
-                .addEventListener('submit', async (e) => {
-                  e.preventDefault();
+            const userbuttonDiv = document.getElementById('user-button');
 
-                  const formData = new FormData(e.target);
-                  const phone = formData.get('phone');
+            clerk.mountUserButton(userbuttonDiv);
+          } else {
+            // Handle the sign-in form
+            document
+              .getElementById('sign-in-form')
+              .addEventListener('submit', async (e) => {
+                e.preventDefault();
 
-                  try {
-                    // Start the sign-in process using the user's identifier.
-                    // In this case, it's their phone number.
-                    const { supportedFirstFactors } = await clerk.client.signIn.create({
-                      identifier: phone,
-                    });
-
-                    // Find the phoneNumberId from all the available first factors for the current sign-in
-                    const firstPhoneFactor = supportedFirstFactors.find((factor) => {
-                      return factor.strategy === 'phone_code';
-                    });
-
-                    const { phoneNumberId } = firstPhoneFactor;
-
-                    // Prepare first factor verification, specifying
-                    // the phone code strategy.
-                    await clerk.client.signIn.prepareFirstFactor({
-                      strategy: 'phone_code',
-                      phoneNumberId,
-                    });
-
-                    // Hide sign-in form
-                    document.getElementById('sign-in').setAttribute('hidden', '');
-                    // Show verification form
-                    document.getElementById('verifying').removeAttribute('hidden');
-                  } catch (error) {
-                    // See https://clerk.com/docs/custom-flows/error-handling
-                    // for more info on error handling
-                    console.error(error);
-                  }
-                });
-
-              // Handle the verification form
-              document.getElementById('verifying').addEventListener('submit', async (e) => {
                 const formData = new FormData(e.target);
-                const code = formData.get('code');
+                const phone = formData.get('phone');
 
                 try {
-                  // Verify the phone number
-                  const verify = await clerk.client.signIn.attemptFirstFactor({
-                    strategy: 'phone_code',
-                    code,
+                  // Start the sign-in process using the user's identifier.
+                  // In this case, it's their phone number.
+                  const { supportedFirstFactors } = await clerk.client.signIn.create({
+                    identifier: phone,
                   });
 
-                  // Now that the user is created, set the session to active.
-                  await clerk.setActive({ session: verify.createdSessionId });
+                  // Find the phoneNumberId from all the available first factors for the current sign-in
+                  const firstPhoneFactor = supportedFirstFactors.find((factor) => {
+                    return factor.strategy === 'phone_code';
+                  });
+
+                  const { phoneNumberId } = firstPhoneFactor;
+
+                  // Prepare first factor verification, specifying
+                  // the phone code strategy.
+                  await clerk.client.signIn.prepareFirstFactor({
+                    strategy: 'phone_code',
+                    phoneNumberId,
+                  });
+
+                  // Hide sign-in form
+                  document.getElementById('sign-in').setAttribute('hidden', '');
+                  // Show verification form
+                  document.getElementById('verifying').removeAttribute('hidden');
                 } catch (error) {
                   // See https://clerk.com/docs/custom-flows/error-handling
                   // for more info on error handling
                   console.error(error);
                 }
               });
-            }
-            ```
-          </Tab>
 
-          <Tab>
-            ```html {{ prettier: false, filename: 'index.html' }}
-            <!DOCTYPE html>
-            <html lang="en">
-              <head>
-                <meta charset="UTF-8" />
-                <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-                <title>Clerk + JavaScript App</title>
-              </head>
-              <body>
-                <div id="signed-in"></div>
+            // Handle the verification form
+            document.getElementById('verifying').addEventListener('submit', async (e) => {
+              const formData = new FormData(e.target);
+              const code = formData.get('code');
 
-                <div id="sign-in">
-                  <h2>Sign in</h2>
-                  <form id="sign-in-form">
-                    <label for="phone">Enter phone number</label>
-                    <input type="tel" name="phone" id="sign-in-phone" />
-                    <button type="submit">Continue</button>
-                  </form>
-                </div>
+              try {
+                // Verify the phone number
+                const verify = await clerk.client.signIn.attemptFirstFactor({
+                  strategy: 'phone_code',
+                  code,
+                });
 
-                <form id="verifying" hidden>
-                  <h2>Verify your phone number</h2>
-                  <label for="code">Enter your verification code</label>
-                  <input id="code" name="code" />
-                  <button type="submit" id="verify-button">Verify</button>
+                // Now that the user is created, set the session to active.
+                await clerk.setActive({ session: verify.createdSessionId });
+              } catch (error) {
+                // See https://clerk.com/docs/custom-flows/error-handling
+                // for more info on error handling
+                console.error(error);
+              }
+            });
+          }
+          ```
+        </Tab>
+
+        <Tab>
+          ```html {{ prettier: false, filename: 'index.html' }}
+          <!DOCTYPE html>
+          <html lang="en">
+            <head>
+              <meta charset="UTF-8" />
+              <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+              <title>Clerk + JavaScript App</title>
+            </head>
+            <body>
+              <div id="signed-in"></div>
+
+              <div id="sign-in">
+                <h2>Sign in</h2>
+                <form id="sign-in-form">
+                  <label for="phone">Enter phone number</label>
+                  <input type="tel" name="phone" id="sign-in-phone" />
+                  <button type="submit">Continue</button>
                 </form>
+              </div>
 
-                <script
-                  async
-                  crossorigin="anonymous"
-                  data-clerk-publishable-key="{{pub_key}}"
-                  src="https://{{fapi_url}}/npm/@clerk/clerk-js@latest/dist/clerk.browser.js"
-                  type="text/javascript"
-                ></script>
+              <form id="verifying" hidden>
+                <h2>Verify your phone number</h2>
+                <label for="code">Enter your verification code</label>
+                <input id="code" name="code" />
+                <button type="submit" id="verify-button">Verify</button>
+              </form>
 
-                <script>
-                  window.addEventListener('load', async function () {
-                    await Clerk.load();
+              <script
+                async
+                crossorigin="anonymous"
+                data-clerk-publishable-key="{{pub_key}}"
+                src="https://{{fapi_url}}/npm/@clerk/clerk-js@latest/dist/clerk.browser.js"
+                type="text/javascript"
+              ></script>
 
-                    if (Clerk.user) {
-                      // Mount user button component
-                      document.getElementById('signed-in').innerHTML = `
-                        <div id="user-button"></div>
-                      `;
+              <script>
+                window.addEventListener('load', async function () {
+                  await Clerk.load();
 
-                      const userbuttonDiv = document.getElementById('user-button');
+                  if (Clerk.user) {
+                    // Mount user button component
+                    document.getElementById('signed-in').innerHTML = `
+                      <div id="user-button"></div>
+                    `;
 
-                      Clerk.mountUserButton(userbuttonDiv);
-                    } else {
-                      // Handle the sign-in form
-                      document.getElementById('sign-in-form')
-                        .addEventListener('submit', async (e) => {
-                          e.preventDefault();
+                    const userbuttonDiv = document.getElementById('user-button');
 
-                          const formData = new FormData(e.target);
-                          const phone = formData.get('phone');
+                    Clerk.mountUserButton(userbuttonDiv);
+                  } else {
+                    // Handle the sign-in form
+                    document.getElementById('sign-in-form')
+                      .addEventListener('submit', async (e) => {
+                        e.preventDefault();
 
-                          try {
-                            // Start the sign-in process using the user's identifier.
-                            // In this case, it's their phone number.
-                            const { supportedFirstFactors } =
-                              await Clerk.client.signIn.create({
-                                identifier: phone,
-                              });
+                        const formData = new FormData(e.target);
+                        const phone = formData.get('phone');
 
-                            // Find the phoneNumberId from all the available first factors for the current sign-in
-                            const firstPhoneFactor = supportedFirstFactors.find(
-                              (factor) => {
-                                return factor.strategy === 'phone_code';
-                              }
-                            );
-
-                            const { phoneNumberId } = firstPhoneFactor;
-
-                            // Prepare first factor verification, specifying
-                            // the phone code strategy.
-                            await Clerk.client.signIn.prepareFirstFactor({
-                              strategy: 'phone_code',
-                              phoneNumberId,
+                        try {
+                          // Start the sign-in process using the user's identifier.
+                          // In this case, it's their phone number.
+                          const { supportedFirstFactors } =
+                            await Clerk.client.signIn.create({
+                              identifier: phone,
                             });
 
-                            // Hide sign-in form
-                            document.getElementById('sign-in').setAttribute('hidden', '');
-                            // Show verification form
-                            document.getElementById('verifying').removeAttribute('hidden');
+                          // Find the phoneNumberId from all the available first factors for the current sign-in
+                          const firstPhoneFactor = supportedFirstFactors.find(
+                            (factor) => {
+                              return factor.strategy === 'phone_code';
+                            }
+                          );
 
-                          } catch (error) {
-                            // See https://clerk.com/docs/custom-flows/error-handling
-                            // for more info on error handling
-                            console.error(error);
-                          }
-                        });
+                          const { phoneNumberId } = firstPhoneFactor;
 
-                      // Handle the verification form
-                      document.getElementById('verifying')
-                        .addEventListener('submit', async (e) => {
-                          const formData = new FormData(e.target);
-                          const code = formData.get('code');
+                          // Prepare first factor verification, specifying
+                          // the phone code strategy.
+                          await Clerk.client.signIn.prepareFirstFactor({
+                            strategy: 'phone_code',
+                            phoneNumberId,
+                          });
 
-                          try {
-                            // Verify the phone number
-                            const verify = await Clerk.client.signIn.attemptFirstFactor({
-                              strategy: 'phone_code',
-                              code,
-                            });
+                          // Hide sign-in form
+                          document.getElementById('sign-in').setAttribute('hidden', '');
+                          // Show verification form
+                          document.getElementById('verifying').removeAttribute('hidden');
 
-                            // Now that the user is created, set the session to active.
-                            await Clerk.setActive({ session: verify.createdSessionId });
-                          } catch (error) {
-                            // See https://clerk.com/docs/custom-flows/error-handling
-                            // for more info on error handling
-                            console.error(error);
-                          }
-                        });
-                    }
-                  });
-                </script>
-              </body>
-            </html>
-            ```
-          </Tab>
-        </Tabs>
-      </InjectKeys>
+                        } catch (error) {
+                          // See https://clerk.com/docs/custom-flows/error-handling
+                          // for more info on error handling
+                          console.error(error);
+                        }
+                      });
+
+                    // Handle the verification form
+                    document.getElementById('verifying')
+                      .addEventListener('submit', async (e) => {
+                        const formData = new FormData(e.target);
+                        const code = formData.get('code');
+
+                        try {
+                          // Verify the phone number
+                          const verify = await Clerk.client.signIn.attemptFirstFactor({
+                            strategy: 'phone_code',
+                            code,
+                          });
+
+                          // Now that the user is created, set the session to active.
+                          await Clerk.setActive({ session: verify.createdSessionId });
+                        } catch (error) {
+                          // See https://clerk.com/docs/custom-flows/error-handling
+                          // for more info on error handling
+                          console.error(error);
+                        }
+                      });
+                  }
+                });
+              </script>
+            </body>
+          </html>
+          ```
+        </Tab>
+      </Tabs>
     </Tab>
 
     <Tab>

--- a/docs/deployments/changing-domains.mdx
+++ b/docs/deployments/changing-domains.mdx
@@ -49,13 +49,11 @@ To update your production domain using Clerk's backend API, you will need to mak
 
 3. Replace `YOUR_PROD_URL` with your new production domain.
 
-<InjectKeys>
-  ```bash {{ prettier: false }}
-  curl -XPOST -H 'Authorization: {{secret}}' -H "Content-type: application/json" -d '{
-  "home_url": "YOUR_PROD_URL"
-  }' 'https://api.clerk.com/v1/instance/change_domain'
-  ```
-</InjectKeys>
+```bash {{ prettier: false }}
+curl -XPOST -H 'Authorization: {{secret}}' -H "Content-type: application/json" -d '{
+"home_url": "YOUR_PROD_URL"
+}' 'https://api.clerk.com/v1/instance/change_domain'
+```
 
 For more information on how to update your instance settings using the backend API, see our [backend API reference](https://clerk.com/docs/reference/backend-api/tag/Beta-Features#operation/UpdateInstanceAuthConfig).
 

--- a/docs/guides/authjs-migration.mdx
+++ b/docs/guides/authjs-migration.mdx
@@ -64,12 +64,10 @@ This guide shows how to migrate an application using Auth.js (formerly NextAuth.
 
   **Pro tip!** If you are signed into your [Clerk Dashboard](https://dashboard.clerk.com/last-active?path=api-keys), your secret key should become visible by clicking on the eye icon.
 
-  <InjectKeys>
-    ```env {{ prettier: false, filename: '.env.local' }}
-    NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY={{pub_key}}
-    CLERK_SECRET_KEY={{secret}}
-    ```
-  </InjectKeys>
+  ```env {{ prettier: false, filename: '.env.local' }}
+  NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY={{pub_key}}
+  CLERK_SECRET_KEY={{secret}}
+  ```
 
   ### Wrap your Next.js app in `<ClerkProvider />`
 

--- a/docs/integrations/databases/convex.mdx
+++ b/docs/integrations/databases/convex.mdx
@@ -120,11 +120,9 @@ This tutorial assumes that you have already [set up a Clerk application](https:/
 
   **Pro tip!** If you are signed into your Clerk Dashboard, you can copy your publishable key below. Otherwise, you can find it in the Clerk Dashboard on the [API Keys](https://dashboard.clerk.com/last-active?path=api-keys) page.
 
-  <InjectKeys>
-    ```env {{ prettier: false, filename: '.env.local' }}
-    VITE_CLERK_PUBLISHABLE_KEY={{pub_key}}
-    ```
-  </InjectKeys>
+  ```env {{ prettier: false, filename: '.env.local' }}
+  VITE_CLERK_PUBLISHABLE_KEY={{pub_key}}
+  ```
 
   ### Configure the Clerk and Convex providers
 

--- a/docs/integrations/webhooks/sync-data.mdx
+++ b/docs/integrations/webhooks/sync-data.mdx
@@ -60,13 +60,11 @@ This guide can be adapted to listen for any Clerk event.
   1. On the endpoint's settings page, copy the **Signing Secret**. It should be on the right side of the page with an eye icon next to it.
   1. In your project's root directory, you should have an `.env.local` file that includes your Clerk API keys. Here, assign your signing secret to `WEBHOOK_SECRET`. Your file should look something like this:
 
-  <InjectKeys>
-    ```env {{ prettier: false, filename: '.env.local' }}
-    NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY={{pub_key}}
-    CLERK_SECRET_KEY={{secret}}
-    WEBHOOK_SECRET=whsec_123
-    ```
-  </InjectKeys>
+  ```env {{ prettier: false, filename: '.env.local' }}
+  NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY={{pub_key}}
+  CLERK_SECRET_KEY={{secret}}
+  WEBHOOK_SECRET=whsec_123
+  ```
 
   ### Set webhook route as public in your Middleware
 

--- a/docs/quickstarts/astro.mdx
+++ b/docs/quickstarts/astro.mdx
@@ -70,12 +70,10 @@ Clerk's [Astro SDK](/docs/references/astro/overview) provides a set of component
     The final result should resemble the following:
   </SignedOut>
 
-  <InjectKeys>
-    ```env {{ prettier: false, filename: '.env' }}
-    PUBLIC_CLERK_PUBLISHABLE_KEY={{pub_key}}
-    CLERK_SECRET_KEY={{secret}}
-    ```
-  </InjectKeys>
+  ```env {{ prettier: false, filename: '.env' }}
+  PUBLIC_CLERK_PUBLISHABLE_KEY={{pub_key}}
+  CLERK_SECRET_KEY={{secret}}
+  ```
 
   ### Update `astro.config.mjs`
 

--- a/docs/quickstarts/fastify.mdx
+++ b/docs/quickstarts/fastify.mdx
@@ -35,12 +35,10 @@ After following this guide, you should have a working Fastify app with public an
 
   **Pro tip!** If you are signed into your Clerk Dashboard, your secret key should become visible by clicking on the eye icon. Otherwise, you can find your keys in the Clerk Dashboard on the [API Keys](https://dashboard.clerk.com/last-active?path=api-keys) page.
 
-  <InjectKeys>
-    ```env {{ prettier: false, filename: '.env.local' }}
-    CLERK_PUBLISHABLE_KEY={{pub_key}}
-    CLERK_SECRET_KEY={{secret}}
-    ```
-  </InjectKeys>
+  ```env {{ prettier: false, filename: '.env.local' }}
+  CLERK_PUBLISHABLE_KEY={{pub_key}}
+  CLERK_SECRET_KEY={{secret}}
+  ```
 
   This examples uses `dotenv` to load the environment variables. You can use any other library or method, if you so wish.
 

--- a/docs/quickstarts/gatsby.mdx
+++ b/docs/quickstarts/gatsby.mdx
@@ -34,12 +34,10 @@ Learn how to use Clerk to quickly and easily add secure authentication and user 
 
   **Pro tip!** If you are signed into your Clerk Dashboard, your secret key should become visible by clicking on the eye icon. Otherwise, you can find your keys in the Clerk Dashboard on the [API Keys](https://dashboard.clerk.com/last-active?path=api-keys) page.
 
-  <InjectKeys>
-    ```env {{ prettier: false, filename: '.env.development' }}
-    GATSBY_CLERK_PUBLISHABLE_KEY={{pub_key}}
-    CLERK_SECRET_KEY={{secret}}
-    ```
-  </InjectKeys>
+  ```env {{ prettier: false, filename: '.env.development' }}
+  GATSBY_CLERK_PUBLISHABLE_KEY={{pub_key}}
+  CLERK_SECRET_KEY={{secret}}
+  ```
 
   ### Update `gatsby-config.ts`
 

--- a/docs/quickstarts/javascript.mdx
+++ b/docs/quickstarts/javascript.mdx
@@ -91,11 +91,9 @@ Select your preferred method below to get started.
 
       1. Create an `.env` file at the root of your project, and add your Clerk **Publishable Key**. If you're signed into Clerk, the `.env` snippet below will contain your key. Otherwise, you can copy it from the Clerk Dashboard by navigating to the [**API Keys**](https://dashboard.clerk.com/last-active?path=api-keys) page.
 
-      <InjectKeys>
-        ```env {{ prettier: false, filename: '.env' }}
-        VITE_CLERK_PUBLISHABLE_KEY={{pub_key}}
-        ```
-      </InjectKeys>
+      ```env {{ prettier: false, filename: '.env' }}
+      VITE_CLERK_PUBLISHABLE_KEY={{pub_key}}
+      ```
 
       2. In your `main.js` file, import the publishable key using Vite's `import.meta.env` object.
 
@@ -196,17 +194,15 @@ Select your preferred method below to get started.
 
       It should look something like this:
 
-      <InjectKeys>
-        ```html {{ prettier: false, filename: 'index.html' }}
-        <script
-          async
-          crossorigin="anonymous"
-          data-clerk-publishable-key="{{pub_key}}"
-          src="https://{{fapi_url}}/npm/@clerk/clerk-js@latest/dist/clerk.browser.js"
-          type="text/javascript"
-        ></script>
-        ```
-      </InjectKeys>
+      ```html {{ prettier: false, filename: 'index.html' }}
+      <script
+        async
+        crossorigin="anonymous"
+        data-clerk-publishable-key="{{pub_key}}"
+        src="https://{{fapi_url}}/npm/@clerk/clerk-js@latest/dist/clerk.browser.js"
+        type="text/javascript"
+      ></script>
+      ```
 
       In the `<script>` tag, the `onload` attribute is used to call the `load()` method when the ClerkJS package is loaded. This is necessary to initialize ClerkJS. For more information on the `load()` method and what options you can pass to it, check out the [reference documentation](/docs/references/javascript/clerk/clerk#load).
 
@@ -235,45 +231,43 @@ Select your preferred method below to get started.
       - [`<SignIn />`](/docs/components/authentication/sign-in): renders a user interface for signing in.
       - [`<UserButton />`](/docs/components/user/user-button): shows the avatar from the account the user is signed in with. When clicked, it opens a dropdown menu with options to sign out.
 
-      <InjectKeys>
-        ```html {{ prettier: false, filename: 'index.html' }}
-        <div id="app"></div>
+      ```html {{ prettier: false, filename: 'index.html' }}
+      <div id="app"></div>
 
-        <!-- Initialize Clerk with your
-        Clerk Publishable key and Frontend API URL -->
-        <script
-          async
-          crossorigin="anonymous"
-          data-clerk-publishable-key="{{pub_key}}"
-          src="https://{{fapi_url}}/npm/@clerk/clerk-js@latest/dist/clerk.browser.js"
-          type="text/javascript"
-        ></script>
+      <!-- Initialize Clerk with your
+      Clerk Publishable key and Frontend API URL -->
+      <script
+        async
+        crossorigin="anonymous"
+        data-clerk-publishable-key="{{pub_key}}"
+        src="https://{{fapi_url}}/npm/@clerk/clerk-js@latest/dist/clerk.browser.js"
+        type="text/javascript"
+      ></script>
 
-        <script>
-          window.addEventListener("load", async function () {
-            await Clerk.load();
+      <script>
+        window.addEventListener("load", async function () {
+          await Clerk.load();
 
-            if (Clerk.user) {
-              document.getElementById("app").innerHTML = `
-                <div id="user-button"></div>
-              `;
+          if (Clerk.user) {
+            document.getElementById("app").innerHTML = `
+              <div id="user-button"></div>
+            `;
 
-              const userButtonDiv = document.getElementById("user-button");
+            const userButtonDiv = document.getElementById("user-button");
 
-              Clerk.mountUserButton(userButtonDiv);
-            } else {
-              document.getElementById("app").innerHTML = `
-                <div id="sign-in"></div>
-              `;
+            Clerk.mountUserButton(userButtonDiv);
+          } else {
+            document.getElementById("app").innerHTML = `
+              <div id="sign-in"></div>
+            `;
 
-              const signInDiv = document.getElementById("sign-in");
+            const signInDiv = document.getElementById("sign-in");
 
-              Clerk.mountSignIn(signInDiv);
-            }
-          });
-        </script>
-        ```
-      </InjectKeys>
+            Clerk.mountSignIn(signInDiv);
+          }
+        });
+      </script>
+      ```
     </Steps>
   </Tab>
 </Tabs>

--- a/docs/quickstarts/nextjs.mdx
+++ b/docs/quickstarts/nextjs.mdx
@@ -63,12 +63,10 @@ description: Add authentication and user management to your Next.js app with Cle
     The final result should resemble the following:
   </SignedOut>
 
-  <InjectKeys>
-    ```env {{ prettier: false, filename: '.env.local' }}
-    NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY={{pub_key}}
-    CLERK_SECRET_KEY={{secret}}
-    ```
-  </InjectKeys>
+  ```env {{ prettier: false, filename: '.env.local' }}
+  NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY={{pub_key}}
+  CLERK_SECRET_KEY={{secret}}
+  ```
 
   ### Add Middleware to your application
 

--- a/docs/quickstarts/react.mdx
+++ b/docs/quickstarts/react.mdx
@@ -91,11 +91,9 @@ description: Add authentication and user management to your React app with Clerk
 
   The final result should look as follows:
 
-  <InjectKeys>
-    ```env {{ prettier: false, filename: '.env.local' }}
-    VITE_CLERK_PUBLISHABLE_KEY={{pub_key}}
-    ```
-  </InjectKeys>
+  ```env {{ prettier: false, filename: '.env.local' }}
+  VITE_CLERK_PUBLISHABLE_KEY={{pub_key}}
+  ```
 
   ### Import the Clerk publishable key
 

--- a/docs/quickstarts/remix.mdx
+++ b/docs/quickstarts/remix.mdx
@@ -59,12 +59,10 @@ Learn how to use Clerk to quickly and easily add secure authentication and user 
 
   **Pro tip!** If you are signed into your Clerk Dashboard, your secret key should become visible by clicking on the eye icon. Otherwise, you can find your keys in the Clerk Dashboard on the [API Keys](https://dashboard.clerk.com/last-active?path=api-keys) page.
 
-  <InjectKeys>
-    ```env {{ prettier: false, filename: '.env' }}
-    CLERK_PUBLISHABLE_KEY={{pub_key}}
-    CLERK_SECRET_KEY={{secret}}
-    ```
-  </InjectKeys>
+  ```env {{ prettier: false, filename: '.env' }}
+  CLERK_PUBLISHABLE_KEY={{pub_key}}
+  CLERK_SECRET_KEY={{secret}}
+  ```
 
   ### Configure `rootAuthLoader`
 

--- a/docs/references/go/other-examples.mdx
+++ b/docs/references/go/other-examples.mdx
@@ -16,66 +16,64 @@ By executing the code in the snippet below, you will:
 > [!NOTE]
 > Your Clerk secret key is required. If you are signed into your Clerk Dashboard, your secret key should become visible by selecting the eye icon. Otherwise, you can retrieve your Clerk secret key from the Clerk Dashboard on the **[API Keys](https://dashboard.clerk.com/last-active?path=api-keys)** page.
 
-<InjectKeys>
-  ```go {{ prettier: false, filename: 'main.go' }}
-  import (
-      "github.com/clerk/clerk-sdk-go/v2"
-      "github.com/clerk/clerk-sdk-go/v2/organization"
-      "github.com/clerk/clerk-sdk-go/v2/organizationmembership"
-      "github.com/clerk/clerk-sdk-go/v2/user"
-  )
+```go {{ prettier: false, filename: 'main.go' }}
+import (
+    "github.com/clerk/clerk-sdk-go/v2"
+    "github.com/clerk/clerk-sdk-go/v2/organization"
+    "github.com/clerk/clerk-sdk-go/v2/organizationmembership"
+    "github.com/clerk/clerk-sdk-go/v2/user"
+)
 
-  func main() {
-    // Each API operation requires a context.Context as the first argument.
-    ctx := context.Background()
+func main() {
+  // Each API operation requires a context.Context as the first argument.
+  ctx := context.Background()
 
-    // Set the API key
-    clerk.SetKey("{{secret}}")
+  // Set the API key
+  clerk.SetKey("{{secret}}")
 
-    // Create an organization
-    org, err := organization.Create(ctx, &organization.CreateParams{
-        Name: clerk.String("Clerk Inc"),
-    })
-    if err != nil {
-      // You can get additional information on the error, if it can
-      // be type-cast to clerk.APIErrorResponse.
-      if apiErr, ok := err.(*clerk.APIErrorResponse); ok {
-        apiErr.TraceID
-        apiErr.Error()
-        apiErr.Response.RawJSON
-      }
-      // handle the error
-      panic(err)
+  // Create an organization
+  org, err := organization.Create(ctx, &organization.CreateParams{
+      Name: clerk.String("Clerk Inc"),
+  })
+  if err != nil {
+    // You can get additional information on the error, if it can
+    // be type-cast to clerk.APIErrorResponse.
+    if apiErr, ok := err.(*clerk.APIErrorResponse); ok {
+      apiErr.TraceID
+      apiErr.Error()
+      apiErr.Response.RawJSON
     }
-
-    // Update the organization
-    org, err = organization.Update(ctx, org.ID, &organization.UpdateParams{
-        Slug: clerk.String("clerk"),
-    })
-    if err != nil {
-      // handle the error
-      panic(err)
-    }
-
-    // List organization memberships
-    listParams := organizationmembership.ListParams{}
-    listParams.Limit = clerk.Int64(10)
-    memberships, err := organizationmembership.List(ctx, params)
-    if err != nil {
-      // handle the error
-      panic(err)
-    }
-    if memberships.TotalCount < 0 {
-        return
-    }
-    membership := memberships[0]
-
-    // Get a user
-    usr, err := user.Get(ctx, membership.UserID)
-    if err != nil {
-      // handle the error
-      panic(err)
-    }
+    // handle the error
+    panic(err)
   }
-  ```
-</InjectKeys>
+
+  // Update the organization
+  org, err = organization.Update(ctx, org.ID, &organization.UpdateParams{
+      Slug: clerk.String("clerk"),
+  })
+  if err != nil {
+    // handle the error
+    panic(err)
+  }
+
+  // List organization memberships
+  listParams := organizationmembership.ListParams{}
+  listParams.Limit = clerk.Int64(10)
+  memberships, err := organizationmembership.List(ctx, params)
+  if err != nil {
+    // handle the error
+    panic(err)
+  }
+  if memberships.TotalCount < 0 {
+      return
+  }
+  membership := memberships[0]
+
+  // Get a user
+  usr, err := user.Get(ctx, membership.UserID)
+  if err != nil {
+    // handle the error
+    panic(err)
+  }
+}
+```

--- a/docs/references/go/verifying-sessions.mdx
+++ b/docs/references/go/verifying-sessions.mdx
@@ -31,53 +31,51 @@ The following example demonstrates how to use the `WithHeaderAuthorization()` mi
 > [!NOTE]
 > Your Clerk secret key is required. If you are signed in to your Clerk Dashboard, your secret key should become visible by selecting the eye icon. Otherwise, you can retrieve your Clerk secret key from the Clerk Dashboard on the **[API Keys](https://dashboard.clerk.com/last-active?path=api-keys)** page.
 
-<InjectKeys>
-  ```go {{ prettier: false, filename: 'main.go' }}
-  package main
+```go {{ prettier: false, filename: 'main.go' }}
+package main
 
-  import (
-    "fmt"
-    "net/http"
+import (
+  "fmt"
+  "net/http"
 
-    "github.com/clerk/clerk-sdk-go/v2"
-    clerkhttp "github.com/clerk/clerk-sdk-go/v2/http"
-    "github.com/clerk/clerk-sdk-go/v2/user"
+  "github.com/clerk/clerk-sdk-go/v2"
+  clerkhttp "github.com/clerk/clerk-sdk-go/v2/http"
+  "github.com/clerk/clerk-sdk-go/v2/user"
+)
+
+func main() {
+  clerk.SetKey("{{secret}}")
+
+  mux := http.NewServeMux()
+  mux.HandleFunc("/", publicRoute)
+  protectedHandler := http.HandlerFunc(protectedRoute)
+  mux.Handle(
+    "/protected",
+    clerkhttp.WithHeaderAuthorization()(protectedHandler),
   )
 
-  func main() {
-    clerk.SetKey("{{secret}}")
+  http.ListenAndServe(":3000", mux)
+}
 
-    mux := http.NewServeMux()
-    mux.HandleFunc("/", publicRoute)
-    protectedHandler := http.HandlerFunc(protectedRoute)
-    mux.Handle(
-      "/protected",
-      clerkhttp.WithHeaderAuthorization()(protectedHandler),
-    )
+func publicRoute(w http.ResponseWriter, r *http.Request) {
+  w.Write([]byte(`{"access": "public"}`))
+}
 
-    http.ListenAndServe(":3000", mux)
+func protectedRoute(w http.ResponseWriter, r *http.Request) {
+  claims, ok := clerk.SessionClaimsFromContext(r.Context())
+  if !ok {
+    w.WriteHeader(http.StatusUnauthorized)
+    w.Write([]byte(`{"access": "unauthorized"}`))
+    return
   }
 
-  func publicRoute(w http.ResponseWriter, r *http.Request) {
-    w.Write([]byte(`{"access": "public"}`))
+  usr, err := user.Get(r.Context(), claims.Subject)
+  if err != nil {
+    // handle the error
   }
-
-  func protectedRoute(w http.ResponseWriter, r *http.Request) {
-    claims, ok := clerk.SessionClaimsFromContext(r.Context())
-    if !ok {
-      w.WriteHeader(http.StatusUnauthorized)
-      w.Write([]byte(`{"access": "unauthorized"}`))
-      return
-    }
-
-    usr, err := user.Get(r.Context(), claims.Subject)
-    if err != nil {
-      // handle the error
-    }
-    fmt.Fprintf(w, `{"user_id": "%s", "user_banned": "%t"}`, usr.ID, usr.Banned)
-  }
-  ```
-</InjectKeys>
+  fmt.Fprintf(w, `{"user_id": "%s", "user_banned": "%t"}`, usr.ID, usr.Banned)
+}
+```
 
 ## Manually verify a session token
 
@@ -89,167 +87,163 @@ Clerk Go SDK provides a set of functions for decoding and verifying JWTs, as wel
 
 The following example demonstrates how to manually verify a session token. If the user tries accessing the route and their session token is valid, the user's ID and banned status will be returned in the response.
 
-<InjectKeys>
-  ```go {{ prettier: false, filename: 'main.go' }}
-  package main
+```go {{ prettier: false, filename: 'main.go' }}
+package main
 
-  import (
-  	"fmt"
-  	"net/http"
-  	"strings"
+import (
+	"fmt"
+	"net/http"
+	"strings"
 
-  	"github.com/clerk/clerk-sdk-go/v2"
-  	"github.com/clerk/clerk-sdk-go/v2/jwt"
-  	"github.com/clerk/clerk-sdk-go/v2/user"
-  )
+	"github.com/clerk/clerk-sdk-go/v2"
+	"github.com/clerk/clerk-sdk-go/v2/jwt"
+	"github.com/clerk/clerk-sdk-go/v2/user"
+)
 
-  func main() {
-    clerk.SetKey("{{secret}}")
+func main() {
+  clerk.SetKey("{{secret}}")
 
-  	mux := http.NewServeMux()
-  	mux.HandleFunc("/", publicRoute)
-  	mux.HandleFunc("/protected", protectedRoute)
+	mux := http.NewServeMux()
+	mux.HandleFunc("/", publicRoute)
+	mux.HandleFunc("/protected", protectedRoute)
 
-  	http.ListenAndServe(":3000", mux)
-  }
+	http.ListenAndServe(":3000", mux)
+}
 
-  func publicRoute(w http.ResponseWriter, r *http.Request) {
-  	w.Write([]byte(`{"access": "public"}`))
-  }
+func publicRoute(w http.ResponseWriter, r *http.Request) {
+	w.Write([]byte(`{"access": "public"}`))
+}
 
-  func protectedRoute(w http.ResponseWriter, r *http.Request) {
-  	// Get the session JWT from the Authorization header
-  	sessionToken := strings.TrimPrefix(r.Header.Get("Authorization"), "Bearer ")
+func protectedRoute(w http.ResponseWriter, r *http.Request) {
+	// Get the session JWT from the Authorization header
+	sessionToken := strings.TrimPrefix(r.Header.Get("Authorization"), "Bearer ")
 
-  	// Verify the session
-  	claims, err := jwt.Verify(r.Context(), &jwt.VerifyParams{
-  		Token: sessionToken,
-  	})
-  	if err != nil {
-  		// handle the error
-  		w.WriteHeader(http.StatusUnauthorized)
-  		w.Write([]byte(`{"access": "unauthorized"}`))
-  		return
-  	}
+	// Verify the session
+	claims, err := jwt.Verify(r.Context(), &jwt.VerifyParams{
+		Token: sessionToken,
+	})
+	if err != nil {
+		// handle the error
+		w.WriteHeader(http.StatusUnauthorized)
+		w.Write([]byte(`{"access": "unauthorized"}`))
+		return
+	}
 
-  	usr, err := user.Get(r.Context(), claims.Subject)
-  	if err != nil {
-  		// handle the error
-  	}
-  	fmt.Fprintf(w, `{"user_id": "%s", "user_banned": "%t"}`, usr.ID, usr.Banned)
-  }
-  ```
-</InjectKeys>
+	usr, err := user.Get(r.Context(), claims.Subject)
+	if err != nil {
+		// handle the error
+	}
+	fmt.Fprintf(w, `{"user_id": "%s", "user_banned": "%t"}`, usr.ID, usr.Banned)
+}
+```
 
 If you need to verify session tokens frequently, it's recommended to cache the JSON Web Key for your instance in order to avoid making too many requests to the Clerk Backend API.
 
 The following example includes the same code as above, with the addition of demonstrating a possible way to store your JSON Web Key. The example is meant to serve as a guide; implementation may vary depending on your needs.
 
-<InjectKeys>
-  ```go {{ prettier: false, filename: 'main.go' }}
-  package main
+```go {{ prettier: false, filename: 'main.go' }}
+package main
 
-  import (
-  	"fmt"
-  	"net/http"
-  	"strings"
+import (
+	"fmt"
+	"net/http"
+	"strings"
 
-  	"github.com/clerk/clerk-sdk-go/v2"
-  	"github.com/clerk/clerk-sdk-go/v2/jwks"
-  	"github.com/clerk/clerk-sdk-go/v2/jwt"
-  	"github.com/clerk/clerk-sdk-go/v2/user"
-  )
+	"github.com/clerk/clerk-sdk-go/v2"
+	"github.com/clerk/clerk-sdk-go/v2/jwks"
+	"github.com/clerk/clerk-sdk-go/v2/jwt"
+	"github.com/clerk/clerk-sdk-go/v2/user"
+)
 
-  func main() {
-  	mux := http.NewServeMux()
-  	mux.HandleFunc("/", publicRoute)
+func main() {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/", publicRoute)
 
-  	// Initialize storage for JSON Web Keys. You can cache/store
-  	// the key for as long as it's valid, and pass it to jwt.Verify.
-  	// This way jwt.Verify won't make requests to the Clerk
-  	// Backend API to refetch the JSON Web Key.
-  	// Make sure you refetch the JSON Web Key whenever your
-  	// Clerk secret key changes.
-  	jwkStore := NewJWKStore()
+	// Initialize storage for JSON Web Keys. You can cache/store
+	// the key for as long as it's valid, and pass it to jwt.Verify.
+	// This way jwt.Verify won't make requests to the Clerk
+	// Backend API to refetch the JSON Web Key.
+	// Make sure you refetch the JSON Web Key whenever your
+	// Clerk secret key changes.
+	jwkStore := NewJWKStore()
 
-  	config := &clerk.ClientConfig{}
-  	config.Key = clerk.String("{{secret}}")
-  	jwksClient := jwks.NewClient(config)
-  	mux.HandleFunc("/protected", protectedRoute(jwksClient, jwkStore))
+	config := &clerk.ClientConfig{}
+	config.Key = clerk.String("{{secret}}")
+	jwksClient := jwks.NewClient(config)
+	mux.HandleFunc("/protected", protectedRoute(jwksClient, jwkStore))
 
-  	http.ListenAndServe(":3000", mux)
-  }
+	http.ListenAndServe(":3000", mux)
+}
 
-  func publicRoute(w http.ResponseWriter, r *http.Request) {
-  	w.Write([]byte(`{"access": "public"}`))
-  }
+func publicRoute(w http.ResponseWriter, r *http.Request) {
+	w.Write([]byte(`{"access": "public"}`))
+}
 
-  func protectedRoute(jwksClient *jwks.Client, store JWKStore) func(http.ResponseWriter, *http.Request) {
-  	return func(w http.ResponseWriter, r *http.Request) {
-  		// Get the session JWT from the Authorization header
-  		sessionToken := strings.TrimPrefix(r.Header.Get("Authorization"), "Bearer ")
+func protectedRoute(jwksClient *jwks.Client, store JWKStore) func(http.ResponseWriter, *http.Request) {
+	return func(w http.ResponseWriter, r *http.Request) {
+		// Get the session JWT from the Authorization header
+		sessionToken := strings.TrimPrefix(r.Header.Get("Authorization"), "Bearer ")
 
-  		// Attempt to get the JSON Web Key from your store.
-  		jwk := store.GetJWK()
-  		if jwk == nil {
-  			// Decode the session JWT so that we can find the key ID.
-  			unsafeClaims, err := jwt.Decode(r.Context(), &jwt.DecodeParams{
-  				Token: sessionToken,
-  			})
-  			if err != nil {
-  				// handle the error
-  				w.WriteHeader(http.StatusUnauthorized)
-  				w.Write([]byte(`{"access": "unauthorized"}`))
-  				return
-  			}
+		// Attempt to get the JSON Web Key from your store.
+		jwk := store.GetJWK()
+		if jwk == nil {
+			// Decode the session JWT so that we can find the key ID.
+			unsafeClaims, err := jwt.Decode(r.Context(), &jwt.DecodeParams{
+				Token: sessionToken,
+			})
+			if err != nil {
+				// handle the error
+				w.WriteHeader(http.StatusUnauthorized)
+				w.Write([]byte(`{"access": "unauthorized"}`))
+				return
+			}
 
-  			// Fetch the JSON Web Key
-  			jwk, err = jwt.GetJSONWebKey(r.Context(), &jwt.GetJSONWebKeyParams{
-  				KeyID:      unsafeClaims.KeyID,
-  				JWKSClient: jwksClient,
-  			})
-  			if err != nil {
-  				// handle the error
-  				w.WriteHeader(http.StatusUnauthorized)
-  				w.Write([]byte(`{"access": "unauthorized"}`))
-  				return
-  			}
-  		}
-  		// Write the JSON Web Key to your store, so that next time
-  		// you can use the cached value.
-  		store.SetJWK(jwk)
+			// Fetch the JSON Web Key
+			jwk, err = jwt.GetJSONWebKey(r.Context(), &jwt.GetJSONWebKeyParams{
+				KeyID:      unsafeClaims.KeyID,
+				JWKSClient: jwksClient,
+			})
+			if err != nil {
+				// handle the error
+				w.WriteHeader(http.StatusUnauthorized)
+				w.Write([]byte(`{"access": "unauthorized"}`))
+				return
+			}
+		}
+		// Write the JSON Web Key to your store, so that next time
+		// you can use the cached value.
+		store.SetJWK(jwk)
 
-  		// Verify the session
-  		claims, err := jwt.Verify(r.Context(), &jwt.VerifyParams{
-  			Token: sessionToken,
-  			JWK:   jwk,
-  		})
-  		if err != nil {
-  			// handle the error
-  			w.WriteHeader(http.StatusUnauthorized)
-  			w.Write([]byte(`{"access": "unauthorized"}`))
-  			return
-  		}
+		// Verify the session
+		claims, err := jwt.Verify(r.Context(), &jwt.VerifyParams{
+			Token: sessionToken,
+			JWK:   jwk,
+		})
+		if err != nil {
+			// handle the error
+			w.WriteHeader(http.StatusUnauthorized)
+			w.Write([]byte(`{"access": "unauthorized"}`))
+			return
+		}
 
-  		usr, err := user.Get(r.Context(), claims.Subject)
-  		if err != nil {
-  			// handle the error
-  		}
-  		fmt.Fprintf(w, `{"user_id": "%s", "user_banned": "%t"}`, usr.ID, usr.Banned)
-  	}
-  }
+		usr, err := user.Get(r.Context(), claims.Subject)
+		if err != nil {
+			// handle the error
+		}
+		fmt.Fprintf(w, `{"user_id": "%s", "user_banned": "%t"}`, usr.ID, usr.Banned)
+	}
+}
 
-  // Sample interface for JSON Web Key storage.
-  // Implementation may vary.
-  type JWKStore interface {
-  	GetJWK() *clerk.JSONWebKey
-  	SetJWK(*clerk.JSONWebKey)
-  }
+// Sample interface for JSON Web Key storage.
+// Implementation may vary.
+type JWKStore interface {
+	GetJWK() *clerk.JSONWebKey
+	SetJWK(*clerk.JSONWebKey)
+}
 
-  func NewJWKStore() JWKStore {
-  	// Implementation may vary. This can be an
-  	// in-memory store, database, caching layer,...
-  	return nil
-  }
-  ```
-</InjectKeys>
+func NewJWKStore() JWKStore {
+	// Implementation may vary. This can be an
+	// in-memory store, database, caching layer,...
+	return nil
+}
+```

--- a/docs/references/javascript/clerk/organization-methods.mdx
+++ b/docs/references/javascript/clerk/organization-methods.mdx
@@ -30,20 +30,85 @@ function getOrganization(organizationId: string): Promise<Organization | undefin
 
 The following example demonstrates how to retrieve information about the currently active organization.
 
-<InjectKeys>
-  <Tabs type="npm-script" items={['NPM module', '<script>']}>
-    <Tab>
-      <CodeBlockTabs options={["main.js", "index.html"]}>
-        ```js {{ prettier: false, filename: 'main.js', mark: [9] }}
-        import { Clerk } from '@clerk/clerk-js';
+<Tabs type="npm-script" items={['NPM module', '<script>']}>
+  <Tab>
+    <CodeBlockTabs options={["main.js", "index.html"]}>
+      ```js {{ prettier: false, filename: 'main.js', mark: [9] }}
+      import { Clerk } from '@clerk/clerk-js';
 
-        // Initialize Clerk with your Clerk publishable key
-        const clerk = new Clerk('{{pub_key}}');
-        await clerk.load();
+      // Initialize Clerk with your Clerk publishable key
+      const clerk = new Clerk('{{pub_key}}');
+      await clerk.load();
 
-        if (clerk.user) {
-          if (clerk.organization.id) {
-            await clerk.getOrganization(clerk.organization.id)
+      if (clerk.user) {
+        if (clerk.organization.id) {
+          await clerk.getOrganization(clerk.organization.id)
+            .then((res) => console.log(res))
+            .catch((error) => console.log("An error occurred:", error.errors));
+        } else {
+          // If there is no active organization,
+          // mount Clerk's <OrganizationSwitcher />
+          // to allow the user to set an organization as active
+          document.getElementById("app").innerHTML = `
+            <h2>Select an organization to set it as active</h2>
+            <div id="org-switcher"></div>
+          `;
+
+          const orgSwitcherDiv = document.getElementById("org-switcher");
+
+          clerk.mountOrganizationSwitcher(orgSwitcherDiv);
+        }
+      } else {
+        document.getElementById("app").innerHTML = `
+          <div id="sign-in"></div>
+        `;
+
+        const signInDiv =
+          document.getElementById("sign-in");
+
+        clerk.mountSignIn(signInDiv);
+      }
+      ```
+
+      ```html {{ prettier: false, filename: 'index.html' }}
+      <!doctype html>
+      <html lang="en">
+        <head>
+          <meta charset="UTF-8" />
+          <link rel="icon" type="image/svg+xml" href="/vite.svg" />
+          <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+          <title>Clerk + JavaScript App</title>
+        </head>
+        <body>
+          <div id="app"></div>
+          <script type="module" src="/main.js"></script>
+        </body>
+      </html>
+      ```
+    </CodeBlockTabs>
+  </Tab>
+
+  <Tab>
+    ```html {{ prettier: false, filename: 'index.html', mark: [19] }}
+    <div id="sign-in"></div>
+
+    <!-- Initialize Clerk with your
+    Clerk Publishable key and Frontend API URL -->
+    <script
+      async
+      crossorigin="anonymous"
+      data-clerk-publishable-key="{{pub_key}}"
+      src="https://{{fapi_url}}/npm/@clerk/clerk-js@latest/dist/clerk.browser.js"
+      type="text/javascript"
+    ></script>
+
+    <script>
+      window.addEventListener("load", async function () {
+        await Clerk.load();
+
+        if (Clerk.user) {
+          if (Clerk.organization.id) {
+            await Clerk.getOrganization(Clerk.organization.id)
               .then((res) => console.log(res))
               .catch((error) => console.log("An error occurred:", error.errors));
           } else {
@@ -57,85 +122,18 @@ The following example demonstrates how to retrieve information about the current
 
             const orgSwitcherDiv = document.getElementById("org-switcher");
 
-            clerk.mountOrganizationSwitcher(orgSwitcherDiv);
+            Clerk.mountOrganizationSwitcher(orgSwitcherDiv);
           }
         } else {
-          document.getElementById("app").innerHTML = `
-            <div id="sign-in"></div>
-          `;
+          const signInDiv = document.getElementById("sign-in");
 
-          const signInDiv =
-            document.getElementById("sign-in");
-
-          clerk.mountSignIn(signInDiv);
+          Clerk.mountSignIn(signInDiv);
         }
-        ```
-
-        ```html {{ prettier: false, filename: 'index.html' }}
-        <!doctype html>
-        <html lang="en">
-          <head>
-            <meta charset="UTF-8" />
-            <link rel="icon" type="image/svg+xml" href="/vite.svg" />
-            <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-            <title>Clerk + JavaScript App</title>
-          </head>
-          <body>
-            <div id="app"></div>
-            <script type="module" src="/main.js"></script>
-          </body>
-        </html>
-        ```
-      </CodeBlockTabs>
-    </Tab>
-
-    <Tab>
-      ```html {{ prettier: false, filename: 'index.html', mark: [19] }}
-      <div id="sign-in"></div>
-
-      <!-- Initialize Clerk with your
-      Clerk Publishable key and Frontend API URL -->
-      <script
-        async
-        crossorigin="anonymous"
-        data-clerk-publishable-key="{{pub_key}}"
-        src="https://{{fapi_url}}/npm/@clerk/clerk-js@latest/dist/clerk.browser.js"
-        type="text/javascript"
-      ></script>
-
-      <script>
-        window.addEventListener("load", async function () {
-          await Clerk.load();
-
-          if (Clerk.user) {
-            if (Clerk.organization.id) {
-              await Clerk.getOrganization(Clerk.organization.id)
-                .then((res) => console.log(res))
-                .catch((error) => console.log("An error occurred:", error.errors));
-            } else {
-              // If there is no active organization,
-              // mount Clerk's <OrganizationSwitcher />
-              // to allow the user to set an organization as active
-              document.getElementById("app").innerHTML = `
-                <h2>Select an organization to set it as active</h2>
-                <div id="org-switcher"></div>
-              `;
-
-              const orgSwitcherDiv = document.getElementById("org-switcher");
-
-              Clerk.mountOrganizationSwitcher(orgSwitcherDiv);
-            }
-          } else {
-            const signInDiv = document.getElementById("sign-in");
-
-            Clerk.mountSignIn(signInDiv);
-          }
-        });
-      </script>
-      ```
-    </Tab>
-  </Tabs>
-</InjectKeys>
+      });
+    </script>
+    ```
+  </Tab>
+</Tabs>
 
 ## `createOrganization()`
 
@@ -157,89 +155,87 @@ function createOrganization({name, slug}: CreateOrganizationParams): Promise<Org
 
 ### Example
 
-<InjectKeys>
-  <Tabs type="npm-script" items={['NPM module', '<script>']}>
-    <Tab>
-      <CodeBlockTabs options={["main.js", "index.html"]}>
-        ```js {{ prettier: false, filename: 'main.js', mark: [[11, 13]] }}
-        import { Clerk } from '@clerk/clerk-js';
+<Tabs type="npm-script" items={['NPM module', '<script>']}>
+  <Tab>
+    <CodeBlockTabs options={["main.js", "index.html"]}>
+      ```js {{ prettier: false, filename: 'main.js', mark: [[11, 13]] }}
+      import { Clerk } from '@clerk/clerk-js';
 
-        // Initialize Clerk with your Clerk publishable key
-        const clerk = new Clerk('{{pub_key}}');
-        await clerk.load();
+      // Initialize Clerk with your Clerk publishable key
+      const clerk = new Clerk('{{pub_key}}');
+      await clerk.load();
 
-        if (clerk.user) {
+      if (clerk.user) {
+        const createOrgButton = document.getElementById("create-org-button");
+        createOrgButton.addEventListener("click", () => {
+          clerk.createOrganization({ name: "test" })
+            .then((res) => console.log(res))
+            .catch((error) => console.log("An error occurred:", error.errors));
+        });
+      } else {
+        document.getElementById("app").innerHTML = `
+          <div id="sign-in"></div>
+        `;
+
+        const signInDiv =
+          document.getElementById("sign-in");
+
+        clerk.mountSignIn(signInDiv);
+      }
+      ```
+
+      ```html {{ prettier: false, filename: 'index.html' }}
+      <!doctype html>
+      <html lang="en">
+        <head>
+          <meta charset="UTF-8" />
+          <link rel="icon" type="image/svg+xml" href="/vite.svg" />
+          <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+          <title>Clerk + JavaScript App</title>
+        </head>
+        <body>
+          <div id="app"></div>
+          <button id="create-org-button">Create Organization</button>
+          <script type="module" src="/main.js"></script>
+        </body>
+      </html>
+      ```
+    </CodeBlockTabs>
+  </Tab>
+
+  <Tab>
+    ```html {{ prettier: false, filename: 'index.html', mark: [[22, 24]] }}
+    <div id="sign-in"></div>
+    <div id="create-org-button"></div>
+
+    <!-- Initialize Clerk with your
+    Clerk Publishable key and Frontend API URL -->
+    <script
+      async
+      crossorigin="anonymous"
+      data-clerk-publishable-key="{{pub_key}}"
+      src="https://{{fapi_url}}/npm/@clerk/clerk-js@latest/dist/clerk.browser.js"
+      type="text/javascript"
+    ></script>
+
+    <script>
+      window.addEventListener("load", async function () {
+        await Clerk.load();
+
+        if (Clerk.user) {
           const createOrgButton = document.getElementById("create-org-button");
           createOrgButton.addEventListener("click", () => {
-            clerk.createOrganization({ name: "test" })
+            Clerk.createOrganization({ name: "test" })
               .then((res) => console.log(res))
               .catch((error) => console.log("An error occurred:", error.errors));
           });
         } else {
-          document.getElementById("app").innerHTML = `
-            <div id="sign-in"></div>
-          `;
+          const signInDiv = document.getElementById("sign-in");
 
-          const signInDiv =
-            document.getElementById("sign-in");
-
-          clerk.mountSignIn(signInDiv);
+          Clerk.mountSignIn(signInDiv);
         }
-        ```
-
-        ```html {{ prettier: false, filename: 'index.html' }}
-        <!doctype html>
-        <html lang="en">
-          <head>
-            <meta charset="UTF-8" />
-            <link rel="icon" type="image/svg+xml" href="/vite.svg" />
-            <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-            <title>Clerk + JavaScript App</title>
-          </head>
-          <body>
-            <div id="app"></div>
-            <button id="create-org-button">Create Organization</button>
-            <script type="module" src="/main.js"></script>
-          </body>
-        </html>
-        ```
-      </CodeBlockTabs>
-    </Tab>
-
-    <Tab>
-      ```html {{ prettier: false, filename: 'index.html', mark: [[22, 24]] }}
-      <div id="sign-in"></div>
-      <div id="create-org-button"></div>
-
-      <!-- Initialize Clerk with your
-      Clerk Publishable key and Frontend API URL -->
-      <script
-        async
-        crossorigin="anonymous"
-        data-clerk-publishable-key="{{pub_key}}"
-        src="https://{{fapi_url}}/npm/@clerk/clerk-js@latest/dist/clerk.browser.js"
-        type="text/javascript"
-      ></script>
-
-      <script>
-        window.addEventListener("load", async function () {
-          await Clerk.load();
-
-          if (Clerk.user) {
-            const createOrgButton = document.getElementById("create-org-button");
-            createOrgButton.addEventListener("click", () => {
-              Clerk.createOrganization({ name: "test" })
-                .then((res) => console.log(res))
-                .catch((error) => console.log("An error occurred:", error.errors));
-            });
-          } else {
-            const signInDiv = document.getElementById("sign-in");
-
-            Clerk.mountSignIn(signInDiv);
-          }
-        });
-      </script>
-      ```
-    </Tab>
-  </Tabs>
-</InjectKeys>
+      });
+    </script>
+    ```
+  </Tab>
+</Tabs>

--- a/docs/references/javascript/organization-invitation.mdx
+++ b/docs/references/javascript/organization-invitation.mdx
@@ -43,114 +43,112 @@ It assumes:
 - you have followed the [quickstart](/docs/quickstarts/javascript) in order to add Clerk to your JavaScript application
 - you have [enabled the Organizations feature in your Clerk Dashboard](/docs/organizations/overview#enable-organizations-in-your-application)
 
-<InjectKeys>
-  <CodeBlockTabs type="npm-script" options={['NPM module', '<script>']}>
-    ```js {{ prettier: false, filename: 'main.js', mark: [21] }}
-    import { Clerk } from '@clerk/clerk-js';
+<CodeBlockTabs type="npm-script" options={['NPM module', '<script>']}>
+  ```js {{ prettier: false, filename: 'main.js', mark: [21] }}
+  import { Clerk } from '@clerk/clerk-js';
 
-    // Initialize Clerk with your Clerk publishable key
-    const clerk = new Clerk('{{pub_key}}');
-    await clerk.load();
+  // Initialize Clerk with your Clerk publishable key
+  const clerk = new Clerk('{{pub_key}}');
+  await clerk.load();
 
-    if (clerk.user) {
-      // Check for an active organization
-      if (clerk.organization) {
-        // Get list of organization invitations
-        const { totalCount, data } = await clerk.organization.getInvitations();
+  if (clerk.user) {
+    // Check for an active organization
+    if (clerk.organization) {
+      // Get list of organization invitations
+      const { totalCount, data } = await clerk.organization.getInvitations();
 
-        const invitations = data;
-        console.log(`Invitations:`, invitations);
+      const invitations = data;
+      console.log(`Invitations:`, invitations);
 
-        if (invitations.length === 0) {
-          console.log("No invitations to revoke.");
-        }
-
-        // Revoke the first invitation in the list
-        invitations[0].revoke()
-          .then((res) => console.log(res))
-          .catch((error) => console.log(error.errors));
-      } else {
-        // If there is no active organization,
-        // mount Clerk's <OrganizationSwitcher />
-        // to allow the user to set an organization as active
-        document.getElementById("app").innerHTML = `
-          <h2>Select an organization to set it as active</h2>
-          <div id="org-switcher"></div>
-        `;
-
-        const orgSwitcherDiv = document.getElementById("org-switcher");
-
-        clerk.mountOrganizationSwitcher(orgSwitcherDiv);
+      if (invitations.length === 0) {
+        console.log("No invitations to revoke.");
       }
+
+      // Revoke the first invitation in the list
+      invitations[0].revoke()
+        .then((res) => console.log(res))
+        .catch((error) => console.log(error.errors));
     } else {
+      // If there is no active organization,
+      // mount Clerk's <OrganizationSwitcher />
+      // to allow the user to set an organization as active
       document.getElementById("app").innerHTML = `
-        <div id="sign-in"></div>
+        <h2>Select an organization to set it as active</h2>
+        <div id="org-switcher"></div>
       `;
 
-      const signInDiv = document.getElementById("sign-in");
+      const orgSwitcherDiv = document.getElementById("org-switcher");
 
-      clerk.mountSignIn(signInDiv);
+      clerk.mountOrganizationSwitcher(orgSwitcherDiv);
     }
-    ```
+  } else {
+    document.getElementById("app").innerHTML = `
+      <div id="sign-in"></div>
+    `;
 
-    ```html {{ prettier: false, filename: 'index.html', mark: [31] }}
-      <div id="app"></div>
+    const signInDiv = document.getElementById("sign-in");
 
-      <!-- Initialize Clerk with your
-      Clerk Publishable key and Frontend API URL -->
-      <script
-        async
-        crossorigin="anonymous"
-        data-clerk-publishable-key="{{pub_key}}"
-        src="https://{{fapi_url}}/npm/@clerk/clerk-js@latest/dist/clerk.browser.js"
-        type="text/javascript"
-      ></script>
+    clerk.mountSignIn(signInDiv);
+  }
+  ```
 
-      <script>
-        window.addEventListener("load", async function () {
-          await Clerk.load();
+  ```html {{ prettier: false, filename: 'index.html', mark: [31] }}
+    <div id="app"></div>
 
-          if (Clerk.user) {
-            // Check for an active organization
-            if (Clerk.organization) {
-            // Get list of organization invitations
-            const { totalCount, data } = await Clerk.organization.getInvitations();
+    <!-- Initialize Clerk with your
+    Clerk Publishable key and Frontend API URL -->
+    <script
+      async
+      crossorigin="anonymous"
+      data-clerk-publishable-key="{{pub_key}}"
+      src="https://{{fapi_url}}/npm/@clerk/clerk-js@latest/dist/clerk.browser.js"
+      type="text/javascript"
+    ></script>
 
-            const invitations = data;
-            console.log(`Invitations:`, invitations);
+    <script>
+      window.addEventListener("load", async function () {
+        await Clerk.load();
 
-            if (invitations.length === 0) {
-              console.log("No invitations to revoke.");
-            }
+        if (Clerk.user) {
+          // Check for an active organization
+          if (Clerk.organization) {
+          // Get list of organization invitations
+          const { totalCount, data } = await Clerk.organization.getInvitations();
 
-            // Revoke the first invitation in the list
-            invitations[0].revoke()
-              .then((res) => console.log(res))
-              .catch((error) => console.log(error.errors));
-          } else {
-            // If there is no active organization,
-            // mount Clerk's <OrganizationSwitcher />
-            // to allow the user to set an organization as active
-            document.getElementById("app").innerHTML = `
-              <h2>Select an organization to set it as active</h2>
-              <div id="org-switcher"></div>
-            `;
+          const invitations = data;
+          console.log(`Invitations:`, invitations);
 
-            const orgSwitcherDiv = document.getElementById("org-switcher");
-
-            Clerk.mountOrganizationSwitcher(orgSwitcherDiv);
+          if (invitations.length === 0) {
+            console.log("No invitations to revoke.");
           }
-          } else {
-            document.getElementById("app").innerHTML = `
-              <div id="sign-in"></div>
-            `;
 
-            const signInDiv = document.getElementById("sign-in");
+          // Revoke the first invitation in the list
+          invitations[0].revoke()
+            .then((res) => console.log(res))
+            .catch((error) => console.log(error.errors));
+        } else {
+          // If there is no active organization,
+          // mount Clerk's <OrganizationSwitcher />
+          // to allow the user to set an organization as active
+          document.getElementById("app").innerHTML = `
+            <h2>Select an organization to set it as active</h2>
+            <div id="org-switcher"></div>
+          `;
 
-            Clerk.mountSignIn(signInDiv);
-          }
-        });
-      </script>
-    ```
-  </CodeBlockTabs>
-</InjectKeys>
+          const orgSwitcherDiv = document.getElementById("org-switcher");
+
+          Clerk.mountOrganizationSwitcher(orgSwitcherDiv);
+        }
+        } else {
+          document.getElementById("app").innerHTML = `
+            <div id="sign-in"></div>
+          `;
+
+          const signInDiv = document.getElementById("sign-in");
+
+          Clerk.mountSignIn(signInDiv);
+        }
+      });
+    </script>
+  ```
+</CodeBlockTabs>

--- a/docs/references/javascript/organization/domains.mdx
+++ b/docs/references/javascript/organization/domains.mdx
@@ -35,93 +35,91 @@ function createDomain: (domainName: string) => Promise<OrganizationDomainResourc
 
 ### Example
 
-<InjectKeys>
-  <CodeBlockTabs type="npm-script" options={['NPM module', '<script>']}>
-    ```js {{ prettier: false, filename: 'main.js', mark: [10] }}
-    import { Clerk } from '@clerk/clerk-js';
+<CodeBlockTabs type="npm-script" options={['NPM module', '<script>']}>
+  ```js {{ prettier: false, filename: 'main.js', mark: [10] }}
+  import { Clerk } from '@clerk/clerk-js';
 
-    // Initialize Clerk with your Clerk publishable key
-    const clerk = new Clerk('{{pub_key}}');
-    await clerk.load();
+  // Initialize Clerk with your Clerk publishable key
+  const clerk = new Clerk('{{pub_key}}');
+  await clerk.load();
 
-    if (clerk.user) {
-      // Check for an active organization
-      if (clerk.organization) {
-        await clerk.organization.createDomain("test-domain.com")
-          .then((res) => console.log(res))
-          .catch((error) => console.log("An error occurred:", error.errors));
-      } else {
-        // If there is no active organization,
-        // mount Clerk's <OrganizationSwitcher />
-        // to allow the user to set an organization as active
-        document.getElementById("app").innerHTML = `
-          <h2>Select an organization to set it as active</h2>
-          <div id="org-switcher"></div>
-        `;
-
-        const orgSwitcherDiv = document.getElementById("org-switcher");
-
-        clerk.mountOrganizationSwitcher(orgSwitcherDiv);
-      }
+  if (clerk.user) {
+    // Check for an active organization
+    if (clerk.organization) {
+      await clerk.organization.createDomain("test-domain.com")
+        .then((res) => console.log(res))
+        .catch((error) => console.log("An error occurred:", error.errors));
     } else {
+      // If there is no active organization,
+      // mount Clerk's <OrganizationSwitcher />
+      // to allow the user to set an organization as active
       document.getElementById("app").innerHTML = `
-        <div id="sign-in"></div>
+        <h2>Select an organization to set it as active</h2>
+        <div id="org-switcher"></div>
       `;
 
-      const signInDiv = document.getElementById("sign-in");
+      const orgSwitcherDiv = document.getElementById("org-switcher");
 
-      clerk.mountSignIn(signInDiv);
+      clerk.mountOrganizationSwitcher(orgSwitcherDiv);
     }
-    ```
+  } else {
+    document.getElementById("app").innerHTML = `
+      <div id="sign-in"></div>
+    `;
 
-    ```html {{ prettier: false, filename: 'index.html', mark: [20] }}
-      <div id="app"></div>
+    const signInDiv = document.getElementById("sign-in");
 
-      <!-- Initialize Clerk with your
-      Clerk Publishable key and Frontend API URL -->
-      <script
-        async
-        crossorigin="anonymous"
-        data-clerk-publishable-key="{{pub_key}}"
-        src="https://{{fapi_url}}/npm/@clerk/clerk-js@latest/dist/clerk.browser.js"
-        type="text/javascript"
-      ></script>
+    clerk.mountSignIn(signInDiv);
+  }
+  ```
 
-      <script>
-        window.addEventListener("load", async function () {
-          await Clerk.load();
+  ```html {{ prettier: false, filename: 'index.html', mark: [20] }}
+    <div id="app"></div>
 
-          if (Clerk.user) {
-            // Check for an active organization
-            if (Clerk.organization) {
-              await Clerk.organization.createDomain("test-domain.com")
-                .then((res) => console.log(res))
-                .catch((error) => console.log("An error occurred:", error.errors));
-            } else {
-              // If there is no active organization,
-              // mount Clerk's <OrganizationSwitcher />
-              // to allow the user to set an organization as active
-              document.getElementById("app").innerHTML = `
-                <h2>Select an organization to set it as active</h2>
-                <div id="org-switcher"></div>
-              `;
+    <!-- Initialize Clerk with your
+    Clerk Publishable key and Frontend API URL -->
+    <script
+      async
+      crossorigin="anonymous"
+      data-clerk-publishable-key="{{pub_key}}"
+      src="https://{{fapi_url}}/npm/@clerk/clerk-js@latest/dist/clerk.browser.js"
+      type="text/javascript"
+    ></script>
 
-              const orgSwitcherDiv = document.getElementById("org-switcher");
+    <script>
+      window.addEventListener("load", async function () {
+        await Clerk.load();
 
-              Clerk.mountOrganizationSwitcher(orgSwitcherDiv);
-            }
+        if (Clerk.user) {
+          // Check for an active organization
+          if (Clerk.organization) {
+            await Clerk.organization.createDomain("test-domain.com")
+              .then((res) => console.log(res))
+              .catch((error) => console.log("An error occurred:", error.errors));
           } else {
+            // If there is no active organization,
+            // mount Clerk's <OrganizationSwitcher />
+            // to allow the user to set an organization as active
             document.getElementById("app").innerHTML = `
-              <div id="sign-in"></div>
+              <h2>Select an organization to set it as active</h2>
+              <div id="org-switcher"></div>
             `;
-            const signInDiv = document.getElementById("sign-in");
-            Clerk.mountSignIn(signInDiv);
+
+            const orgSwitcherDiv = document.getElementById("org-switcher");
+
+            Clerk.mountOrganizationSwitcher(orgSwitcherDiv);
           }
-        });
-      </script>
-    ```
-  </CodeBlockTabs>
-</InjectKeys>
+        } else {
+          document.getElementById("app").innerHTML = `
+            <div id="sign-in"></div>
+          `;
+          const signInDiv = document.getElementById("sign-in");
+          Clerk.mountSignIn(signInDiv);
+        }
+      });
+    </script>
+  ```
+</CodeBlockTabs>
 
 ## `getDomains()`
 
@@ -147,93 +145,91 @@ function getDomains(params?: GetDomainsParams): Promise<ClerkPaginatedResponse<O
 
 ### Example
 
-<InjectKeys>
-  <CodeBlockTabs type="npm-script" options={['NPM module', '<script>']}>
-    ```js {{ prettier: false, filename: 'main.js', mark: [10] }}
-    import { Clerk } from '@clerk/clerk-js';
+<CodeBlockTabs type="npm-script" options={['NPM module', '<script>']}>
+  ```js {{ prettier: false, filename: 'main.js', mark: [10] }}
+  import { Clerk } from '@clerk/clerk-js';
 
-    // Initialize Clerk with your Clerk publishable key
-    const clerk = new Clerk('{{pub_key}}');
-    await clerk.load();
+  // Initialize Clerk with your Clerk publishable key
+  const clerk = new Clerk('{{pub_key}}');
+  await clerk.load();
 
-    if (clerk.user) {
-      // Check for an active organization
-      if (clerk.organization) {
-        await clerk.organization.getDomains()
-          .then((res) => console.log(res))
-          .catch((error) => console.log("An error occurred:", error.errors));
-      } else {
-        // If there is no active organization,
-        // mount Clerk's <OrganizationSwitcher />
-        // to allow the user to set an organization as active
-        document.getElementById("app").innerHTML = `
-          <h2>Select an organization to set it as active</h2>
-          <div id="org-switcher"></div>
-        `;
-
-        const orgSwitcherDiv = document.getElementById("org-switcher");
-
-        clerk.mountOrganizationSwitcher(orgSwitcherDiv);
-      }
+  if (clerk.user) {
+    // Check for an active organization
+    if (clerk.organization) {
+      await clerk.organization.getDomains()
+        .then((res) => console.log(res))
+        .catch((error) => console.log("An error occurred:", error.errors));
     } else {
+      // If there is no active organization,
+      // mount Clerk's <OrganizationSwitcher />
+      // to allow the user to set an organization as active
       document.getElementById("app").innerHTML = `
-        <div id="sign-in"></div>
+        <h2>Select an organization to set it as active</h2>
+        <div id="org-switcher"></div>
       `;
 
-      const signInDiv = document.getElementById("sign-in");
+      const orgSwitcherDiv = document.getElementById("org-switcher");
 
-      clerk.mountSignIn(signInDiv);
+      clerk.mountOrganizationSwitcher(orgSwitcherDiv);
     }
-    ```
+  } else {
+    document.getElementById("app").innerHTML = `
+      <div id="sign-in"></div>
+    `;
 
-    ```html {{ prettier: false, filename: 'index.html', mark: [20] }}
-      <div id="app"></div>
+    const signInDiv = document.getElementById("sign-in");
 
-      <!-- Initialize Clerk with your
-      Clerk Publishable key and Frontend API URL -->
-      <script
-        async
-        crossorigin="anonymous"
-        data-clerk-publishable-key="{{pub_key}}"
-        src="https://{{fapi_url}}/npm/@clerk/clerk-js@latest/dist/clerk.browser.js"
-        type="text/javascript"
-      ></script>
+    clerk.mountSignIn(signInDiv);
+  }
+  ```
 
-      <script>
-        window.addEventListener("load", async function () {
-          await Clerk.load();
+  ```html {{ prettier: false, filename: 'index.html', mark: [20] }}
+    <div id="app"></div>
 
-          if (Clerk.user) {
-            // Check for an active organization
-            if (Clerk.organization) {
-              await Clerk.organization.getDomains()
-                .then((res) => console.log(res))
-                .catch((error) => console.log("An error occurred:", error.errors));
-            } else {
-              // If there is no active organization,
-              // mount Clerk's <OrganizationSwitcher />
-              // to allow the user to set an organization as active
-              document.getElementById("app").innerHTML = `
-                <h2>Select an organization to set it as active</h2>
-                <div id="org-switcher"></div>
-              `;
+    <!-- Initialize Clerk with your
+    Clerk Publishable key and Frontend API URL -->
+    <script
+      async
+      crossorigin="anonymous"
+      data-clerk-publishable-key="{{pub_key}}"
+      src="https://{{fapi_url}}/npm/@clerk/clerk-js@latest/dist/clerk.browser.js"
+      type="text/javascript"
+    ></script>
 
-              const orgSwitcherDiv = document.getElementById("org-switcher");
+    <script>
+      window.addEventListener("load", async function () {
+        await Clerk.load();
 
-              Clerk.mountOrganizationSwitcher(orgSwitcherDiv);
-            }
+        if (Clerk.user) {
+          // Check for an active organization
+          if (Clerk.organization) {
+            await Clerk.organization.getDomains()
+              .then((res) => console.log(res))
+              .catch((error) => console.log("An error occurred:", error.errors));
           } else {
+            // If there is no active organization,
+            // mount Clerk's <OrganizationSwitcher />
+            // to allow the user to set an organization as active
             document.getElementById("app").innerHTML = `
-              <div id="sign-in"></div>
+              <h2>Select an organization to set it as active</h2>
+              <div id="org-switcher"></div>
             `;
-            const signInDiv = document.getElementById("sign-in");
-            Clerk.mountSignIn(signInDiv);
+
+            const orgSwitcherDiv = document.getElementById("org-switcher");
+
+            Clerk.mountOrganizationSwitcher(orgSwitcherDiv);
           }
-        });
-      </script>
-    ```
-  </CodeBlockTabs>
-</InjectKeys>
+        } else {
+          document.getElementById("app").innerHTML = `
+            <div id="sign-in"></div>
+          `;
+          const signInDiv = document.getElementById("sign-in");
+          Clerk.mountSignIn(signInDiv);
+        }
+      });
+    </script>
+  ```
+</CodeBlockTabs>
 
 ## `getDomain()`
 
@@ -257,96 +253,94 @@ function getDomain(params: GetDomainParams): Promise<OrganizationDomain>;
 
 ### Example
 
-<InjectKeys>
-  <CodeBlockTabs type="npm-script" options={['NPM module', '<script>']}>
-    ```js {{ prettier: false, filename: 'main.js', mark: [12] }}
-    import { Clerk } from '@clerk/clerk-js';
+<CodeBlockTabs type="npm-script" options={['NPM module', '<script>']}>
+  ```js {{ prettier: false, filename: 'main.js', mark: [12] }}
+  import { Clerk } from '@clerk/clerk-js';
 
-    // Initialize Clerk with your Clerk publishable key
-    const clerk = new Clerk('{{pub_key}}');
-    await clerk.load();
+  // Initialize Clerk with your Clerk publishable key
+  const clerk = new Clerk('{{pub_key}}');
+  await clerk.load();
 
-    if (clerk.user) {
-      // Check for an active organization
-      if (clerk.organization) {
-        const domainId = "orgdmn_123";
+  if (clerk.user) {
+    // Check for an active organization
+    if (clerk.organization) {
+      const domainId = "orgdmn_123";
 
-        await clerk.organization.getDomain({ domainId })
-          .then((res) => console.log(`Domains:`, res))
-          .catch((error) => console.log("An error occurred:", error.errors));
-      } else {
-        // If there is no active organization,
-        // mount Clerk's <OrganizationSwitcher />
-        // to allow the user to set an organization as active
-        document.getElementById("app").innerHTML = `
-          <h2>Select an organization to set it as active</h2>
-          <div id="org-switcher"></div>
-        `;
-
-        const orgSwitcherDiv = document.getElementById("org-switcher");
-
-        clerk.mountOrganizationSwitcher(orgSwitcherDiv);
-      }
+      await clerk.organization.getDomain({ domainId })
+        .then((res) => console.log(`Domains:`, res))
+        .catch((error) => console.log("An error occurred:", error.errors));
     } else {
+      // If there is no active organization,
+      // mount Clerk's <OrganizationSwitcher />
+      // to allow the user to set an organization as active
       document.getElementById("app").innerHTML = `
-        <div id="sign-in"></div>
+        <h2>Select an organization to set it as active</h2>
+        <div id="org-switcher"></div>
       `;
 
-      const signInDiv = document.getElementById("sign-in");
+      const orgSwitcherDiv = document.getElementById("org-switcher");
 
-      clerk.mountSignIn(signInDiv);
+      clerk.mountOrganizationSwitcher(orgSwitcherDiv);
     }
-    ```
+  } else {
+    document.getElementById("app").innerHTML = `
+      <div id="sign-in"></div>
+    `;
 
-    ```html {{ prettier: false, filename: 'index.html', mark: [22] }}
-      <div id="app"></div>
+    const signInDiv = document.getElementById("sign-in");
 
-      <!-- Initialize Clerk with your
-      Clerk Publishable key and Frontend API URL -->
-      <script
-        async
-        crossorigin="anonymous"
-        data-clerk-publishable-key="{{pub_key}}"
-        src="https://{{fapi_url}}/npm/@clerk/clerk-js@latest/dist/clerk.browser.js"
-        type="text/javascript"
-      ></script>
+    clerk.mountSignIn(signInDiv);
+  }
+  ```
 
-      <script>
-        window.addEventListener("load", async function () {
-          await Clerk.load();
+  ```html {{ prettier: false, filename: 'index.html', mark: [22] }}
+    <div id="app"></div>
 
-          if (Clerk.user) {
-            // Check for an active organization
-            if (Clerk.organization) {
-              const domainId = "orgdmn_123";
+    <!-- Initialize Clerk with your
+    Clerk Publishable key and Frontend API URL -->
+    <script
+      async
+      crossorigin="anonymous"
+      data-clerk-publishable-key="{{pub_key}}"
+      src="https://{{fapi_url}}/npm/@clerk/clerk-js@latest/dist/clerk.browser.js"
+      type="text/javascript"
+    ></script>
 
-              await Clerk.organization.getDomain({ domainId })
-                .then((res) => console.log(`Domains:`, res))
-                .catch((error) => console.log("An error occurred:", error.errors));
-            } else {
-              // If there is no active organization,
-              // mount Clerk's <OrganizationSwitcher />
-              // to allow the user to set an organization as active
-              document.getElementById("app").innerHTML = `
-                <h2>Select an organization to set it as active</h2>
-                <div id="org-switcher"></div>
-              `;
+    <script>
+      window.addEventListener("load", async function () {
+        await Clerk.load();
 
-              const orgSwitcherDiv = document.getElementById("org-switcher");
+        if (Clerk.user) {
+          // Check for an active organization
+          if (Clerk.organization) {
+            const domainId = "orgdmn_123";
 
-              Clerk.mountOrganizationSwitcher(orgSwitcherDiv);
-            }
+            await Clerk.organization.getDomain({ domainId })
+              .then((res) => console.log(`Domains:`, res))
+              .catch((error) => console.log("An error occurred:", error.errors));
           } else {
+            // If there is no active organization,
+            // mount Clerk's <OrganizationSwitcher />
+            // to allow the user to set an organization as active
             document.getElementById("app").innerHTML = `
-              <div id="sign-in"></div>
+              <h2>Select an organization to set it as active</h2>
+              <div id="org-switcher"></div>
             `;
-            const signInDiv = document.getElementById("sign-in");
-            Clerk.mountSignIn(signInDiv);
+
+            const orgSwitcherDiv = document.getElementById("org-switcher");
+
+            Clerk.mountOrganizationSwitcher(orgSwitcherDiv);
           }
-        });
-      </script>
-    ```
-  </CodeBlockTabs>
-</InjectKeys>
+        } else {
+          document.getElementById("app").innerHTML = `
+            <div id="sign-in"></div>
+          `;
+          const signInDiv = document.getElementById("sign-in");
+          Clerk.mountSignIn(signInDiv);
+        }
+      });
+    </script>
+  ```
+</CodeBlockTabs>
 
 [org-domain-ref]: /docs/references/javascript/organization-domain

--- a/docs/references/javascript/organization/invitations.mdx
+++ b/docs/references/javascript/organization/invitations.mdx
@@ -36,95 +36,93 @@ function getInvitations(params?: GetInvitationsParams): Promise<ClerkPaginatedRe
 
 ### Example
 
-<InjectKeys>
-  <CodeBlockTabs type="npm-script" options={['NPM module', '<script>']}>
-    ```js {{ prettier: false, filename: 'main.js', mark: [10] }}
-    import { Clerk } from '@clerk/clerk-js';
+<CodeBlockTabs type="npm-script" options={['NPM module', '<script>']}>
+  ```js {{ prettier: false, filename: 'main.js', mark: [10] }}
+  import { Clerk } from '@clerk/clerk-js';
 
-    // Initialize Clerk with your Clerk publishable key
-    const clerk = new Clerk('{{pub_key}}');
-    await clerk.load();
+  // Initialize Clerk with your Clerk publishable key
+  const clerk = new Clerk('{{pub_key}}');
+  await clerk.load();
 
-    if (clerk.user) {
-      // Check for an active organization
-      if (clerk.organization) {
-        await clerk.organization.getInvitations()
-          .then((res) => console.log(res))
-          .catch((error) => console.log("An error occurred:", error.errors));
-      } else {
-        // If there is no active organization,
-        // mount Clerk's <OrganizationSwitcher />
-        // to allow the user to set an organization as active
-        document.getElementById("app").innerHTML = `
-          <h2>Select an organization to set it as active</h2>
-          <div id="org-switcher"></div>
-        `;
-
-        const orgSwitcherDiv = document.getElementById("org-switcher");
-
-        clerk.mountOrganizationSwitcher(orgSwitcherDiv);
-      }
+  if (clerk.user) {
+    // Check for an active organization
+    if (clerk.organization) {
+      await clerk.organization.getInvitations()
+        .then((res) => console.log(res))
+        .catch((error) => console.log("An error occurred:", error.errors));
     } else {
+      // If there is no active organization,
+      // mount Clerk's <OrganizationSwitcher />
+      // to allow the user to set an organization as active
       document.getElementById("app").innerHTML = `
-        <div id="sign-in"></div>
+        <h2>Select an organization to set it as active</h2>
+        <div id="org-switcher"></div>
       `;
 
-      const signInDiv = document.getElementById("sign-in");
+      const orgSwitcherDiv = document.getElementById("org-switcher");
 
-      clerk.mountSignIn(signInDiv);
+      clerk.mountOrganizationSwitcher(orgSwitcherDiv);
     }
-    ```
+  } else {
+    document.getElementById("app").innerHTML = `
+      <div id="sign-in"></div>
+    `;
 
-    ```html {{ prettier: false, filename: 'index.html', mark: [20] }}
-      <div id="app"></div>
+    const signInDiv = document.getElementById("sign-in");
 
-      <!-- Initialize Clerk with your
-      Clerk Publishable key and Frontend API URL -->
-      <script
-        async
-        crossorigin="anonymous"
-        data-clerk-publishable-key="{{pub_key}}"
-        src="https://{{fapi_url}}/npm/@clerk/clerk-js@latest/dist/clerk.browser.js"
-        type="text/javascript"
-      ></script>
+    clerk.mountSignIn(signInDiv);
+  }
+  ```
 
-      <script>
-        window.addEventListener("load", async function () {
-          await Clerk.load();
+  ```html {{ prettier: false, filename: 'index.html', mark: [20] }}
+    <div id="app"></div>
 
-          if (Clerk.user) {
-            // Check for an active organization
-            if (Clerk.organization) {
-              await Clerk.organization.getInvitations()
-                .then((res) => console.log(res))
-                .catch((error) => console.log("An error occurred:", error.errors));
-            } else {
-              // If there is no active organization,
-              // mount Clerk's <OrganizationSwitcher />
-              // to allow the user to set an organization as active
-              document.getElementById("app").innerHTML = `
-                <h2>Select an organization to set it as active</h2>
-                <div id="org-switcher"></div>
-              `;
+    <!-- Initialize Clerk with your
+    Clerk Publishable key and Frontend API URL -->
+    <script
+      async
+      crossorigin="anonymous"
+      data-clerk-publishable-key="{{pub_key}}"
+      src="https://{{fapi_url}}/npm/@clerk/clerk-js@latest/dist/clerk.browser.js"
+      type="text/javascript"
+    ></script>
 
-              const orgSwitcherDiv = document.getElementById("org-switcher");
+    <script>
+      window.addEventListener("load", async function () {
+        await Clerk.load();
 
-              Clerk.mountOrganizationSwitcher(orgSwitcherDiv);
-            }
+        if (Clerk.user) {
+          // Check for an active organization
+          if (Clerk.organization) {
+            await Clerk.organization.getInvitations()
+              .then((res) => console.log(res))
+              .catch((error) => console.log("An error occurred:", error.errors));
           } else {
+            // If there is no active organization,
+            // mount Clerk's <OrganizationSwitcher />
+            // to allow the user to set an organization as active
             document.getElementById("app").innerHTML = `
-              <div id="sign-in"></div>
+              <h2>Select an organization to set it as active</h2>
+              <div id="org-switcher"></div>
             `;
 
-            const signInDiv = document.getElementById("sign-in");
+            const orgSwitcherDiv = document.getElementById("org-switcher");
 
-            Clerk.mountSignIn(signInDiv);
+            Clerk.mountOrganizationSwitcher(orgSwitcherDiv);
           }
-        });
-      </script>
-    ```
-  </CodeBlockTabs>
-</InjectKeys>
+        } else {
+          document.getElementById("app").innerHTML = `
+            <div id="sign-in"></div>
+          `;
+
+          const signInDiv = document.getElementById("sign-in");
+
+          Clerk.mountSignIn(signInDiv);
+        }
+      });
+    </script>
+  ```
+</CodeBlockTabs>
 
 ## `inviteMember()`
 
@@ -149,101 +147,99 @@ function inviteMember(params: InviteMemberParams): Promise<OrganizationInvitatio
 
 ### Example
 
-<InjectKeys>
-  <CodeBlockTabs type="npm-script" options={['NPM module', '<script>']}>
-    ```js {{ prettier: false, filename: 'main.js', mark: [13] }}
-    import { Clerk } from '@clerk/clerk-js';
+<CodeBlockTabs type="npm-script" options={['NPM module', '<script>']}>
+  ```js {{ prettier: false, filename: 'main.js', mark: [13] }}
+  import { Clerk } from '@clerk/clerk-js';
 
-    // Initialize Clerk with your Clerk publishable key
-    const clerk = new Clerk('{{pub_key}}');
-    await clerk.load();
+  // Initialize Clerk with your Clerk publishable key
+  const clerk = new Clerk('{{pub_key}}');
+  await clerk.load();
 
-    if (clerk.user) {
-      // Check for an active organization
-      if (clerk.organization) {
-        const emailAddress = "test@test.com";
-        const role = "org:member";
+  if (clerk.user) {
+    // Check for an active organization
+    if (clerk.organization) {
+      const emailAddress = "test@test.com";
+      const role = "org:member";
 
-        await clerk.organization.inviteMember({ emailAddress, role })
-          .then((res) => console.log(res))
-          .catch((error) => console.log("An error occurred:", error.errors));
-      } else {
-        // If there is no active organization,
-        // mount Clerk's <OrganizationSwitcher />
-        // to allow the user to set an organization as active
-        document.getElementById("app").innerHTML = `
-          <h2>Select an organization to set it as active</h2>
-          <div id="org-switcher"></div>
-        `;
-
-        const orgSwitcherDiv = document.getElementById("org-switcher");
-
-        clerk.mountOrganizationSwitcher(orgSwitcherDiv);
-      }
+      await clerk.organization.inviteMember({ emailAddress, role })
+        .then((res) => console.log(res))
+        .catch((error) => console.log("An error occurred:", error.errors));
     } else {
+      // If there is no active organization,
+      // mount Clerk's <OrganizationSwitcher />
+      // to allow the user to set an organization as active
       document.getElementById("app").innerHTML = `
-        <div id="sign-in"></div>
+        <h2>Select an organization to set it as active</h2>
+        <div id="org-switcher"></div>
       `;
 
-      const signInDiv = document.getElementById("sign-in");
+      const orgSwitcherDiv = document.getElementById("org-switcher");
 
-      clerk.mountSignIn(signInDiv);
+      clerk.mountOrganizationSwitcher(orgSwitcherDiv);
     }
-    ```
+  } else {
+    document.getElementById("app").innerHTML = `
+      <div id="sign-in"></div>
+    `;
 
-    ```html {{ prettier: false, filename: 'index.html', mark: [23] }}
-      <div id="app"></div>
+    const signInDiv = document.getElementById("sign-in");
 
-      <!-- Initialize Clerk with your
-      Clerk Publishable key and Frontend API URL -->
-      <script
-        async
-        crossorigin="anonymous"
-        data-clerk-publishable-key="{{pub_key}}"
-        src="https://{{fapi_url}}/npm/@clerk/clerk-js@latest/dist/clerk.browser.js"
-        type="text/javascript"
-      ></script>
+    clerk.mountSignIn(signInDiv);
+  }
+  ```
 
-      <script>
-        window.addEventListener("load", async function () {
-          await Clerk.load();
+  ```html {{ prettier: false, filename: 'index.html', mark: [23] }}
+    <div id="app"></div>
 
-          if (Clerk.user) {
-            // Check for an active organization
-            if (Clerk.organization) {
-              const emailAddress = "test@test.com";
-              const role = "org:member";
+    <!-- Initialize Clerk with your
+    Clerk Publishable key and Frontend API URL -->
+    <script
+      async
+      crossorigin="anonymous"
+      data-clerk-publishable-key="{{pub_key}}"
+      src="https://{{fapi_url}}/npm/@clerk/clerk-js@latest/dist/clerk.browser.js"
+      type="text/javascript"
+    ></script>
 
-              await Clerk.organization.inviteMember({ emailAddress, role })
-                .then((res) => console.log(res))
-                .catch((error) => console.log("An error occurred:", error.errors));
-            } else {
-              // If there is no active organization,
-              // mount Clerk's <OrganizationSwitcher />
-              // to allow the user to set an organization as active
-              document.getElementById("app").innerHTML = `
-                <h2>Select an organization to set it as active</h2>
-                <div id="org-switcher"></div>
-              `;
+    <script>
+      window.addEventListener("load", async function () {
+        await Clerk.load();
 
-              const orgSwitcherDiv = document.getElementById("org-switcher");
+        if (Clerk.user) {
+          // Check for an active organization
+          if (Clerk.organization) {
+            const emailAddress = "test@test.com";
+            const role = "org:member";
 
-              Clerk.mountOrganizationSwitcher(orgSwitcherDiv);
-            }
+            await Clerk.organization.inviteMember({ emailAddress, role })
+              .then((res) => console.log(res))
+              .catch((error) => console.log("An error occurred:", error.errors));
           } else {
+            // If there is no active organization,
+            // mount Clerk's <OrganizationSwitcher />
+            // to allow the user to set an organization as active
             document.getElementById("app").innerHTML = `
-              <div id="sign-in"></div>
+              <h2>Select an organization to set it as active</h2>
+              <div id="org-switcher"></div>
             `;
 
-            const signInDiv = document.getElementById("sign-in");
+            const orgSwitcherDiv = document.getElementById("org-switcher");
 
-            Clerk.mountSignIn(signInDiv);
+            Clerk.mountOrganizationSwitcher(orgSwitcherDiv);
           }
-        });
-      </script>
-    ```
-  </CodeBlockTabs>
-</InjectKeys>
+        } else {
+          document.getElementById("app").innerHTML = `
+            <div id="sign-in"></div>
+          `;
+
+          const signInDiv = document.getElementById("sign-in");
+
+          Clerk.mountSignIn(signInDiv);
+        }
+      });
+    </script>
+  ```
+</CodeBlockTabs>
 
 ## `inviteMembers()`
 
@@ -268,100 +264,98 @@ function inviteMembers(params: InviteMembersParams): Promise<OrganizationInvitat
 
 ### Example
 
-<InjectKeys>
-  <CodeBlockTabs type="npm-script" options={['NPM module', '<script>']}>
-    ```js {{ prettier: false, filename: 'main.js', mark: [13] }}
-    import { Clerk } from '@clerk/clerk-js';
+<CodeBlockTabs type="npm-script" options={['NPM module', '<script>']}>
+  ```js {{ prettier: false, filename: 'main.js', mark: [13] }}
+  import { Clerk } from '@clerk/clerk-js';
 
-    // Initialize Clerk with your Clerk publishable key
-    const clerk = new Clerk('{{pub_key}}');
-    await clerk.load();
+  // Initialize Clerk with your Clerk publishable key
+  const clerk = new Clerk('{{pub_key}}');
+  await clerk.load();
 
-    if (clerk.user) {
-      // Check for an active organization
-      if (clerk.organization) {
-        const emailAddresses = ["test@test.com", "test2@test.com", "test3@test.com"];
-        const role = "org:member";
+  if (clerk.user) {
+    // Check for an active organization
+    if (clerk.organization) {
+      const emailAddresses = ["test@test.com", "test2@test.com", "test3@test.com"];
+      const role = "org:member";
 
-        await clerk.organization.inviteMembers({ emailAddresses, role })
-          .then((res) => console.log(res))
-          .catch((error) => console.log("An error occurred:", error.errors));
-      } else {
-        // If there is no active organization,
-        // mount Clerk's <OrganizationSwitcher />
-        // to allow the user to set an organization as active
-        document.getElementById("app").innerHTML = `
-          <h2>Select an organization to set it as active</h2>
-          <div id="org-switcher"></div>
-        `;
-
-        const orgSwitcherDiv = document.getElementById("org-switcher");
-
-        clerk.mountOrganizationSwitcher(orgSwitcherDiv);
-      }
+      await clerk.organization.inviteMembers({ emailAddresses, role })
+        .then((res) => console.log(res))
+        .catch((error) => console.log("An error occurred:", error.errors));
     } else {
+      // If there is no active organization,
+      // mount Clerk's <OrganizationSwitcher />
+      // to allow the user to set an organization as active
       document.getElementById("app").innerHTML = `
-        <div id="sign-in"></div>
+        <h2>Select an organization to set it as active</h2>
+        <div id="org-switcher"></div>
       `;
 
-      const signInDiv = document.getElementById("sign-in");
+      const orgSwitcherDiv = document.getElementById("org-switcher");
 
-      clerk.mountSignIn(signInDiv);
+      clerk.mountOrganizationSwitcher(orgSwitcherDiv);
     }
-    ```
+  } else {
+    document.getElementById("app").innerHTML = `
+      <div id="sign-in"></div>
+    `;
 
-    ```html {{ prettier: false, filename: 'index.html', mark: [23] }}
-      <div id="app"></div>
+    const signInDiv = document.getElementById("sign-in");
 
-      <!-- Initialize Clerk with your
-      Clerk Publishable key and Frontend API URL -->
-      <script
-        async
-        crossorigin="anonymous"
-        data-clerk-publishable-key="{{pub_key}}"
-        src="https://{{fapi_url}}/npm/@clerk/clerk-js@latest/dist/clerk.browser.js"
-        type="text/javascript"
-      ></script>
+    clerk.mountSignIn(signInDiv);
+  }
+  ```
 
-      <script>
-        window.addEventListener("load", async function () {
-          await Clerk.load();
+  ```html {{ prettier: false, filename: 'index.html', mark: [23] }}
+    <div id="app"></div>
 
-          if (Clerk.user) {
-            // Check for an active organization
-            if (Clerk.organization) {
-              const emailAddresses = ["test@test.com", "test2@test.com", "test3@test.com"];
-              const role = "org:member";
+    <!-- Initialize Clerk with your
+    Clerk Publishable key and Frontend API URL -->
+    <script
+      async
+      crossorigin="anonymous"
+      data-clerk-publishable-key="{{pub_key}}"
+      src="https://{{fapi_url}}/npm/@clerk/clerk-js@latest/dist/clerk.browser.js"
+      type="text/javascript"
+    ></script>
 
-              await Clerk.organization.inviteMembers({ emailAddresses, role })
-                .then((res) => console.log(res))
-                .catch((error) => console.log("An error occurred:", error.errors));
-            } else {
-              // If there is no active organization,
-              // mount Clerk's <OrganizationSwitcher />
-              // to allow the user to set an organization as active
-              document.getElementById("app").innerHTML = `
-                <h2>Select an organization to set it as active</h2>
-                <div id="org-switcher"></div>
-              `;
+    <script>
+      window.addEventListener("load", async function () {
+        await Clerk.load();
 
-              const orgSwitcherDiv = document.getElementById("org-switcher");
+        if (Clerk.user) {
+          // Check for an active organization
+          if (Clerk.organization) {
+            const emailAddresses = ["test@test.com", "test2@test.com", "test3@test.com"];
+            const role = "org:member";
 
-              Clerk.mountOrganizationSwitcher(orgSwitcherDiv);
-            }
+            await Clerk.organization.inviteMembers({ emailAddresses, role })
+              .then((res) => console.log(res))
+              .catch((error) => console.log("An error occurred:", error.errors));
           } else {
+            // If there is no active organization,
+            // mount Clerk's <OrganizationSwitcher />
+            // to allow the user to set an organization as active
             document.getElementById("app").innerHTML = `
-              <div id="sign-in"></div>
+              <h2>Select an organization to set it as active</h2>
+              <div id="org-switcher"></div>
             `;
 
-            const signInDiv = document.getElementById("sign-in");
+            const orgSwitcherDiv = document.getElementById("org-switcher");
 
-            Clerk.mountSignIn(signInDiv);
+            Clerk.mountOrganizationSwitcher(orgSwitcherDiv);
           }
-        });
-      </script>
-    ```
-  </CodeBlockTabs>
-</InjectKeys>
+        } else {
+          document.getElementById("app").innerHTML = `
+            <div id="sign-in"></div>
+          `;
+
+          const signInDiv = document.getElementById("sign-in");
+
+          Clerk.mountSignIn(signInDiv);
+        }
+      });
+    </script>
+  ```
+</CodeBlockTabs>
 
 [orginv-ref]: /docs/references/javascript/organization-invitation

--- a/docs/references/javascript/organization/members.mdx
+++ b/docs/references/javascript/organization/members.mdx
@@ -106,453 +106,451 @@ function removeMember(userId: string): Promise<OrganizationMembership>;
 
 The following example demonstrates how to use the organization membership methods to manage the members of an organization. To ease the development process, the response or error message of a method will be displayed on the user interface.
 
-<InjectKeys>
-  <Tabs type="npm-script" items={['NPM module', '<script>']}>
-    <Tab>
-      For the following example, your HTML file should look like this:
+<Tabs type="npm-script" items={['NPM module', '<script>']}>
+  <Tab>
+    For the following example, your HTML file should look like this:
 
-      ```html {{ prettier: false, filename: 'index.html' }}
-      <!doctype html>
-      <html lang="en">
-        <head>
-          <meta charset="UTF-8" />
-          <link rel="icon" type="image/svg+xml" href="/vite.svg" />
-          <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-          <title>Clerk + JavaScript App</title>
-          <style>
-            /* Style for the table */
-            table {
-              border-collapse: collapse; /* Collapse borders into a single border */
-              border: 1px solid black; /* Border for the entire table */
-            }
-
-            /* Style for table cells */
-            td,
-            th {
-              border: 1px solid black; /* Border for each cell */
-              padding: 2px; /* Optional: Add padding to cells */
-            }
-          </style>
-        </head>
-        <body>
-          <div id="app"></div>
-
-          <p id="error-container" hidden>
-            Error:
-            <span id="error-message"></span>
-          </p>
-
-          <h2>Memberships List</h2>
-          <table id="memberships_table">
-            <thead>
-              <tr>
-                <th>User ID</th>
-                <th>Identifier</th>
-                <th>Role</th>
-                <th id="update-role-head" hidden>Update role</th>
-                <th id="remove-member-head" hidden>Remove member</th>
-              </tr>
-            </thead>
-            <tbody id="memberships_table_body"></tbody>
-          </table>
-
-          <div id="add-member-container">
-            <h2>Add member</h2>
-            <input id="member-user-id" placeholder="Enter member's user ID" />
-            <button id="add-member">Add member</button>
-          </div>
-
-          <h2>Response:</p>
-          <pre id="response"></pre>
-
-          <script type="module" src="/main.js"></script>
-        </body>
-      </html>
-      ```
-
-      And your JavaScript file should look like this:
-
-      ```js {{ prettier: false, filename: 'main.js', mark: [13, 41, 60, 79] }}
-      import { Clerk } from '@clerk/clerk-js';
-
-      // Initialize Clerk with your Clerk publishable key
-      const clerk = new Clerk('{{pub_key}}');
-      await clerk.load();
-
-      if (clerk.user) {
-        // Check for an active organization
-        if (clerk.organization) {
-          // Render list of organization memberships
-          async function renderMemberships(organization, isAdmin) {
-            try {
-              const { data } = await organization.getMemberships();
-
-              const memberships = data;
-              console.log(`getMemberships:`, memberships);
-
-              memberships.map((membership) => {
-                const membershipTable = document.getElementById("memberships_table");
-                const row = membershipTable.insertRow();
-                row.insertCell().textContent = membership.publicUserData.userId;
-                row.insertCell().textContent = membership.publicUserData.identifier;
-                row.insertCell().textContent = membership.role;
-
-                // Add administrative actions:
-                // Add and remove a member, and update a member's role.
-                if (isAdmin) {
-                  // Show add, update, remove member buttons
-                  document.getElementById("add-member-container").removeAttribute("hidden");
-                  document.getElementById("update-role-head").removeAttribute("hidden");
-                  document.getElementById("remove-member-head").removeAttribute("hidden");
-
-                  // Get the user ID of the member
-                  const userId = membership.publicUserData.userId;
-
-                  // Update a member's role
-                  const updateBtn = document.createElement("button");
-                  updateBtn.textContent = "Change role";
-                  updateBtn.addEventListener("click", async function (e) {
-                    e.preventDefault();
-                    const role =
-                      membership.role === "org:admin" ? "org:member" : "org:admin";
-                    await organization.updateMember({ userId, role })
-                      .then((res) => {
-                        document.getElementById("response").innerHTML =
-                          JSON.stringify(res);
-                      })
-                      .catch((error) => {
-                        document.getElementById("error-container").removeAttribute("hidden");
-                        document.getElementById("error-message").innerHTML =
-                          error.errors[0].longMessage;
-                        console.log("An error occurred:", error.errors);
-                      });
-                  });
-                  row.insertCell().appendChild(updateBtn);
-
-                  // Remove a member
-                  const removeBtn = document.createElement("button");
-                  removeBtn.textContent = "Remove";
-                  removeBtn.addEventListener("click", async function (e) {
-                    e.preventDefault();
-                    await organization.removeMember(userId)
-                      .then((res) => {
-                        document.getElementById("response").innerHTML =
-                          JSON.stringify(res);
-                      })
-                      .catch((error) => {
-                        document.getElementById("error-container").removeAttribute("hidden");
-                        document.getElementById("error-message").innerHTML =
-                          error.errors[0].longMessage;
-                        console.log("An error occurred:", error.errors);
-                      });
-                  });
-                  row.insertCell().appendChild(removeBtn);
-
-                  // Add a new member to the organization
-                  document.getElementById("add-member")
-                    .addEventListener("click", () => {
-                      const userId = document.getElementById("member-user-id").value;
-
-                      organization.addMember({ userId, role: "org:member" })
-                        .then((res) => {
-                          document.getElementById("response").innerHTML =
-                            JSON.stringify(res);
-                        })
-                        .catch((error) => {
-                          document.getElementById("error-container").removeAttribute("hidden");
-                          document.getElementById("error-message").innerHTML =
-                            error.errors[0].longMessage;
-                          console.log("An error occurred:", error.errors);
-                        });
-                    });
-                }
-              });
-            } catch (error) {
-              document.getElementById("error-container").removeAttribute("hidden");
-              document.getElementById("error-message").innerHTML =
-                error.errors[0].longMessage;
-              console.log("An error occurred:", error.errors);
-            }
+    ```html {{ prettier: false, filename: 'index.html' }}
+    <!doctype html>
+    <html lang="en">
+      <head>
+        <meta charset="UTF-8" />
+        <link rel="icon" type="image/svg+xml" href="/vite.svg" />
+        <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+        <title>Clerk + JavaScript App</title>
+        <style>
+          /* Style for the table */
+          table {
+            border-collapse: collapse; /* Collapse borders into a single border */
+            border: 1px solid black; /* Border for the entire table */
           }
 
-          /**
-           * Checks if a user is an admin of the
-           * currently active organization and
-           * renders the organization's memberships.
-           */
-          async function checkAdminAndRenderMemberships() {
-            const organizationId = clerk.organization.id;
-
-            const { data } =
-              await clerk.user.getOrganizationMemberships();
-
-            const organizationMemberships = data;
-
-            const currentMembership = organizationMemberships.find(
-              (membership) => membership.organization.id === organizationId
-            );
-            const currentOrganization = currentMembership.organization;
-
-            if (!currentOrganization) {
-              return;
-            }
-            const isAdmin = currentMembership.role === "org:admin";
-
-            console.log(`Organization:`, currentOrganization);
-
-            renderMemberships(currentOrganization, isAdmin);
+          /* Style for table cells */
+          td,
+          th {
+            border: 1px solid black; /* Border for each cell */
+            padding: 2px; /* Optional: Add padding to cells */
           }
+        </style>
+      </head>
+      <body>
+        <div id="app"></div>
 
-          checkAdminAndRenderMemberships();
-        } else {
-          // If there is no active organization,
-          // mount Clerk's <OrganizationSwitcher />
-          // to allow the user to set an organization as active
-          document.getElementById("app").innerHTML = `
-            <h2>Select an organization to set it as active</h2>
-            <div id="org-switcher"></div>
-          `;
+        <p id="error-container" hidden>
+          Error:
+          <span id="error-message"></span>
+        </p>
 
-          const orgSwitcherDiv = document.getElementById("org-switcher");
+        <h2>Memberships List</h2>
+        <table id="memberships_table">
+          <thead>
+            <tr>
+              <th>User ID</th>
+              <th>Identifier</th>
+              <th>Role</th>
+              <th id="update-role-head" hidden>Update role</th>
+              <th id="remove-member-head" hidden>Remove member</th>
+            </tr>
+          </thead>
+          <tbody id="memberships_table_body"></tbody>
+        </table>
 
-          clerk.mountOrganizationSwitcher(orgSwitcherDiv);
-        }
-      } else {
-        document.getElementById("app").innerHTML = `
-          <div id="sign-in"></div>
-        `;
+        <div id="add-member-container">
+          <h2>Add member</h2>
+          <input id="member-user-id" placeholder="Enter member's user ID" />
+          <button id="add-member">Add member</button>
+        </div>
 
-        const signInDiv = document.getElementById("sign-in");
+        <h2>Response:</p>
+        <pre id="response"></pre>
 
-        clerk.mountSignIn(signInDiv);
-      }
-      ```
-    </Tab>
+        <script type="module" src="/main.js"></script>
+      </body>
+    </html>
+    ```
 
-    <Tab>
-      ```html {{ prettier: false, filename: 'index.html', mark: [74, 102, 121, 140] }}
-      <!doctype html>
-      <html lang="en">
-        <head>
-          <meta charset="UTF-8" />
-          <link rel="icon" type="image/svg+xml" href="/vite.svg" />
-          <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-          <title>Clerk + JavaScript App</title>
-          <style>
-            /* Style for the table */
-            table {
-              border-collapse: collapse; /* Collapse borders into a single border */
-              border: 1px solid black; /* Border for the entire table */
-            }
+    And your JavaScript file should look like this:
 
-            /* Style for table cells */
-            td,
-            th {
-              border: 1px solid black; /* Border for each cell */
-              padding: 2px; /* Optional: Add padding to cells */
-            }
-          </style>
-        </head>
-        <body>
-          <div id="app"></div>
+    ```js {{ prettier: false, filename: 'main.js', mark: [13, 41, 60, 79] }}
+    import { Clerk } from '@clerk/clerk-js';
 
-          <p id="error-container" hidden>
-            Error:
-            <span id="error-message"></span>
-          </p>
+    // Initialize Clerk with your Clerk publishable key
+    const clerk = new Clerk('{{pub_key}}');
+    await clerk.load();
 
-          <h2>Memberships List</h2>
-          <table id="memberships_table">
-            <thead>
-              <tr>
-                <th>User ID</th>
-                <th>Identifier</th>
-                <th>Role</th>
-                <th id="update-role-head" hidden>Update role</th>
-                <th id="remove-member-head" hidden>Remove member</th>
-              </tr>
-            </thead>
-            <tbody id="memberships_table_body"></tbody>
-          </table>
+    if (clerk.user) {
+      // Check for an active organization
+      if (clerk.organization) {
+        // Render list of organization memberships
+        async function renderMemberships(organization, isAdmin) {
+          try {
+            const { data } = await organization.getMemberships();
 
-          <div id="add-member-container">
-            <h2>Add member</h2>
-            <input id="member-user-id" placeholder="Enter member's user ID" />
-            <button id="add-member">Add member</button>
-          </div>
+            const memberships = data;
+            console.log(`getMemberships:`, memberships);
 
-          <h2>Response:</p>
-          <pre id="response"></pre>
+            memberships.map((membership) => {
+              const membershipTable = document.getElementById("memberships_table");
+              const row = membershipTable.insertRow();
+              row.insertCell().textContent = membership.publicUserData.userId;
+              row.insertCell().textContent = membership.publicUserData.identifier;
+              row.insertCell().textContent = membership.role;
 
-          <!-- Initialize Clerk with your
-          Clerk Publishable key and Frontend API URL -->
-          <script
-            async
-            crossorigin="anonymous"
-            data-clerk-publishable-key="{{pub_key}}"
-            src="https://{{fapi_url}}/npm/@clerk/clerk-js@latest/dist/clerk.browser.js"
-            type="text/javascript"
-          ></script>
+              // Add administrative actions:
+              // Add and remove a member, and update a member's role.
+              if (isAdmin) {
+                // Show add, update, remove member buttons
+                document.getElementById("add-member-container").removeAttribute("hidden");
+                document.getElementById("update-role-head").removeAttribute("hidden");
+                document.getElementById("remove-member-head").removeAttribute("hidden");
 
-          <script>
-            window.addEventListener("load", async function () {
-              await Clerk.load();
+                // Get the user ID of the member
+                const userId = membership.publicUserData.userId;
 
-              if (Clerk.user) {
-                // Check for an active organization
-                if (Clerk.organization) {
-                  // Render list of organization memberships
-                  async function renderMemberships(organization, isAdmin) {
-                    try {
-                      const { data } = await organization.getMemberships();
-
-                      const memberships = data;
-                      console.log(`getMemberships:`, memberships);
-
-                      memberships.map((membership) => {
-                        const membershipTable = document.getElementById("memberships_table");
-                        const row = membershipTable.insertRow();
-                        row.insertCell().textContent = membership.publicUserData.userId;
-                        row.insertCell().textContent = membership.publicUserData.identifier;
-                        row.insertCell().textContent = membership.role;
-
-                        // Add administrative actions:
-                        // Add and remove a member, and update a member's role.
-                        if (isAdmin) {
-                          // Show add, update, remove member buttons
-                          document.getElementById("add-member-container").removeAttribute("hidden");
-                          document.getElementById("update-role-head").removeAttribute("hidden");
-                          document.getElementById("remove-member-head").removeAttribute("hidden");
-
-                          // Get the user ID of the member
-                          const userId = membership.publicUserData.userId;
-
-                          // Update a member's role
-                          const updateBtn = document.createElement("button");
-                          updateBtn.textContent = "Change role";
-                          updateBtn.addEventListener("click", async function (e) {
-                            e.preventDefault();
-                            const role =
-                              membership.role === "org:admin" ? "org:member" : "org:admin";
-                            await organization.updateMember({ userId, role })
-                              .then((res) => {
-                                document.getElementById("response").innerHTML =
-                                  JSON.stringify(res);
-                              })
-                              .catch((error) => {
-                                document.getElementById("error-container").removeAttribute("hidden");
-                                document.getElementById("error-message").innerHTML =
-                                  error.errors[0].longMessage;
-                                console.log("An error occurred:", error.errors);
-                              });
-                          });
-                          row.insertCell().appendChild(updateBtn);
-
-                          // Remove a member
-                          const removeBtn = document.createElement("button");
-                          removeBtn.textContent = "Remove";
-                          removeBtn.addEventListener("click", async function (e) {
-                            e.preventDefault();
-                            await organization.removeMember(userId)
-                              .then((res) => {
-                                document.getElementById("response").innerHTML =
-                                  JSON.stringify(res);
-                              })
-                              .catch((error) => {
-                                document.getElementById("error-container").removeAttribute("hidden");
-                                document.getElementById("error-message").innerHTML =
-                                  error.errors[0].longMessage;
-                                console.log("An error occurred:", error.errors);
-                              });
-                          });
-                          row.insertCell().appendChild(removeBtn);
-
-                          // Add a new member to the organization
-                          document.getElementById("add-member")
-                            .addEventListener("click", () => {
-                              const userId = document.getElementById("member-user-id").value;
-
-                              organization.addMember({ userId, role: "org:member" })
-                              .then((res) => {
-                                document.getElementById("response").innerHTML =
-                                  JSON.stringify(res);
-                              })
-                              .catch((error) => {
-                                document.getElementById("error-container").removeAttribute("hidden");
-                                document.getElementById("error-message").innerHTML =
-                                  error.errors[0].longMessage;
-                                console.log("An error occurred:", error.errors);
-                              });
-                            });
-                        }
-                      });
-                    } catch (error) {
+                // Update a member's role
+                const updateBtn = document.createElement("button");
+                updateBtn.textContent = "Change role";
+                updateBtn.addEventListener("click", async function (e) {
+                  e.preventDefault();
+                  const role =
+                    membership.role === "org:admin" ? "org:member" : "org:admin";
+                  await organization.updateMember({ userId, role })
+                    .then((res) => {
+                      document.getElementById("response").innerHTML =
+                        JSON.stringify(res);
+                    })
+                    .catch((error) => {
                       document.getElementById("error-container").removeAttribute("hidden");
                       document.getElementById("error-message").innerHTML =
                         error.errors[0].longMessage;
                       console.log("An error occurred:", error.errors);
-                    }
-                  }
+                    });
+                });
+                row.insertCell().appendChild(updateBtn);
 
-                  /**
-                  * Checks if a user is an admin of the
-                  * currently active organization and
-                  * renders the organization's memberships.
-                  */
-                  async function checkAdminAndRenderMemberships() {
-                    const organizationId = Clerk.organization.id;
+                // Remove a member
+                const removeBtn = document.createElement("button");
+                removeBtn.textContent = "Remove";
+                removeBtn.addEventListener("click", async function (e) {
+                  e.preventDefault();
+                  await organization.removeMember(userId)
+                    .then((res) => {
+                      document.getElementById("response").innerHTML =
+                        JSON.stringify(res);
+                    })
+                    .catch((error) => {
+                      document.getElementById("error-container").removeAttribute("hidden");
+                      document.getElementById("error-message").innerHTML =
+                        error.errors[0].longMessage;
+                      console.log("An error occurred:", error.errors);
+                    });
+                });
+                row.insertCell().appendChild(removeBtn);
 
-                    const { data } =
-                      await Clerk.user.getOrganizationMemberships();
+                // Add a new member to the organization
+                document.getElementById("add-member")
+                  .addEventListener("click", () => {
+                    const userId = document.getElementById("member-user-id").value;
 
-                    const organizationMemberships = data;
-
-                    const currentMembership = organizationMemberships.find(
-                      (membership) => membership.organization.id === organizationId
-                    );
-                    const currentOrganization = currentMembership.organization;
-
-                    if (!currentOrganization) {
-                      return;
-                    }
-                    const isAdmin = currentMembership.role === "org:admin";
-
-                    console.log(`Organization:`, currentOrganization);
-
-                    renderMemberships(currentOrganization, isAdmin);
-                  }
-
-                  checkAdminAndRenderMemberships();
-                } else {
-                  // If there is no active organization,
-                  // mount Clerk's <OrganizationSwitcher />
-                  // to allow the user to set an organization as active
-                  document.getElementById("app").innerHTML = `
-                    <h2>Select an organization to set it as active</h2>
-                    <div id="org-switcher"></div>
-                  `;
-
-                  const orgSwitcherDiv = document.getElementById("org-switcher");
-
-                  Clerk.mountOrganizationSwitcher(orgSwitcherDiv);
-                }
-              } else {
-                document.getElementById("app").innerHTML = `
-                  <div id="sign-in"></div>
-                `;
-
-                const signInDiv = document.getElementById("sign-in");
-
-                Clerk.mountSignIn(signInDiv);
+                    organization.addMember({ userId, role: "org:member" })
+                      .then((res) => {
+                        document.getElementById("response").innerHTML =
+                          JSON.stringify(res);
+                      })
+                      .catch((error) => {
+                        document.getElementById("error-container").removeAttribute("hidden");
+                        document.getElementById("error-message").innerHTML =
+                          error.errors[0].longMessage;
+                        console.log("An error occurred:", error.errors);
+                      });
+                  });
               }
             });
-          </script>
-        </body>
-      </html>
-      ```
-    </Tab>
-  </Tabs>
-</InjectKeys>
+          } catch (error) {
+            document.getElementById("error-container").removeAttribute("hidden");
+            document.getElementById("error-message").innerHTML =
+              error.errors[0].longMessage;
+            console.log("An error occurred:", error.errors);
+          }
+        }
+
+        /**
+         * Checks if a user is an admin of the
+         * currently active organization and
+         * renders the organization's memberships.
+         */
+        async function checkAdminAndRenderMemberships() {
+          const organizationId = clerk.organization.id;
+
+          const { data } =
+            await clerk.user.getOrganizationMemberships();
+
+          const organizationMemberships = data;
+
+          const currentMembership = organizationMemberships.find(
+            (membership) => membership.organization.id === organizationId
+          );
+          const currentOrganization = currentMembership.organization;
+
+          if (!currentOrganization) {
+            return;
+          }
+          const isAdmin = currentMembership.role === "org:admin";
+
+          console.log(`Organization:`, currentOrganization);
+
+          renderMemberships(currentOrganization, isAdmin);
+        }
+
+        checkAdminAndRenderMemberships();
+      } else {
+        // If there is no active organization,
+        // mount Clerk's <OrganizationSwitcher />
+        // to allow the user to set an organization as active
+        document.getElementById("app").innerHTML = `
+          <h2>Select an organization to set it as active</h2>
+          <div id="org-switcher"></div>
+        `;
+
+        const orgSwitcherDiv = document.getElementById("org-switcher");
+
+        clerk.mountOrganizationSwitcher(orgSwitcherDiv);
+      }
+    } else {
+      document.getElementById("app").innerHTML = `
+        <div id="sign-in"></div>
+      `;
+
+      const signInDiv = document.getElementById("sign-in");
+
+      clerk.mountSignIn(signInDiv);
+    }
+    ```
+  </Tab>
+
+  <Tab>
+    ```html {{ prettier: false, filename: 'index.html', mark: [74, 102, 121, 140] }}
+    <!doctype html>
+    <html lang="en">
+      <head>
+        <meta charset="UTF-8" />
+        <link rel="icon" type="image/svg+xml" href="/vite.svg" />
+        <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+        <title>Clerk + JavaScript App</title>
+        <style>
+          /* Style for the table */
+          table {
+            border-collapse: collapse; /* Collapse borders into a single border */
+            border: 1px solid black; /* Border for the entire table */
+          }
+
+          /* Style for table cells */
+          td,
+          th {
+            border: 1px solid black; /* Border for each cell */
+            padding: 2px; /* Optional: Add padding to cells */
+          }
+        </style>
+      </head>
+      <body>
+        <div id="app"></div>
+
+        <p id="error-container" hidden>
+          Error:
+          <span id="error-message"></span>
+        </p>
+
+        <h2>Memberships List</h2>
+        <table id="memberships_table">
+          <thead>
+            <tr>
+              <th>User ID</th>
+              <th>Identifier</th>
+              <th>Role</th>
+              <th id="update-role-head" hidden>Update role</th>
+              <th id="remove-member-head" hidden>Remove member</th>
+            </tr>
+          </thead>
+          <tbody id="memberships_table_body"></tbody>
+        </table>
+
+        <div id="add-member-container">
+          <h2>Add member</h2>
+          <input id="member-user-id" placeholder="Enter member's user ID" />
+          <button id="add-member">Add member</button>
+        </div>
+
+        <h2>Response:</p>
+        <pre id="response"></pre>
+
+        <!-- Initialize Clerk with your
+        Clerk Publishable key and Frontend API URL -->
+        <script
+          async
+          crossorigin="anonymous"
+          data-clerk-publishable-key="{{pub_key}}"
+          src="https://{{fapi_url}}/npm/@clerk/clerk-js@latest/dist/clerk.browser.js"
+          type="text/javascript"
+        ></script>
+
+        <script>
+          window.addEventListener("load", async function () {
+            await Clerk.load();
+
+            if (Clerk.user) {
+              // Check for an active organization
+              if (Clerk.organization) {
+                // Render list of organization memberships
+                async function renderMemberships(organization, isAdmin) {
+                  try {
+                    const { data } = await organization.getMemberships();
+
+                    const memberships = data;
+                    console.log(`getMemberships:`, memberships);
+
+                    memberships.map((membership) => {
+                      const membershipTable = document.getElementById("memberships_table");
+                      const row = membershipTable.insertRow();
+                      row.insertCell().textContent = membership.publicUserData.userId;
+                      row.insertCell().textContent = membership.publicUserData.identifier;
+                      row.insertCell().textContent = membership.role;
+
+                      // Add administrative actions:
+                      // Add and remove a member, and update a member's role.
+                      if (isAdmin) {
+                        // Show add, update, remove member buttons
+                        document.getElementById("add-member-container").removeAttribute("hidden");
+                        document.getElementById("update-role-head").removeAttribute("hidden");
+                        document.getElementById("remove-member-head").removeAttribute("hidden");
+
+                        // Get the user ID of the member
+                        const userId = membership.publicUserData.userId;
+
+                        // Update a member's role
+                        const updateBtn = document.createElement("button");
+                        updateBtn.textContent = "Change role";
+                        updateBtn.addEventListener("click", async function (e) {
+                          e.preventDefault();
+                          const role =
+                            membership.role === "org:admin" ? "org:member" : "org:admin";
+                          await organization.updateMember({ userId, role })
+                            .then((res) => {
+                              document.getElementById("response").innerHTML =
+                                JSON.stringify(res);
+                            })
+                            .catch((error) => {
+                              document.getElementById("error-container").removeAttribute("hidden");
+                              document.getElementById("error-message").innerHTML =
+                                error.errors[0].longMessage;
+                              console.log("An error occurred:", error.errors);
+                            });
+                        });
+                        row.insertCell().appendChild(updateBtn);
+
+                        // Remove a member
+                        const removeBtn = document.createElement("button");
+                        removeBtn.textContent = "Remove";
+                        removeBtn.addEventListener("click", async function (e) {
+                          e.preventDefault();
+                          await organization.removeMember(userId)
+                            .then((res) => {
+                              document.getElementById("response").innerHTML =
+                                JSON.stringify(res);
+                            })
+                            .catch((error) => {
+                              document.getElementById("error-container").removeAttribute("hidden");
+                              document.getElementById("error-message").innerHTML =
+                                error.errors[0].longMessage;
+                              console.log("An error occurred:", error.errors);
+                            });
+                        });
+                        row.insertCell().appendChild(removeBtn);
+
+                        // Add a new member to the organization
+                        document.getElementById("add-member")
+                          .addEventListener("click", () => {
+                            const userId = document.getElementById("member-user-id").value;
+
+                            organization.addMember({ userId, role: "org:member" })
+                            .then((res) => {
+                              document.getElementById("response").innerHTML =
+                                JSON.stringify(res);
+                            })
+                            .catch((error) => {
+                              document.getElementById("error-container").removeAttribute("hidden");
+                              document.getElementById("error-message").innerHTML =
+                                error.errors[0].longMessage;
+                              console.log("An error occurred:", error.errors);
+                            });
+                          });
+                      }
+                    });
+                  } catch (error) {
+                    document.getElementById("error-container").removeAttribute("hidden");
+                    document.getElementById("error-message").innerHTML =
+                      error.errors[0].longMessage;
+                    console.log("An error occurred:", error.errors);
+                  }
+                }
+
+                /**
+                * Checks if a user is an admin of the
+                * currently active organization and
+                * renders the organization's memberships.
+                */
+                async function checkAdminAndRenderMemberships() {
+                  const organizationId = Clerk.organization.id;
+
+                  const { data } =
+                    await Clerk.user.getOrganizationMemberships();
+
+                  const organizationMemberships = data;
+
+                  const currentMembership = organizationMemberships.find(
+                    (membership) => membership.organization.id === organizationId
+                  );
+                  const currentOrganization = currentMembership.organization;
+
+                  if (!currentOrganization) {
+                    return;
+                  }
+                  const isAdmin = currentMembership.role === "org:admin";
+
+                  console.log(`Organization:`, currentOrganization);
+
+                  renderMemberships(currentOrganization, isAdmin);
+                }
+
+                checkAdminAndRenderMemberships();
+              } else {
+                // If there is no active organization,
+                // mount Clerk's <OrganizationSwitcher />
+                // to allow the user to set an organization as active
+                document.getElementById("app").innerHTML = `
+                  <h2>Select an organization to set it as active</h2>
+                  <div id="org-switcher"></div>
+                `;
+
+                const orgSwitcherDiv = document.getElementById("org-switcher");
+
+                Clerk.mountOrganizationSwitcher(orgSwitcherDiv);
+              }
+            } else {
+              document.getElementById("app").innerHTML = `
+                <div id="sign-in"></div>
+              `;
+
+              const signInDiv = document.getElementById("sign-in");
+
+              Clerk.mountSignIn(signInDiv);
+            }
+          });
+        </script>
+      </body>
+    </html>
+    ```
+  </Tab>
+</Tabs>
 
 [pag-ref]: /docs/references/javascript/types/clerk-paginated-response
 

--- a/docs/references/javascript/organization/membership-request.mdx
+++ b/docs/references/javascript/organization/membership-request.mdx
@@ -39,355 +39,353 @@ function getMembershipRequests: (params?: GetMembershipRequestParams) => Promise
 
 The following example demonstrates how to use the `getMembershipRequests()` method to render a table of membership requests for the active organization. To ease the development process, the response or error message of a method will be displayed on the user interface.
 
-<InjectKeys>
-  <Tabs type="npm-script" items={['NPM module', '<script>']}>
-    <Tab>
-      For the following example, your HTML file should look like this:
+<Tabs type="npm-script" items={['NPM module', '<script>']}>
+  <Tab>
+    For the following example, your HTML file should look like this:
 
-      ```html {{ prettier: false, filename: 'index.html' }}
-      <!doctype html>
-      <html lang="en">
-        <head>
-          <meta charset="UTF-8" />
-          <link rel="icon" type="image/svg+xml" href="/vite.svg" />
-          <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-          <title>Clerk + JavaScript App</title>
-          <style>
-            /* Style for the table */
-            table {
-              border-collapse: collapse; /* Collapse borders into a single border */
-              border: 1px solid black; /* Border for the entire table */
-            }
-            /* Style for table cells */
-            td,
-            th {
-              border: 1px solid black; /* Border for each cell */
-              padding: 2px; /* Optional: Add padding to cells */
-            }
-          </style>
-        </head>
-        <body>
-          <div id="app"></div>
-
-          <p id="error-container" hidden>
-            Error:
-            <span id="error-message"></span>
-          </p>
-
-          <h2>Membership Requests</h2>
-          <table id="requests_table">
-            <thead>
-              <tr>
-                <th>User ID</th>
-                <th>Identifier</th>
-                <th>Status</th>
-                <th id="add-member-head" hidden>Add member</th>
-              </tr>
-            </thead>
-            <tbody id="requests_table_body"></tbody>
-          </table>
-
-          <p>Response:</p>
-          <pre id="response"></pre>
-
-          <script type="module" src="/main.js"></script>
-        </body>
-      </html>
-      ```
-
-      And your JavaScript file should look like this:
-
-      ```js {{ prettier: false, filename: 'main.js', mark: [13] }}
-      import { Clerk } from '@clerk/clerk-js';
-
-      // Initialize Clerk with your Clerk publishable key
-      const clerk = new Clerk('{{pub_key}}');
-      await clerk.load();
-
-      if (clerk.user) {
-        // Check for an active organization
-        if (clerk.organization) {
-          // Render list of organization membership requests
-          async function renderMembershipRequests(organization, isAdmin) {
-            try {
-              const { data } = await organization.getMembershipRequests();
-              const membershipRequests = data;
-              console.log(`getMembershipRequests:`, membershipRequests);
-
-              membershipRequests.map((membershipRequest) => {
-                const requestsTable = document.getElementById("requests_table");
-                const row = requestsTable.insertRow();
-                row.insertCell().textContent =
-                  membershipRequest.publicUserData.userId;
-                row.insertCell().textContent =
-                  membershipRequest.publicUserData.identifier;
-                row.insertCell().textContent = membershipRequest.status;
-
-                // Add administrative actions:
-                // Add member (removes request)
-                if (isAdmin) {
-                  // Show add member button
-                  document.getElementById("add-member-head").removeAttribute("hidden");
-
-                  // Get the user ID of the member
-                  const userId = membershipRequest.publicUserData.userId;
-
-                  // Add member to organization
-                  const addBtn = document.createElement("button");
-                  addBtn.textContent = "Add member";
-                  addBtn.addEventListener("click", async function (e) {
-                    e.preventDefault();
-
-                    const role = "org:member";
-
-                    await organization.addMember({ userId, role })
-                      .then((res) => {
-                        document.getElementById("response").innerHTML =
-                          JSON.stringify(res);
-                      })
-                      .catch((error) => {
-                        document.getElementById("error-container").removeAttribute("hidden");
-                        document.getElementById("error-message").innerHTML =
-                          error.errors[0].longMessage;
-                        console.log("An error occurred:", error.errors);
-                      });
-                  });
-                  row.insertCell().appendChild(addBtn);
-                }
-              });
-            } catch (error) {
-              document.getElementById("error-container").removeAttribute("hidden");
-              document.getElementById("error-message").innerHTML =
-                error.errors[0].longMessage;
-              console.log("An error occurred:", error.errors);
-            }
+    ```html {{ prettier: false, filename: 'index.html' }}
+    <!doctype html>
+    <html lang="en">
+      <head>
+        <meta charset="UTF-8" />
+        <link rel="icon" type="image/svg+xml" href="/vite.svg" />
+        <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+        <title>Clerk + JavaScript App</title>
+        <style>
+          /* Style for the table */
+          table {
+            border-collapse: collapse; /* Collapse borders into a single border */
+            border: 1px solid black; /* Border for the entire table */
           }
-
-          /**
-           * Checks if a user is an admin of the
-           * currently active organization and
-           * renders the organization's membership requests.
-           */
-          async function checkAdminAndRenderRequests() {
-            const organizationId = clerk.organization.id;
-
-            const organizationMemberships =
-              await clerk.user.getOrganizationMemberships();
-
-            const currentMembership = organizationMemberships.find(
-              (membership) => membership.organization.id === organizationId
-            );
-            const currentOrganization = currentMembership.organization;
-
-            if (!currentOrganization) {
-              return;
-            }
-            const isAdmin = currentMembership.role === "org:admin";
-
-            console.log(`Organization:`, currentOrganization);
-
-            renderMembershipRequests(currentOrganization, isAdmin);
+          /* Style for table cells */
+          td,
+          th {
+            border: 1px solid black; /* Border for each cell */
+            padding: 2px; /* Optional: Add padding to cells */
           }
+        </style>
+      </head>
+      <body>
+        <div id="app"></div>
 
-          checkAdminAndRenderRequests();
-        } else {
-          // If there is no active organization,
-          // mount Clerk's <OrganizationSwitcher />
-          // to allow the user to set an organization as active
-          document.getElementById("app").innerHTML = `
-            <h2>Select an organization to set it as active</h2>
-            <div id="org-switcher"></div>
-          `;
+        <p id="error-container" hidden>
+          Error:
+          <span id="error-message"></span>
+        </p>
 
-          const orgSwitcherDiv = document.getElementById("org-switcher");
+        <h2>Membership Requests</h2>
+        <table id="requests_table">
+          <thead>
+            <tr>
+              <th>User ID</th>
+              <th>Identifier</th>
+              <th>Status</th>
+              <th id="add-member-head" hidden>Add member</th>
+            </tr>
+          </thead>
+          <tbody id="requests_table_body"></tbody>
+        </table>
 
-          clerk.mountOrganizationSwitcher(orgSwitcherDiv);
-        }
-      } else {
-        document.getElementById("app").innerHTML = `
-          <div id="sign-in"></div>
-        `;
+        <p>Response:</p>
+        <pre id="response"></pre>
 
-        const signInDiv = document.getElementById("sign-in");
+        <script type="module" src="/main.js"></script>
+      </body>
+    </html>
+    ```
 
-        clerk.mountSignIn(signInDiv);
-      }
-      ```
-    </Tab>
+    And your JavaScript file should look like this:
 
-    <Tab>
-      ```html {{ prettier: false, filename: 'index.html', mark: [65] }}
-      <!doctype html>
-      <html lang="en">
-        <head>
-          <meta charset="UTF-8" />
-          <link rel="icon" type="image/svg+xml" href="/vite.svg" />
-          <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-          <title>Clerk + JavaScript App</title>
-          <style>
-            /* Style for the table */
-            table {
-              border-collapse: collapse; /* Collapse borders into a single border */
-              border: 1px solid black; /* Border for the entire table */
-            }
-            /* Style for table cells */
-            td,
-            th {
-              border: 1px solid black; /* Border for each cell */
-              padding: 2px; /* Optional: Add padding to cells */
-            }
-          </style>
-        </head>
-        <body>
-          <div id="app"></div>
+    ```js {{ prettier: false, filename: 'main.js', mark: [13] }}
+    import { Clerk } from '@clerk/clerk-js';
 
-          <p id="error-container" hidden>
-            Error:
-            <span id="error-message"></span>
-          </p>
+    // Initialize Clerk with your Clerk publishable key
+    const clerk = new Clerk('{{pub_key}}');
+    await clerk.load();
 
-          <h2>Membership Requests</h2>
-          <table id="requests_table">
-            <thead>
-              <tr>
-                <th>User ID</th>
-                <th>Identifier</th>
-                <th>Status</th>
-                <th id="add-member-head" hidden>Add member</th>
-              </tr>
-            </thead>
-            <tbody id="requests_table_body"></tbody>
-          </table>
+    if (clerk.user) {
+      // Check for an active organization
+      if (clerk.organization) {
+        // Render list of organization membership requests
+        async function renderMembershipRequests(organization, isAdmin) {
+          try {
+            const { data } = await organization.getMembershipRequests();
+            const membershipRequests = data;
+            console.log(`getMembershipRequests:`, membershipRequests);
 
-          <p>Response:</p>
-          <pre id="response"></pre>
+            membershipRequests.map((membershipRequest) => {
+              const requestsTable = document.getElementById("requests_table");
+              const row = requestsTable.insertRow();
+              row.insertCell().textContent =
+                membershipRequest.publicUserData.userId;
+              row.insertCell().textContent =
+                membershipRequest.publicUserData.identifier;
+              row.insertCell().textContent = membershipRequest.status;
 
-          <!-- Initialize Clerk with your
-          Clerk Publishable key and Frontend API URL -->
-          <script
-            async
-            crossorigin="anonymous"
-            data-clerk-publishable-key="{{pub_key}}"
-            src="https://{{fapi_url}}/npm/@clerk/clerk-js@latest/dist/clerk.browser.js"
-            type="text/javascript"
-          ></script>
+              // Add administrative actions:
+              // Add member (removes request)
+              if (isAdmin) {
+                // Show add member button
+                document.getElementById("add-member-head").removeAttribute("hidden");
 
-          <script>
-            window.addEventListener("load", async function () {
-              await Clerk.load();
-              if (Clerk.user) {
-                // Check for an active organization
-                if (Clerk.organization) {
-                  // Render list of organization membership requests
-                  async function renderMembershipRequests(organization, isAdmin) {
-                    try {
-                      const { data } = await organization.getMembershipRequests();
-                      const membershipRequests = data;
-                      console.log(`getMembershipRequests:`, membershipRequests);
+                // Get the user ID of the member
+                const userId = membershipRequest.publicUserData.userId;
 
-                      membershipRequests.map((membershipRequest) => {
-                        const requestsTable = document.getElementById("requests_table");
-                        const row = requestsTable.insertRow();
-                        row.insertCell().textContent =
-                          membershipRequest.publicUserData.userId;
-                        row.insertCell().textContent =
-                          membershipRequest.publicUserData.identifier;
-                        row.insertCell().textContent = membershipRequest.status;
+                // Add member to organization
+                const addBtn = document.createElement("button");
+                addBtn.textContent = "Add member";
+                addBtn.addEventListener("click", async function (e) {
+                  e.preventDefault();
 
-                        // Add administrative actions:
-                        // Add member (removes request)
-                        if (isAdmin) {
-                          // Show add member button
-                          document.getElementById("add-member-head").removeAttribute("hidden");
+                  const role = "org:member";
 
-                          // Get the user ID of the member
-                          const userId = membershipRequest.publicUserData.userId;
-
-                          // Add member to organization
-                          const addBtn = document.createElement("button");
-                          addBtn.textContent = "Add member";
-                          addBtn.addEventListener("click", async function (e) {
-                            e.preventDefault();
-
-                            const role = "org:member";
-
-                            await organization.addMember({ userId, role })
-                              .then((res) => {
-                                document.getElementById("response").innerHTML =
-                                  JSON.stringify(res);
-                              })
-                              .catch((error) => {
-                                document.getElementById("error-container").removeAttribute("hidden");
-                                document.getElementById("error-message").innerHTML =
-                                  error.errors[0].longMessage;
-                                console.log("An error occurred:", error.errors);
-                              });
-                          });
-                          row.insertCell().appendChild(addBtn);
-                        }
-                      });
-                    } catch (error) {
+                  await organization.addMember({ userId, role })
+                    .then((res) => {
+                      document.getElementById("response").innerHTML =
+                        JSON.stringify(res);
+                    })
+                    .catch((error) => {
                       document.getElementById("error-container").removeAttribute("hidden");
                       document.getElementById("error-message").innerHTML =
                         error.errors[0].longMessage;
                       console.log("An error occurred:", error.errors);
-                    }
-                  }
-                  /**
-                  * Checks if a user is an admin of the
-                  * currently active organization and
-                  * renders the organization's membership requests.
-                  */
-                  async function checkAdminAndRenderRequests() {
-                    const organizationId = Clerk.organization.id;
-
-                    const organizationMemberships =
-                      await Clerk.user.getOrganizationMemberships();
-
-                    const currentMembership = organizationMemberships.find(
-                      (membership) => membership.organization.id === organizationId
-                    );
-
-                    const currentOrganization = currentMembership.organization;
-
-                    if (!currentOrganization) {
-                      return;
-                    }
-
-                    const isAdmin = currentMembership.role === "org:admin";
-
-                    console.log(`Organization:`, currentOrganization);
-
-                    renderMembershipRequests(currentOrganization, isAdmin);
-                  }
-                  checkAdminAndRenderRequests();
-                } else {
-                  // If there is no active organization,
-                  // mount Clerk's <OrganizationSwitcher />
-                  // to allow the user to set an organization as active
-                  document.getElementById("app").innerHTML = `
-                    <h2>Select an organization to set it as active</h2>
-                    <div id="org-switcher"></div>
-                  `;
-
-                  const orgSwitcherDiv = document.getElementById("org-switcher");
-
-                  Clerk.mountOrganizationSwitcher(orgSwitcherDiv);
-                }
-              } else {
-                document.getElementById("app").innerHTML = `
-                  <div id="sign-in"></div>
-                `;
-
-                const signInDiv = document.getElementById("sign-in");
-
-                Clerk.mountSignIn(signInDiv);
+                    });
+                });
+                row.insertCell().appendChild(addBtn);
               }
             });
-          </script>
-        </body>
-      </html>
-      ```
-    </Tab>
-  </Tabs>
-</InjectKeys>
+          } catch (error) {
+            document.getElementById("error-container").removeAttribute("hidden");
+            document.getElementById("error-message").innerHTML =
+              error.errors[0].longMessage;
+            console.log("An error occurred:", error.errors);
+          }
+        }
+
+        /**
+         * Checks if a user is an admin of the
+         * currently active organization and
+         * renders the organization's membership requests.
+         */
+        async function checkAdminAndRenderRequests() {
+          const organizationId = clerk.organization.id;
+
+          const organizationMemberships =
+            await clerk.user.getOrganizationMemberships();
+
+          const currentMembership = organizationMemberships.find(
+            (membership) => membership.organization.id === organizationId
+          );
+          const currentOrganization = currentMembership.organization;
+
+          if (!currentOrganization) {
+            return;
+          }
+          const isAdmin = currentMembership.role === "org:admin";
+
+          console.log(`Organization:`, currentOrganization);
+
+          renderMembershipRequests(currentOrganization, isAdmin);
+        }
+
+        checkAdminAndRenderRequests();
+      } else {
+        // If there is no active organization,
+        // mount Clerk's <OrganizationSwitcher />
+        // to allow the user to set an organization as active
+        document.getElementById("app").innerHTML = `
+          <h2>Select an organization to set it as active</h2>
+          <div id="org-switcher"></div>
+        `;
+
+        const orgSwitcherDiv = document.getElementById("org-switcher");
+
+        clerk.mountOrganizationSwitcher(orgSwitcherDiv);
+      }
+    } else {
+      document.getElementById("app").innerHTML = `
+        <div id="sign-in"></div>
+      `;
+
+      const signInDiv = document.getElementById("sign-in");
+
+      clerk.mountSignIn(signInDiv);
+    }
+    ```
+  </Tab>
+
+  <Tab>
+    ```html {{ prettier: false, filename: 'index.html', mark: [65] }}
+    <!doctype html>
+    <html lang="en">
+      <head>
+        <meta charset="UTF-8" />
+        <link rel="icon" type="image/svg+xml" href="/vite.svg" />
+        <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+        <title>Clerk + JavaScript App</title>
+        <style>
+          /* Style for the table */
+          table {
+            border-collapse: collapse; /* Collapse borders into a single border */
+            border: 1px solid black; /* Border for the entire table */
+          }
+          /* Style for table cells */
+          td,
+          th {
+            border: 1px solid black; /* Border for each cell */
+            padding: 2px; /* Optional: Add padding to cells */
+          }
+        </style>
+      </head>
+      <body>
+        <div id="app"></div>
+
+        <p id="error-container" hidden>
+          Error:
+          <span id="error-message"></span>
+        </p>
+
+        <h2>Membership Requests</h2>
+        <table id="requests_table">
+          <thead>
+            <tr>
+              <th>User ID</th>
+              <th>Identifier</th>
+              <th>Status</th>
+              <th id="add-member-head" hidden>Add member</th>
+            </tr>
+          </thead>
+          <tbody id="requests_table_body"></tbody>
+        </table>
+
+        <p>Response:</p>
+        <pre id="response"></pre>
+
+        <!-- Initialize Clerk with your
+        Clerk Publishable key and Frontend API URL -->
+        <script
+          async
+          crossorigin="anonymous"
+          data-clerk-publishable-key="{{pub_key}}"
+          src="https://{{fapi_url}}/npm/@clerk/clerk-js@latest/dist/clerk.browser.js"
+          type="text/javascript"
+        ></script>
+
+        <script>
+          window.addEventListener("load", async function () {
+            await Clerk.load();
+            if (Clerk.user) {
+              // Check for an active organization
+              if (Clerk.organization) {
+                // Render list of organization membership requests
+                async function renderMembershipRequests(organization, isAdmin) {
+                  try {
+                    const { data } = await organization.getMembershipRequests();
+                    const membershipRequests = data;
+                    console.log(`getMembershipRequests:`, membershipRequests);
+
+                    membershipRequests.map((membershipRequest) => {
+                      const requestsTable = document.getElementById("requests_table");
+                      const row = requestsTable.insertRow();
+                      row.insertCell().textContent =
+                        membershipRequest.publicUserData.userId;
+                      row.insertCell().textContent =
+                        membershipRequest.publicUserData.identifier;
+                      row.insertCell().textContent = membershipRequest.status;
+
+                      // Add administrative actions:
+                      // Add member (removes request)
+                      if (isAdmin) {
+                        // Show add member button
+                        document.getElementById("add-member-head").removeAttribute("hidden");
+
+                        // Get the user ID of the member
+                        const userId = membershipRequest.publicUserData.userId;
+
+                        // Add member to organization
+                        const addBtn = document.createElement("button");
+                        addBtn.textContent = "Add member";
+                        addBtn.addEventListener("click", async function (e) {
+                          e.preventDefault();
+
+                          const role = "org:member";
+
+                          await organization.addMember({ userId, role })
+                            .then((res) => {
+                              document.getElementById("response").innerHTML =
+                                JSON.stringify(res);
+                            })
+                            .catch((error) => {
+                              document.getElementById("error-container").removeAttribute("hidden");
+                              document.getElementById("error-message").innerHTML =
+                                error.errors[0].longMessage;
+                              console.log("An error occurred:", error.errors);
+                            });
+                        });
+                        row.insertCell().appendChild(addBtn);
+                      }
+                    });
+                  } catch (error) {
+                    document.getElementById("error-container").removeAttribute("hidden");
+                    document.getElementById("error-message").innerHTML =
+                      error.errors[0].longMessage;
+                    console.log("An error occurred:", error.errors);
+                  }
+                }
+                /**
+                * Checks if a user is an admin of the
+                * currently active organization and
+                * renders the organization's membership requests.
+                */
+                async function checkAdminAndRenderRequests() {
+                  const organizationId = Clerk.organization.id;
+
+                  const organizationMemberships =
+                    await Clerk.user.getOrganizationMemberships();
+
+                  const currentMembership = organizationMemberships.find(
+                    (membership) => membership.organization.id === organizationId
+                  );
+
+                  const currentOrganization = currentMembership.organization;
+
+                  if (!currentOrganization) {
+                    return;
+                  }
+
+                  const isAdmin = currentMembership.role === "org:admin";
+
+                  console.log(`Organization:`, currentOrganization);
+
+                  renderMembershipRequests(currentOrganization, isAdmin);
+                }
+                checkAdminAndRenderRequests();
+              } else {
+                // If there is no active organization,
+                // mount Clerk's <OrganizationSwitcher />
+                // to allow the user to set an organization as active
+                document.getElementById("app").innerHTML = `
+                  <h2>Select an organization to set it as active</h2>
+                  <div id="org-switcher"></div>
+                `;
+
+                const orgSwitcherDiv = document.getElementById("org-switcher");
+
+                Clerk.mountOrganizationSwitcher(orgSwitcherDiv);
+              }
+            } else {
+              document.getElementById("app").innerHTML = `
+                <div id="sign-in"></div>
+              `;
+
+              const signInDiv = document.getElementById("sign-in");
+
+              Clerk.mountSignIn(signInDiv);
+            }
+          });
+        </script>
+      </body>
+    </html>
+    ```
+  </Tab>
+</Tabs>

--- a/docs/references/javascript/organization/organization.mdx
+++ b/docs/references/javascript/organization/organization.mdx
@@ -54,94 +54,92 @@ function update(params: UpdateOrganizationParams): Promise<Organization>;
 
 #### Example
 
-<InjectKeys>
-  <CodeBlockTabs type="npm-script" options={['NPM module', '<script>']}>
-    ```js {{ prettier: false, filename: 'main.js', mark: [10] }}
-    import { Clerk } from '@clerk/clerk-js';
+<CodeBlockTabs type="npm-script" options={['NPM module', '<script>']}>
+  ```js {{ prettier: false, filename: 'main.js', mark: [10] }}
+  import { Clerk } from '@clerk/clerk-js';
 
-    // Initialize Clerk with your Clerk publishable key
-    const clerk = new Clerk('{{pub_key}}');
-    await clerk.load();
+  // Initialize Clerk with your Clerk publishable key
+  const clerk = new Clerk('{{pub_key}}');
+  await clerk.load();
 
-    if (clerk.user) {
-      // Check for an active organization
-      if (clerk.organization){
-        await clerk.organization.update({ name: "New Name" })
-        .then((res) => console.log(res))
-        .catch((error) => console.log("An error occurred:", error.errors));
-      } else {
-        // If there is no active organization,
-        // mount Clerk's <OrganizationSwitcher />
-        // to allow the user to set an organization as active
-        document.getElementById("app").innerHTML = `
-          <h2>Select an organization to set it as active</h2>
-          <div id="org-switcher"></div>
-        `;
-
-        const orgSwitcherDiv = document.getElementById("org-switcher");
-
-        clerk.mountOrganizationSwitcher(orgSwitcherDiv);
-      }
+  if (clerk.user) {
+    // Check for an active organization
+    if (clerk.organization){
+      await clerk.organization.update({ name: "New Name" })
+      .then((res) => console.log(res))
+      .catch((error) => console.log("An error occurred:", error.errors));
     } else {
+      // If there is no active organization,
+      // mount Clerk's <OrganizationSwitcher />
+      // to allow the user to set an organization as active
       document.getElementById("app").innerHTML = `
-        <div id="sign-in"></div>
+        <h2>Select an organization to set it as active</h2>
+        <div id="org-switcher"></div>
       `;
 
-      const signInDiv = document.getElementById("sign-in");
+      const orgSwitcherDiv = document.getElementById("org-switcher");
 
-      clerk.mountSignIn(signInDiv);
+      clerk.mountOrganizationSwitcher(orgSwitcherDiv);
     }
-    ```
+  } else {
+    document.getElementById("app").innerHTML = `
+      <div id="sign-in"></div>
+    `;
 
-    ```html {{ prettier: false, filename: 'index.html', mark: [19] }}
-      <div id="app"></div>
+    const signInDiv = document.getElementById("sign-in");
 
-      <!-- Initialize Clerk with your
-      Clerk Publishable key and Frontend API URL -->
-      <script
-        async
-        crossorigin="anonymous"
-        data-clerk-publishable-key="{{pub_key}}"
-        src="https://{{fapi_url}}/npm/@clerk/clerk-js@latest/dist/clerk.browser.js"
-        type="text/javascript"
-      ></script>
+    clerk.mountSignIn(signInDiv);
+  }
+  ```
 
-      <script>
-        window.addEventListener("load", async function () {
-          await Clerk.load();
-          if (Clerk.user) {
-            // Check for an active organization
-            if (Clerk.organization){
-              await Clerk.organization.update({ name: "New Name" })
-                .then((res) => console.log(res))
-                .catch((error) => console.log("An error occurred:", error.errors));
-            } else {
-              // If there is no active organization,
-              // mount Clerk's <OrganizationSwitcher />
-              // to allow the user to set an organization as active
-              document.getElementById("app").innerHTML = `
-                <h2>Select an organization to set it as active</h2>
-                <div id="org-switcher"></div>
-              `;
+  ```html {{ prettier: false, filename: 'index.html', mark: [19] }}
+    <div id="app"></div>
 
-              const orgSwitcherDiv = document.getElementById("org-switcher");
+    <!-- Initialize Clerk with your
+    Clerk Publishable key and Frontend API URL -->
+    <script
+      async
+      crossorigin="anonymous"
+      data-clerk-publishable-key="{{pub_key}}"
+      src="https://{{fapi_url}}/npm/@clerk/clerk-js@latest/dist/clerk.browser.js"
+      type="text/javascript"
+    ></script>
 
-              Clerk.mountOrganizationSwitcher(orgSwitcherDiv);
-            }
+    <script>
+      window.addEventListener("load", async function () {
+        await Clerk.load();
+        if (Clerk.user) {
+          // Check for an active organization
+          if (Clerk.organization){
+            await Clerk.organization.update({ name: "New Name" })
+              .then((res) => console.log(res))
+              .catch((error) => console.log("An error occurred:", error.errors));
           } else {
+            // If there is no active organization,
+            // mount Clerk's <OrganizationSwitcher />
+            // to allow the user to set an organization as active
             document.getElementById("app").innerHTML = `
-              <div id="sign-in"></div>
+              <h2>Select an organization to set it as active</h2>
+              <div id="org-switcher"></div>
             `;
 
-            const signInDiv = document.getElementById("sign-in");
+            const orgSwitcherDiv = document.getElementById("org-switcher");
 
-            Clerk.mountSignIn(signInDiv);
+            Clerk.mountOrganizationSwitcher(orgSwitcherDiv);
           }
-        });
-      </script>
-    ```
-  </CodeBlockTabs>
-</InjectKeys>
+        } else {
+          document.getElementById("app").innerHTML = `
+            <div id="sign-in"></div>
+          `;
+
+          const signInDiv = document.getElementById("sign-in");
+
+          Clerk.mountSignIn(signInDiv);
+        }
+      });
+    </script>
+  ```
+</CodeBlockTabs>
 
 ### `destroy()`
 
@@ -161,94 +159,92 @@ function destroy(): Promise<void>;
 
 #### Example
 
-<InjectKeys>
-  <CodeBlockTabs type="npm-script" options={['NPM module', '<script>']}>
-    ```js {{ prettier: false, filename: 'main.js', mark: [10] }}
-    import { Clerk } from '@clerk/clerk-js';
+<CodeBlockTabs type="npm-script" options={['NPM module', '<script>']}>
+  ```js {{ prettier: false, filename: 'main.js', mark: [10] }}
+  import { Clerk } from '@clerk/clerk-js';
 
-    // Initialize Clerk with your Clerk publishable key
-    const clerk = new Clerk('{{pub_key}}');
-    await clerk.load();
+  // Initialize Clerk with your Clerk publishable key
+  const clerk = new Clerk('{{pub_key}}');
+  await clerk.load();
 
-    if (clerk.user) {
-      // Check for an active organization
-      if (clerk.organization){
-        await clerk.organization.destroy()
-          .then((res) => console.log(res))
-          .catch((error) => console.log("An error occurred:", error.errors));
-      } else {
-        // If there is no active organization,
-        // mount Clerk's <OrganizationSwitcher />
-        // to allow the user to set an organization as active
-        document.getElementById("app").innerHTML = `
-          <h2>Select an organization to set it as active</h2>
-          <div id="org-switcher"></div>
-        `;
-
-        const orgSwitcherDiv = document.getElementById("org-switcher");
-
-        clerk.mountOrganizationSwitcher(orgSwitcherDiv);
-      }
+  if (clerk.user) {
+    // Check for an active organization
+    if (clerk.organization){
+      await clerk.organization.destroy()
+        .then((res) => console.log(res))
+        .catch((error) => console.log("An error occurred:", error.errors));
     } else {
+      // If there is no active organization,
+      // mount Clerk's <OrganizationSwitcher />
+      // to allow the user to set an organization as active
       document.getElementById("app").innerHTML = `
-        <div id="sign-in"></div>
+        <h2>Select an organization to set it as active</h2>
+        <div id="org-switcher"></div>
       `;
 
-      const signInDiv = document.getElementById("sign-in");
+      const orgSwitcherDiv = document.getElementById("org-switcher");
 
-      clerk.mountSignIn(signInDiv);
+      clerk.mountOrganizationSwitcher(orgSwitcherDiv);
     }
-    ```
+  } else {
+    document.getElementById("app").innerHTML = `
+      <div id="sign-in"></div>
+    `;
 
-    ```html {{ prettier: false, filename: 'index.html', mark: [19] }}
-      <div id="app"></div>
+    const signInDiv = document.getElementById("sign-in");
 
-      <!-- Initialize Clerk with your
-      Clerk Publishable key and Frontend API URL -->
-      <script
-        async
-        crossorigin="anonymous"
-        data-clerk-publishable-key="{{pub_key}}"
-        src="https://{{fapi_url}}/npm/@clerk/clerk-js@latest/dist/clerk.browser.js"
-        type="text/javascript"
-      ></script>
+    clerk.mountSignIn(signInDiv);
+  }
+  ```
 
-      <script>
-        window.addEventListener("load", async function () {
-          await Clerk.load();
-          if (Clerk.user) {
-            // Check for an active organization
-            if (Clerk.organization){
-              await Clerk.organization.destroy()
-                .then((res) => console.log(res))
-                .catch((error) => console.log("An error occurred:", error.errors));
-            } else {
-              // If there is no active organization,
-              // mount Clerk's <OrganizationSwitcher />
-              // to allow the user to set an organization as active
-              document.getElementById("app").innerHTML = `
-                <h2>Select an organization to set it as active</h2>
-                <div id="org-switcher"></div>
-              `;
+  ```html {{ prettier: false, filename: 'index.html', mark: [19] }}
+    <div id="app"></div>
 
-              const orgSwitcherDiv = document.getElementById("org-switcher");
+    <!-- Initialize Clerk with your
+    Clerk Publishable key and Frontend API URL -->
+    <script
+      async
+      crossorigin="anonymous"
+      data-clerk-publishable-key="{{pub_key}}"
+      src="https://{{fapi_url}}/npm/@clerk/clerk-js@latest/dist/clerk.browser.js"
+      type="text/javascript"
+    ></script>
 
-              Clerk.mountOrganizationSwitcher(orgSwitcherDiv);
-            }
+    <script>
+      window.addEventListener("load", async function () {
+        await Clerk.load();
+        if (Clerk.user) {
+          // Check for an active organization
+          if (Clerk.organization){
+            await Clerk.organization.destroy()
+              .then((res) => console.log(res))
+              .catch((error) => console.log("An error occurred:", error.errors));
           } else {
+            // If there is no active organization,
+            // mount Clerk's <OrganizationSwitcher />
+            // to allow the user to set an organization as active
             document.getElementById("app").innerHTML = `
-              <div id="sign-in"></div>
+              <h2>Select an organization to set it as active</h2>
+              <div id="org-switcher"></div>
             `;
 
-            const signInDiv = document.getElementById("sign-in");
+            const orgSwitcherDiv = document.getElementById("org-switcher");
 
-            Clerk.mountSignIn(signInDiv);
+            Clerk.mountOrganizationSwitcher(orgSwitcherDiv);
           }
-        });
-      </script>
-    ```
-  </CodeBlockTabs>
-</InjectKeys>
+        } else {
+          document.getElementById("app").innerHTML = `
+            <div id="sign-in"></div>
+          `;
+
+          const signInDiv = document.getElementById("sign-in");
+
+          Clerk.mountSignIn(signInDiv);
+        }
+      });
+    </script>
+  ```
+</CodeBlockTabs>
 
 ### `setLogo()`
 
@@ -272,136 +268,134 @@ function setLogo(params: SetOrganizationLogoParams): Promise<Organization>;
 
 #### Example
 
-<InjectKeys>
-  <Tabs type="npm-script" items={['NPM module', '<script>']}>
-    <Tab>
-      For the following example, your HTML file should look like this:
+<Tabs type="npm-script" items={['NPM module', '<script>']}>
+  <Tab>
+    For the following example, your HTML file should look like this:
 
-      ```html {{ prettier: false, filename: 'index.html' }}
-      <!doctype html>
-      <html lang="en">
-        <head>
-          <meta charset="UTF-8" />
-          <link rel="icon" type="image/svg+xml" href="/vite.svg" />
-          <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-          <title>Clerk + JavaScript App</title>
-        </head>
-        <body>
-          <div id="app"></div>
-
-          <input type="file" id="org-logo" />
-          <button id="upload-logo">Upload Logo</button>
-
-          <script type="module" src="/main.js"></script>
-        </body>
-      </html>
-      ```
-
-      And your JavaScript file should look like this:
-
-      ```js {{ prettier: false, filename: 'main.js', mark: [14] }}
-      import { Clerk } from '@clerk/clerk-js';
-
-      // Initialize Clerk with your Clerk publishable key
-      const clerk = new Clerk('{{pub_key}}');
-      await clerk.load();
-
-      if (clerk.user) {
-        // Check for an active organization
-        if (clerk.organization){
-          // Update the organization's logo
-          document.getElementById("upload-logo").addEventListener("click", () => {
-            const orgLogo = document.getElementById("org-logo").files[0];
-
-            clerk.organization.setLogo({ file: orgLogo })
-              .then((res) => console.log(res))
-              .catch((error) => console.log("An error occurred:", error.errors));
-          });
-        } else {
-          // If there is no active organization,
-          // mount Clerk's <OrganizationSwitcher />
-          // to allow the user to set an organization as active
-          document.getElementById("app").innerHTML = `
-            <h2>Select an organization to set it as active</h2>
-            <div id="org-switcher"></div>
-          `;
-
-          const orgSwitcherDiv = document.getElementById("org-switcher");
-
-          clerk.mountOrganizationSwitcher(orgSwitcherDiv);
-        }
-      } else {
-        document.getElementById("app").innerHTML = `
-          <div id="sign-in"></div>
-        `;
-
-        const signInDiv = document.getElementById("sign-in");
-
-        clerk.mountSignIn(signInDiv);
-      }
-      ```
-    </Tab>
-
-    <Tab>
-      ```html {{ prettier: false, filename: 'index.html', mark: [27] }}
+    ```html {{ prettier: false, filename: 'index.html' }}
+    <!doctype html>
+    <html lang="en">
+      <head>
+        <meta charset="UTF-8" />
+        <link rel="icon" type="image/svg+xml" href="/vite.svg" />
+        <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+        <title>Clerk + JavaScript App</title>
+      </head>
+      <body>
         <div id="app"></div>
 
         <input type="file" id="org-logo" />
         <button id="upload-logo">Upload Logo</button>
 
-        <!-- Initialize Clerk with your
-      Clerk Publishable key and Frontend API URL -->
-      <script
-        async
-        crossorigin="anonymous"
-        data-clerk-publishable-key="{{pub_key}}"
-        src="https://{{fapi_url}}/npm/@clerk/clerk-js@latest/dist/clerk.browser.js"
-        type="text/javascript"
-      ></script>
+        <script type="module" src="/main.js"></script>
+      </body>
+    </html>
+    ```
 
-        <script>
-          window.addEventListener("load", async function () {
-            await Clerk.load();
+    And your JavaScript file should look like this:
 
-            if (Clerk.user) {
-              // Check for an active organization
-              if (Clerk.organization){
-                // Update the organization's logo
-                document.getElementById("upload-logo").addEventListener("click", () => {
-                  const orgLogo = document.getElementById("org-logo").files[0];
+    ```js {{ prettier: false, filename: 'main.js', mark: [14] }}
+    import { Clerk } from '@clerk/clerk-js';
 
-                  Clerk.organization.setLogo({ file: orgLogo })
-                    .then((res) => console.log(res))
-                    .catch((error) => console.log("An error occurred:", error.errors));
-                });
-              } else {
-                // If there is no active organization,
-                // mount Clerk's <OrganizationSwitcher />
-                // to allow the user to set an organization as active
-                document.getElementById("app").innerHTML = `
-                  <h2>Select an organization to set it as active</h2>
-                  <div id="org-switcher"></div>
-                `;
+    // Initialize Clerk with your Clerk publishable key
+    const clerk = new Clerk('{{pub_key}}');
+    await clerk.load();
 
-                const orgSwitcherDiv = document.getElementById("org-switcher");
+    if (clerk.user) {
+      // Check for an active organization
+      if (clerk.organization){
+        // Update the organization's logo
+        document.getElementById("upload-logo").addEventListener("click", () => {
+          const orgLogo = document.getElementById("org-logo").files[0];
 
-                Clerk.mountOrganizationSwitcher(orgSwitcherDiv);
-              }
+          clerk.organization.setLogo({ file: orgLogo })
+            .then((res) => console.log(res))
+            .catch((error) => console.log("An error occurred:", error.errors));
+        });
+      } else {
+        // If there is no active organization,
+        // mount Clerk's <OrganizationSwitcher />
+        // to allow the user to set an organization as active
+        document.getElementById("app").innerHTML = `
+          <h2>Select an organization to set it as active</h2>
+          <div id="org-switcher"></div>
+        `;
+
+        const orgSwitcherDiv = document.getElementById("org-switcher");
+
+        clerk.mountOrganizationSwitcher(orgSwitcherDiv);
+      }
+    } else {
+      document.getElementById("app").innerHTML = `
+        <div id="sign-in"></div>
+      `;
+
+      const signInDiv = document.getElementById("sign-in");
+
+      clerk.mountSignIn(signInDiv);
+    }
+    ```
+  </Tab>
+
+  <Tab>
+    ```html {{ prettier: false, filename: 'index.html', mark: [27] }}
+      <div id="app"></div>
+
+      <input type="file" id="org-logo" />
+      <button id="upload-logo">Upload Logo</button>
+
+      <!-- Initialize Clerk with your
+    Clerk Publishable key and Frontend API URL -->
+    <script
+      async
+      crossorigin="anonymous"
+      data-clerk-publishable-key="{{pub_key}}"
+      src="https://{{fapi_url}}/npm/@clerk/clerk-js@latest/dist/clerk.browser.js"
+      type="text/javascript"
+    ></script>
+
+      <script>
+        window.addEventListener("load", async function () {
+          await Clerk.load();
+
+          if (Clerk.user) {
+            // Check for an active organization
+            if (Clerk.organization){
+              // Update the organization's logo
+              document.getElementById("upload-logo").addEventListener("click", () => {
+                const orgLogo = document.getElementById("org-logo").files[0];
+
+                Clerk.organization.setLogo({ file: orgLogo })
+                  .then((res) => console.log(res))
+                  .catch((error) => console.log("An error occurred:", error.errors));
+              });
             } else {
+              // If there is no active organization,
+              // mount Clerk's <OrganizationSwitcher />
+              // to allow the user to set an organization as active
               document.getElementById("app").innerHTML = `
-                <div id="sign-in"></div>
+                <h2>Select an organization to set it as active</h2>
+                <div id="org-switcher"></div>
               `;
 
-              const signInDiv = document.getElementById("sign-in");
+              const orgSwitcherDiv = document.getElementById("org-switcher");
 
-              Clerk.mountSignIn(signInDiv);
+              Clerk.mountOrganizationSwitcher(orgSwitcherDiv);
             }
-          });
-        </script>
-      ```
-    </Tab>
-  </Tabs>
-</InjectKeys>
+          } else {
+            document.getElementById("app").innerHTML = `
+              <div id="sign-in"></div>
+            `;
+
+            const signInDiv = document.getElementById("sign-in");
+
+            Clerk.mountSignIn(signInDiv);
+          }
+        });
+      </script>
+    ```
+  </Tab>
+</Tabs>
 
 ### `getRoles()`
 
@@ -453,94 +447,92 @@ An _experimental_ interface that includes information about a user's permission.
 
 #### Example
 
-<InjectKeys>
-  <CodeBlockTabs type="npm-script" options={['NPM module', '<script>']}>
-    ```js {{ prettier: false, filename: 'main.js', mark: [10] }}
-    import { Clerk } from '@clerk/clerk-js';
+<CodeBlockTabs type="npm-script" options={['NPM module', '<script>']}>
+  ```js {{ prettier: false, filename: 'main.js', mark: [10] }}
+  import { Clerk } from '@clerk/clerk-js';
 
-    // Initialize Clerk with your Clerk publishable key
-    const clerk = new Clerk('{{pub_key}}');
-    await clerk.load();
+  // Initialize Clerk with your Clerk publishable key
+  const clerk = new Clerk('{{pub_key}}');
+  await clerk.load();
 
-    if (clerk.user) {
-      // Check for an active organization
-      if (clerk.organization) {
-        await clerk.organization.getRoles()
-          .then((res) => console.log(res))
-          .catch((error) => console.log("An error occurred:", error.errors));
-      }else {
-        // If there is no active organization,
-        // mount Clerk's <OrganizationSwitcher />
-        // to allow the user to set an organization as active
-        document.getElementById("app").innerHTML = `
-          <h2>Select an organization to set it as active</h2>
-          <div id="org-switcher"></div>
-        `;
-
-        const orgSwitcherDiv = document.getElementById("org-switcher");
-
-        clerk.mountOrganizationSwitcher(orgSwitcherDiv);
-      }
-    } else {
+  if (clerk.user) {
+    // Check for an active organization
+    if (clerk.organization) {
+      await clerk.organization.getRoles()
+        .then((res) => console.log(res))
+        .catch((error) => console.log("An error occurred:", error.errors));
+    }else {
+      // If there is no active organization,
+      // mount Clerk's <OrganizationSwitcher />
+      // to allow the user to set an organization as active
       document.getElementById("app").innerHTML = `
-        <div id="sign-in"></div>
+        <h2>Select an organization to set it as active</h2>
+        <div id="org-switcher"></div>
       `;
 
-      const signInDiv = document.getElementById("sign-in");
+      const orgSwitcherDiv = document.getElementById("org-switcher");
 
-      clerk.mountSignIn(signInDiv);
+      clerk.mountOrganizationSwitcher(orgSwitcherDiv);
     }
-    ```
+  } else {
+    document.getElementById("app").innerHTML = `
+      <div id="sign-in"></div>
+    `;
 
-    ```html {{ prettier: false, filename: 'index.html', mark: [19] }}
-      <div id="app"></div>
+    const signInDiv = document.getElementById("sign-in");
 
-      <!-- Initialize Clerk with your
-      Clerk Publishable key and Frontend API URL -->
-      <script
-        async
-        crossorigin="anonymous"
-        data-clerk-publishable-key="{{pub_key}}"
-        src="https://{{fapi_url}}/npm/@clerk/clerk-js@latest/dist/clerk.browser.js"
-        type="text/javascript"
-      ></script>
+    clerk.mountSignIn(signInDiv);
+  }
+  ```
 
-      <script>
-        window.addEventListener("load", async function () {
-          await Clerk.load();
-          if (Clerk.user) {
-            // Check for an active organization
-            if (Clerk.organization) {
-              await Clerk.organization.getRoles()
-                .then((res) => console.log(res))
-                .catch((error) => console.log("An error occurred:", error.errors));
-            } else {
-              // If there is no active organization,
-              // mount Clerk's <OrganizationSwitcher />
-              // to allow the user to set an organization as active
-              document.getElementById("app").innerHTML = `
-                <h2>Select an organization to set it as active</h2>
-                <div id="org-switcher"></div>
-              `;
+  ```html {{ prettier: false, filename: 'index.html', mark: [19] }}
+    <div id="app"></div>
 
-              const orgSwitcherDiv = document.getElementById("org-switcher");
+    <!-- Initialize Clerk with your
+    Clerk Publishable key and Frontend API URL -->
+    <script
+      async
+      crossorigin="anonymous"
+      data-clerk-publishable-key="{{pub_key}}"
+      src="https://{{fapi_url}}/npm/@clerk/clerk-js@latest/dist/clerk.browser.js"
+      type="text/javascript"
+    ></script>
 
-              Clerk.mountOrganizationSwitcher(orgSwitcherDiv);
-            }
+    <script>
+      window.addEventListener("load", async function () {
+        await Clerk.load();
+        if (Clerk.user) {
+          // Check for an active organization
+          if (Clerk.organization) {
+            await Clerk.organization.getRoles()
+              .then((res) => console.log(res))
+              .catch((error) => console.log("An error occurred:", error.errors));
           } else {
+            // If there is no active organization,
+            // mount Clerk's <OrganizationSwitcher />
+            // to allow the user to set an organization as active
             document.getElementById("app").innerHTML = `
-              <div id="sign-in"></div>
+              <h2>Select an organization to set it as active</h2>
+              <div id="org-switcher"></div>
             `;
 
-            const signInDiv = document.getElementById("sign-in");
+            const orgSwitcherDiv = document.getElementById("org-switcher");
 
-            Clerk.mountSignIn(signInDiv);
+            Clerk.mountOrganizationSwitcher(orgSwitcherDiv);
           }
-        });
-      </script>
-    ```
-  </CodeBlockTabs>
-</InjectKeys>
+        } else {
+          document.getElementById("app").innerHTML = `
+            <div id="sign-in"></div>
+          `;
+
+          const signInDiv = document.getElementById("sign-in");
+
+          Clerk.mountSignIn(signInDiv);
+        }
+      });
+    </script>
+  ```
+</CodeBlockTabs>
 
 ## Additional methods
 

--- a/docs/references/javascript/session.mdx
+++ b/docs/references/javascript/session.mdx
@@ -84,65 +84,63 @@ function getToken(options?: GetTokenOptions): Promise<string | null>;
 
 #### Example
 
-<InjectKeys>
-  <CodeBlockTabs type="npm-script" options={['NPM module', '<script>']}>
-    ```js {{ prettier: false, filename: 'main.js', mark: [8] }}
-    import { Clerk } from '@clerk/clerk-js';
+<CodeBlockTabs type="npm-script" options={['NPM module', '<script>']}>
+  ```js {{ prettier: false, filename: 'main.js', mark: [8] }}
+  import { Clerk } from '@clerk/clerk-js';
 
-    // Initialize Clerk with your Clerk publishable key
-    const clerk = new Clerk('{{pub_key}}');
-    await clerk.load();
+  // Initialize Clerk with your Clerk publishable key
+  const clerk = new Clerk('{{pub_key}}');
+  await clerk.load();
 
-    if (clerk.user) {
-      await clerk.session.getToken({ template: "Test" })
-        .then((res) => console.log(res))
-        .catch((error) => console.log("An error occurred:", error.errors));
-    } else {
-      document.getElementById("app").innerHTML = `
-        <div id="sign-in"></div>
-      `;
+  if (clerk.user) {
+    await clerk.session.getToken({ template: "Test" })
+      .then((res) => console.log(res))
+      .catch((error) => console.log("An error occurred:", error.errors));
+  } else {
+    document.getElementById("app").innerHTML = `
+      <div id="sign-in"></div>
+    `;
 
-      const signInDiv = document.getElementById("sign-in");
+    const signInDiv = document.getElementById("sign-in");
 
-      clerk.mountSignIn(signInDiv);
-    }
-    ```
+    clerk.mountSignIn(signInDiv);
+  }
+  ```
 
-    ```html {{ prettier: false, filename: 'index.html', mark: [18] }}
-    <div id="app"></div>
+  ```html {{ prettier: false, filename: 'index.html', mark: [18] }}
+  <div id="app"></div>
 
-    <!-- Initialize Clerk with your
-    Clerk Publishable key and Frontend API URL -->
-    <script
-      async
-      crossorigin="anonymous"
-      data-clerk-publishable-key="{{pub_key}}"
-      src="https://{{fapi_url}}/npm/@clerk/clerk-js@latest/dist/clerk.browser.js"
-      type="text/javascript"
-    ></script>
+  <!-- Initialize Clerk with your
+  Clerk Publishable key and Frontend API URL -->
+  <script
+    async
+    crossorigin="anonymous"
+    data-clerk-publishable-key="{{pub_key}}"
+    src="https://{{fapi_url}}/npm/@clerk/clerk-js@latest/dist/clerk.browser.js"
+    type="text/javascript"
+  ></script>
 
-    <script>
-      window.addEventListener('load', async function () {
-        await Clerk.load();
+  <script>
+    window.addEventListener('load', async function () {
+      await Clerk.load();
 
-        if (Clerk.user) {
-          await Clerk.session.getToken({ template: "Test" })
-            .then((res) => console.log(res))
-            .catch((error) => console.log("An error occurred:", error.errors));
-        } else {
-          document.getElementById("app").innerHTML = `
-            <div id="sign-in"></div>
-          `;
+      if (Clerk.user) {
+        await Clerk.session.getToken({ template: "Test" })
+          .then((res) => console.log(res))
+          .catch((error) => console.log("An error occurred:", error.errors));
+      } else {
+        document.getElementById("app").innerHTML = `
+          <div id="sign-in"></div>
+        `;
 
-          const signInDiv = document.getElementById("sign-in");
+        const signInDiv = document.getElementById("sign-in");
 
-          Clerk.mountSignIn(signInDiv);
-        }
-      });
-    </script>
-    ```
-  </CodeBlockTabs>
-</InjectKeys>
+        Clerk.mountSignIn(signInDiv);
+      }
+    });
+  </script>
+  ```
+</CodeBlockTabs>
 
 ```js {{ prettier: false }}
 try {

--- a/docs/references/javascript/user/create-metadata.mdx
+++ b/docs/references/javascript/user/create-metadata.mdx
@@ -30,69 +30,67 @@ function createEmailAddress: (params: CreateEmailAddressParams) => Promise<Email
 
 The following example adds `test@test.com` as an email address for the user. If the user is not signed in, the user will be prompted to sign in.
 
-<InjectKeys>
-  <CodeBlockTabs type="npm-script" options={['NPM module', '<script>']}>
-    ```js {{ prettier: false, filename: 'main.js' }}
-    import { Clerk } from '@clerk/clerk-js';
+<CodeBlockTabs type="npm-script" options={['NPM module', '<script>']}>
+  ```js {{ prettier: false, filename: 'main.js' }}
+  import { Clerk } from '@clerk/clerk-js';
 
-    // Initialize Clerk with your Clerk publishable key
-    const clerk = new Clerk('{{pub_key}}');
-    await clerk.load();
+  // Initialize Clerk with your Clerk publishable key
+  const clerk = new Clerk('{{pub_key}}');
+  await clerk.load();
 
-    if (clerk.user) {
-      const email = "test@test.com";
+  if (clerk.user) {
+    const email = "test@test.com";
 
-      clerk.user.createEmailAddress({ email })
-        .then((response) => console.log(response))
-        .catch((error) => console.log("An error occurred:", error.errors));
-    } else {
-      document.getElementById("app").innerHTML = `
-        <div id="sign-in"></div>
-      `;
+    clerk.user.createEmailAddress({ email })
+      .then((response) => console.log(response))
+      .catch((error) => console.log("An error occurred:", error.errors));
+  } else {
+    document.getElementById("app").innerHTML = `
+      <div id="sign-in"></div>
+    `;
 
-      const signInDiv = document.getElementById("sign-in");
+    const signInDiv = document.getElementById("sign-in");
 
-      clerk.mountSignIn(signInDiv);
-    }
-    ```
+    clerk.mountSignIn(signInDiv);
+  }
+  ```
 
-    ```html {{ prettier: false, filename: 'index.html' }}
-      <div id="app"></div>
+  ```html {{ prettier: false, filename: 'index.html' }}
+    <div id="app"></div>
 
-      <!-- Initialize Clerk with your
-      Clerk Publishable key and Frontend API URL -->
-      <script
-        async
-        crossorigin="anonymous"
-        data-clerk-publishable-key="{{pub_key}}"
-        src="https://{{fapi_url}}/npm/@clerk/clerk-js@latest/dist/clerk.browser.js"
-        type="text/javascript"
-      ></script>
+    <!-- Initialize Clerk with your
+    Clerk Publishable key and Frontend API URL -->
+    <script
+      async
+      crossorigin="anonymous"
+      data-clerk-publishable-key="{{pub_key}}"
+      src="https://{{fapi_url}}/npm/@clerk/clerk-js@latest/dist/clerk.browser.js"
+      type="text/javascript"
+    ></script>
 
-      <script>
-        window.addEventListener("load", async function () {
-          await Clerk.load();
+    <script>
+      window.addEventListener("load", async function () {
+        await Clerk.load();
 
-          if (Clerk.user) {
-            const email = "test@test.com";
+        if (Clerk.user) {
+          const email = "test@test.com";
 
-            Clerk.user.createEmailAddress({ email })
-              .then((response) => console.log(response))
-              .catch((error) => console.log("An error occurred:", error.errors));
-          } else {
-            document.getElementById("app").innerHTML = `
-                <div id="sign-in"></div>
-              `;
+          Clerk.user.createEmailAddress({ email })
+            .then((response) => console.log(response))
+            .catch((error) => console.log("An error occurred:", error.errors));
+        } else {
+          document.getElementById("app").innerHTML = `
+              <div id="sign-in"></div>
+            `;
 
-            const signInDiv = document.getElementById("sign-in");
+          const signInDiv = document.getElementById("sign-in");
 
-            Clerk.mountSignIn(signInDiv);
-          }
-        });
-      </script>
-    ```
-  </CodeBlockTabs>
-</InjectKeys>
+          Clerk.mountSignIn(signInDiv);
+        }
+      });
+    </script>
+  ```
+</CodeBlockTabs>
 
 ## `createPhoneNumber()`
 
@@ -115,69 +113,67 @@ function createPhoneNumber: (params: CreatePhoneNumberParams) => Promise<PhoneNu
 
 The following example adds `15551234567` as a phone number for the user. If the user is not signed in, the user will be prompted to sign in.
 
-<InjectKeys>
-  <CodeBlockTabs type="npm-script" options={['NPM module', '<script>']}>
-    ```js {{ prettier: false, filename: 'main.js' }}
-    import { Clerk } from '@clerk/clerk-js';
+<CodeBlockTabs type="npm-script" options={['NPM module', '<script>']}>
+  ```js {{ prettier: false, filename: 'main.js' }}
+  import { Clerk } from '@clerk/clerk-js';
 
-    // Initialize Clerk with your Clerk publishable key
-    const clerk = new Clerk('{{pub_key}}');
-    await clerk.load();
+  // Initialize Clerk with your Clerk publishable key
+  const clerk = new Clerk('{{pub_key}}');
+  await clerk.load();
 
-    if (clerk.user) {
-      const phoneNumber = "15551234567";
+  if (clerk.user) {
+    const phoneNumber = "15551234567";
 
-      clerk.user.createPhoneNumber({ phoneNumber })
-        .then((response) => console.log(response))
-        .catch((error) => console.log("An error occurred:", error.errors));
-    } else {
-      document.getElementById("app").innerHTML = `
-        <div id="sign-in"></div>
-      `;
+    clerk.user.createPhoneNumber({ phoneNumber })
+      .then((response) => console.log(response))
+      .catch((error) => console.log("An error occurred:", error.errors));
+  } else {
+    document.getElementById("app").innerHTML = `
+      <div id="sign-in"></div>
+    `;
 
-      const signInDiv = document.getElementById("sign-in");
+    const signInDiv = document.getElementById("sign-in");
 
-      clerk.mountSignIn(signInDiv);
-    }
-    ```
+    clerk.mountSignIn(signInDiv);
+  }
+  ```
 
-    ```html {{ prettier: false, filename: 'index.html' }}
-      <div id="app"></div>
+  ```html {{ prettier: false, filename: 'index.html' }}
+    <div id="app"></div>
 
-      <!-- Initialize Clerk with your
-      Clerk Publishable key and Frontend API URL -->
-      <script
-        async
-        crossorigin="anonymous"
-        data-clerk-publishable-key="{{pub_key}}"
-        src="https://{{fapi_url}}/npm/@clerk/clerk-js@latest/dist/clerk.browser.js"
-        type="text/javascript"
-      ></script>
+    <!-- Initialize Clerk with your
+    Clerk Publishable key and Frontend API URL -->
+    <script
+      async
+      crossorigin="anonymous"
+      data-clerk-publishable-key="{{pub_key}}"
+      src="https://{{fapi_url}}/npm/@clerk/clerk-js@latest/dist/clerk.browser.js"
+      type="text/javascript"
+    ></script>
 
-      <script>
-        window.addEventListener("load", async function () {
-          await Clerk.load();
+    <script>
+      window.addEventListener("load", async function () {
+        await Clerk.load();
 
-          if (Clerk.user) {
-            const phoneNumber = "15551234567";
+        if (Clerk.user) {
+          const phoneNumber = "15551234567";
 
-            Clerk.user.createPhoneNumber({ phoneNumber })
-              .then((response) => console.log(response))
-              .catch((error) => console.log("An error occurred:", error.errors));
-          } else {
-            document.getElementById("app").innerHTML = `
-                <div id="sign-in"></div>
-              `;
+          Clerk.user.createPhoneNumber({ phoneNumber })
+            .then((response) => console.log(response))
+            .catch((error) => console.log("An error occurred:", error.errors));
+        } else {
+          document.getElementById("app").innerHTML = `
+              <div id="sign-in"></div>
+            `;
 
-            const signInDiv = document.getElementById("sign-in");
+          const signInDiv = document.getElementById("sign-in");
 
-            Clerk.mountSignIn(signInDiv);
-          }
-        });
-      </script>
-    ```
-  </CodeBlockTabs>
-</InjectKeys>
+          Clerk.mountSignIn(signInDiv);
+        }
+      });
+    </script>
+  ```
+</CodeBlockTabs>
 
 ## `createWeb3Wallet()`
 
@@ -200,69 +196,67 @@ function createWeb3Wallet: (params: CreateWeb3WalletParams) => Promise<Web3Walle
 
 The following example adds `0x0123456789ABCDEF0123456789ABCDEF01234567` as a web3 wallet for the user. If the user is not signed in, the user will be prompted to sign in.
 
-<InjectKeys>
-  <CodeBlockTabs type="npm-script" options={['NPM module', '<script>']}>
-    ```js {{ prettier: false, filename: 'main.js' }}
-    import { Clerk } from '@clerk/clerk-js';
+<CodeBlockTabs type="npm-script" options={['NPM module', '<script>']}>
+  ```js {{ prettier: false, filename: 'main.js' }}
+  import { Clerk } from '@clerk/clerk-js';
 
-    // Initialize Clerk with your Clerk publishable key
-    const clerk = new Clerk('{{pub_key}}');
-    await clerk.load();
+  // Initialize Clerk with your Clerk publishable key
+  const clerk = new Clerk('{{pub_key}}');
+  await clerk.load();
 
-    if (clerk.user) {
-      const web3Wallet = "0x0123456789ABCDEF0123456789ABCDEF01234567";
+  if (clerk.user) {
+    const web3Wallet = "0x0123456789ABCDEF0123456789ABCDEF01234567";
 
-      clerk.user.createWeb3Wallet({ web3Wallet })
-        .then((response) => console.log(response))
-        .catch((error) => console.log("An error occurred:", error.errors));
-    } else {
-      document.getElementById("app").innerHTML = `
-        <div id="sign-in"></div>
-      `;
+    clerk.user.createWeb3Wallet({ web3Wallet })
+      .then((response) => console.log(response))
+      .catch((error) => console.log("An error occurred:", error.errors));
+  } else {
+    document.getElementById("app").innerHTML = `
+      <div id="sign-in"></div>
+    `;
 
-      const signInDiv = document.getElementById("sign-in");
+    const signInDiv = document.getElementById("sign-in");
 
-      clerk.mountSignIn(signInDiv);
-    }
-    ```
+    clerk.mountSignIn(signInDiv);
+  }
+  ```
 
-    ```html {{ prettier: false, filename: 'index.html' }}
-      <div id="app"></div>
+  ```html {{ prettier: false, filename: 'index.html' }}
+    <div id="app"></div>
 
-      <!-- Initialize Clerk with your
-      Clerk Publishable key and Frontend API URL -->
-      <script
-        async
-        crossorigin="anonymous"
-        data-clerk-publishable-key="{{pub_key}}"
-        src="https://{{fapi_url}}/npm/@clerk/clerk-js@latest/dist/clerk.browser.js"
-        type="text/javascript"
-      ></script>
+    <!-- Initialize Clerk with your
+    Clerk Publishable key and Frontend API URL -->
+    <script
+      async
+      crossorigin="anonymous"
+      data-clerk-publishable-key="{{pub_key}}"
+      src="https://{{fapi_url}}/npm/@clerk/clerk-js@latest/dist/clerk.browser.js"
+      type="text/javascript"
+    ></script>
 
-      <script>
-        window.addEventListener("load", async function () {
-          await Clerk.load();
+    <script>
+      window.addEventListener("load", async function () {
+        await Clerk.load();
 
-          if (Clerk.user) {
-            const web3Wallet = "0x0123456789ABCDEF0123456789ABCDEF01234567";
+        if (Clerk.user) {
+          const web3Wallet = "0x0123456789ABCDEF0123456789ABCDEF01234567";
 
-            Clerk.user.createWeb3Wallet({ web3Wallet })
-              .then((response) => console.log(response))
-              .catch((error) => console.log("An error occurred:", error.errors));
-          } else {
-            document.getElementById("app").innerHTML = `
-                <div id="sign-in"></div>
-              `;
+          Clerk.user.createWeb3Wallet({ web3Wallet })
+            .then((response) => console.log(response))
+            .catch((error) => console.log("An error occurred:", error.errors));
+        } else {
+          document.getElementById("app").innerHTML = `
+              <div id="sign-in"></div>
+            `;
 
-            const signInDiv = document.getElementById("sign-in");
+          const signInDiv = document.getElementById("sign-in");
 
-            Clerk.mountSignIn(signInDiv);
-          }
-        });
-      </script>
-    ```
-  </CodeBlockTabs>
-</InjectKeys>
+          Clerk.mountSignIn(signInDiv);
+        }
+      });
+    </script>
+  ```
+</CodeBlockTabs>
 
 ## `createExternalAccount()`
 
@@ -294,135 +288,133 @@ Upon return, inspect within the `user.externalAccounts` the entry that correspon
 
 The following example demonstrates how to add a Notion account as an external account for the user. When the user selects the "Add Notion as a social connection" button, the user will be redirected to Notion to connect their account. After connecting their account, they will be redirected to the `/` route of your application, and the status of the connection will be displayed.
 
-<InjectKeys>
-  <Tabs type="npm-script" items={['NPM module', '<script>']}>
-    <Tab>
-      For the following example, your HTML file should look like this:
+<Tabs type="npm-script" items={['NPM module', '<script>']}>
+  <Tab>
+    For the following example, your HTML file should look like this:
 
-      ```html {{ prettier: false, filename: 'index.html' }}
-      <!doctype html>
-      <html lang="en">
-        <head>
-          <meta charset="UTF-8" />
-          <link rel="icon" type="image/svg+xml" href="/vite.svg" />
-          <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-          <title>Clerk + JavaScript App</title>
-        </head>
-        <body>
-          <div id="app"></div>
-
-          <p>
-            Notion verification status:
-            <span id="notion-status"></span>
-          </p>
-          <button id="add-notion">Add Notion as a social connection</button>
-
-          <script type="module" src="/main.js"></script>
-        </body>
-      </html>
-      ```
-
-      And your JavaScript file should look like this:
-
-      ```js {{ prettier: false, filename: 'main.js' }}
-      import { Clerk } from '@clerk/clerk-js';
-
-      // Initialize Clerk with your Clerk publishable key
-      const clerk = new Clerk('{{pub_key}}');
-      await clerk.load();
-
-      if (clerk.user) {
-        // Find the external account for the provider
-        const externalAccount = clerk.user.externalAccounts.find(
-          (p) => p.provider === "notion"
-        );
-        // If the external account exists, display its status
-        document.getElementById("notion-status").innerHTML =
-          externalAccount.verification.status;
-
-        // When the button is clicked, initiate the connection with the provider
-        document.getElementById("add-notion").addEventListener("click", async () => {
-          clerk.user
-            .createExternalAccount({ strategy: "oauth_notion", redirect_url: "/" })
-            .then((externalAccount) => {
-              window.location.href =
-                externalAccount.verification.externalVerificationRedirectURL;
-            })
-            .catch((error) => {
-              console.log("An error occurred:", error.errors);
-            });
-        });
-      } else {
-        document.getElementById("app").innerHTML = `
-          <div id="sign-in"></div>
-        `;
-
-        const signInDiv = document.getElementById("sign-in");
-
-        clerk.mountSignIn(signInDiv);
-      }
-      ```
-    </Tab>
-
-    <Tab>
-      ```html {{ prettier: false, filename: 'index.html' }}
+    ```html {{ prettier: false, filename: 'index.html' }}
+    <!doctype html>
+    <html lang="en">
+      <head>
+        <meta charset="UTF-8" />
+        <link rel="icon" type="image/svg+xml" href="/vite.svg" />
+        <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+        <title>Clerk + JavaScript App</title>
+      </head>
+      <body>
         <div id="app"></div>
+
         <p>
           Notion verification status:
           <span id="notion-status"></span>
         </p>
         <button id="add-notion">Add Notion as a social connection</button>
 
-        <!-- Initialize Clerk with your
-        Clerk Publishable key and Frontend API URL -->
-        <script
-          async
-          crossorigin="anonymous"
-          data-clerk-publishable-key="{{pub_key}}"
-          src="https://{{fapi_url}}/npm/@clerk/clerk-js@latest/dist/clerk.browser.js"
-          type="text/javascript"
-        ></script>
+        <script type="module" src="/main.js"></script>
+      </body>
+    </html>
+    ```
 
-        <script>
-          window.addEventListener("load", async function () {
-            await Clerk.load();
+    And your JavaScript file should look like this:
 
-            if (Clerk.user) {
-              // Find the external account for the provider
-              const externalAccount = Clerk.user.externalAccounts.find(
-                (p) => p.provider === "notion"
-              );
-              // If the external account exists, display its status
-              document.getElementById("notion-status").innerHTML =
-                externalAccount.verification.status;
+    ```js {{ prettier: false, filename: 'main.js' }}
+    import { Clerk } from '@clerk/clerk-js';
 
-              // When the button is clicked, initiate the connection with the provider
-              document.getElementById("add-notion").addEventListener("click", async () => {
-                Clerk.user
-                  .createExternalAccount({ strategy: "oauth_notion", redirect_url: "/" })
-                  .then((externalAccount) => {
-                    window.location.href =
-                      externalAccount.verification.externalVerificationRedirectURL;
-                  })
-                  .catch((error) => {
-                    console.log("An error occurred:", error.errors);
-                  });
-              });
-            } else {
-              document.getElementById("app").innerHTML = `
-                  <div id="sign-in"></div>
-                `;
+    // Initialize Clerk with your Clerk publishable key
+    const clerk = new Clerk('{{pub_key}}');
+    await clerk.load();
 
-              const signInDiv = document.getElementById("sign-in");
+    if (clerk.user) {
+      // Find the external account for the provider
+      const externalAccount = clerk.user.externalAccounts.find(
+        (p) => p.provider === "notion"
+      );
+      // If the external account exists, display its status
+      document.getElementById("notion-status").innerHTML =
+        externalAccount.verification.status;
 
-              Clerk.mountSignIn(signInDiv);
-            }
+      // When the button is clicked, initiate the connection with the provider
+      document.getElementById("add-notion").addEventListener("click", async () => {
+        clerk.user
+          .createExternalAccount({ strategy: "oauth_notion", redirect_url: "/" })
+          .then((externalAccount) => {
+            window.location.href =
+              externalAccount.verification.externalVerificationRedirectURL;
+          })
+          .catch((error) => {
+            console.log("An error occurred:", error.errors);
           });
-        </script>
-      ```
-    </Tab>
-  </Tabs>
-</InjectKeys>
+      });
+    } else {
+      document.getElementById("app").innerHTML = `
+        <div id="sign-in"></div>
+      `;
+
+      const signInDiv = document.getElementById("sign-in");
+
+      clerk.mountSignIn(signInDiv);
+    }
+    ```
+  </Tab>
+
+  <Tab>
+    ```html {{ prettier: false, filename: 'index.html' }}
+      <div id="app"></div>
+      <p>
+        Notion verification status:
+        <span id="notion-status"></span>
+      </p>
+      <button id="add-notion">Add Notion as a social connection</button>
+
+      <!-- Initialize Clerk with your
+      Clerk Publishable key and Frontend API URL -->
+      <script
+        async
+        crossorigin="anonymous"
+        data-clerk-publishable-key="{{pub_key}}"
+        src="https://{{fapi_url}}/npm/@clerk/clerk-js@latest/dist/clerk.browser.js"
+        type="text/javascript"
+      ></script>
+
+      <script>
+        window.addEventListener("load", async function () {
+          await Clerk.load();
+
+          if (Clerk.user) {
+            // Find the external account for the provider
+            const externalAccount = Clerk.user.externalAccounts.find(
+              (p) => p.provider === "notion"
+            );
+            // If the external account exists, display its status
+            document.getElementById("notion-status").innerHTML =
+              externalAccount.verification.status;
+
+            // When the button is clicked, initiate the connection with the provider
+            document.getElementById("add-notion").addEventListener("click", async () => {
+              Clerk.user
+                .createExternalAccount({ strategy: "oauth_notion", redirect_url: "/" })
+                .then((externalAccount) => {
+                  window.location.href =
+                    externalAccount.verification.externalVerificationRedirectURL;
+                })
+                .catch((error) => {
+                  console.log("An error occurred:", error.errors);
+                });
+            });
+          } else {
+            document.getElementById("app").innerHTML = `
+                <div id="sign-in"></div>
+              `;
+
+            const signInDiv = document.getElementById("sign-in");
+
+            Clerk.mountSignIn(signInDiv);
+          }
+        });
+      </script>
+    ```
+  </Tab>
+</Tabs>
 
 [email-ref]: /docs/references/javascript/email-address
 

--- a/docs/references/javascript/user/password-management.mdx
+++ b/docs/references/javascript/user/password-management.mdx
@@ -27,79 +27,20 @@ function updatePassword: (params: UpdateUserPasswordParams) => Promise<User>;
 
 ### Example
 
-<InjectKeys>
-  <Tabs type="npm-script" items={['NPM module', '<script>']}>
-    <Tab>
-      For the following example, your HTML file should look like this:
+<Tabs type="npm-script" items={['NPM module', '<script>']}>
+  <Tab>
+    For the following example, your HTML file should look like this:
 
-      ```html {{ prettier: false, filename: 'index.html' }}
-      <!doctype html>
-      <html lang="en">
-        <head>
-          <meta charset="UTF-8" />
-          <link rel="icon" type="image/svg+xml" href="/vite.svg" />
-          <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-          <title>Clerk + JavaScript App</title>
-        </head>
-        <body>
-          <div id="app"></div>
-
-          <h1>Update password</h1>
-          <input
-            type="password"
-            id="current-password"
-            placeholder="Current password"
-          />
-          <input
-            type="password"
-            id="new-password"
-            placeholder="New password"
-          />
-          <p id="error"></p>
-          <button id="update-password-button">Update password</button>
-
-          <script type="module" src="/main.js"></script>
-        </body>
-      </html>
-      ```
-
-      And your JavaScript file should look like this:
-
-      ```js {{ prettier: false, filename: 'main.js' }}
-      import { Clerk } from '@clerk/clerk-js';
-
-      // Initialize Clerk with your Clerk publishable key
-      const clerk = new Clerk('{{pub_key}}');
-      await clerk.load();
-
-      if (clerk.user) {
-        document.getElementById("update-password-button")
-          .addEventListener("click", async function () {
-            const currentPassword = document.getElementById("current-password").value;
-
-            const newPassword = document.getElementById("new-password").value;
-            clerk.user.updatePassword({ currentPassword, newPassword })
-            .then((response) => console.log(response))
-            .catch((error) => {
-              document.getElementById("error").innerHTML =
-                error.errors[0].longMessage;
-              console.log("An error occurred:", error.errors);
-            });
-          });
-      } else {
-        document.getElementById("app").innerHTML = `
-          <div id="sign-in"></div>
-        `;
-
-        const signInDiv = document.getElementById("sign-in");
-
-        clerk.mountSignIn(signInDiv);
-      }
-      ```
-    </Tab>
-
-    <Tab>
-      ```html {{ prettier: false, filename: 'index.html' }}
+    ```html {{ prettier: false, filename: 'index.html' }}
+    <!doctype html>
+    <html lang="en">
+      <head>
+        <meta charset="UTF-8" />
+        <link rel="icon" type="image/svg+xml" href="/vite.svg" />
+        <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+        <title>Clerk + JavaScript App</title>
+      </head>
+      <body>
         <div id="app"></div>
 
         <h1>Update password</h1>
@@ -116,50 +57,107 @@ function updatePassword: (params: UpdateUserPasswordParams) => Promise<User>;
         <p id="error"></p>
         <button id="update-password-button">Update password</button>
 
-        <!-- Initialize Clerk with your
-        Clerk Publishable key and Frontend API URL -->
-        <script
-          async
-          crossorigin="anonymous"
-          data-clerk-publishable-key="{{pub_key}}"
-          src="https://{{fapi_url}}/npm/@clerk/clerk-js@latest/dist/clerk.browser.js"
-          type="text/javascript"
-        ></script>
+        <script type="module" src="/main.js"></script>
+      </body>
+    </html>
+    ```
 
-        <script>
-          window.addEventListener("load", async function () {
-            await Clerk.load();
+    And your JavaScript file should look like this:
 
-            if (Clerk.user) {
-              document.getElementById("update-password-button")
-                .addEventListener("click", async function () {
-                  const currentPassword =
-                    document.getElementById("current-password").value;
-                  const newPassword = document.getElementById("new-password").value;
+    ```js {{ prettier: false, filename: 'main.js' }}
+    import { Clerk } from '@clerk/clerk-js';
 
-                  Clerk.user.updatePassword({ currentPassword, newPassword})
-                  .then((response) => console.log(response))
-                  .catch((error) => {
-                    document.getElementById("error").innerHTML =
-                      error.errors[0].longMessage;
-                    console.log("An error occurred:", error.errors);
-                  });
-                });
-            } else {
-              document.getElementById("app").innerHTML = `
-                  <div id="sign-in"></div>
-                `;
+    // Initialize Clerk with your Clerk publishable key
+    const clerk = new Clerk('{{pub_key}}');
+    await clerk.load();
 
-              const signInDiv = document.getElementById("sign-in");
+    if (clerk.user) {
+      document.getElementById("update-password-button")
+        .addEventListener("click", async function () {
+          const currentPassword = document.getElementById("current-password").value;
 
-              Clerk.mountSignIn(signInDiv);
-            }
+          const newPassword = document.getElementById("new-password").value;
+          clerk.user.updatePassword({ currentPassword, newPassword })
+          .then((response) => console.log(response))
+          .catch((error) => {
+            document.getElementById("error").innerHTML =
+              error.errors[0].longMessage;
+            console.log("An error occurred:", error.errors);
           });
-        </script>
-      ```
-    </Tab>
-  </Tabs>
-</InjectKeys>
+        });
+    } else {
+      document.getElementById("app").innerHTML = `
+        <div id="sign-in"></div>
+      `;
+
+      const signInDiv = document.getElementById("sign-in");
+
+      clerk.mountSignIn(signInDiv);
+    }
+    ```
+  </Tab>
+
+  <Tab>
+    ```html {{ prettier: false, filename: 'index.html' }}
+      <div id="app"></div>
+
+      <h1>Update password</h1>
+      <input
+        type="password"
+        id="current-password"
+        placeholder="Current password"
+      />
+      <input
+        type="password"
+        id="new-password"
+        placeholder="New password"
+      />
+      <p id="error"></p>
+      <button id="update-password-button">Update password</button>
+
+      <!-- Initialize Clerk with your
+      Clerk Publishable key and Frontend API URL -->
+      <script
+        async
+        crossorigin="anonymous"
+        data-clerk-publishable-key="{{pub_key}}"
+        src="https://{{fapi_url}}/npm/@clerk/clerk-js@latest/dist/clerk.browser.js"
+        type="text/javascript"
+      ></script>
+
+      <script>
+        window.addEventListener("load", async function () {
+          await Clerk.load();
+
+          if (Clerk.user) {
+            document.getElementById("update-password-button")
+              .addEventListener("click", async function () {
+                const currentPassword =
+                  document.getElementById("current-password").value;
+                const newPassword = document.getElementById("new-password").value;
+
+                Clerk.user.updatePassword({ currentPassword, newPassword})
+                .then((response) => console.log(response))
+                .catch((error) => {
+                  document.getElementById("error").innerHTML =
+                    error.errors[0].longMessage;
+                  console.log("An error occurred:", error.errors);
+                });
+              });
+          } else {
+            document.getElementById("app").innerHTML = `
+                <div id="sign-in"></div>
+              `;
+
+            const signInDiv = document.getElementById("sign-in");
+
+            Clerk.mountSignIn(signInDiv);
+          }
+        });
+      </script>
+    ```
+  </Tab>
+</Tabs>
 
 ## `removePassword()`
 
@@ -177,72 +175,53 @@ function removePassword: (params: RemoveUserPasswordParams) => Promise<User>;
 
 ### Example
 
-<InjectKeys>
-  <Tabs type="npm-script" items={['NPM module', '<script>']}>
-    <Tab>
-      For the following example, your HTML file should look like this:
+<Tabs type="npm-script" items={['NPM module', '<script>']}>
+  <Tab>
+    For the following example, your HTML file should look like this:
 
-      ```js {{ prettier: false, filename: 'main.js' }}
-      import { Clerk } from '@clerk/clerk-js';
+    ```js {{ prettier: false, filename: 'main.js' }}
+    import { Clerk } from '@clerk/clerk-js';
 
-      // Initialize Clerk with your Clerk publishable key
-      const clerk = new Clerk('{{pub_key}}');
-      await clerk.load();
+    // Initialize Clerk with your Clerk publishable key
+    const clerk = new Clerk('{{pub_key}}');
+    await clerk.load();
 
-      if (clerk.user) {
-        document.getElementById("remove-password-button")
-          .addEventListener("click", async () => {
-            const currentPassword = document.getElementById("current-password").value;
+    if (clerk.user) {
+      document.getElementById("remove-password-button")
+        .addEventListener("click", async () => {
+          const currentPassword = document.getElementById("current-password").value;
 
-            clerk.user.removePassword({ currentPassword })
-              .then((response) => console.log(response))
-              .catch((error) => {
-                document.getElementById("error").innerHTML =
-                  error.errors[0].longMessage;
-                console.log("An error occurred:", error.errors);
-              });
-          });
-      } else {
-        document.getElementById("app").innerHTML = `
-          <div id="sign-in"></div>
-        `;
+          clerk.user.removePassword({ currentPassword })
+            .then((response) => console.log(response))
+            .catch((error) => {
+              document.getElementById("error").innerHTML =
+                error.errors[0].longMessage;
+              console.log("An error occurred:", error.errors);
+            });
+        });
+    } else {
+      document.getElementById("app").innerHTML = `
+        <div id="sign-in"></div>
+      `;
 
-        const signInDiv = document.getElementById("sign-in");
+      const signInDiv = document.getElementById("sign-in");
 
-        clerk.mountSignIn(signInDiv);
-      }
-      ```
+      clerk.mountSignIn(signInDiv);
+    }
+    ```
 
-      And your HTML file should look like this:
+    And your HTML file should look like this:
 
-      ```html {{ prettier: false, filename: 'index.html' }}
-      <!doctype html>
-      <html lang="en">
-        <head>
-          <meta charset="UTF-8" />
-          <link rel="icon" type="image/svg+xml" href="/vite.svg" />
-          <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-          <title>Clerk + JavaScript App</title>
-        </head>
-        <body>
-          <div id="app"></div>
-
-          <input
-            type="password"
-            id="current-password"
-            placeholder="Current password"
-          />
-          <p id="error"></p>
-          <button id="remove-password-button">Remove Password</button>
-
-          <script type="module" src="/main.js"></script>
-        </body>
-      </html>
-      ```
-    </Tab>
-
-    <Tab>
-      ```html {{ prettier: false, filename: 'index.html' }}
+    ```html {{ prettier: false, filename: 'index.html' }}
+    <!doctype html>
+    <html lang="en">
+      <head>
+        <meta charset="UTF-8" />
+        <link rel="icon" type="image/svg+xml" href="/vite.svg" />
+        <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+        <title>Clerk + JavaScript App</title>
+      </head>
+      <body>
         <div id="app"></div>
 
         <input
@@ -253,46 +232,63 @@ function removePassword: (params: RemoveUserPasswordParams) => Promise<User>;
         <p id="error"></p>
         <button id="remove-password-button">Remove Password</button>
 
-        <!-- Initialize Clerk with your
-        Clerk Publishable key and Frontend API URL -->
-        <script
-          async
-          crossorigin="anonymous"
-          data-clerk-publishable-key="{{pub_key}}"
-          src="https://{{fapi_url}}/npm/@clerk/clerk-js@latest/dist/clerk.browser.js"
-          type="text/javascript"
-        ></script>
+        <script type="module" src="/main.js"></script>
+      </body>
+    </html>
+    ```
+  </Tab>
 
-        <script>
-          window.addEventListener("load", async function () {
-            await Clerk.load();
+  <Tab>
+    ```html {{ prettier: false, filename: 'index.html' }}
+      <div id="app"></div>
 
-            if (Clerk.user) {
-              document.getElementById("remove-password-button")
-                .addEventListener("click", async () => {
-                  const currentPassword =
-                    document.getElementById("current-password").value;
+      <input
+        type="password"
+        id="current-password"
+        placeholder="Current password"
+      />
+      <p id="error"></p>
+      <button id="remove-password-button">Remove Password</button>
 
-                  Clerk.user.removePassword({ currentPassword })
-                    .then((response) => console.log(response))
-                    .catch((error) => {
-                      document.getElementById("error").innerHTML =
-                        error.errors[0].longMessage;
-                      console.log("An error occurred:", error.errors);
-                    });
-                });
-            } else {
-              document.getElementById("app").innerHTML = `
-                  <div id="sign-in"></div>
-                `;
+      <!-- Initialize Clerk with your
+      Clerk Publishable key and Frontend API URL -->
+      <script
+        async
+        crossorigin="anonymous"
+        data-clerk-publishable-key="{{pub_key}}"
+        src="https://{{fapi_url}}/npm/@clerk/clerk-js@latest/dist/clerk.browser.js"
+        type="text/javascript"
+      ></script>
 
-              const signInDiv = document.getElementById("sign-in");
+      <script>
+        window.addEventListener("load", async function () {
+          await Clerk.load();
 
-              Clerk.mountSignIn(signInDiv);
-            }
-          });
-        </script>
-      ```
-    </Tab>
-  </Tabs>
-</InjectKeys>
+          if (Clerk.user) {
+            document.getElementById("remove-password-button")
+              .addEventListener("click", async () => {
+                const currentPassword =
+                  document.getElementById("current-password").value;
+
+                Clerk.user.removePassword({ currentPassword })
+                  .then((response) => console.log(response))
+                  .catch((error) => {
+                    document.getElementById("error").innerHTML =
+                      error.errors[0].longMessage;
+                    console.log("An error occurred:", error.errors);
+                  });
+              });
+          } else {
+            document.getElementById("app").innerHTML = `
+                <div id="sign-in"></div>
+              `;
+
+            const signInDiv = document.getElementById("sign-in");
+
+            Clerk.mountSignIn(signInDiv);
+          }
+        });
+      </script>
+    ```
+  </Tab>
+</Tabs>

--- a/docs/references/javascript/user/totp.mdx
+++ b/docs/references/javascript/user/totp.mdx
@@ -88,142 +88,20 @@ The following example assumes:
 - you have followed the [quickstart](/docs/quickstarts/javascript) in order to add Clerk to your JavaScript application
 - you have [enabled **Authenticator application** and **Backup codes** as multi-factor strategies in your Clerk Dashboard](/docs/authentication/configuration/sign-up-sign-in-options#authentication-strategies)
 
-<InjectKeys>
-  <Tabs type="npm-script" items={['NPM module', '<script>']}>
-    <Tab>
-      For the following example, your HTML file should look like this:
+<Tabs type="npm-script" items={['NPM module', '<script>']}>
+  <Tab>
+    For the following example, your HTML file should look like this:
 
-      ```html {{ prettier: false, filename: 'index.html' }}
-      <!doctype html>
-      <html lang="en">
-        <head>
-          <meta charset="UTF-8" />
-          <link rel="icon" type="image/svg+xml" href="/vite.svg" />
-          <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-          <title>Clerk + JavaScript App</title>
-        </head>
-        <body>
-          <div id="app"></div>
-
-          <p id="error-container" hidden>
-            Error:
-            <span id="error-message"></span>
-          </p>
-
-          <button id="create-totp">Create TOTP</button>
-          <button id="disable-totp">Disable TOTP</button>
-          <button id="create-backup-codes">Create Backup Codes</button>
-
-          <div id="totp-container" hidden>
-            <p id="enter-totp-secret">
-              Enter the TOTP secret into your authenticator app:
-              <span id="totp-secret"></span>
-            </p>
-
-            <label for="totp-code">
-              Enter the code from your authenticator app
-            </label>
-            <input id="totp-code" type="text" />
-            <button id="verify-totp">Verify TOTP</button>
-          </div>
-
-          <h2>Response:</h2>
-          <pre id="response"></pre>
-
-          <script type="module" src="/main.js"></script>
-        </body>
-      </html>
-      ```
-
-      And your JavaScript file should look like this:
-
-      ```js {{ prettier: false, filename: 'main.js' }}
-      import { Clerk } from '@clerk/clerk-js';
-
-      // Initialize Clerk with your Clerk publishable key
-      const clerk = new Clerk('{{pub_key}}');
-      await clerk.load();
-
-      if (clerk.user) {
-        // Create and verify TOTP
-        document.getElementById("create-totp")
-          .addEventListener("click", async () => {
-            clerk.user.createTOTP()
-              .then((res) => {
-                // Show the TOTP container with the secret and verify button
-                document.getElementById("totp-container").removeAttribute("hidden");
-
-                // Display the secret to the user
-                document.getElementById("totp-secret").innerHTML = res.secret;
-
-                // Add event listener to verify TOTP button
-                document.getElementById("verify-totp")
-                  .addEventListener("click", async () => {
-                    const code = document.getElementById("totp-code").value;
-                    clerk.user.verifyTOTP({ code })
-                      .then((res) => {
-                        document.getElementById("response").innerHTML =
-                          JSON.stringify(res);
-                      })
-                      .catch((error) => {
-                        document.getElementById("error-container").removeAttribute("hidden");
-                        document.getElementById("error-message").innerHTML =
-                          error.errors[0].longMessage;
-                        console.log("An error occurred:", error.errors);
-                      });
-                  });
-              })
-              .catch((error) => {
-                document.getElementById("error-container").removeAttribute("hidden");
-                document.getElementById("error-message").innerHTML =
-                  error.errors[0].longMessage;
-                console.log("An error occurred:", error.errors);
-              });
-        });
-
-        // Disable TOTP
-        document.getElementById("disable-totp")
-          .addEventListener("click", async () => {
-            clerk.user.disableTOTP()
-              .then((res) => {
-                document.getElementById("response").innerHTML = JSON.stringify(res);
-              })
-              .catch((error) => {
-                document.getElementById("error-container").removeAttribute("hidden");
-                document.getElementById("error-message").innerHTML =
-                  error.errors[0].longMessage;
-                console.log("An error occurred:", error.errors);
-              });
-          });
-
-        // Create backup codes
-        document.getElementById("create-backup-codes")
-          .addEventListener("click", async () => {
-            clerk.user.createBackupCode()
-              .then((res) => {
-                document.getElementById("response").innerHTML = JSON.stringify(res);
-              })
-              .catch((error) => {
-                document.getElementById("error-container").removeAttribute("hidden");
-                document.getElementById("error-message").innerHTML =
-                  error.errors[0].longMessage;
-                console.log("An error occurred:", error.errors);
-              });
-          });
-      } else {
-        document.getElementById("app").innerHTML = `
-          <div id="sign-in"></div>
-        `;
-
-        const signInDiv = document.getElementById("sign-in");
-
-        clerk.mountSignIn(signInDiv);
-      }
-      ```
-    </Tab>
-
-    <Tab>
-      ```html {{ prettier: false, filename: 'index.html' }}
+    ```html {{ prettier: false, filename: 'index.html' }}
+    <!doctype html>
+    <html lang="en">
+      <head>
+        <meta charset="UTF-8" />
+        <link rel="icon" type="image/svg+xml" href="/vite.svg" />
+        <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+        <title>Clerk + JavaScript App</title>
+      </head>
+      <body>
         <div id="app"></div>
 
         <p id="error-container" hidden>
@@ -251,47 +129,40 @@ The following example assumes:
         <h2>Response:</h2>
         <pre id="response"></pre>
 
-        <!-- Initialize Clerk with your
-        Clerk Publishable key and Frontend API URL -->
-        <script
-          async
-          crossorigin="anonymous"
-          data-clerk-publishable-key="{{pub_key}}"
-          src="https://{{fapi_url}}/npm/@clerk/clerk-js@latest/dist/clerk.browser.js"
-          type="text/javascript"
-        ></script>
+        <script type="module" src="/main.js"></script>
+      </body>
+    </html>
+    ```
 
-        <script>
-          window.addEventListener("load", async function () {
-            await Clerk.load();
-            if (Clerk.user) {
-              // Create and verify TOTP
-              document.getElementById("create-totp")
+    And your JavaScript file should look like this:
+
+    ```js {{ prettier: false, filename: 'main.js' }}
+    import { Clerk } from '@clerk/clerk-js';
+
+    // Initialize Clerk with your Clerk publishable key
+    const clerk = new Clerk('{{pub_key}}');
+    await clerk.load();
+
+    if (clerk.user) {
+      // Create and verify TOTP
+      document.getElementById("create-totp")
+        .addEventListener("click", async () => {
+          clerk.user.createTOTP()
+            .then((res) => {
+              // Show the TOTP container with the secret and verify button
+              document.getElementById("totp-container").removeAttribute("hidden");
+
+              // Display the secret to the user
+              document.getElementById("totp-secret").innerHTML = res.secret;
+
+              // Add event listener to verify TOTP button
+              document.getElementById("verify-totp")
                 .addEventListener("click", async () => {
-                  Clerk.user.createTOTP()
+                  const code = document.getElementById("totp-code").value;
+                  clerk.user.verifyTOTP({ code })
                     .then((res) => {
-                      // Show the TOTP container with the secret and verify button
-                      document.getElementById("totp-container").removeAttribute("hidden");
-
-                      // Display the secret to the user
-                      document.getElementById("totp-secret").innerHTML = res.secret;
-
-                      // Add event listener to verify TOTP button
-                      document.getElementById("verify-totp")
-                        .addEventListener("click", async () => {
-                          const code = document.getElementById("totp-code").value;
-                          Clerk.user.verifyTOTP({ code })
-                            .then((res) => {
-                              document.getElementById("response").innerHTML =
-                                JSON.stringify(res);
-                            })
-                            .catch((error) => {
-                              document.getElementById("error-container").removeAttribute("hidden");
-                              document.getElementById("error-message").innerHTML =
-                                error.errors[0].longMessage;
-                              console.log("An error occurred:", error.errors);
-                            });
-                        });
+                      document.getElementById("response").innerHTML =
+                        JSON.stringify(res);
                     })
                     .catch((error) => {
                       document.getElementById("error-container").removeAttribute("hidden");
@@ -299,49 +170,176 @@ The following example assumes:
                         error.errors[0].longMessage;
                       console.log("An error occurred:", error.errors);
                     });
+                });
+            })
+            .catch((error) => {
+              document.getElementById("error-container").removeAttribute("hidden");
+              document.getElementById("error-message").innerHTML =
+                error.errors[0].longMessage;
+              console.log("An error occurred:", error.errors);
+            });
+      });
+
+      // Disable TOTP
+      document.getElementById("disable-totp")
+        .addEventListener("click", async () => {
+          clerk.user.disableTOTP()
+            .then((res) => {
+              document.getElementById("response").innerHTML = JSON.stringify(res);
+            })
+            .catch((error) => {
+              document.getElementById("error-container").removeAttribute("hidden");
+              document.getElementById("error-message").innerHTML =
+                error.errors[0].longMessage;
+              console.log("An error occurred:", error.errors);
+            });
+        });
+
+      // Create backup codes
+      document.getElementById("create-backup-codes")
+        .addEventListener("click", async () => {
+          clerk.user.createBackupCode()
+            .then((res) => {
+              document.getElementById("response").innerHTML = JSON.stringify(res);
+            })
+            .catch((error) => {
+              document.getElementById("error-container").removeAttribute("hidden");
+              document.getElementById("error-message").innerHTML =
+                error.errors[0].longMessage;
+              console.log("An error occurred:", error.errors);
+            });
+        });
+    } else {
+      document.getElementById("app").innerHTML = `
+        <div id="sign-in"></div>
+      `;
+
+      const signInDiv = document.getElementById("sign-in");
+
+      clerk.mountSignIn(signInDiv);
+    }
+    ```
+  </Tab>
+
+  <Tab>
+    ```html {{ prettier: false, filename: 'index.html' }}
+      <div id="app"></div>
+
+      <p id="error-container" hidden>
+        Error:
+        <span id="error-message"></span>
+      </p>
+
+      <button id="create-totp">Create TOTP</button>
+      <button id="disable-totp">Disable TOTP</button>
+      <button id="create-backup-codes">Create Backup Codes</button>
+
+      <div id="totp-container" hidden>
+        <p id="enter-totp-secret">
+          Enter the TOTP secret into your authenticator app:
+          <span id="totp-secret"></span>
+        </p>
+
+        <label for="totp-code">
+          Enter the code from your authenticator app
+        </label>
+        <input id="totp-code" type="text" />
+        <button id="verify-totp">Verify TOTP</button>
+      </div>
+
+      <h2>Response:</h2>
+      <pre id="response"></pre>
+
+      <!-- Initialize Clerk with your
+      Clerk Publishable key and Frontend API URL -->
+      <script
+        async
+        crossorigin="anonymous"
+        data-clerk-publishable-key="{{pub_key}}"
+        src="https://{{fapi_url}}/npm/@clerk/clerk-js@latest/dist/clerk.browser.js"
+        type="text/javascript"
+      ></script>
+
+      <script>
+        window.addEventListener("load", async function () {
+          await Clerk.load();
+          if (Clerk.user) {
+            // Create and verify TOTP
+            document.getElementById("create-totp")
+              .addEventListener("click", async () => {
+                Clerk.user.createTOTP()
+                  .then((res) => {
+                    // Show the TOTP container with the secret and verify button
+                    document.getElementById("totp-container").removeAttribute("hidden");
+
+                    // Display the secret to the user
+                    document.getElementById("totp-secret").innerHTML = res.secret;
+
+                    // Add event listener to verify TOTP button
+                    document.getElementById("verify-totp")
+                      .addEventListener("click", async () => {
+                        const code = document.getElementById("totp-code").value;
+                        Clerk.user.verifyTOTP({ code })
+                          .then((res) => {
+                            document.getElementById("response").innerHTML =
+                              JSON.stringify(res);
+                          })
+                          .catch((error) => {
+                            document.getElementById("error-container").removeAttribute("hidden");
+                            document.getElementById("error-message").innerHTML =
+                              error.errors[0].longMessage;
+                            console.log("An error occurred:", error.errors);
+                          });
+                      });
+                  })
+                  .catch((error) => {
+                    document.getElementById("error-container").removeAttribute("hidden");
+                    document.getElementById("error-message").innerHTML =
+                      error.errors[0].longMessage;
+                    console.log("An error occurred:", error.errors);
+                  });
+            });
+
+            // Disable TOTP
+            document.getElementById("disable-totp")
+              .addEventListener("click", async () => {
+                Clerk.user.disableTOTP()
+                  .then((res) => {
+                    document.getElementById("response").innerHTML = JSON.stringify(res);
+                  })
+                  .catch((error) => {
+                    document.getElementById("error-container").removeAttribute("hidden");
+                    document.getElementById("error-message").innerHTML =
+                      error.errors[0].longMessage;
+                    console.log("An error occurred:", error.errors);
+                  });
               });
 
-              // Disable TOTP
-              document.getElementById("disable-totp")
-                .addEventListener("click", async () => {
-                  Clerk.user.disableTOTP()
-                    .then((res) => {
-                      document.getElementById("response").innerHTML = JSON.stringify(res);
-                    })
-                    .catch((error) => {
-                      document.getElementById("error-container").removeAttribute("hidden");
-                      document.getElementById("error-message").innerHTML =
-                        error.errors[0].longMessage;
-                      console.log("An error occurred:", error.errors);
-                    });
-                });
+            // Create backup codes
+            document.getElementById("create-backup-codes")
+              .addEventListener("click", async () => {
+                Clerk.user.createBackupCode()
+                  .then((res) => {
+                    document.getElementById("response").innerHTML = JSON.stringify(res);
+                  })
+                  .catch((error) => {
+                    document.getElementById("error-container").removeAttribute("hidden");
+                    document.getElementById("error-message").innerHTML =
+                      error.errors[0].longMessage;
+                    console.log("An error occurred:", error.errors);
+                  });
+              });
+          } else {
+            document.getElementById("app").innerHTML = `
+                <div id="sign-in"></div>
+              `;
 
-              // Create backup codes
-              document.getElementById("create-backup-codes")
-                .addEventListener("click", async () => {
-                  Clerk.user.createBackupCode()
-                    .then((res) => {
-                      document.getElementById("response").innerHTML = JSON.stringify(res);
-                    })
-                    .catch((error) => {
-                      document.getElementById("error-container").removeAttribute("hidden");
-                      document.getElementById("error-message").innerHTML =
-                        error.errors[0].longMessage;
-                      console.log("An error occurred:", error.errors);
-                    });
-                });
-            } else {
-              document.getElementById("app").innerHTML = `
-                  <div id="sign-in"></div>
-                `;
+            const signInDiv = document.getElementById("sign-in");
 
-              const signInDiv = document.getElementById("sign-in");
-
-              Clerk.mountSignIn(signInDiv);
-            }
-          });
-        </script>
-      ```
-    </Tab>
-  </Tabs>
-</InjectKeys>
+            Clerk.mountSignIn(signInDiv);
+          }
+        });
+      </script>
+    ```
+  </Tab>
+</Tabs>

--- a/docs/references/javascript/user/user.mdx
+++ b/docs/references/javascript/user/user.mdx
@@ -84,65 +84,63 @@ All props below are optional.
 
 In the following example, the user's first name is updated to "Test".
 
-<InjectKeys>
-  <CodeBlockTabs type="npm-script" options={['NPM module', '<script>']}>
-    ```js {{ prettier: false, filename: 'main.js', mark: [8] }}
-    import { Clerk } from '@clerk/clerk-js';
+<CodeBlockTabs type="npm-script" options={['NPM module', '<script>']}>
+  ```js {{ prettier: false, filename: 'main.js', mark: [8] }}
+  import { Clerk } from '@clerk/clerk-js';
 
-    // Initialize Clerk with your Clerk publishable key
-    const clerk = new Clerk('{{pub_key}}');
-    await clerk.load();
+  // Initialize Clerk with your Clerk publishable key
+  const clerk = new Clerk('{{pub_key}}');
+  await clerk.load();
 
-    if (clerk.user) {
-      await clerk.user.update({ firstName: "Test" })
-        .then((res) => console.log(res))
-        .catch((error) => console.log("An error occurred:", error.errors));
-    } else {
-      document.getElementById("app").innerHTML = `
-        <div id="sign-in"></div>
-      `;
+  if (clerk.user) {
+    await clerk.user.update({ firstName: "Test" })
+      .then((res) => console.log(res))
+      .catch((error) => console.log("An error occurred:", error.errors));
+  } else {
+    document.getElementById("app").innerHTML = `
+      <div id="sign-in"></div>
+    `;
 
-      const signInDiv = document.getElementById("sign-in");
+    const signInDiv = document.getElementById("sign-in");
 
-      clerk.mountSignIn(signInDiv);
-    }
-    ```
+    clerk.mountSignIn(signInDiv);
+  }
+  ```
 
-    ```html {{ prettier: false, filename: 'index.html', mark: [18] }}
-    <div id="app"></div>
+  ```html {{ prettier: false, filename: 'index.html', mark: [18] }}
+  <div id="app"></div>
 
-    <!-- Initialize Clerk with your
-    Clerk Publishable key and Frontend API URL -->
-    <script
-      async
-      crossorigin="anonymous"
-      data-clerk-publishable-key="{{pub_key}}"
-      src="https://{{fapi_url}}/npm/@clerk/clerk-js@latest/dist/clerk.browser.js"
-      type="text/javascript"
-    ></script>
+  <!-- Initialize Clerk with your
+  Clerk Publishable key and Frontend API URL -->
+  <script
+    async
+    crossorigin="anonymous"
+    data-clerk-publishable-key="{{pub_key}}"
+    src="https://{{fapi_url}}/npm/@clerk/clerk-js@latest/dist/clerk.browser.js"
+    type="text/javascript"
+  ></script>
 
-    <script>
-      window.addEventListener('load', async function () {
-        await Clerk.load();
+  <script>
+    window.addEventListener('load', async function () {
+      await Clerk.load();
 
-        if (Clerk.user) {
-          await Clerk.user.update({ firstName: "Test" })
-            .then((res) => console.log(res))
-            .catch((error) => console.log("An error occurred:", error.errors));
-        } else {
-          document.getElementById("app").innerHTML = `
-            <div id="sign-in"></div>
-          `;
+      if (Clerk.user) {
+        await Clerk.user.update({ firstName: "Test" })
+          .then((res) => console.log(res))
+          .catch((error) => console.log("An error occurred:", error.errors));
+      } else {
+        document.getElementById("app").innerHTML = `
+          <div id="sign-in"></div>
+        `;
 
-          const signInDiv = document.getElementById("sign-in");
+        const signInDiv = document.getElementById("sign-in");
 
-          Clerk.mountSignIn(signInDiv);
-        }
-      });
-    </script>
-    ```
-  </CodeBlockTabs>
-</InjectKeys>
+        Clerk.mountSignIn(signInDiv);
+      }
+    });
+  </script>
+  ```
+</CodeBlockTabs>
 
 ### `delete()`
 
@@ -154,65 +152,63 @@ function delete: () => Promise<void>;
 
 #### Example
 
-<InjectKeys>
-  <CodeBlockTabs type="npm-script" options={['NPM module', '<script>']}>
-    ```js {{ prettier: false, filename: 'main.js', mark: [8] }}
-    import { Clerk } from '@clerk/clerk-js';
+<CodeBlockTabs type="npm-script" options={['NPM module', '<script>']}>
+  ```js {{ prettier: false, filename: 'main.js', mark: [8] }}
+  import { Clerk } from '@clerk/clerk-js';
 
-    // Initialize Clerk with your Clerk publishable key
-    const clerk = new Clerk('{{pub_key}}');
-    await clerk.load();
+  // Initialize Clerk with your Clerk publishable key
+  const clerk = new Clerk('{{pub_key}}');
+  await clerk.load();
 
-    if (clerk.user) {
-      await clerk.user.delete()
-        .then((res) => console.log(res))
-        .catch((error) => console.log("An error occurred:", error.errors));
-    } else {
-      document.getElementById("app").innerHTML = `
-        <div id="sign-in"></div>
-      `;
+  if (clerk.user) {
+    await clerk.user.delete()
+      .then((res) => console.log(res))
+      .catch((error) => console.log("An error occurred:", error.errors));
+  } else {
+    document.getElementById("app").innerHTML = `
+      <div id="sign-in"></div>
+    `;
 
-      const signInDiv = document.getElementById("sign-in");
+    const signInDiv = document.getElementById("sign-in");
 
-      clerk.mountSignIn(signInDiv);
-    }
-    ```
+    clerk.mountSignIn(signInDiv);
+  }
+  ```
 
-    ```html {{ prettier: false, filename: 'index.html', mark: [18] }}
-    <div id="app"></div>
+  ```html {{ prettier: false, filename: 'index.html', mark: [18] }}
+  <div id="app"></div>
 
-    <!-- Initialize Clerk with your
-    Clerk Publishable key and Frontend API URL -->
-    <script
-      async
-      crossorigin="anonymous"
-      data-clerk-publishable-key="{{pub_key}}"
-      src="https://{{fapi_url}}/npm/@clerk/clerk-js@latest/dist/clerk.browser.js"
-      type="text/javascript"
-    ></script>
+  <!-- Initialize Clerk with your
+  Clerk Publishable key and Frontend API URL -->
+  <script
+    async
+    crossorigin="anonymous"
+    data-clerk-publishable-key="{{pub_key}}"
+    src="https://{{fapi_url}}/npm/@clerk/clerk-js@latest/dist/clerk.browser.js"
+    type="text/javascript"
+  ></script>
 
-    <script>
-      window.addEventListener('load', async function () {
-        await Clerk.load();
+  <script>
+    window.addEventListener('load', async function () {
+      await Clerk.load();
 
-        if (Clerk.user) {
-          await Clerk.user.delete()
-            .then((res) => console.log(res))
-            .catch((error) => console.log("An error occurred:", error.errors));
-        } else {
-          document.getElementById("app").innerHTML = `
-            <div id="sign-in"></div>
-          `;
+      if (Clerk.user) {
+        await Clerk.user.delete()
+          .then((res) => console.log(res))
+          .catch((error) => console.log("An error occurred:", error.errors));
+      } else {
+        document.getElementById("app").innerHTML = `
+          <div id="sign-in"></div>
+        `;
 
-          const signInDiv = document.getElementById("sign-in");
+        const signInDiv = document.getElementById("sign-in");
 
-          Clerk.mountSignIn(signInDiv);
-        }
-      });
-    </script>
-    ```
-  </CodeBlockTabs>
-</InjectKeys>
+        Clerk.mountSignIn(signInDiv);
+      }
+    });
+  </script>
+  ```
+</CodeBlockTabs>
 
 ### `setProfileImage()`
 
@@ -238,110 +234,108 @@ function setProfileImage: (params: SetProfileImageParams) => Promise<ImageResour
 
 #### Example
 
-<InjectKeys>
-  <Tabs type="npm-script" items={['NPM module', '<script>']}>
-    <Tab>
-      For the following example, your HTML file should look like this:
+<Tabs type="npm-script" items={['NPM module', '<script>']}>
+  <Tab>
+    For the following example, your HTML file should look like this:
 
-      ```html {{ prettier: false, filename: 'index.html' }}
-      <!doctype html>
-      <html lang="en">
-        <head>
-          <meta charset="UTF-8" />
-          <link rel="icon" type="image/svg+xml" href="/vite.svg" />
-          <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-          <title>Clerk + JavaScript App</title>
-        </head>
-        <body>
-          <div id="app"></div>
-
-          <input type="file" id="profile-image" />
-          <button id="upload-image">Upload profile image</button>
-
-          <script type="module" src="/main.js"></script>
-        </body>
-      </html>
-      ```
-
-      And your JavaScript file should look like this:
-
-      ```js {{ prettier: false, filename: 'main.js' }}
-      import { Clerk } from '@clerk/clerk-js';
-
-      // Initialize Clerk with your Clerk publishable key
-      const clerk = new Clerk('{{pub_key}}');
-      await clerk.load();
-
-      if (clerk.user) {
-        // Get the current organization
-        const currentOrganization = clerk.organization;
-
-        // Update the user's profile image
-        document.getElementById("upload-image").addEventListener("click", () => {
-          const profileImage = document.getElementById("profile-image").files[0];
-          console.log(profileImage);
-
-          currentOrganization.setLogo({ file: profileImage })
-            .then((res) => console.log(res))
-            .catch((error) => console.log("An error occurred:", error.errors));
-          });
-      } else {
-        document.getElementById("app").innerHTML = `
-          <div id="sign-in"></div>
-        `;
-
-        const signInDiv = document.getElementById("sign-in");
-
-        clerk.mountSignIn(signInDiv);
-      }
-      ```
-    </Tab>
-
-    <Tab>
-      ```html {{ prettier: false, filename: 'index.html' }}
+    ```html {{ prettier: false, filename: 'index.html' }}
+    <!doctype html>
+    <html lang="en">
+      <head>
+        <meta charset="UTF-8" />
+        <link rel="icon" type="image/svg+xml" href="/vite.svg" />
+        <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+        <title>Clerk + JavaScript App</title>
+      </head>
+      <body>
         <div id="app"></div>
 
         <input type="file" id="profile-image" />
         <button id="upload-image">Upload profile image</button>
 
-        <!-- Initialize Clerk with your
-        Clerk Publishable key and Frontend API URL -->
-        <script
-          async
-          crossorigin="anonymous"
-          data-clerk-publishable-key="{{pub_key}}"
-          src="https://{{fapi_url}}/npm/@clerk/clerk-js@latest/dist/clerk.browser.js"
-          type="text/javascript"
-        ></script>
+        <script type="module" src="/main.js"></script>
+      </body>
+    </html>
+    ```
 
-        <script>
-          window.addEventListener("load", async function () {
-            await Clerk.load();
-            if (Clerk.user) {
-              // Get the current organization
-              const currentOrganization = Clerk.organization;
+    And your JavaScript file should look like this:
 
-              // Update the user's profile image
-              document.getElementById("upload-image").addEventListener("click", () => {
-                const profileImage = document.getElementById("profile-image").files[0];
+    ```js {{ prettier: false, filename: 'main.js' }}
+    import { Clerk } from '@clerk/clerk-js';
 
-                currentOrganization.setLogo({ file: profileImage })
-                  .then((res) => console.log(res))
-                  .catch((error) => console.log("An error occurred:", error.errors));
-                });
-            } else {
-              document.getElementById("app").innerHTML = `
-                <div id="sign-in"></div>
-              `;
-              const signInDiv = document.getElementById("sign-in");
-              Clerk.mountSignIn(signInDiv);
-            }
-          });
-        </script>
-      ```
-    </Tab>
-  </Tabs>
-</InjectKeys>
+    // Initialize Clerk with your Clerk publishable key
+    const clerk = new Clerk('{{pub_key}}');
+    await clerk.load();
+
+    if (clerk.user) {
+      // Get the current organization
+      const currentOrganization = clerk.organization;
+
+      // Update the user's profile image
+      document.getElementById("upload-image").addEventListener("click", () => {
+        const profileImage = document.getElementById("profile-image").files[0];
+        console.log(profileImage);
+
+        currentOrganization.setLogo({ file: profileImage })
+          .then((res) => console.log(res))
+          .catch((error) => console.log("An error occurred:", error.errors));
+        });
+    } else {
+      document.getElementById("app").innerHTML = `
+        <div id="sign-in"></div>
+      `;
+
+      const signInDiv = document.getElementById("sign-in");
+
+      clerk.mountSignIn(signInDiv);
+    }
+    ```
+  </Tab>
+
+  <Tab>
+    ```html {{ prettier: false, filename: 'index.html' }}
+      <div id="app"></div>
+
+      <input type="file" id="profile-image" />
+      <button id="upload-image">Upload profile image</button>
+
+      <!-- Initialize Clerk with your
+      Clerk Publishable key and Frontend API URL -->
+      <script
+        async
+        crossorigin="anonymous"
+        data-clerk-publishable-key="{{pub_key}}"
+        src="https://{{fapi_url}}/npm/@clerk/clerk-js@latest/dist/clerk.browser.js"
+        type="text/javascript"
+      ></script>
+
+      <script>
+        window.addEventListener("load", async function () {
+          await Clerk.load();
+          if (Clerk.user) {
+            // Get the current organization
+            const currentOrganization = Clerk.organization;
+
+            // Update the user's profile image
+            document.getElementById("upload-image").addEventListener("click", () => {
+              const profileImage = document.getElementById("profile-image").files[0];
+
+              currentOrganization.setLogo({ file: profileImage })
+                .then((res) => console.log(res))
+                .catch((error) => console.log("An error occurred:", error.errors));
+              });
+          } else {
+            document.getElementById("app").innerHTML = `
+              <div id="sign-in"></div>
+            `;
+            const signInDiv = document.getElementById("sign-in");
+            Clerk.mountSignIn(signInDiv);
+          }
+        });
+      </script>
+    ```
+  </Tab>
+</Tabs>
 
 ### `reload()`
 
@@ -359,39 +353,37 @@ function reload: (p?: ClerkResourceReloadParams) => Promise<this>;
 
 #### Example
 
-<InjectKeys>
-  <CodeBlockTabs type="npm-script" options={['NPM module', '<script>']}>
-    ```js {{ prettier: false, filename: 'main.js', mark: [7] }}
-    import { Clerk } from '@clerk/clerk-js';
+<CodeBlockTabs type="npm-script" options={['NPM module', '<script>']}>
+  ```js {{ prettier: false, filename: 'main.js', mark: [7] }}
+  import { Clerk } from '@clerk/clerk-js';
 
-    // Initialize Clerk with your Clerk publishable key
-    const clerk = new Clerk('{{pub_key}}');
-    await clerk.load();
+  // Initialize Clerk with your Clerk publishable key
+  const clerk = new Clerk('{{pub_key}}');
+  await clerk.load();
 
-    await clerk.user.reload();
-    ```
+  await clerk.user.reload();
+  ```
 
-    ```html {{ prettier: false, filename: 'index.html', mark: [15] }}
-    <!-- Initialize Clerk with your
-    Clerk Publishable key and Frontend API URL -->
-    <script
-      async
-      crossorigin="anonymous"
-      data-clerk-publishable-key="{{pub_key}}"
-      src="https://{{fapi_url}}/npm/@clerk/clerk-js@latest/dist/clerk.browser.js"
-      type="text/javascript"
-    ></script>
+  ```html {{ prettier: false, filename: 'index.html', mark: [15] }}
+  <!-- Initialize Clerk with your
+  Clerk Publishable key and Frontend API URL -->
+  <script
+    async
+    crossorigin="anonymous"
+    data-clerk-publishable-key="{{pub_key}}"
+    src="https://{{fapi_url}}/npm/@clerk/clerk-js@latest/dist/clerk.browser.js"
+    type="text/javascript"
+  ></script>
 
-    <script>
-      window.addEventListener("load", async function () {
-        await Clerk.load();
+  <script>
+    window.addEventListener("load", async function () {
+      await Clerk.load();
 
-        await Clerk.user.reload();
-      });
-    </script>
-    ```
-  </CodeBlockTabs>
-</InjectKeys>
+      await Clerk.user.reload();
+    });
+  </script>
+  ```
+</CodeBlockTabs>
 
 ### `getSessions()`
 
@@ -409,65 +401,63 @@ function getSessions: () => Promise<SessionWithActivities[]>;
 
 #### Example
 
-<InjectKeys>
-  <CodeBlockTabs type="npm-script" options={['NPM module', '<script>']}>
-    ```js {{ prettier: false, filename: 'main.js', mark: [8] }}
-    import { Clerk } from '@clerk/clerk-js';
+<CodeBlockTabs type="npm-script" options={['NPM module', '<script>']}>
+  ```js {{ prettier: false, filename: 'main.js', mark: [8] }}
+  import { Clerk } from '@clerk/clerk-js';
 
-    // Initialize Clerk with your Clerk publishable key
-    const clerk = new Clerk('{{pub_key}}');
-    await clerk.load();
+  // Initialize Clerk with your Clerk publishable key
+  const clerk = new Clerk('{{pub_key}}');
+  await clerk.load();
 
-    if (clerk.user) {
-      await clerk.user.getSessions()
-        .then((res) => console.log(res))
-        .catch((error) => console.log("An error occurred:", error.errors));
-    } else {
-      document.getElementById("app").innerHTML = `
-        <div id="sign-in"></div>
-      `;
+  if (clerk.user) {
+    await clerk.user.getSessions()
+      .then((res) => console.log(res))
+      .catch((error) => console.log("An error occurred:", error.errors));
+  } else {
+    document.getElementById("app").innerHTML = `
+      <div id="sign-in"></div>
+    `;
 
-      const signInDiv = document.getElementById("sign-in");
+    const signInDiv = document.getElementById("sign-in");
 
-      clerk.mountSignIn(signInDiv);
-    }
-    ```
+    clerk.mountSignIn(signInDiv);
+  }
+  ```
 
-    ```html {{ prettier: false, filename: 'index.html', mark: [18] }}
-    <div id="app"></div>
+  ```html {{ prettier: false, filename: 'index.html', mark: [18] }}
+  <div id="app"></div>
 
-    <!-- Initialize Clerk with your
-    Clerk Publishable key and Frontend API URL -->
-    <script
-      async
-      crossorigin="anonymous"
-      data-clerk-publishable-key="{{pub_key}}"
-      src="https://{{fapi_url}}/npm/@clerk/clerk-js@latest/dist/clerk.browser.js"
-      type="text/javascript"
-    ></script>
+  <!-- Initialize Clerk with your
+  Clerk Publishable key and Frontend API URL -->
+  <script
+    async
+    crossorigin="anonymous"
+    data-clerk-publishable-key="{{pub_key}}"
+    src="https://{{fapi_url}}/npm/@clerk/clerk-js@latest/dist/clerk.browser.js"
+    type="text/javascript"
+  ></script>
 
-    <script>
-      window.addEventListener("load", async function () {
-        await Clerk.load();
+  <script>
+    window.addEventListener("load", async function () {
+      await Clerk.load();
 
-        if (Clerk.user) {
-          await Clerk.user.getSessions()
-            .then((res) => console.log(res))
-            .catch((error) => console.log("An error occurred:", error.errors));
-        } else {
-          document.getElementById("app").innerHTML = `
-            <div id="sign-in"></div>
-          `;
+      if (Clerk.user) {
+        await Clerk.user.getSessions()
+          .then((res) => console.log(res))
+          .catch((error) => console.log("An error occurred:", error.errors));
+      } else {
+        document.getElementById("app").innerHTML = `
+          <div id="sign-in"></div>
+        `;
 
-          const signInDiv = document.getElementById("sign-in");
+        const signInDiv = document.getElementById("sign-in");
 
-          Clerk.mountSignIn(signInDiv);
-        }
-      });
-    </script>
-    ```
-  </CodeBlockTabs>
-</InjectKeys>
+        Clerk.mountSignIn(signInDiv);
+      }
+    });
+  </script>
+  ```
+</CodeBlockTabs>
 
 ### `createPasskey()`
 
@@ -524,65 +514,63 @@ function getOrganizationInvitations: (params?: GetUserOrganizationInvitationsPar
 
 #### Example
 
-<InjectKeys>
-  <CodeBlockTabs type="npm-script" options={['NPM module', '<script>']}>
-    ```js {{ prettier: false, filename: 'main.js', mark: [8] }}
-    import { Clerk } from '@clerk/clerk-js';
+<CodeBlockTabs type="npm-script" options={['NPM module', '<script>']}>
+  ```js {{ prettier: false, filename: 'main.js', mark: [8] }}
+  import { Clerk } from '@clerk/clerk-js';
 
-    // Initialize Clerk with your Clerk publishable key
-    const clerk = new Clerk('{{pub_key}}');
-    await clerk.load();
+  // Initialize Clerk with your Clerk publishable key
+  const clerk = new Clerk('{{pub_key}}');
+  await clerk.load();
 
-    if (clerk.user) {
-      await clerk.user.getOrganizationInvitations()
-        .then((res) => console.log(res))
-        .catch((error) => console.log("An error occurred:", error.errors));
-    } else {
-      document.getElementById("app").innerHTML = `
-        <div id="sign-in"></div>
-      `;
+  if (clerk.user) {
+    await clerk.user.getOrganizationInvitations()
+      .then((res) => console.log(res))
+      .catch((error) => console.log("An error occurred:", error.errors));
+  } else {
+    document.getElementById("app").innerHTML = `
+      <div id="sign-in"></div>
+    `;
 
-      const signInDiv = document.getElementById("sign-in");
+    const signInDiv = document.getElementById("sign-in");
 
-      clerk.mountSignIn(signInDiv);
-    }
-    ```
+    clerk.mountSignIn(signInDiv);
+  }
+  ```
 
-    ```html {{ prettier: false, filename: 'index.html', mark: [18] }}
-    <div id="app"></div>
+  ```html {{ prettier: false, filename: 'index.html', mark: [18] }}
+  <div id="app"></div>
 
-    <!-- Initialize Clerk with your
-    Clerk Publishable key and Frontend API URL -->
-    <script
-      async
-      crossorigin="anonymous"
-      data-clerk-publishable-key="{{pub_key}}"
-      src="https://{{fapi_url}}/npm/@clerk/clerk-js@latest/dist/clerk.browser.js"
-      type="text/javascript"
-    ></script>
+  <!-- Initialize Clerk with your
+  Clerk Publishable key and Frontend API URL -->
+  <script
+    async
+    crossorigin="anonymous"
+    data-clerk-publishable-key="{{pub_key}}"
+    src="https://{{fapi_url}}/npm/@clerk/clerk-js@latest/dist/clerk.browser.js"
+    type="text/javascript"
+  ></script>
 
-    <script>
-      window.addEventListener("load", async function () {
-        await Clerk.load();
+  <script>
+    window.addEventListener("load", async function () {
+      await Clerk.load();
 
-        if (Clerk.user) {
-          await Clerk.user.getOrganizationInvitations()
-            .then((res) => console.log(res))
-            .catch((error) => console.log("An error occurred:", error.errors));
-        } else {
-          document.getElementById("app").innerHTML = `
-            <div id="sign-in"></div>
-          `;
+      if (Clerk.user) {
+        await Clerk.user.getOrganizationInvitations()
+          .then((res) => console.log(res))
+          .catch((error) => console.log("An error occurred:", error.errors));
+      } else {
+        document.getElementById("app").innerHTML = `
+          <div id="sign-in"></div>
+        `;
 
-          const signInDiv = document.getElementById("sign-in");
+        const signInDiv = document.getElementById("sign-in");
 
-          Clerk.mountSignIn(signInDiv);
-        }
-      });
-    </script>
-    ```
-  </CodeBlockTabs>
-</InjectKeys>
+        Clerk.mountSignIn(signInDiv);
+      }
+    });
+  </script>
+  ```
+</CodeBlockTabs>
 
 ### `getOrganizationSuggestions()`
 
@@ -608,65 +596,63 @@ function getOrganizationSuggestions: (params?: GetUserOrganizationSuggestionsPar
 
 #### Example
 
-<InjectKeys>
-  <CodeBlockTabs type="npm-script" options={['NPM module', '<script>']}>
-    ```js {{ prettier: false, filename: 'main.js', mark: [8] }}
-    import { Clerk } from '@clerk/clerk-js';
+<CodeBlockTabs type="npm-script" options={['NPM module', '<script>']}>
+  ```js {{ prettier: false, filename: 'main.js', mark: [8] }}
+  import { Clerk } from '@clerk/clerk-js';
 
-    // Initialize Clerk with your Clerk publishable key
-    const clerk = new Clerk('{{pub_key}}');
-    await clerk.load();
+  // Initialize Clerk with your Clerk publishable key
+  const clerk = new Clerk('{{pub_key}}');
+  await clerk.load();
 
-    if (clerk.user) {
-      await clerk.user.getOrganizationSuggestions()
-        .then((res) => console.log(res))
-        .catch((error) => console.log("An error occurred:", error.errors));
-    } else {
-      document.getElementById("app").innerHTML = `
-        <div id="sign-in"></div>
-      `;
+  if (clerk.user) {
+    await clerk.user.getOrganizationSuggestions()
+      .then((res) => console.log(res))
+      .catch((error) => console.log("An error occurred:", error.errors));
+  } else {
+    document.getElementById("app").innerHTML = `
+      <div id="sign-in"></div>
+    `;
 
-      const signInDiv = document.getElementById("sign-in");
+    const signInDiv = document.getElementById("sign-in");
 
-      clerk.mountSignIn(signInDiv);
-    }
-    ```
+    clerk.mountSignIn(signInDiv);
+  }
+  ```
 
-    ```html {{ prettier: false, filename: 'index.html', mark: [18] }}
-    <div id="app"></div>
+  ```html {{ prettier: false, filename: 'index.html', mark: [18] }}
+  <div id="app"></div>
 
-    <!-- Initialize Clerk with your
-    Clerk Publishable key and Frontend API URL -->
-    <script
-      async
-      crossorigin="anonymous"
-      data-clerk-publishable-key="{{pub_key}}"
-      src="https://{{fapi_url}}/npm/@clerk/clerk-js@latest/dist/clerk.browser.js"
-      type="text/javascript"
-    ></script>
+  <!-- Initialize Clerk with your
+  Clerk Publishable key and Frontend API URL -->
+  <script
+    async
+    crossorigin="anonymous"
+    data-clerk-publishable-key="{{pub_key}}"
+    src="https://{{fapi_url}}/npm/@clerk/clerk-js@latest/dist/clerk.browser.js"
+    type="text/javascript"
+  ></script>
 
-    <script>
-      window.addEventListener("load", async function () {
-        await Clerk.load();
+  <script>
+    window.addEventListener("load", async function () {
+      await Clerk.load();
 
-        if (Clerk.user) {
-          await Clerk.user.getOrganizationSuggestions()
-            .then((res) => console.log(res))
-            .catch((error) => console.log("An error occurred:", error.errors));
-        } else {
-          document.getElementById("app").innerHTML = `
-            <div id="sign-in"></div>
-          `;
+      if (Clerk.user) {
+        await Clerk.user.getOrganizationSuggestions()
+          .then((res) => console.log(res))
+          .catch((error) => console.log("An error occurred:", error.errors));
+      } else {
+        document.getElementById("app").innerHTML = `
+          <div id="sign-in"></div>
+        `;
 
-          const signInDiv = document.getElementById("sign-in");
+        const signInDiv = document.getElementById("sign-in");
 
-          Clerk.mountSignIn(signInDiv);
-        }
-      });
-    </script>
-    ```
-  </CodeBlockTabs>
-</InjectKeys>
+        Clerk.mountSignIn(signInDiv);
+      }
+    });
+  </script>
+  ```
+</CodeBlockTabs>
 
 ### `getOrganizationMemberships()`
 
@@ -691,65 +677,63 @@ function getOrganizationMemberships: (params?: GetUserOrganizationMembershipPara
 
 #### Example
 
-<InjectKeys>
-  <CodeBlockTabs type="npm-script" options={['NPM module', '<script>']}>
-    ```js {{ prettier: false, filename: 'main.js', mark: [8] }}
-    import { Clerk } from '@clerk/clerk-js';
+<CodeBlockTabs type="npm-script" options={['NPM module', '<script>']}>
+  ```js {{ prettier: false, filename: 'main.js', mark: [8] }}
+  import { Clerk } from '@clerk/clerk-js';
 
-    // Initialize Clerk with your Clerk publishable key
-    const clerk = new Clerk('{{pub_key}}');
-    await clerk.load();
+  // Initialize Clerk with your Clerk publishable key
+  const clerk = new Clerk('{{pub_key}}');
+  await clerk.load();
 
-    if (clerk.user) {
-      await clerk.user.getOrganizationMemberships()
-        .then((res) => console.log(res))
-        .catch((error) => console.log("An error occurred:", error.errors));
-    } else {
-      document.getElementById("app").innerHTML = `
-        <div id="sign-in"></div>
-      `;
+  if (clerk.user) {
+    await clerk.user.getOrganizationMemberships()
+      .then((res) => console.log(res))
+      .catch((error) => console.log("An error occurred:", error.errors));
+  } else {
+    document.getElementById("app").innerHTML = `
+      <div id="sign-in"></div>
+    `;
 
-      const signInDiv = document.getElementById("sign-in");
+    const signInDiv = document.getElementById("sign-in");
 
-      clerk.mountSignIn(signInDiv);
-    }
-    ```
+    clerk.mountSignIn(signInDiv);
+  }
+  ```
 
-    ```html {{ prettier: false, filename: 'index.html', mark: [18] }}
-    <div id="app"></div>
+  ```html {{ prettier: false, filename: 'index.html', mark: [18] }}
+  <div id="app"></div>
 
-    <!-- Initialize Clerk with your
-    Clerk Publishable key and Frontend API URL -->
-    <script
-      async
-      crossorigin="anonymous"
-      data-clerk-publishable-key="{{pub_key}}"
-      src="https://{{fapi_url}}/npm/@clerk/clerk-js@latest/dist/clerk.browser.js"
-      type="text/javascript"
-    ></script>
+  <!-- Initialize Clerk with your
+  Clerk Publishable key and Frontend API URL -->
+  <script
+    async
+    crossorigin="anonymous"
+    data-clerk-publishable-key="{{pub_key}}"
+    src="https://{{fapi_url}}/npm/@clerk/clerk-js@latest/dist/clerk.browser.js"
+    type="text/javascript"
+  ></script>
 
-    <script>
-      window.addEventListener("load", async function () {
-        await Clerk.load();
+  <script>
+    window.addEventListener("load", async function () {
+      await Clerk.load();
 
-        if (Clerk.user) {
-          await Clerk.user.getOrganizationMemberships()
-            .then((res) => console.log(res))
-            .catch((error) => console.log("An error occurred:", error.errors));
-        } else {
-          document.getElementById("app").innerHTML = `
-            <div id="sign-in"></div>
-          `;
+      if (Clerk.user) {
+        await Clerk.user.getOrganizationMemberships()
+          .then((res) => console.log(res))
+          .catch((error) => console.log("An error occurred:", error.errors));
+      } else {
+        document.getElementById("app").innerHTML = `
+          <div id="sign-in"></div>
+        `;
 
-          const signInDiv = document.getElementById("sign-in");
+        const signInDiv = document.getElementById("sign-in");
 
-          Clerk.mountSignIn(signInDiv);
-        }
-      });
-    </script>
-    ```
-  </CodeBlockTabs>
-</InjectKeys>
+        Clerk.mountSignIn(signInDiv);
+      }
+    });
+  </script>
+  ```
+</CodeBlockTabs>
 
 ## Additional methods
 

--- a/docs/references/nodejs/available-methods.mdx
+++ b/docs/references/nodejs/available-methods.mdx
@@ -39,28 +39,26 @@ If you would like to customize the behavior of the SDK, you can instantiate a `c
 
 The example below shows how to use `createClerkClient` to create a `clerkClient` instance and pass a Clerk secret key _instead of_ setting a `CLERK_SECRET_KEY` environment variable.
 
-<InjectKeys>
-  <CodeBlockTabs options={["ESM", "CJS"]}>
-    ```js {{ prettier: false }}
-    import { createClerkClient } from '@clerk/clerk-sdk-node';
+<CodeBlockTabs options={["ESM", "CJS"]}>
+  ```js {{ prettier: false }}
+  import { createClerkClient } from '@clerk/clerk-sdk-node';
 
-    const clerkClient = createClerkClient({ secretKey: '{{secret}}' });
+  const clerkClient = createClerkClient({ secretKey: '{{secret}}' });
 
-    const clientList = await clerkClient.clients.getClientList();
-    ```
+  const clientList = await clerkClient.clients.getClientList();
+  ```
 
-    ```js {{ prettier: false }}
-    const Clerk = require('@clerk/clerk-sdk-node/cjs/instance').default;
+  ```js {{ prettier: false }}
+  const Clerk = require('@clerk/clerk-sdk-node/cjs/instance').default;
 
-    const clerkClient = Clerk({ secretKey: '{{secret}}' });
+  const clerkClient = Clerk({ secretKey: '{{secret}}' });
 
-    clerkClient.sessions
-      .getSessionList()
-      .then((sessions) => console.log(sessions))
-      .catch((error) => console.error(error));
-    ```
-  </CodeBlockTabs>
-</InjectKeys>
+  clerkClient.sessions
+    .getSessionList()
+    .then((sessions) => console.log(sessions))
+    .catch((error) => console.error(error));
+  ```
+</CodeBlockTabs>
 
 ### Customizing resources
 

--- a/docs/references/nodejs/overview.mdx
+++ b/docs/references/nodejs/overview.mdx
@@ -36,12 +36,10 @@ description: Learn how to integrate Node.js into your Clerk application.
 
   **Pro tip!** If you are signed into your Clerk Dashboard, your secret key should become visible by clicking on the eye icon. Otherwise, you can find your keys in the Clerk Dashboard on the [API Keys](https://dashboard.clerk.com/last-active?path=api-keys) page.
 
-  <InjectKeys>
-    ```env {{ prettier: false, filename: '.env.local' }}
-    CLERK_PUBLISHABLE_KEY={{pub_key}}
-    CLERK_SECRET_KEY={{secret}}
-    ```
-  </InjectKeys>
+  ```env {{ prettier: false, filename: '.env.local' }}
+  CLERK_PUBLISHABLE_KEY={{pub_key}}
+  CLERK_SECRET_KEY={{secret}}
+  ```
 </Steps>
 
 ## Available methods

--- a/docs/references/redwood/overview.mdx
+++ b/docs/references/redwood/overview.mdx
@@ -30,12 +30,10 @@ Learn how to use Clerk to quickly and easily add secure authentication and user 
 
   **Pro tip!** If you are signed into your Clerk Dashboard, your secret key should become visible by clicking on the eye icon. Otherwise, you can find your keys in the Clerk Dashboard on the [API Keys](https://dashboard.clerk.com/last-active?path=api-keys) page.
 
-  <InjectKeys>
-    ```env {{ prettier: false, filename: '.env.local' }}
-    CLERK_PUBLISHABLE_KEY={{pub_key}}
-    CLERK_SECRET_KEY={{secret}}
-    ```
-  </InjectKeys>
+  ```env {{ prettier: false, filename: '.env.local' }}
+  CLERK_PUBLISHABLE_KEY={{pub_key}}
+  CLERK_SECRET_KEY={{secret}}
+  ```
 
   #### Update redwood.toml
 

--- a/docs/references/remix/spa-mode.mdx
+++ b/docs/references/remix/spa-mode.mdx
@@ -61,11 +61,9 @@ description: Clerk supports Remix SPA mode out-of-the-box.
 
   The final result should look as follows:
 
-  <InjectKeys>
-    ```env {{ prettier: false, filename: '.env' }}
-    VITE_CLERK_PUBLISHABLE_KEY={{pub_key}}
-    ```
-  </InjectKeys>
+  ```env {{ prettier: false, filename: '.env' }}
+  VITE_CLERK_PUBLISHABLE_KEY={{pub_key}}
+  ```
 
   ### Configure `ClerkApp`
 

--- a/docs/references/ruby/overview.mdx
+++ b/docs/references/ruby/overview.mdx
@@ -40,28 +40,26 @@ description: Learn how to integrate Ruby into your Clerk application.
 
   This examples shows how to instantiate an instance of `Clerk::SDK` with your secret key and then send your first user a welcome email.
 
-  <InjectKeys>
-    ```ruby {{ prettier: false }}
-    clerk = Clerk::SDK.new(api_key: `{{secret}}`)
+  ```ruby {{ prettier: false }}
+  clerk = Clerk::SDK.new(api_key: `{{secret}}`)
 
-    # List all users
-    clerk.users.all
+  # List all users
+  clerk.users.all
 
-    # Get your first user
-    user = clerk.users.all(limit: 1).first
+  # Get your first user
+  user = clerk.users.all(limit: 1).first
 
-    # Extract their primary email address ID
-    email_id = user["primary_email_address_id"]
+  # Extract their primary email address ID
+  email_id = user["primary_email_address_id"]
 
-    # Send them a welcome email
-    clerk.emails.create(
-        email_address_id: email_id,
-        from_email_name: "welcome",
-        subject: "Welcome to MyApp",
-        body: "Welcome to MyApp, #{user["first_name"]}",
-    )
-    ```
-  </InjectKeys>
+  # Send them a welcome email
+  clerk.emails.create(
+      email_address_id: email_id,
+      from_email_name: "welcome",
+      subject: "Welcome to MyApp",
+      body: "Welcome to MyApp, #{user["first_name"]}",
+  )
+  ```
 
   ### Configuration
 
@@ -75,30 +73,26 @@ description: Learn how to integrate Ruby into your Clerk application.
 
   You can customize each instance of the `Clerk::SDK` object by passing keyword arguments to the constructor:
 
-  <InjectKeys>
-    ```ruby {{ prettier: false }}
-    clerk = Clerk::SDK.new(
-        api_key: `{{secret}}`,
-        base_url: "Y",
-        logger: Logger.new()
-    )
-    ```
-  </InjectKeys>
+  ```ruby {{ prettier: false }}
+  clerk = Clerk::SDK.new(
+      api_key: `{{secret}}`,
+      base_url: "Y",
+      logger: Logger.new()
+  )
+  ```
 
   #### Configuration object
 
   If an argument is not provided, the configuration object is looked up, which falls back to the associated environment variable. Here's an example with all supported configuration settings their environment variable equivalents:
 
-  <InjectKeys>
-    ```ruby {{ prettier: false }}
-    Clerk.configure do |c|
-      c.api_key = `{{secret}}` # if omitted: ENV["CLERK_SECRET_KEY"] - API calls will fail if unset
-      c.base_url = "https://..." # if omitted: "https://api.clerk.com/v1/"
-      c.logger = Logger.new(STDOUT) # if omitted, no logging
-      c.middleware_cache_store = Rails.cache # if omitted: no caching
-    end
-    ```
-  </InjectKeys>
+  ```ruby {{ prettier: false }}
+  Clerk.configure do |c|
+    c.api_key = `{{secret}}` # if omitted: ENV["CLERK_SECRET_KEY"] - API calls will fail if unset
+    c.base_url = "https://..." # if omitted: "https://api.clerk.com/v1/"
+    c.logger = Logger.new(STDOUT) # if omitted, no logging
+    c.middleware_cache_store = Rails.cache # if omitted: no caching
+  end
+  ```
 
   Refer to the [Faraday documentation](https://lostisland.github.io/faraday/#/) for details.
 


### PR DESCRIPTION
This PR removes all usage of `<InjectKeys>`. `<InjectKeys>` has been redundant since we shipped the docs redesign, and is currently implemented as:

```jsx
function InjectKeys({ children }) {
  return children
}
```