### PR TITLE
chore(elements): Add captcha usage to examples

### DIFF
--- a/docs/elements/examples/shadcn-ui.mdx
+++ b/docs/elements/examples/shadcn-ui.mdx
@@ -141,7 +141,7 @@ You must also configure the appropriate settings in Clerk:
                     </CardContent>
                     <CardFooter>
                       <div className="grid w-full gap-y-4">
-                        <SignUp.Captcha />
+                        <SignUp.Captcha className="empty:hidden" />
                         <SignUp.Action submit asChild>
                           <Button disabled={isGlobalLoading}>
                             <Clerk.Loading>

--- a/docs/elements/examples/shadcn-ui.mdx
+++ b/docs/elements/examples/shadcn-ui.mdx
@@ -141,6 +141,7 @@ You must also configure the appropriate settings in Clerk:
                     </CardContent>
                     <CardFooter>
                       <div className="grid w-full gap-y-4">
+                        <SignUp.Captcha />
                         <SignUp.Action submit asChild>
                           <Button disabled={isGlobalLoading}>
                             <Clerk.Loading>

--- a/docs/elements/examples/sign-up.mdx
+++ b/docs/elements/examples/sign-up.mdx
@@ -74,6 +74,7 @@ Before you build your sign-up flow, you need to configure the appropriate settin
                 <Clerk.FieldError className="block text-sm text-red-400" />
               </Clerk.Field>
             </div>
+            <SignUp.Captcha />
             <SignUp.Action
               submit
               className="relative isolate w-full rounded-md bg-blue-500 px-3.5 py-1.5 text-center text-sm font-medium text-white shadow-[0_1px_0_0_theme(colors.white/10%)_inset,0_0_0_1px_theme(colors.white/5%)] outline-none before:absolute before:inset-0 before:-z-10 before:rounded-md before:bg-white/5 before:opacity-0 hover:before:opacity-100 focus-visible:outline-[1.5px] focus-visible:outline-offset-2 focus-visible:outline-blue-400 active:text-white/70 active:before:bg-black/10"

--- a/docs/elements/examples/sign-up.mdx
+++ b/docs/elements/examples/sign-up.mdx
@@ -74,7 +74,7 @@ Before you build your sign-up flow, you need to configure the appropriate settin
                 <Clerk.FieldError className="block text-sm text-red-400" />
               </Clerk.Field>
             </div>
-            <SignUp.Captcha />
+            <SignUp.Captcha className="empty:hidden" />
             <SignUp.Action
               submit
               className="relative isolate w-full rounded-md bg-blue-500 px-3.5 py-1.5 text-center text-sm font-medium text-white shadow-[0_1px_0_0_theme(colors.white/10%)_inset,0_0_0_1px_theme(colors.white/5%)] outline-none before:absolute before:inset-0 before:-z-10 before:rounded-md before:bg-white/5 before:opacity-0 hover:before:opacity-100 focus-visible:outline-[1.5px] focus-visible:outline-offset-2 focus-visible:outline-blue-400 active:text-white/70 active:before:bg-black/10"

--- a/docs/elements/guides/sign-up.mdx
+++ b/docs/elements/guides/sign-up.mdx
@@ -84,7 +84,7 @@ description: Learn how to build a complete sign-up form with Clerk Elements.
 
   Make it functional by adding input fields. The following example uses the `<Clerk.Field>` component to render the `emailAddress` and `username` fields, as well as the `<Connection>` component to allow users to sign up with a social connection, like Google:
 
-  ```tsx {{ prettier: false, filename: '/app/sign-up/[[...sign-up]]/page.tsx', mark: [[12, 34]] }}
+  ```tsx {{ prettier: false, filename: '/app/sign-up/[[...sign-up]]/page.tsx', mark: [[12, 36]] }}
   'use client'
 
   import * as Clerk from '@clerk/elements/common'
@@ -117,6 +117,8 @@ description: Learn how to build a complete sign-up form with Clerk Elements.
             <Clerk.Input />
             <Clerk.FieldError />
           </Clerk.Field>
+
+          <SignUp.Captcha />
 
           <SignUp.Action submit>Sign up</SignUp.Action>
         </SignUp.Step>

--- a/docs/elements/reference/sign-up.mdx
+++ b/docs/elements/reference/sign-up.mdx
@@ -61,6 +61,8 @@ Renders the beginning sign-up form. Once a sign up attempt has been created from
     <Clerk.FieldError />
   </Clerk.Field>
 
+  <SignUp.Captcha />
+
   <SignUp.Action submit>Sign up</SignUp.Action>
 </SignUp.Step>
 ```


### PR DESCRIPTION
<!--- Add the "deploy-preview" label and add your page previews here -->

> [!IMPORTANT]
> 🔎 Previews:
>
> - https://clerk.com/docs/pr/1398/elements/examples/shadcn-ui#sign-up
> - https://clerk.com/docs/pr/1398/elements/reference/sign-up#usage

<!--- Describe your changes in detail. Why does this change need to happen? Include any links to Slack discussions, Linear comments, etc. -->

### Explanation:

<!--- How does this PR solve the problem? -->

### This PR:

- Adding `<SignUp.Captcha />` usage to Elements examples
