### PR TITLE
feat: Adds docs on the new tranferable prop

### DIFF
--- a/docs/components/authentication/sign-in.mdx
+++ b/docs/components/authentication/sign-in.mdx
@@ -88,7 +88,7 @@ All props are optional.
   - `transferable?`
   - `boolean`
 
-  Indicates whether or not sign in attempts are transferable to the sign up flow. Defaults to true. When set to false, prevents opaque sign ups when a user attempts to sign in via OAuth with an email that doesn't exist. See [OAuth account transfer flows](https://clerk.com/docs/custom-flows/oauth-connections#o-auth-account-transfer-flows) for more details.
+  Indicates whether or not sign in attempts are transferable to the sign up flow. Defaults to `true`. When set to `false`, prevents opaque sign ups when a user attempts to sign in via OAuth with an email that doesn't exist. See [OAuth account transfer flows](/docs/custom-flows/oauth-connections#o-auth-account-transfer-flows) for more details.
 </Properties>
 
 ## Usage with frameworks

--- a/docs/components/authentication/sign-in.mdx
+++ b/docs/components/authentication/sign-in.mdx
@@ -82,6 +82,13 @@ All props are optional.
   - [`SignInInitialValues`](/docs/references/javascript/types/sign-in-initial-values)
 
   The values used to prefill the sign-in fields with.
+
+  ---
+
+  - `transferable?`
+  - `boolean`
+
+  Indicates whether or not sign in attempts are transferable to the sign up flow. Defaults to true. When set to false, prevents opaque sign ups when a user attempts to sign in via OAuth with an email that doesn't exist. See [OAuth account transfer flows](https://clerk.com/docs/custom-flows/oauth-connections#o-auth-account-transfer-flows) for more details.
 </Properties>
 
 ## Usage with frameworks

--- a/docs/references/javascript/clerk/handle-navigation.mdx
+++ b/docs/references/javascript/clerk/handle-navigation.mdx
@@ -188,6 +188,13 @@ function handleRedirectCallback(
   - `string | undefined | null`
 
   Full URL or path to navigate after requesting phone verification.
+
+  ---
+
+  - `transferable?`
+  - `boolean`
+
+  Indicates whether or not sign in attempts are transferable to the sign up flow. Defaults to true. When set to false, prevents opaque sign ups when a user attempts to sign in via OAuth with an email that doesn't exist. See [OAuth account transfer flows](https://clerk.com/docs/custom-flows/oauth-connections#o-auth-account-transfer-flows) for more details.
 </Properties>
 
 ## `handleUnauthenticated()`

--- a/docs/references/javascript/clerk/handle-navigation.mdx
+++ b/docs/references/javascript/clerk/handle-navigation.mdx
@@ -194,7 +194,7 @@ function handleRedirectCallback(
   - `transferable?`
   - `boolean`
 
-  Indicates whether or not sign in attempts are transferable to the sign up flow. Defaults to true. When set to false, prevents opaque sign ups when a user attempts to sign in via OAuth with an email that doesn't exist. See [OAuth account transfer flows](https://clerk.com/docs/custom-flows/oauth-connections#o-auth-account-transfer-flows) for more details.
+  Indicates whether or not sign in attempts are transferable to the sign up flow. Defaults to `true`. When set to `false`, prevents opaque sign ups when a user attempts to sign in via OAuth with an email that doesn't exist. See [OAuth account transfer flows](/docs/custom-flows/oauth-connections#o-auth-account-transfer-flows) for more details.
 </Properties>
 
 ## `handleUnauthenticated()`


### PR DESCRIPTION
<!--- Add the "deploy-preview" label and add your page previews here -->

> [!IMPORTANT]
> 🔎 Previews:
>
> - https://clerk.com/docs/pr/1401/components/authentication/sign-in#properties
> - https://clerk.com/docs/pr/1401/references/javascript/clerk/handle-navigation#handle-o-auth-callback-params

<!--- Describe your changes in detail. Why does this change need to happen? Include any links to Slack discussions, Linear comments, etc. -->

### Explanation:

<!--- How does this PR solve the problem? -->
Introduce docs for a recently added prop to `<SignIn />`: `transferable`. This was also added as a parameter to `Clerk.handleRedirectCallback()`, and the docs were updated accordingly.