### PR TITLE
(/email-sms-otp) Remove setError call in code example

### DIFF
--- a/docs/custom-flows/email-sms-otp.mdx
+++ b/docs/custom-flows/email-sms-otp.mdx
@@ -78,7 +78,6 @@ This guide will walk you through how to build a custom SMS OTP sign-up and sign-
 
         async function handleVerification(e: React.FormEvent) {
           e.preventDefault();
-          setError('');
 
           if (!isLoaded && !signUp) return null;
 
@@ -366,7 +365,7 @@ This guide will walk you through how to build a custom SMS OTP sign-up and sign-
         @State private var phoneNumber = ""
         @State private var code = ""
         @State private var isVerifying = false
-        
+
         var body: some View {
           if isVerifying {
             TextField("Enter your verification code", text: $code)
@@ -383,16 +382,16 @@ This guide will walk you through how to build a custom SMS OTP sign-up and sign-
       }
 
       extension SMSOTPSignUpView {
-          
+
         func submit(phoneNumber: String) async {
           do {
             // Start the sign-up process using the phone number method.
             let signUp = try await SignUp.create(strategy: .standard(phoneNumber: phoneNumber))
-            
+
             // Start the verification - a SMS message will be sent to the
             // number with a one-time code.
             try await signUp.prepareVerification(strategy: .phoneCode)
-            
+
             // Set isVerifying to true to display second form and capture the OTP code.
             isVerifying = true
           } catch {
@@ -401,15 +400,15 @@ This guide will walk you through how to build a custom SMS OTP sign-up and sign-
             dump(error)
           }
         }
-          
+
         func verify(code: String) async {
           do {
             // Access the in progress sign up stored on the client object.
             guard let inProgressSignUp = Clerk.shared.client?.signUp else { return }
-            
+
             // Use the code provided by the user and attempt verification.
             let signUp = try await inProgressSignUp.attemptVerification(.phoneCode(code: code))
-            
+
             switch signUp.status {
             case .complete:
               // If verification was completed, navigate the user as needed.
@@ -828,7 +827,7 @@ This guide will walk you through how to build a custom SMS OTP sign-up and sign-
         @State private var phoneNumber = ""
         @State private var code = ""
         @State private var isVerifying = false
-        
+
         var body: some View {
           if isVerifying {
             TextField("Enter your verification code", text: $code)
@@ -845,15 +844,15 @@ This guide will walk you through how to build a custom SMS OTP sign-up and sign-
       }
 
       extension SMSOTPSignInView {
-          
+
         func submit(phoneNumber: String) async {
           do {
             // Start the sign-in process using the phone number method.
             let signIn = try await SignIn.create(strategy: .identifier(phoneNumber))
-            
+
             // Send the OTP code to the user.
             try await signIn.prepareFirstFactor(for: .phoneCode)
-            
+
             // Set isVerifying to true to display second form
             // and capture the OTP code.
             isVerifying = true
@@ -863,15 +862,15 @@ This guide will walk you through how to build a custom SMS OTP sign-up and sign-
             dump(error)
           }
         }
-          
+
         func verify(code: String) async {
           do {
             // Access the in progress sign in stored on the client object.
             guard let inProgressSignIn = Clerk.shared.client?.signIn else { return }
-            
+
             // Use the code provided by the user and attempt verification.
             let signIn = try await inProgressSignIn.attemptFirstFactor(for: .phoneCode(code: code))
-            
+
             switch signIn.status {
             case .complete:
               // If verification was completed, navigate the user as needed.


### PR DESCRIPTION
<!--- Add the "deploy-preview" label and add your page previews here -->

> [!IMPORTANT]
> 🔎 Previews:
>
> - https://clerk.com/docs/pr/1374/custom-flows/email-sms-otp

<!--- Describe your changes in detail. Why does this change need to happen? Include any links to Slack discussions, Linear comments, etc. -->

### Explanation:

[User feedback ticket ](https://linear.app/clerk/issue/DOCS-8901/remove-seterror-from-custom-flow-guide)reads:
> Small typo in the code snippet, setError doesnt exist

<!--- How does this PR solve the problem? -->

### This PR:

-
