### PR TITLE
Allow diff to be used as language for codeblocks

### DIFF
--- a/prettier-mdx.mjs
+++ b/prettier-mdx.mjs
@@ -19,7 +19,7 @@ const processor = remark()
   .use(remarkFrontmatter)
   .use(remarkGfm, { tablePipeAlign: false })
   .use(remarkMdx, { printWidth: 120 })
-  .use(remarkDisallowDiffLang)
+// .use(remarkDisallowDiffLang) - allow for now
 
 function remarkDisallowDiffLang() {
   return function traverse(tree) {


### PR DESCRIPTION
The `{{ ins, del }}` syntax for codeblocks is still supported, but we want to support `diff` as a language, as well.