### PR TITLE
Replace `<Callout>` usage

### DIFF
--- a/docs/authentication/social-connections/custom-provider.mdx
+++ b/docs/authentication/social-connections/custom-provider.mdx
@@ -4,10 +4,8 @@ description: Configure a custom OpenID Connect (OIDC) compatible authentication 
 
 # OAuth with a custom auth provider
 
-<Callout type="warning">
-  Custom auth providers are in beta. Please [contact support](/contact/support) to get your application whitelisted for
-  this feature.
-</Callout>
+> [!WARNING]
+> Custom auth providers are in beta. Please [contact support](/contact/support) to get your application whitelisted for this feature.
 
 <TutorialHero
   beforeYouStart={[

--- a/docs/deployments/clerk-cookies.mdx
+++ b/docs/deployments/clerk-cookies.mdx
@@ -20,4 +20,5 @@ These cookies:
 | .clerk.com | `__session`, `__client_uat` | First party |
 | .clerk.com, .dashboard.clerk.com (cloudflare) | `_cfuvid` | Third party<br />[Cloudflare Cookies](https://developers.cloudflare.com/fundamentals/reference/policies-compliances/cloudflare-cookies/) |
 
-<Callout level="warn">You should seek legal advice before using this information to craft your privacy policy.</Callout>
+> [!WARNING]
+> You should seek legal advice before using this information to craft your privacy policy.

--- a/docs/references/ios/overview.mdx
+++ b/docs/references/ios/overview.mdx
@@ -4,9 +4,8 @@ description: Learn how to use Clerk to quickly and easily add secure authenticat
 
 # Clerk iOS SDK (Beta)
 
-<Callout type="warning">
-  The Clerk iOS SDK is currently in beta. It is **not yet recommended for production use**.
-</Callout>
+> [!WARNING]
+> The Clerk iOS SDK is currently in beta. It is **not yet recommended for production use**.
 
 Clerk makes it simple to add authentication to your iOS application. This documentation covers the capabilities and methods available from Clerk's iOS SDK.
 


### PR DESCRIPTION
Replacing a few instances of `<Callout>` so we can remove support for using the component directly 🔪