### PR TITLE
(/custom-flows/overview) add callout pointing users to guides

### DIFF
--- a/docs/custom-flows/overview.mdx
+++ b/docs/custom-flows/overview.mdx
@@ -8,7 +8,7 @@ description: Learn the process behind building custom sign-up and sign-in flows 
 A _custom flow_ refers to a user flow created entirely from scratch using the Clerk API. If Clerk's [prebuilt components](/docs/components/overview) don't meet your specific needs or if you require more control over the logic, you can rebuild the existing Clerk flows using the Clerk API.
 
 > [!TIP]
-> The information in this guide will help you get a general understanding of custom flows concepts. To skip to code examples, choose the guide that best fits your needs from the navigation on the left.
+> The information in this guide will help you get a general understanding of custom flow concepts. To skip to code examples, choose the guide that best fits your needs from the navigation on the left.
 
 ## How authentication flows work in Clerk
 

--- a/docs/custom-flows/overview.mdx
+++ b/docs/custom-flows/overview.mdx
@@ -7,6 +7,9 @@ description: Learn the process behind building custom sign-up and sign-in flows 
 
 A _custom flow_ refers to a user flow created entirely from scratch using the Clerk API. If Clerk's [prebuilt components](/docs/components/overview) don't meet your specific needs or if you require more control over the logic, you can rebuild the existing Clerk flows using the Clerk API.
 
+> [!TIP]
+> The information in this guide will help you get a general understanding of custom flows concepts. To skip to code examples, choose the guide that best fits your needs from the navigation on the left.
+
 ## How authentication flows work in Clerk
 
 Before building custom authentication flows, read the following sections to get a general understanding of how authentication flows work in Clerk.


### PR DESCRIPTION
<!--- Add the "deploy-preview" label and add your page previews here -->

> [!IMPORTANT]
> 🔎 Previews:
>
> - https://clerk.com/docs/pr/1373/custom-flows/overview

<!--- Describe your changes in detail. Why does this change need to happen? Include any links to Slack discussions, Linear comments, etc. -->

### Explanation:

<!--- How does this PR solve the problem? -->

Ticket reads:
> This page walks through the primitives, where following one of the guides is more or less always what user will want to do. [There's an example here](https://clerkinc.slack.com/archives/C05AVH96DAA/p1719871397075779) of a user who wanted a custom flow but got derailed by the low level instructions on the overview page rather than jumping into the guides in the sidebar.
> I think something like a callout at the top linking to the most common or popular custom flow guides, with a more explicit mention before the "fundamentals" section might be helpful. Or even moving the fundamentals into a separate document that we link to from overview?

### This PR:

- Adds a callout that points users to custom flow guides
