### PR TITLE
Enable Prettier for code blocks: `references/{expo,gatsby,go,nextjs,nodejs,redwood,ruby}`

### DIFF
--- a/docs/references/expo/read-session-user-data.mdx
+++ b/docs/references/expo/read-session-user-data.mdx
@@ -14,23 +14,23 @@ See [the React Client-side Helpers reference guides](/docs/references/react/use-
 
 The following example demonstrates how to use `useAuth()` to get and display session and user data:
 
-```tsx {{ prettier: false, filename: 'components/UseAuthExample.tsx' }}
-import { useAuth } from "@clerk/clerk-expo";
-import { Text } from "react-native";
+```tsx {{ filename: 'components/UseAuthExample.tsx' }}
+import { useAuth } from '@clerk/clerk-expo'
+import { Text } from 'react-native'
 
 export default function UseAuthExample() {
-  const { isLoaded, userId, sessionId } = useAuth();
+  const { isLoaded, userId, sessionId } = useAuth()
 
   // In case the user signs out while on the page.
   if (!isLoaded || !userId) {
-    return null;
+    return null
   }
 
   return (
     <Text>
       Hello, {userId} your current active session is {sessionId}
     </Text>
-  );
+  )
 }
 ```
 
@@ -40,17 +40,17 @@ export default function UseAuthExample() {
 
 The following example demonstrates how to use `useUser()` to check if the user is signed in and display their first name.
 
-```tsx {{ prettier: false, filename: 'component/UseUserExample.tsx' }}
-import { useUser } from "@clerk/clerk-expo";
-import { Text } from "react-native";
+```tsx {{ filename: 'component/UseUserExample.tsx' }}
+import { useUser } from '@clerk/clerk-expo'
+import { Text } from 'react-native'
 
 export default function UseUserExample() {
-  const { isLoaded, isSignedIn, user } = useUser();
+  const { isLoaded, isSignedIn, user } = useUser()
 
   if (!isLoaded || !isSignedIn) {
-    return null;
+    return null
   }
 
-  return <Text>Hello, {user.firstName} welcome to Clerk</Text>;
+  return <Text>Hello, {user.firstName} welcome to Clerk</Text>
 }
 ```

--- a/docs/references/gatsby/with-server-auth.mdx
+++ b/docs/references/gatsby/with-server-auth.mdx
@@ -7,17 +7,17 @@ description: The withServerAuth() function facilitates server-side authenticatio
 
 ## Usage
 
-```tsx {{ prettier: false }}
-import * as React from 'react';
-import { withServerAuth } from 'gatsby-plugin-clerk/ssr';
-import { PageProps } from "gatsby";
+```tsx
+import * as React from 'react'
+import { withServerAuth } from 'gatsby-plugin-clerk/ssr'
+import { PageProps } from 'gatsby'
 
 export const getServerData = withServerAuth(
-  async props => {
-    return { props: { data: '1', auth: props.auth } };
+  async (props) => {
+    return { props: { data: '1', auth: props.auth } }
   },
   { loadUser: true },
-);
+)
 
 function SSRPage({ serverData }: PageProps) {
   return (
@@ -25,10 +25,10 @@ function SSRPage({ serverData }: PageProps) {
       <h1>SSR Page with Clerk</h1>
       <pre>{JSON.stringify(serverData, null, 2)}</pre>
     </main>
-  );
+  )
 }
 
-export default SSRPage;
+export default SSRPage
 ```
 
 ## Properties
@@ -37,8 +37,8 @@ export default SSRPage;
 
 {/* CB is technically optional, but no matter what options I set here I couldn't get anything returned to `serverData` */}
 
-```typescript {{ prettier: false }}
-function withServer(cb: Callback, options: Options): GetServerDataReturn;
+```typescript
+function withServer(cb: Callback, options: Options): GetServerDataReturn
 ```
 
 Gatsby then automatically passes the result of `withServer`'s callback to the `serverData` property on the page's component props.

--- a/docs/references/go/other-examples.mdx
+++ b/docs/references/go/other-examples.mdx
@@ -16,7 +16,7 @@ By executing the code in the snippet below, you will:
 > [!NOTE]
 > Your Clerk secret key is required. If you are signed into your Clerk Dashboard, your secret key should become visible by selecting the eye icon. Otherwise, you can retrieve your Clerk secret key from the Clerk Dashboard on the **[API Keys](https://dashboard.clerk.com/last-active?path=api-keys)** page.
 
-```go {{ prettier: false, filename: 'main.go' }}
+```go {{ filename: 'main.go' }}
 import (
     "github.com/clerk/clerk-sdk-go/v2"
     "github.com/clerk/clerk-sdk-go/v2/organization"

--- a/docs/references/go/overview.mdx
+++ b/docs/references/go/overview.mdx
@@ -11,7 +11,7 @@ The [Clerk Go SDK](https://github.com/clerk/clerk-sdk-go) is a wrapper over the 
 
 If you're using Go Modules and have a `go.mod` file in your project's root, you can import `clerk-sdk-go` directly:
 
-```go {{ prettier: false }}
+```go
 import (
   "github.com/clerk/clerk-sdk-go/v2"
 )
@@ -19,7 +19,7 @@ import (
 
 Alternatively, you can `go get` the package explicitly:
 
-```sh {{ prettier: false, filename: 'terminal' }}
+```sh {{ filename: 'terminal' }}
 go get -u github.com/clerk/clerk-sdk-go/v2
 ```
 
@@ -50,7 +50,7 @@ The following examples demonstrate both approaches.
 
 If you only use one API key, you can import the packages required for the APIs you need. Then you can execute your desired request methods as functions, such as `$resource$.Get()` or `$resource$.Delete()`. The following example demonstrates this process:
 
-```go {{ prettier: false }}
+```go
 import (
   "github.com/clerk/clerk-sdk-go/v2"
   "github.com/clerk/clerk-sdk-go/v2/$resource$"
@@ -87,7 +87,7 @@ If you're working with multiple keys, it's recommended to use Clerk Go with a cl
 resource export a `Client`, which supports all the API's operations.
 This way, you can create as many clients as needed, each with their own API key, as shown in the following example:
 
-```go {{ prettier: false }}
+```go
 import (
   "github.com/clerk/clerk-sdk-go/v2"
   "github.com/clerk/clerk-sdk-go/v2/$resource$"

--- a/docs/references/go/verifying-sessions.mdx
+++ b/docs/references/go/verifying-sessions.mdx
@@ -31,7 +31,7 @@ The following example demonstrates how to use the `WithHeaderAuthorization()` mi
 > [!NOTE]
 > Your Clerk secret key is required. If you are signed in to your Clerk Dashboard, your secret key should become visible by selecting the eye icon. Otherwise, you can retrieve your Clerk secret key from the Clerk Dashboard on the **[API Keys](https://dashboard.clerk.com/last-active?path=api-keys)** page.
 
-```go {{ prettier: false, filename: 'main.go' }}
+```go {{ filename: 'main.go' }}
 package main
 
 import (
@@ -87,7 +87,7 @@ Clerk Go SDK provides a set of functions for decoding and verifying JWTs, as wel
 
 The following example demonstrates how to manually verify a session token. If the user tries accessing the route and their session token is valid, the user's ID and banned status will be returned in the response.
 
-```go {{ prettier: false, filename: 'main.go' }}
+```go {{ filename: 'main.go' }}
 package main
 
 import (
@@ -141,7 +141,7 @@ If you need to verify session tokens frequently, it's recommended to cache the J
 
 The following example includes the same code as above, with the addition of demonstrating a possible way to store your JSON Web Key. The example is meant to serve as a guide; implementation may vary depending on your needs.
 
-```go {{ prettier: false, filename: 'main.go' }}
+```go {{ filename: 'main.go' }}
 package main
 
 import (

--- a/docs/references/nextjs/auth-middleware.mdx
+++ b/docs/references/nextjs/auth-middleware.mdx
@@ -18,10 +18,10 @@ Create a `middleware.ts` file. If your application uses the `src/` directory, yo
 > For more information about middleware in Next.js, see the [Next.js
 > documentation](https://nextjs.org/docs/pages/building-your-application/routing/middleware).
 
-```ts {{ prettier: false, filename: 'middleware.ts' }}
-import { authMiddleware } from "@clerk/nextjs/server";
+```ts {{ filename: 'middleware.ts' }}
+import { authMiddleware } from '@clerk/nextjs/server'
 
-export default authMiddleware();
+export default authMiddleware()
 
 export const config = {
   matcher: [
@@ -30,7 +30,7 @@ export const config = {
     // Always run for API routes
     '/(api|trpc)(.*)',
   ],
-};
+}
 ```
 
 With the recommended matcher, all routes are protected by Clerk's authentication middleware, with the exception of internal `/_next/` routes and static files. Static files are detected by matching on paths that end in `.+\..+`. If your middleware needs to run on all routes but you don't want Clerk to protect every route, use the [`ignoredRoutes` option](#options).
@@ -67,7 +67,7 @@ Assuming that the `.env` based settings for sign-in and sign-up are set to `/sig
   };
   ```
 
-  ```bash {{ prettier: false, filename: '.env.local' }}
+  ```bash {{ filename: '.env.local' }}
   NEXT_PUBLIC_CLERK_SIGN_IN_URL=/sign-in
   NEXT_PUBLIC_CLERK_SIGN_UP_URL=/sign-up
   NEXT_PUBLIC_CLERK_SIGN_IN_FALLBACK_URL=/
@@ -79,33 +79,29 @@ Assuming that the `.env` based settings for sign-in and sign-up are set to `/sig
 
 Some developers will need to handle specific cases such as handling redirects differently or detecting if a user is inside an organization. These cases can be handled with `afterAuth()`.
 
-```ts {{ prettier: false, filename: 'middleware.ts' }}
-import { NextResponse } from "next/server";
-import { authMiddleware, redirectToSignIn } from "@clerk/nextjs/server";
+```ts {{ filename: 'middleware.ts' }}
+import { NextResponse } from 'next/server'
+import { authMiddleware, redirectToSignIn } from '@clerk/nextjs/server'
 
 export default authMiddleware({
   afterAuth(auth, req, evt) {
     // Handle users who aren't authenticated
     if (!auth.userId && !auth.isPublicRoute) {
-      return redirectToSignIn({ returnBackUrl: req.url });
+      return redirectToSignIn({ returnBackUrl: req.url })
     }
     // Redirect signed in users to organization selection page if they are not active in an organization
-    if (
-      auth.userId &&
-      !auth.orgId &&
-      req.nextUrl.pathname !== "/org-selection"
-    ) {
-      const orgSelection = new URL("/org-selection", req.url);
-      return NextResponse.redirect(orgSelection);
+    if (auth.userId && !auth.orgId && req.nextUrl.pathname !== '/org-selection') {
+      const orgSelection = new URL('/org-selection', req.url)
+      return NextResponse.redirect(orgSelection)
     }
     // If the user is signed in and trying to access a protected route, allow them to access route
     if (auth.userId && !auth.isPublicRoute) {
-      return NextResponse.next();
+      return NextResponse.next()
     }
     // Allow users visiting public routes to access them
-    return NextResponse.next();
+    return NextResponse.next()
   },
-});
+})
 ```
 
 #### Understanding `afterAuth` configuration
@@ -116,59 +112,59 @@ Looking at the example immediately above, the following is happening:
 
 1. Redirect all users who are not signed in but who are visiting a protected page to the sign-in route.
 
-```ts {{ prettier: false }}
+```ts
 if (!auth.userId && !auth.isPublicRoute) {
-  return redirectToSignIn({ returnBackUrl: req.url });
+  return redirectToSignIn({ returnBackUrl: req.url })
 }
 ```
 
 2. If the user is signed in but is not currently active in an organization and is not visiting the route for selecting an organization, then redirect them to the organization selector. This will force users to select and be active in an organization to visit other parts of the site.
 
-```ts {{ prettier: false }}
-if (auth.userId && !auth.orgId && req.nextUrl.pathname !== "/org-selection") {
-  const orgSelection = new URL("/org-selection", req.url);
-  return NextResponse.redirect(orgSelection);
+```ts
+if (auth.userId && !auth.orgId && req.nextUrl.pathname !== '/org-selection') {
+  const orgSelection = new URL('/org-selection', req.url)
+  return NextResponse.redirect(orgSelection)
 }
 ```
 
 3. If the user is signed in and accessing a protected route, allow them to access it.
 
-```ts {{ prettier: false }}
+```ts
 if (auth.userId && !auth.isPublicRoute) {
-  return NextResponse.next();
+  return NextResponse.next()
 }
 ```
 
 4. If none of the above match, then the user is visiting a public route. Allow them to. Don't check if they are signed in -- it doesn't matter.
 
-```ts {{ prettier: false }}
-return NextResponse.next();
+```ts
+return NextResponse.next()
 ```
 
 ### Use `beforeAuth()` to execute middleware before authentication
 
 If you need additional middleware handlers to execute before Clerk's authentication middleware, use `beforeAuth()`. An example where the middleware handler from `next-intl` is executed can be seen below.
 
-```ts {{ prettier: false, filename: 'middleware.ts' }}
-import { authMiddleware } from "@clerk/nextjs/server";
+```ts {{ filename: 'middleware.ts' }}
+import { authMiddleware } from '@clerk/nextjs/server'
 
-import createMiddleware from "next-intl/middleware";
+import createMiddleware from 'next-intl/middleware'
 
 const intlMiddleware = createMiddleware({
-  locales: ["en", "el"],
+  locales: ['en', 'el'],
 
-  defaultLocale: "en",
-});
+  defaultLocale: 'en',
+})
 
 export default authMiddleware({
   beforeAuth: (req) => {
     // Execute next-intl middleware before Clerk's auth middleware
-    return intlMiddleware(req);
+    return intlMiddleware(req)
   },
 
   // Ensure that locale specific sign-in pages are public
-  publicRoutes: ["/", "/:locale/sign-in"],
-});
+  publicRoutes: ['/', '/:locale/sign-in'],
+})
 
 export const config = {
   matcher: [
@@ -177,7 +173,7 @@ export const config = {
     // Always run for API routes
     '/(api|trpc)(.*)',
   ],
-};
+}
 ```
 
 ### Make routes public by using `publicRoutes`

--- a/docs/references/nextjs/auth-object.mdx
+++ b/docs/references/nextjs/auth-object.mdx
@@ -141,15 +141,15 @@ In the following example:
 - `has()` is used to check if the user has the `org:team_settings:manage` permission.
 - If the user does not have the permission, `null` is returned and the "Team Settings" component is not rendered.
 
-```tsx {{ prettier: false, filename: 'app/page.tsx' }}
-import { auth } from '@clerk/nextjs/server';
+```tsx {{ filename: 'app/page.tsx' }}
+import { auth } from '@clerk/nextjs/server'
 
 export default async function Page() {
-  const { has } = auth();
+  const { has } = auth()
 
-  const canManage = has({ permission:"org:team_settings:manage" });
+  const canManage = has({ permission: 'org:team_settings:manage' })
 
-  if(!canManage) return null;
+  if (!canManage) return null
 
   return <h1>Team Settings</h1>
 }
@@ -163,8 +163,8 @@ Tokens can only be generated if the user is signed in.
 
 #### `ServerGetToken`
 
-```typescript {{ prettier: false }}
-type ServerGetToken = (options?: ServerGetTokenOptions) => Promise<string | null>;
+```typescript
+type ServerGetToken = (options?: ServerGetTokenOptions) => Promise<string | null>
 ```
 
 #### `ServerGetTokenOptions`
@@ -195,13 +195,13 @@ The `Auth` object is not available in the frontend. To use the `getToken()` meth
     - In Pages Router applications, use the [`getAuth()`](/docs/references/nextjs/get-auth) helper.
 
     <CodeBlockTabs type="router" options={["App Router", "Pages Router"]}>
-      ```js {{ prettier: false, filename: 'app/api/get-token-example/route.ts' }}
-      import { auth } from "@clerk/nextjs/server";
+      ```js {{ filename: 'app/api/get-token-example/route.ts' }}
+      import { auth } from '@clerk/nextjs/server'
 
       export async function GET() {
-        const { getToken } = auth();
+        const { getToken } = auth()
 
-        const template = 'test';
+        const template = 'test'
 
         const token = await getToken({ template })
 
@@ -229,8 +229,9 @@ The `Auth` object is not available in the frontend. To use the `getToken()` meth
   <Tab>
     To use the `getToken()` method in the backend, you can acccess it using the `Auth` object returned by the request.
 
-    ```js {{ prettier: false, filename: 'getToken.ts' }}
-    app.post('/api/get-token',
+    ```js {{ filename: 'getToken.ts' }}
+    app.post(
+      '/api/get-token',
       // ClerkExpressRequireAuth returns an error for unauthorized requests
       ClerkExpressRequireAuth(),
 
@@ -245,7 +246,8 @@ The `Auth` object is not available in the frontend. To use the `getToken()` meth
         const token = await getToken({ template })
 
         res.json({ token })
-      })
+      },
+    )
     ```
   </Tab>
 

--- a/docs/references/nextjs/auth.mdx
+++ b/docs/references/nextjs/auth.mdx
@@ -94,15 +94,15 @@ For more information on how to use `protect()`, see the [examples](#use-auth-to-
 
 You can use `auth()` to check if a `userId` exists. If it does not, that means there is no user signed in. You can use this information to protect pages, as shown in the following example:
 
-```tsx {{ prettier: false, filename: 'app/page.tsx' }}
-import { auth } from '@clerk/nextjs/server';
+```tsx {{ filename: 'app/page.tsx' }}
+import { auth } from '@clerk/nextjs/server'
 
 export default function Page() {
-  const { userId } : { userId: string | null } = auth();
+  const { userId }: { userId: string | null } = auth()
 
-  if (!userId) return null;
+  if (!userId) return null
 
-  return <h1>Hello, {userId}</h1>;
+  return <h1>Hello, {userId}</h1>
 }
 ```
 
@@ -110,26 +110,26 @@ export default function Page() {
 
 When using a Clerk integration, or if you need to send a JWT along to a server, you can use the `getToken()` function that is returned by `auth()`.
 
-```tsx {{ prettier: false, filename: 'app/api/example/route.ts' }}
-import { auth } from '@clerk/nextjs/server';
+```tsx {{ filename: 'app/api/example/route.ts' }}
+import { auth } from '@clerk/nextjs/server'
 
 export async function GET() {
-  const {userId, getToken} = auth();
+  const { userId, getToken } = auth()
 
-  if(!userId){
-    return new Response("User is not signed in.", { status: 401 });
+  if (!userId) {
+    return new Response('User is not signed in.', { status: 401 })
   }
 
   try {
-    const token = await getToken({template: "supabase"});
+    const token = await getToken({ template: 'supabase' })
 
     // Add logic here to fetch data from Supabase and return it.
 
-    const data = { supabaseData: 'Hello World' };
+    const data = { supabaseData: 'Hello World' }
 
-    return Response.json({ data });
+    return Response.json({ data })
   } catch (error) {
-    return Response.json(error);
+    return Response.json(error)
   }
 }
 ```
@@ -144,10 +144,10 @@ In the following example,
 - If the user is not authenticated, they will be redirected to the sign-in route.
 - If the user is authenticated, they can view any `/dashboard` route and its children.
 
-```tsx {{ prettier: false, filename: 'app/dashboard/layout.tsx' }}
+```tsx {{ filename: 'app/dashboard/layout.tsx' }}
 import { auth } from '@clerk/nextjs/server'
 
-export default async function Layout({ children }:{ children: React.ReactNode }){
+export default async function Layout({ children }: { children: React.ReactNode }) {
   auth().protect()
 
   return <>{children}</>
@@ -170,15 +170,15 @@ You can protect certain parts of your application or even entire routes based on
     - If the user does not have the permission, `has()` will return `false`, causing the component to return `null`.
     - If the user has the permission, `has()` will return `true`, allowing the component to render its children.
 
-    ```tsx {{ prettier: false, filename: 'app/team-settings/page.tsx' }}
-    import { auth } from '@clerk/nextjs/server';
+    ```tsx {{ filename: 'app/team-settings/page.tsx' }}
+    import { auth } from '@clerk/nextjs/server'
 
     export default async function Page() {
-      const { has } = auth();
+      const { has } = auth()
 
-      const canManage = has({ permission:"org:team_settings:manage" });
+      const canManage = has({ permission: 'org:team_settings:manage' })
 
-      if(!canManage) return null;
+      if (!canManage) return null
 
       return <h1>Team Settings</h1>
     }
@@ -195,13 +195,13 @@ You can protect certain parts of your application or even entire routes based on
     - If the user is authenticated but is not authorized (as in, does not have the `org:team_settings:manage` permission), `protect()` will throw a `404` error.
     - If the user is both authenticated and authorized, `protect()` will return the user's `userId`.
 
-    ```tsx {{ prettier: false, filename: 'app/api/create-team/route.ts' }}
-    import { auth } from "@clerk/nextjs/server";
+    ```tsx {{ filename: 'app/api/create-team/route.ts' }}
+    import { auth } from '@clerk/nextjs/server'
 
     export const POST = () => {
-      const { userId } = auth().protect({ permission: "org:team_settings:manage" });
+      const { userId } = auth().protect({ permission: 'org:team_settings:manage' })
 
-      return users.createTeam(userId);
+      return users.createTeam(userId)
     }
     ```
   </Tab>
@@ -213,11 +213,11 @@ In some cases, you need to check your user's current organization role before di
 
 Check the current user's role with the `orgRole` property of the `Auth` object returned by `auth()`, as shown in the following example:
 
-```tsx {{ prettier: false, filename: 'app/page.tsx' }}
-import { auth } from '@clerk/nextjs/server';
+```tsx {{ filename: 'app/page.tsx' }}
+import { auth } from '@clerk/nextjs/server'
 
 export default async function Page() {
-  const { orgRole } = auth();
+  const { orgRole } = auth()
 
   return (
     <>

--- a/docs/references/nextjs/build-clerk-props.mdx
+++ b/docs/references/nextjs/build-clerk-props.mdx
@@ -11,52 +11,52 @@ Clerk uses `buildClerkProps` to inform the client side helpers of the authentica
 
 #### Basic usage
 
-```tsx {{ prettier: false, filename: 'pages/myServerSidePage' }}
-import { getAuth, buildClerkProps } from "@clerk/nextjs/server";
-import { GetServerSideProps } from "next";
+```tsx {{ filename: 'pages/myServerSidePage' }}
+import { getAuth, buildClerkProps } from '@clerk/nextjs/server'
+import { GetServerSideProps } from 'next'
 
 export const getServerSideProps: GetServerSideProps = async (ctx) => {
-  const { userId } = getAuth(ctx.req);
+  const { userId } = getAuth(ctx.req)
 
   if (!userId) {
     // handle user is not signed in.
   }
 
   // Load any data your application needs for the page using the userId
-  return { props: { ...buildClerkProps(ctx.req) } };
-};
+  return { props: { ...buildClerkProps(ctx.req) } }
+}
 ```
 
 #### Protecting pages using SSR
 
 It is important to protect your API routes to ensure that only authenticated users can access them. You can do this by checking if the `userId` is present in the `getAuth()` response.
 
-```tsx {{ prettier: false, filename: 'pages/api/example.ts' }}
-import { clerkClient, getAuth, buildClerkProps } from "@clerk/nextjs/server";
-import { GetServerSideProps } from "next";
+```tsx {{ filename: 'pages/api/example.ts' }}
+import { clerkClient, getAuth, buildClerkProps } from '@clerk/nextjs/server'
+import { GetServerSideProps } from 'next'
 
 export const getServerSideProps: GetServerSideProps = async (ctx) => {
-  const { userId } = getAuth(ctx.req);
+  const { userId } = getAuth(ctx.req)
 
-  const user = userId ? await clerkClient().users.getUser(userId) : undefined;
+  const user = userId ? await clerkClient().users.getUser(userId) : undefined
 
-  return { props: { ...buildClerkProps(ctx.req, { user }) } };
-};
+  return { props: { ...buildClerkProps(ctx.req, { user }) } }
+}
 ```
 
 #### Usage with `clerkClient`
 
 The `clerkClient` allows you to access the Clerk API. You can use this to retrieve or update data.
 
-```tsx {{ prettier: false, filename: 'pages/api/example.ts' }}
-import { getAuth, buildClerkProps, clerkClient } from "@clerk/nextjs/server";
-import { GetServerSideProps } from "next";
+```tsx {{ filename: 'pages/api/example.ts' }}
+import { getAuth, buildClerkProps, clerkClient } from '@clerk/nextjs/server'
+import { GetServerSideProps } from 'next'
 
 export const getServerSideProps: GetServerSideProps = async (ctx) => {
-  const { userId } = getAuth(ctx.req);
+  const { userId } = getAuth(ctx.req)
 
-  const user = userId ? await clerkClient().users.getUser(userId) : undefined;
+  const user = userId ? await clerkClient().users.getUser(userId) : undefined
 
-  return { props: { ...buildClerkProps(ctx.req, { user }) } };
-};
+  return { props: { ...buildClerkProps(ctx.req, { user }) } }
+}
 ```

--- a/docs/references/nextjs/clerk-middleware.mdx
+++ b/docs/references/nextjs/clerk-middleware.mdx
@@ -14,8 +14,8 @@ Create a `middleware.ts` file at the root of your project, or in your `src/` dir
 > [!NOTE]
 > For more information about Middleware in Next.js, see the [Next.js documentation](https://nextjs.org/docs/pages/building-your-application/routing/middleware).
 
-```tsx {{ prettier: false, filename: 'middleware.ts' }}
-import { clerkMiddleware } from '@clerk/nextjs/server';
+```tsx {{ filename: 'middleware.ts' }}
+import { clerkMiddleware } from '@clerk/nextjs/server'
 
 export default clerkMiddleware()
 
@@ -26,7 +26,7 @@ export const config = {
     // Always run for API routes
     '/(api|trpc)(.*)',
   ],
-};
+}
 ```
 
 By default, `clerkMiddleware` will not protect any routes. All routes are public and you must opt-in to protection for routes.
@@ -39,11 +39,8 @@ The `createRouteMatcher()` helper returns a function that, if called with the `r
 
 In the following example, `createRouteMatcher()` sets all `/dashboard` and `/forum` routes as protected routes.
 
-```tsx {{ prettier: false }}
-const isProtectedRoute = createRouteMatcher([
-  '/dashboard(.*)',
-  '/forum(.*)',
-]);
+```tsx
+const isProtectedRoute = createRouteMatcher(['/dashboard(.*)', '/forum(.*)'])
 ```
 
 ## Protect routes
@@ -63,20 +60,14 @@ There are two methods that you can use:
 - Use [`auth().userId`](/docs/references/nextjs/auth#retrieving-user-id) if you want more control over what your app does based on user authentication status.
 
 <CodeBlockTabs options={["auth().protect()", "auth().userId()"]}>
-  ```tsx {{ prettier: false, filename: 'middleware.ts' }}
-  import {
-    clerkMiddleware,
-    createRouteMatcher
-  } from '@clerk/nextjs/server';
+  ```tsx {{ filename: 'middleware.ts' }}
+  import { clerkMiddleware, createRouteMatcher } from '@clerk/nextjs/server'
 
-  const isProtectedRoute = createRouteMatcher([
-    '/dashboard(.*)',
-    '/forum(.*)',
-  ]);
+  const isProtectedRoute = createRouteMatcher(['/dashboard(.*)', '/forum(.*)'])
 
   export default clerkMiddleware((auth, req) => {
-    if (isProtectedRoute(req)) auth().protect();
-  });
+    if (isProtectedRoute(req)) auth().protect()
+  })
 
   export const config = {
     matcher: [
@@ -85,25 +76,21 @@ There are two methods that you can use:
       // Always run for API routes
       '/(api|trpc)(.*)',
     ],
-  };
+  }
   ```
 
-  ```tsx {{ prettier: false, filename: 'app/middleware.ts' }}
-  import { clerkMiddleware, createRouteMatcher } from '@clerk/nextjs/server';
+  ```tsx {{ filename: 'app/middleware.ts' }}
+  import { clerkMiddleware, createRouteMatcher } from '@clerk/nextjs/server'
 
-  const isProtectedRoute = createRouteMatcher([
-    '/dashboard(.*)',
-    '/forum(.*)',
-  ]);
+  const isProtectedRoute = createRouteMatcher(['/dashboard(.*)', '/forum(.*)'])
 
   export default clerkMiddleware((auth, req) => {
     if (!auth().userId && isProtectedRoute(req)) {
-
       // Add custom logic to run before redirecting
 
-      return auth().redirectToSignIn();
+      return auth().redirectToSignIn()
     }
-  });
+  })
 
   export const config = {
     matcher: [
@@ -112,7 +99,7 @@ There are two methods that you can use:
       // Always run for API routes
       '/(api|trpc)(.*)',
     ],
-  };
+  }
   ```
 </CodeBlockTabs>
 
@@ -126,24 +113,22 @@ There are two methods that you can use:
 - Use [`auth().has()`](/docs/references/nextjs/auth-object#has) if you want more control over what your app does based on the authorization status.
 
 <CodeBlockTabs options={["auth().protect()", "auth().has()"]}>
-  ```tsx {{ prettier: false, filename: 'middleware.ts' }}
-  import { clerkMiddleware, createRouteMatcher } from '@clerk/nextjs/server';
+  ```tsx {{ filename: 'middleware.ts' }}
+  import { clerkMiddleware, createRouteMatcher } from '@clerk/nextjs/server'
 
-  const isProtectedRoute = createRouteMatcher([
-    '/admin(.*)',
-  ]);
+  const isProtectedRoute = createRouteMatcher(['/admin(.*)'])
 
   export default clerkMiddleware((auth, req) => {
     // Restrict admin routes to users with specific permissions
     if (isProtectedRoute(req)) {
-      auth().protect(has => {
+      auth().protect((has) => {
         return (
           has({ permission: 'org:sys_memberships:manage' }) ||
           has({ permission: 'org:sys_domains_manage' })
         )
       })
     }
-  });
+  })
 
   export const config = {
     matcher: [
@@ -152,29 +137,26 @@ There are two methods that you can use:
       // Always run for API routes
       '/(api|trpc)(.*)',
     ],
-  };
+  }
   ```
 
-  ```tsx {{ prettier: false, filename: 'middleware.ts' }}
-  import { clerkMiddleware, createRouteMatcher } from '@clerk/nextjs/server';
+  ```tsx {{ filename: 'middleware.ts' }}
+  import { clerkMiddleware, createRouteMatcher } from '@clerk/nextjs/server'
 
-  const isProtectedRoute = createRouteMatcher([
-    '/admin(.*)',
-  ]);
+  const isProtectedRoute = createRouteMatcher(['/admin(.*)'])
 
   export default clerkMiddleware((auth, req) => {
     const { has, redirectToSignIn } = auth()
     // Restrict admin routes to users with specific permissions
-    if (isProtectedRoute(req) &&
-      !has({ permission: 'org:sys_memberships:manage' }) ||
+    if (
+      (isProtectedRoute(req) && !has({ permission: 'org:sys_memberships:manage' })) ||
       !has({ permission: 'org:sys_domains_manage' })
-    ){
-
+    ) {
       // Add logic to run if the user does not have the required permissions
 
-      return redirectToSignIn();
+      return redirectToSignIn()
     }
-  });
+  })
 
   export const config = {
     matcher: [
@@ -183,7 +165,7 @@ There are two methods that you can use:
       // Always run for API routes
       '/(api|trpc)(.*)',
     ],
-  };
+  }
   ```
 </CodeBlockTabs>
 
@@ -193,27 +175,17 @@ You can use more than one `createRouteMatcher()` in your application if you have
 
 The following example uses the [`has()`](/docs/references/nextjs/auth-object#has) method from Clerk's `auth()` helper.
 
-```tsx {{ prettier: false, filename: 'middleware.ts' }}
-import {
-  clerkMiddleware,
-  createRouteMatcher
-} from '@clerk/nextjs/server';
+```tsx {{ filename: 'middleware.ts' }}
+import { clerkMiddleware, createRouteMatcher } from '@clerk/nextjs/server'
 
-const isTenantRoute = createRouteMatcher([
-  '/organization-selector(.*)',
-  '/orgid/(.*)'
-])
+const isTenantRoute = createRouteMatcher(['/organization-selector(.*)', '/orgid/(.*)'])
 
-const isTenantAdminRoute = createRouteMatcher([
-  '/orgId/(.*)/memberships',
-  '/orgId/(.*)/domain',
-]);
-
+const isTenantAdminRoute = createRouteMatcher(['/orgId/(.*)/memberships', '/orgId/(.*)/domain'])
 
 export default clerkMiddleware((auth, req) => {
   // Restrict admin routes to users with specific permissions
   if (isTenantAdminRoute(req)) {
-    auth().protect(has => {
+    auth().protect((has) => {
       return (
         has({ permission: 'org:sys_memberships:manage' }) ||
         has({ permission: 'org:sys_domains_manage' })
@@ -221,8 +193,8 @@ export default clerkMiddleware((auth, req) => {
     })
   }
   // Restrict organization routes to signed in users
-  if (isTenantRoute(req)) auth().protect();
-});
+  if (isTenantRoute(req)) auth().protect()
+})
 
 export const config = {
   matcher: [
@@ -231,23 +203,23 @@ export const config = {
     // Always run for API routes
     '/(api|trpc)(.*)',
   ],
-};
+}
 ```
 
 ## Protect all routes
 
 To protect all routes in your application and define specific routes as public, you can use any of the above methods and simply invert the `if` condition.
 
-```jsx {{ prettier: false, filename: 'middleware.ts' }}
+```jsx {{ filename: 'middleware.ts' }}
 import { clerkMiddleware, createRouteMatcher } from '@clerk/nextjs/server'
 
-const isPublicRoute = createRouteMatcher(['/sign-in(.*)', '/sign-up(.*)']);
+const isPublicRoute = createRouteMatcher(['/sign-in(.*)', '/sign-up(.*)'])
 
 export default clerkMiddleware((auth, request) => {
-  if(!isPublicRoute(request)) {
-    auth().protect();
+  if (!isPublicRoute(request)) {
+    auth().protect()
   }
-});
+})
 
 export const config = {
   matcher: [
@@ -256,7 +228,7 @@ export const config = {
     // Always run for API routes
     '/(api|trpc)(.*)',
   ],
-};
+}
 ```
 
 ## Debug your Middleware
@@ -286,31 +258,25 @@ If you would like to set up debugging for your development environment only, you
 
 You can combine other Middleware with Clerk's Middleware by returning the second Middleware from `clerkMiddleware()`.
 
-```js {{ prettier: false, filename: 'middleware.ts' }}
-import {
-  clerkMiddleware,
-  createRouteMatcher,
-  redirectToSignIn,
-} from '@clerk/nextjs/server';
-import createMiddleware from 'next-intl/middleware';
+```js {{ filename: 'middleware.ts' }}
+import { clerkMiddleware, createRouteMatcher, redirectToSignIn } from '@clerk/nextjs/server'
+import createMiddleware from 'next-intl/middleware'
 
-import { AppConfig } from './utils/AppConfig';
+import { AppConfig } from './utils/AppConfig'
 
 const intlMiddleware = createMiddleware({
   locales: AppConfig.locales,
   localePrefix: AppConfig.localePrefix,
   defaultLocale: AppConfig.defaultLocale,
-});
+})
 
-const isProtectedRoute = createRouteMatcher([
-  'dashboard/(.*)',
-]);
+const isProtectedRoute = createRouteMatcher(['dashboard/(.*)'])
 
 export default clerkMiddleware((auth, req) => {
-  if (isProtectedRoute(req)) auth().protect();
+  if (isProtectedRoute(req)) auth().protect()
 
-  return intlMiddleware(req);
-});
+  return intlMiddleware(req)
+})
 
 export const config = {
   matcher: [
@@ -319,7 +285,7 @@ export const config = {
     // Always run for API routes
     '/(api|trpc)(.*)',
   ],
-};
+}
 ```
 
 ## `clerkMiddleware()` options
@@ -416,7 +382,7 @@ Dynamic keys are encrypted and shared during request time using a [AES encryptio
 
 When providing `CLERK_ENCRYPTION_KEY`, it is recommended to use a 32-byte (256-bit), pseudorandom value. You can use `openssl` to generate a key:
 
-```sh {{ prettier: false, filename: 'terminal' }}
+```sh {{ filename: 'terminal' }}
 openssl rand --hex 32
 ```
 

--- a/docs/references/nextjs/current-user.mdx
+++ b/docs/references/nextjs/current-user.mdx
@@ -13,14 +13,14 @@ Under the hood, this helper:
 - uses the `GET /v1/users/me` endpoint.
 - counts towards the [Backend API Request Rate Limit](/docs/backend-requests/resources/rate-limits#rate-limits).
 
-```tsx {{ prettier: false, filename: 'app/page.tsx' }}
-import { currentUser } from '@clerk/nextjs/server';
+```tsx {{ filename: 'app/page.tsx' }}
+import { currentUser } from '@clerk/nextjs/server'
 
 export default async function Page() {
-  const user = await currentUser();
+  const user = await currentUser()
 
-  if (!user) return <div>Not signed in</div>;
+  if (!user) return <div>Not signed in</div>
 
-  return <div>Hello {user?.firstName}</div>;
+  return <div>Hello {user?.firstName}</div>
 }
 ```

--- a/docs/references/nextjs/custom-signup-signin-pages.mdx
+++ b/docs/references/nextjs/custom-signup-signin-pages.mdx
@@ -23,19 +23,19 @@ If Clerk's prebuilt components don't meet your specific needs or if you require 
   Create a new file that will be used to render the sign-up page. In the file, import the [`<SignUp />`](/docs/components/authentication/sign-up) component from `@clerk/nextjs` and render it.
 
   <CodeBlockTabs type="router" options={["App Router", "Pages Router"]}>
-    ```tsx {{ prettier: false, filename: 'app/sign-up/[[...sign-up]]/page.tsx' }}
-    import { SignUp } from "@clerk/nextjs";
+    ```tsx {{ filename: 'app/sign-up/[[...sign-up]]/page.tsx' }}
+    import { SignUp } from '@clerk/nextjs'
 
     export default function Page() {
-      return <SignUp />;
+      return <SignUp />
     }
     ```
 
-    ```tsx {{ prettier: false, filename: '/pages/sign-up/[[...index]].tsx' }}
-    import { SignUp } from "@clerk/nextjs";
+    ```tsx {{ filename: '/pages/sign-up/[[...index]].tsx' }}
+    import { SignUp } from '@clerk/nextjs'
 
     export default function Page() {
-      return <SignUp />;
+      return <SignUp />
     }
     ```
   </CodeBlockTabs>
@@ -45,19 +45,19 @@ If Clerk's prebuilt components don't meet your specific needs or if you require 
   Create a new file that will be used to render the sign-in page. In the file, import the [`<SignIn />`](/docs/components/authentication/sign-in) component from `@clerk/nextjs` and render it.
 
   <CodeBlockTabs type="router" options={["App Router", "Pages Router"]}>
-    ```tsx {{ prettier: false, filename: 'app/sign-in/[[...sign-in]]/page.tsx' }}
-    import { SignIn } from "@clerk/nextjs";
+    ```tsx {{ filename: 'app/sign-in/[[...sign-in]]/page.tsx' }}
+    import { SignIn } from '@clerk/nextjs'
 
     export default function Page() {
-      return <SignIn />;
+      return <SignIn />
     }
     ```
 
-    ```tsx {{ prettier: false, filename: '/pages/sign-in/[[...index]].tsx' }}
-    import { SignIn } from "@clerk/nextjs";
+    ```tsx {{ filename: '/pages/sign-in/[[...index]].tsx' }}
+    import { SignIn } from '@clerk/nextjs'
 
     export default function Page() {
-      return <SignIn />;
+      return <SignIn />
     }
     ```
   </CodeBlockTabs>
@@ -68,7 +68,7 @@ If Clerk's prebuilt components don't meet your specific needs or if you require 
 
   In Next.js applications, you can either pass the `path` prop, _or_ you can define the `NEXT_PUBLIC_CLERK_SIGN_IN_URL` and `NEXT_PUBLIC_CLERK_SIGN_UP_URL` environment variables, like so:
 
-  ```env {{ prettier: false, filename: '.env.local' }}
+  ```env {{ filename: '.env.local' }}
   NEXT_PUBLIC_CLERK_SIGN_IN_URL=/sign-in
   NEXT_PUBLIC_CLERK_SIGN_UP_URL=/sign-up
   ```
@@ -78,15 +78,15 @@ If Clerk's prebuilt components don't meet your specific needs or if you require 
   Run your project with the following terminal command from the root directory of your project:
 
   <CodeBlockTabs type="installer" options={["npm", "yarn", "pnpm"]}>
-    ```bash {{ prettier: false, filename: 'terminal' }}
+    ```bash {{ filename: 'terminal' }}
     npm run dev
     ```
 
-    ```bash {{ prettier: false, filename: 'terminal' }}
+    ```bash {{ filename: 'terminal' }}
     yarn dev
     ```
 
-    ```bash {{ prettier: false, filename: 'terminal' }}
+    ```bash {{ filename: 'terminal' }}
     pnpm dev
     ```
   </CodeBlockTabs>

--- a/docs/references/nextjs/get-auth.mdx
+++ b/docs/references/nextjs/get-auth.mdx
@@ -27,19 +27,16 @@ The `getAuth()` helper retrieves the authentication state, allowing you to prote
 
 The following example demonstrates how to use `getAuth()` to retrieve authentication information in an API route.
 
-```tsx {{ prettier: false, filename: 'app/api/example/route.ts' }}
-import { getAuth } from "@clerk/nextjs/server";
-import type { NextApiRequest, NextApiResponse } from "next";
+```tsx {{ filename: 'app/api/example/route.ts' }}
+import { getAuth } from '@clerk/nextjs/server'
+import type { NextApiRequest, NextApiResponse } from 'next'
 
-export default async function handler(
-  req: NextApiRequest,
-  res: NextApiResponse
-) {
-  const { userId } = getAuth(req);
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  const { userId } = getAuth(req)
 
   // Add logic that retrieves the data for the API route
 
-  return res.status(200).json({ userId: userId });
+  return res.status(200).json({ userId: userId })
 }
 ```
 
@@ -47,23 +44,20 @@ export default async function handler(
 
 It is important to protect your API routes to ensure that only authenticated users can access them. You can do this by checking if the `userId` is present in the `getAuth()` response, like in the following example:
 
-```tsx {{ prettier: false, filename: 'app/api/example/route.ts' }}
-import { getAuth } from "@clerk/nextjs/server";
-import type { NextApiRequest, NextApiResponse } from "next";
+```tsx {{ filename: 'app/api/example/route.ts' }}
+import { getAuth } from '@clerk/nextjs/server'
+import type { NextApiRequest, NextApiResponse } from 'next'
 
-export default async function handler(
-  req: NextApiRequest,
-  res: NextApiResponse
-) {
-  const { userId } = getAuth(req);
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  const { userId } = getAuth(req)
 
   if (!userId) {
-    return res.status(401).json({ error: "Not authenticated" });
+    return res.status(401).json({ error: 'Not authenticated' })
   }
 
   // Add logic that retrieves the data for the API route
 
-  return res.status(200).json({ userId: userId });
+  return res.status(200).json({ userId: userId })
 }
 ```
 
@@ -71,22 +65,19 @@ export default async function handler(
 
 `getAuth()` returns `getToken()`, which is a method that returns the current user's session token. You can also use this function to retrieve a custom JWT template, like in the following example:
 
-```tsx {{ prettier: false, filename: 'app/api/example/route.ts' }}
-import { getAuth } from "@clerk/nextjs/server";
-import type { NextApiRequest, NextApiResponse } from "next";
+```tsx {{ filename: 'app/api/example/route.ts' }}
+import { getAuth } from '@clerk/nextjs/server'
+import type { NextApiRequest, NextApiResponse } from 'next'
 
-export default async function handler(
-  req: NextApiRequest,
-  res: NextApiResponse
-) {
-  const { getToken } = getAuth(req);
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  const { getToken } = getAuth(req)
 
-  const token = await getToken({ template: "supabase" });
+  const token = await getToken({ template: 'supabase' })
 
   // Add logic that retrieves the data
   // from your database using the token
 
-  return res.status(200).json({});
+  return res.status(200).json({})
 }
 ```
 
@@ -94,18 +85,15 @@ export default async function handler(
 
 `clerkClient` is used to access the [Backend SDK](/docs/references/backend/overview), which exposes Clerk's backend API resources. You can use `getAuth()` to pass authentication information that many of the Backend SDK methods require, like in the following example:
 
-```tsx {{ prettier: false, filename: 'app/api/example/route.ts' }}
-import { clerkClient, getAuth } from "@clerk/nextjs/server";
-import type { NextApiRequest, NextApiResponse } from "next";
+```tsx {{ filename: 'app/api/example/route.ts' }}
+import { clerkClient, getAuth } from '@clerk/nextjs/server'
+import type { NextApiRequest, NextApiResponse } from 'next'
 
-export default async function handler(
-  req: NextApiRequest,
-  res: NextApiResponse
-) {
-  const { userId } = getAuth(req);
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  const { userId } = getAuth(req)
 
-  const user = userId ? await clerkClient().users.getUser(userId) : null;
+  const user = userId ? await clerkClient().users.getUser(userId) : null
 
-  return res.status(200).json({});
+  return res.status(200).json({})
 }
 ```

--- a/docs/references/nextjs/read-session-data.mdx
+++ b/docs/references/nextjs/read-session-data.mdx
@@ -26,13 +26,12 @@ Under the hood, `currentUser()` uses the [`clerkClient`](/docs/references/backen
   <Tab>
     This example uses the new `auth()` helper to validate an authenticated user and the new `currentUser()` helper to access the `Backend API User` object for the authenticated user.
 
-    ```tsx {{ prettier: false, filename: 'app/page.tsx' }}
-    import { auth, currentUser } from "@clerk/nextjs/server";
+    ```tsx {{ filename: 'app/page.tsx' }}
+    import { auth, currentUser } from '@clerk/nextjs/server'
 
     export default async function Page() {
-
       // Get the userId from auth() -- if null, the user is not signed in
-      const { userId } = auth();
+      const { userId } = auth()
 
       if (userId) {
         // Query DB for user specific information or display assets only to signed in users
@@ -48,22 +47,21 @@ Under the hood, `currentUser()` uses the [`clerkClient`](/docs/references/backen
   <Tab>
     A Route Handler can use the [`auth()`](/docs/references/nextjs/auth) helper to return information about the user or their authentication state, or to control access to some or all of the Route Handler. The `auth()` helper does require [Middleware](/docs/references/nextjs/clerk-middleware).
 
-    ```tsx {{ prettier: false, filename: 'app/api/user/route.tsx' }}
-    import { NextResponse } from 'next/server';
-    import { auth } from '@clerk/nextjs/server';
+    ```tsx {{ filename: 'app/api/user/route.tsx' }}
+    import { NextResponse } from 'next/server'
+    import { auth } from '@clerk/nextjs/server'
 
     export async function GET() {
-
       // Get the userId from auth() -- if null, the user is not signed in
-      const { userId } = auth();
+      const { userId } = auth()
 
       if (!userId) {
-        return new NextResponse("Unauthorized", { status: 401 });
+        return new NextResponse('Unauthorized', { status: 401 })
       }
 
       // Perform your Route Handler's logic
 
-      return NextResponse.json({ userId }, { status: 200 });
+      return NextResponse.json({ userId }, { status: 200 })
     }
     ```
   </Tab>
@@ -73,25 +71,24 @@ Under the hood, `currentUser()` uses the [`clerkClient`](/docs/references/backen
 
     In this example, the `auth()` helper is used to validate an authenticated user and the `currentUser()` helper is used to access the `Backend User` object for the authenticated user.
 
-    ```tsx {{ prettier: false, filename: 'app/api/user/route.ts' }}
-    import { NextResponse } from 'next/server';
-    import { currentUser, auth } from "@clerk/nextjs/server";
+    ```tsx {{ filename: 'app/api/user/route.ts' }}
+    import { NextResponse } from 'next/server'
+    import { currentUser, auth } from '@clerk/nextjs/server'
 
     export async function GET() {
-
       // Get the userId from auth() -- if null, the user is not signed in
-      const { userId } = auth();
+      const { userId } = auth()
 
       if (!userId) {
-        return new NextResponse("Unauthorized", { status: 401 });
+        return new NextResponse('Unauthorized', { status: 401 })
       }
 
       // Get the Backend API User object when you need access to the user's information
-      const user = await currentUser();
+      const user = await currentUser()
 
       // Perform your Route Handler's logic with the returned user object
 
-      return NextResponse.json({ "user": user }, { status: 200 })
+      return NextResponse.json({ user: user }, { status: 200 })
     }
     ```
   </Tab>
@@ -103,20 +100,20 @@ Under the hood, `currentUser()` uses the [`clerkClient`](/docs/references/backen
   <Tab>
     For Next.js applications using the Pages Router, you can retrieve information about the user and their authentication state, or control access to some or all of your API routes by using the [`getAuth()`](/docs/references/nextjs/get-auth) helper. The `getAuth()` helper does require [Middleware](/docs/references/nextjs/clerk-middleware).
 
-    ```tsx {{ prettier: false, filename: 'pages/api/auth.ts' }}
-    import type { NextApiRequest, NextApiResponse } from "next";
-    import { getAuth } from "@clerk/nextjs/server";
+    ```tsx {{ filename: 'pages/api/auth.ts' }}
+    import type { NextApiRequest, NextApiResponse } from 'next'
+    import { getAuth } from '@clerk/nextjs/server'
 
     export default function handler(req: NextApiRequest, res: NextApiResponse) {
-      const { userId } = getAuth(req);
+      const { userId } = getAuth(req)
 
       if (!userId) {
-        return res.status(401).json({ error: "Unauthorized" });
+        return res.status(401).json({ error: 'Unauthorized' })
       }
 
       // retrieve data from your database
 
-      res.status(200).json({});
+      res.status(200).json({})
     }
     ```
   </Tab>
@@ -126,25 +123,22 @@ Under the hood, `currentUser()` uses the [`clerkClient`](/docs/references/backen
 
     In some cases, you may need the full `User` object. For example, if you want to access the user's email address address or name, you can use the [`clerkClient`](/docs/references/backend/overview) helper to get the full `User` object.
 
-    ```tsx {{ prettier: false, filename: 'pages/api/auth.ts' }}
-    import { getAuth, clerkClient } from "@clerk/nextjs/server";
-    import type { NextApiRequest, NextApiResponse } from "next";
+    ```tsx {{ filename: 'pages/api/auth.ts' }}
+    import { getAuth, clerkClient } from '@clerk/nextjs/server'
+    import type { NextApiRequest, NextApiResponse } from 'next'
 
-    export default async function handler(
-      req: NextApiRequest,
-      res: NextApiResponse
-    ) {
-      const { userId } = getAuth(req);
+    export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+      const { userId } = getAuth(req)
 
       if (!userId) {
-        return res.status(401).json({ error: "Unauthorized" });
+        return res.status(401).json({ error: 'Unauthorized' })
       }
 
-      const user = await clerkClient().users.getUser(userId);
+      const user = await clerkClient().users.getUser(userId)
 
       // use the user object to decide what data to return
 
-      return res.status(200).json({});
+      return res.status(200).json({})
     }
     ```
   </Tab>
@@ -155,12 +149,12 @@ Under the hood, `currentUser()` uses the [`clerkClient`](/docs/references/backen
     > [!NOTE]
     > Please note the addition of `buildClerkProps` in the return statement, which informs the Clerk React helpers of the authentication state during server-side rendering (like `useAuth()`, `<SignedIn>`, and `<SignedOut>`).
 
-    ```tsx {{ prettier: false, filename: 'pages/example.tsx' }}
-    import { getAuth, buildClerkProps } from "@clerk/nextjs/server";
-    import { GetServerSideProps } from "next";
+    ```tsx {{ filename: 'pages/example.tsx' }}
+    import { getAuth, buildClerkProps } from '@clerk/nextjs/server'
+    import { GetServerSideProps } from 'next'
 
     export const getServerSideProps: GetServerSideProps = async (ctx) => {
-      const { userId } = getAuth(ctx.req);
+      const { userId } = getAuth(ctx.req)
 
       if (!userId) {
         // handle user is not signed in.
@@ -168,23 +162,23 @@ Under the hood, `currentUser()` uses the [`clerkClient`](/docs/references/backen
 
       // Load any data your application needs for the page using the userId
 
-      return { props: { ...buildClerkProps(ctx.req) } };
-    };
+      return { props: { ...buildClerkProps(ctx.req) } }
+    }
     ```
 
     You can also access the full `User` object before passing it to the page by using the `clerkClient` helper.
 
-    ```tsx {{ prettier: false, filename: 'pages/example.tsx' }}
-    import { getAuth, buildClerkProps, clerkClient } from "@clerk/nextjs/server";
-    import { GetServerSideProps } from "next";
+    ```tsx {{ filename: 'pages/example.tsx' }}
+    import { getAuth, buildClerkProps, clerkClient } from '@clerk/nextjs/server'
+    import { GetServerSideProps } from 'next'
 
     export const getServerSideProps: GetServerSideProps = async (ctx) => {
-      const { userId } = getAuth(ctx.req);
+      const { userId } = getAuth(ctx.req)
 
-      const user = userId ? await clerkClient.users.getUser(userId) : undefined;
+      const user = userId ? await clerkClient.users.getUser(userId) : undefined
 
-      return { props: { ...buildClerkProps(ctx.req, { user }) } };
-    };
+      return { props: { ...buildClerkProps(ctx.req, { user }) } }
+    }
     ```
   </Tab>
 </Tabs>
@@ -195,23 +189,23 @@ Under the hood, `currentUser()` uses the [`clerkClient`](/docs/references/backen
 
 The [`useAuth`](/docs/references/react/use-auth) hook is a convenient way to access the current auth state. This hook provides the minimal information needed for data-loading and helper methods to manage the current active session.
 
-```tsx {{ prettier: false, filename: 'example.tsx' }}
-"use client";
-import { useAuth } from "@clerk/nextjs";
+```tsx {{ filename: 'example.tsx' }}
+'use client'
+import { useAuth } from '@clerk/nextjs'
 
 export default function Example() {
-  const { isLoaded, userId, sessionId, getToken } = useAuth();
+  const { isLoaded, userId, sessionId, getToken } = useAuth()
 
   // In case the user signs out while on the page.
   if (!isLoaded || !userId) {
-    return null;
+    return null
   }
 
   return (
     <div>
       Hello, {userId} your current active session is {sessionId}
     </div>
-  );
+  )
 }
 ```
 
@@ -219,17 +213,17 @@ export default function Example() {
 
 The [`useUser`](/docs/references/react/use-user) hook is a convenient way to access the current user data where you need it. This hook provides the user data and helper methods to manage the current active session.
 
-```tsx {{ prettier: false, filename: 'example.tsx' }}
-"use client";
-import { useUser } from "@clerk/nextjs";
+```tsx {{ filename: 'example.tsx' }}
+'use client'
+import { useUser } from '@clerk/nextjs'
 
 export default function Example() {
-  const { isLoaded, isSignedIn, user } = useUser();
+  const { isLoaded, isSignedIn, user } = useUser()
 
   if (!isLoaded || !isSignedIn) {
-    return null;
+    return null
   }
 
-  return <div>Hello, {user.firstName} welcome to Clerk</div>;
+  return <div>Hello, {user.firstName} welcome to Clerk</div>
 }
 ```

--- a/docs/references/nextjs/route-handlers.mdx
+++ b/docs/references/nextjs/route-handlers.mdx
@@ -15,8 +15,8 @@ If you aren't protecting your Route Handler using [`clerkMiddleware()`](/docs/re
 - Use [`auth().userId`](/docs/references/nextjs/auth#retrieving-user-id) if you want to customize the behavior or error message.
 
 <CodeBlockTabs type="router" options={["auth().protect()", "auth().userId()"]}>
-  ```tsx {{ prettier: false, filename: '/app/api/route.ts' }}
-  import { auth } from "@clerk/nextjs/server";
+  ```tsx {{ filename: '/app/api/route.ts' }}
+  import { auth } from '@clerk/nextjs/server'
 
   export async function GET() {
     // If there is no signed in user, this will return a 404 error
@@ -24,27 +24,24 @@ If you aren't protecting your Route Handler using [`clerkMiddleware()`](/docs/re
 
     // Add your Route Handler logic here
 
-    return Response.json({ message: "Hello world!" })
+    return Response.json({ message: 'Hello world!' })
   }
   ```
 
-  ```tsx {{ prettier: false, filename: 'app/api/route.ts' }}
-  import { auth } from '@clerk/nextjs/server';
-  import { NextResponse } from 'next/server';
+  ```tsx {{ filename: 'app/api/route.ts' }}
+  import { auth } from '@clerk/nextjs/server'
+  import { NextResponse } from 'next/server'
 
   export async function GET() {
-    const { userId } = auth();
+    const { userId } = auth()
 
     if (!userId) {
-      return NextResponse.json(
-        { error: 'Error: No signed in user' },
-        { status: 401 },
-      );
+      return NextResponse.json({ error: 'Error: No signed in user' }, { status: 401 })
     }
 
     // Add your Route Handler logic here
 
-    return NextResponse.json({ userId });
+    return NextResponse.json({ userId })
   }
   ```
 </CodeBlockTabs>
@@ -55,22 +52,22 @@ Clerk provides integrations with a number of popular databases.
 
 The following example demonstrates how to use [`auth().getToken()`](/docs/references/nextjs/auth-object#get-token) to retrieve a token from a JWT template and use it to fetch data from the external source.
 
-```ts {{ prettier: false, filename: 'app/api/route.ts' }}
-import { NextResponse } from 'next/server';
-import { auth } from '@clerk/nextjs/server';
+```ts {{ filename: 'app/api/route.ts' }}
+import { NextResponse } from 'next/server'
+import { auth } from '@clerk/nextjs/server'
 export async function GET() {
-  const { userId, getToken } = auth();
+  const { userId, getToken } = auth()
 
-  if(!userId){
-    return new Response("Unauthorized", { status: 401 });
+  if (!userId) {
+    return new Response('Unauthorized', { status: 401 })
   }
 
-  const token = await getToken({ template: "supabase" });
+  const token = await getToken({ template: 'supabase' })
 
   // Fetch data from Supabase and return it.
-  const data = { supabaseData: 'Hello World' };
+  const data = { supabaseData: 'Hello World' }
 
-  return NextResponse.json({ data });
+  return NextResponse.json({ data })
 }
 ```
 
@@ -78,17 +75,17 @@ export async function GET() {
 
 In some cases, you might need the current user in your Route Handler. Clerk provides an asynchronous helper called [`currentUser()`](/docs/references/nextjs/current-user) to retrieve the current [`Backend User`](/docs/references/backend/types/backend-user) object.
 
-```ts {{ prettier: false, filename: 'app/api/route.ts' }}
-import { NextResponse } from 'next/server';
-import { currentUser } from '@clerk/nextjs/server';
+```ts {{ filename: 'app/api/route.ts' }}
+import { NextResponse } from 'next/server'
+import { currentUser } from '@clerk/nextjs/server'
 export async function GET() {
-  const user = await currentUser();
+  const user = await currentUser()
 
-  if(!user){
-    return new Response("Unauthorized", { status: 401 });
+  if (!user) {
+    return new Response('Unauthorized', { status: 401 })
   }
 
-  return NextResponse.json({ user });
+  return NextResponse.json({ user })
 }
 ```
 
@@ -98,19 +95,19 @@ The [JavaScript Backend SDK](/docs/references/backend/overview) exposes [Clerk's
 
 `clerkClient` exposes an instance of the JavaScript Backend SDK for use in server environments.
 
-```ts {{ prettier: false, filename: 'app/api/route.ts' }}
-import { NextResponse, NextRequest } from 'next/server';
-import { auth, clerkClient } from '@clerk/nextjs/server';
+```ts {{ filename: 'app/api/route.ts' }}
+import { NextResponse, NextRequest } from 'next/server'
+import { auth, clerkClient } from '@clerk/nextjs/server'
 
-export async function POST(req:NextRequest) {
-  const { userId } = auth();
+export async function POST(req: NextRequest) {
+  const { userId } = auth()
 
-  if (!userId) return NextResponse.redirect(new URL('/sign-in',req.url));
+  if (!userId) return NextResponse.redirect(new URL('/sign-in', req.url))
 
-  const params = { firstName: 'John', lastName: 'Wick' };
+  const params = { firstName: 'John', lastName: 'Wick' }
 
-  const user = await clerkClient().users.updateUser(userId, params);
+  const user = await clerkClient().users.updateUser(userId, params)
 
-  return NextResponse.json({ user });
+  return NextResponse.json({ user })
 }
 ```

--- a/docs/references/nextjs/server-actions.mdx
+++ b/docs/references/nextjs/server-actions.mdx
@@ -15,32 +15,28 @@ The following guide provides examples for using Server Actions in Server Compone
 
 You can use the [`auth()`](/docs/references/nextjs/auth) helper to protect your server actions. This helper will return the current user's ID if they are signed in, or `null` if they are not.
 
-```tsx {{ prettier: false, filename: 'actions.ts' }}
-import { auth } from '@clerk/nextjs/server';
+```tsx {{ filename: 'actions.ts' }}
+import { auth } from '@clerk/nextjs/server'
 
 export default function AddToCart() {
   async function addItem(formData: FormData) {
-    'use server';
+    'use server'
 
-    const { userId } = auth();
+    const { userId } = auth()
 
     if (!userId) {
-      throw new Error('You must be signed in to add an item to your cart');
+      throw new Error('You must be signed in to add an item to your cart')
     }
 
-    console.log('add item server action', formData);
+    console.log('add item server action', formData)
   }
 
   return (
     <form action={addItem}>
-      <input
-        value={'test'}
-        type='text'
-        name='name'
-      />
-      <button type='submit'>Add to Cart</button>
+      <input value={'test'} type="text" name="name" />
+      <button type="submit">Add to Cart</button>
     </form>
-  );
+  )
 }
 ```
 
@@ -48,38 +44,34 @@ export default function AddToCart() {
 
 Current user data is important for data enrichment. You can use the [`currentUser()`](/docs/references/nextjs/current-user) helper to fetch the current user's data in your server actions.
 
-```tsx {{ prettier: false, filename: 'app/page.tsx' }}
-import { currentUser } from '@clerk/nextjs/server';
+```tsx {{ filename: 'app/page.tsx' }}
+import { currentUser } from '@clerk/nextjs/server'
 
 export default function AddHobby() {
   async function addHobby(formData: FormData) {
-    'use server';
+    'use server'
 
-    const user = await currentUser();
+    const user = await currentUser()
 
     if (!user) {
-      throw new Error('You must be signed in to use this feature');
+      throw new Error('You must be signed in to use this feature')
     }
 
     const serverData = {
-      usersHobby: formData.get("hobby"),
+      usersHobby: formData.get('hobby'),
       userId: user.id,
-      profileImage: user.imageUrl
-    };
+      profileImage: user.imageUrl,
+    }
 
-    console.log('add item server action completed with user details ', serverData);
+    console.log('add item server action completed with user details ', serverData)
   }
 
   return (
     <form action={addHobby}>
-      <input
-        value={'soccer'}
-        type='text'
-        name='hobby'
-      />
-      <button type='submit'>Submit your hobby</button>
+      <input value={'soccer'} type="text" name="hobby" />
+      <button type="submit">Submit your hobby</button>
     </form>
-  );
+  )
 }
 ```
 
@@ -92,45 +84,39 @@ When using Server Actions in Client Components, you need to make sure you use pr
 Use the following tabs to see an example of how to protect a Server Action that is used in a Client Component.
 
 <CodeBlockTabs options={["Server Action", "Client Component", "Page"]}>
-  ```tsx {{ prettier: false, filename: 'app/actions.ts' }}
+  ```tsx {{ filename: 'app/actions.ts' }}
   'use server'
-  import { auth } from '@clerk/nextjs/server';
+  import { auth } from '@clerk/nextjs/server'
 
   export async function addItem(formData: FormData) {
-    const { userId } = auth();
+    const { userId } = auth()
 
     if (!userId) {
-      throw new Error('You must be signed in to add an item to your cart');
+      throw new Error('You must be signed in to add an item to your cart')
     }
 
-    console.log('add item server action', formData);
+    console.log('add item server action', formData)
   }
   ```
 
-  ```tsx {{ prettier: false, filename: 'app/components/AddItem.tsx' }}
+  ```tsx {{ filename: 'app/components/AddItem.tsx' }}
   'use client'
 
   export default function AddItem({ addItem }) {
     return (
       <form action={addItem}>
-        <input
-          value={'test'}
-          type='text'
-          name='name'
-        />
-        <button type='submit'>Add to Cart</button>
+        <input value={'test'} type="text" name="name" />
+        <button type="submit">Add to Cart</button>
       </form>
     )
   }
   ```
 
-  ```tsx {{ prettier: false, filename: 'app/page.tsx' }}
-  import AddItem from "./components/AddItem";
-  import { addItem } from "./actions"
+  ```tsx {{ filename: 'app/page.tsx' }}
+  import AddItem from './components/AddItem'
+  import { addItem } from './actions'
   export default function Hobby() {
-    return (
-      <AddItem addItem={addItem} />
-    );
+    return <AddItem addItem={addItem} />
   }
   ```
 </CodeBlockTabs>
@@ -140,52 +126,45 @@ Use the following tabs to see an example of how to protect a Server Action that 
 Use the following tabs to see an example of how to access the current user in a Server Action that is used in a Client Component.
 
 <CodeBlockTabs options={["Server Action", "Client Component", "Page"]}>
-  ```tsx {{ prettier: false, filename: 'app/actions.ts' }}
+  ```tsx {{ filename: 'app/actions.ts' }}
   'use server'
-  import { currentUser } from "@clerk/nextjs/server";
+  import { currentUser } from '@clerk/nextjs/server'
 
   export async function addHobby(formData: FormData) {
-    const user = await currentUser();
+    const user = await currentUser()
 
     if (!user) {
-      throw new Error('You must be signed in to use this feature');
+      throw new Error('You must be signed in to use this feature')
     }
 
     const serverData = {
-      usersHobby: formData.get("hobby"),
+      usersHobby: formData.get('hobby'),
       userId: user.id,
-      profileImage: user.imageUrl
-    };
+      profileImage: user.imageUrl,
+    }
 
-    console.log('add Hobby completed with user details ', serverData);
+    console.log('add Hobby completed with user details ', serverData)
   }
   ```
 
-  ```tsx {{ prettier: false, filename: 'app/components/AddHobby.tsx' }}
-  "use client"
+  ```tsx {{ filename: 'app/components/AddHobby.tsx' }}
+  'use client'
 
   export default function UI({ addHobby }) {
-
     return (
       <form action={addHobby}>
-        <input
-          value={'soccer'}
-          type='text'
-          name='hobby'
-        />
-        <button type='submit'>Submit your hobby</button>
+        <input value={'soccer'} type="text" name="hobby" />
+        <button type="submit">Submit your hobby</button>
       </form>
     )
   }
   ```
 
-  ```tsx {{ prettier: false, filename: 'app/page.tsx' }}
-  import AddHobby from "./components/AddHobby";
-  import { addHobby } from "./actions"
+  ```tsx {{ filename: 'app/page.tsx' }}
+  import AddHobby from './components/AddHobby'
+  import { addHobby } from './actions'
   export default function Hobby() {
-    return (
-      <AddHobby addHobby={addHobby} />
-    );
+    return <AddHobby addHobby={addHobby} />
   }
   ```
 </CodeBlockTabs>

--- a/docs/references/nextjs/trpc.mdx
+++ b/docs/references/nextjs/trpc.mdx
@@ -35,33 +35,31 @@ description: Learn how to integrate Clerk into your Next.js Pages Router applica
 
   To add Clerk's authentication context (`Auth` object) to your tRPC server, create a context file that will be used to create the context for every tRPC query sent to the server. This context file will use the [`getAuth()`](/docs/references/nextjs/get-auth) helper from Clerk to access the user's `Auth` object.
 
-  ```ts {{ prettier: false, filename: 'src/server/context.ts' }}
-  import * as trpc from '@trpc/server';
-  import * as trpcNext from '@trpc/server/adapters/next';
-  import { getAuth } from '@clerk/nextjs/server';
-   
-  export const createContext = async (
-    opts: trpcNext.CreateNextContextOptions
-  ) => {
+  ```ts {{ filename: 'src/server/context.ts' }}
+  import * as trpc from '@trpc/server'
+  import * as trpcNext from '@trpc/server/adapters/next'
+  import { getAuth } from '@clerk/nextjs/server'
+
+  export const createContext = async (opts: trpcNext.CreateNextContextOptions) => {
     return { auth: getAuth(opts.req) }
   }
 
-  export type Context = trpc.inferAsyncReturnType<typeof createContext>;
+  export type Context = trpc.inferAsyncReturnType<typeof createContext>
   ```
 
   ### Create tRPC context
 
   Create the tRPC context to use the Clerk context in your tRPC queries.
 
-  ```ts {{ prettier: false, filename: 'src/pages/api/trpc/[trpc].ts' }}
+  ```ts {{ filename: 'src/pages/api/trpc/[trpc].ts' }}
   import { appRouter } from '@/server/routers'
   import * as trpcNext from '@trpc/server/adapters/next'
-  import { createContext } from 'src/server/context';
+  import { createContext } from 'src/server/context'
 
   export default trpcNext.createNextApiHandler({
     router: appRouter,
     createContext: createContext,
-  });
+  })
   ```
 
   ### Access the context data in your backend
@@ -70,15 +68,15 @@ description: Learn how to integrate Clerk into your Next.js Pages Router applica
 
   In the following example, the `ctx` is used to access the user's ID and return a greeting message. If the user is not signed in, the `greeting` will return `hello! undefined`.
 
-  ```ts {{ prettier: false, filename: 'src/server/routers/index.ts' }}
-  import { router, publicProcedure } from '../trpc';
+  ```ts {{ filename: 'src/server/routers/index.ts' }}
+  import { router, publicProcedure } from '../trpc'
 
   export const exampleRouter = router({
-    hello: publicProcedure.query(({ctx}) => {
+    hello: publicProcedure.query(({ ctx }) => {
       return {
-        greeting: `hello! ${ctx.auth?.userId}`
+        greeting: `hello! ${ctx.auth?.userId}`,
       }
-    })
+    }),
   })
   ```
 
@@ -88,7 +86,7 @@ description: Learn how to integrate Clerk into your Next.js Pages Router applica
 
   In the following example, tRPC middleware is used to access the `ctx`, which contains the user's authentication information. If the user's ID exists in the authentication context, this means that the user is signed in. If the user is not signed in, an `UNAUTHORIZED` error is thrown.
 
-  ```ts {{ prettier: false, filename: 'src/server/trpc.ts' }}
+  ```ts {{ filename: 'src/server/trpc.ts' }}
   import { initTRPC, TRPCError } from '@trpc/server'
   import superjson from 'superjson'
   import { type Context } from './context'
@@ -97,7 +95,7 @@ description: Learn how to integrate Clerk into your Next.js Pages Router applica
     transformer: superjson,
     errorFormatter({ shape }) {
       return shape
-    }
+    },
   })
 
   // check if the user is signed in, otherwise throw an UNAUTHORIZED code
@@ -126,15 +124,15 @@ description: Learn how to integrate Clerk into your Next.js Pages Router applica
 
   In the following example, the protected procedure is used to return a secret message that includes the user's ID. If the user is not signed in, the `hello` procedure will return an `UNAUTHORIZED` error, as configured in the step above.
 
-  ```ts {{ prettier: false, filename: 'src/server/routers/index.ts' }}
+  ```ts {{ filename: 'src/server/routers/index.ts' }}
   import { router, protectedProcedure } from '../trpc'
 
   export const protectedRouter = router({
     hello: protectedProcedure.query(({ ctx }) => {
       return {
-        secret: `${ctx.auth?.userId} is using a protected procedure`
+        secret: `${ctx.auth?.userId} is using a protected procedure`,
       }
-    })
+    }),
   })
   ```
 </Steps>

--- a/docs/references/nextjs/usage-with-older-versions.mdx
+++ b/docs/references/nextjs/usage-with-older-versions.mdx
@@ -16,15 +16,15 @@ Clerk's [prebuilt components](/docs/components/overview) are exported from the `
   Install `^4.0.0` of `@clerk/nextjs`. Newer major versions of `@clerk/nextjs` only support Next.js 13+.
 
   <CodeBlockTabs type="installer" options={["npm", "yarn", "pnpm"]}>
-    ```bash {{ prettier: false, filename: 'terminal' }}
+    ```bash {{ filename: 'terminal' }}
     npm install @clerk/nextjs@^4.0.0
     ```
 
-    ```bash {{ prettier: false, filename: 'terminal' }}
+    ```bash {{ filename: 'terminal' }}
     yarn add @clerk/nextjs@^4.0.0
     ```
 
-    ```bash {{ prettier: false, filename: 'terminal' }}
+    ```bash {{ filename: 'terminal' }}
     pnpm add @clerk/nextjs@^4.0.0
     ```
   </CodeBlockTabs>

--- a/docs/references/nodejs/available-methods.mdx
+++ b/docs/references/nodejs/available-methods.mdx
@@ -13,22 +13,22 @@ If you would like to use the default instance of `clerkClient` provided by the S
 
 <Tabs items={["ESM", "CJS"]}>
   <Tab>
-    ```js {{ prettier: false }}
-    import { clerkClient } from '@clerk/clerk-sdk-node';
+    ```js
+    import { clerkClient } from '@clerk/clerk-sdk-node'
 
-    const userList = await clerkClient.users.getUserList();
+    const userList = await clerkClient.users.getUserList()
     ```
   </Tab>
 
   <Tab>
-    ```js {{ prettier: false }}
-    const pkg = require('@clerk/clerk-sdk-node');
-    const clerkClient = pkg.default;
+    ```js
+    const pkg = require('@clerk/clerk-sdk-node')
+    const clerkClient = pkg.default
 
     clerkClient.sessions
       .getSessionList()
       .then((sessions) => console.log(sessions))
-      .catch((error) => console.error(error));
+      .catch((error) => console.error(error))
     ```
   </Tab>
 </Tabs>
@@ -40,23 +40,23 @@ If you would like to customize the behavior of the SDK, you can instantiate a `c
 The example below shows how to use `createClerkClient` to create a `clerkClient` instance and pass a Clerk secret key _instead of_ setting a `CLERK_SECRET_KEY` environment variable.
 
 <CodeBlockTabs options={["ESM", "CJS"]}>
-  ```js {{ prettier: false }}
-  import { createClerkClient } from '@clerk/clerk-sdk-node';
+  ```js
+  import { createClerkClient } from '@clerk/clerk-sdk-node'
 
-  const clerkClient = createClerkClient({ secretKey: '{{secret}}' });
+  const clerkClient = createClerkClient({ secretKey: '{{secret}}' })
 
-  const clientList = await clerkClient.clients.getClientList();
+  const clientList = await clerkClient.clients.getClientList()
   ```
 
-  ```js {{ prettier: false }}
-  const Clerk = require('@clerk/clerk-sdk-node/cjs/instance').default;
+  ```js
+  const Clerk = require('@clerk/clerk-sdk-node/cjs/instance').default
 
-  const clerkClient = Clerk({ secretKey: '{{secret}}' });
+  const clerkClient = Clerk({ secretKey: '{{secret}}' })
 
   clerkClient.sessions
     .getSessionList()
     .then((sessions) => console.log(sessions))
-    .catch((error) => console.error(error));
+    .catch((error) => console.error(error))
   ```
 </CodeBlockTabs>
 

--- a/docs/references/nodejs/overview.mdx
+++ b/docs/references/nodejs/overview.mdx
@@ -17,15 +17,15 @@ description: Learn how to integrate Node.js into your Clerk application.
   Once a Clerk application has been created, you can install and then start using Clerk Node.js in your application. An ESM module for the Clerk Node SDK is available under the [`@clerk/clerk-sdk-node`](https://www.npmjs.com/package/@clerk/clerk-sdk-node) npm package.
 
   <CodeBlockTabs type="installer" options={["npm", "yarn", "pnpm"]}>
-    ```sh {{ prettier: false, filename: 'terminal' }}
+    ```sh {{ filename: 'terminal' }}
     npm install @clerk/clerk-sdk-node
     ```
 
-    ```sh {{ prettier: false, filename: 'terminal' }}
+    ```sh {{ filename: 'terminal' }}
     yarn add @clerk/clerk-sdk-node
     ```
 
-    ```sh {{ prettier: false, filename: 'terminal' }}
+    ```sh {{ filename: 'terminal' }}
     pnpm add @clerk/clerk-sdk-node
     ```
   </CodeBlockTabs>
@@ -36,7 +36,7 @@ description: Learn how to integrate Node.js into your Clerk application.
 
   **Pro tip!** If you are signed into your Clerk Dashboard, your secret key should become visible by clicking on the eye icon. Otherwise, you can find your keys in the Clerk Dashboard on the [API Keys](https://dashboard.clerk.com/last-active?path=api-keys) page.
 
-  ```env {{ prettier: false, filename: '.env.local' }}
+  ```env {{ filename: '.env.local' }}
   CLERK_PUBLISHABLE_KEY={{pub_key}}
   CLERK_SECRET_KEY={{secret}}
   ```
@@ -60,9 +60,9 @@ The Clerk Node SDK offers two [middlewares](/docs/backend-requests/handling/node
 
 Node SDK functions throw errors (`ClerkAPIResponseError`) when something goes wrong. You'll need to catch them in a `try/catch` block and handle them gracefully. For example:
 
-```ts {{ prettier: false, filename: 'example.ts' }}
+```ts {{ filename: 'example.ts' }}
 try {
-  const res = await someBackendApiCall();
+  const res = await someBackendApiCall()
 } catch (error) {
   // Error handling
 }

--- a/docs/references/redwood/overview.mdx
+++ b/docs/references/redwood/overview.mdx
@@ -11,15 +11,15 @@ Learn how to use Clerk to quickly and easily add secure authentication and user 
   ### Create a RedwoodJS application
 
   <CodeBlockTabs type="installer" options={["npm", "yarn", "pnpm"]}>
-    ```bash {{ prettier: false, filename: 'terminal' }}
+    ```bash {{ filename: 'terminal' }}
     npm create redwood-app my-redwood-project --typescript
     ```
 
-    ```bash {{ prettier: false, filename: 'terminal' }}
+    ```bash {{ filename: 'terminal' }}
     yarn create redwood-app my-redwood-project --typescript
     ```
 
-    ```bash {{ prettier: false, filename: 'terminal' }}
+    ```bash {{ filename: 'terminal' }}
     pnpm create redwood-app my-redwood-project --typescript
     ```
   </CodeBlockTabs>
@@ -30,14 +30,14 @@ Learn how to use Clerk to quickly and easily add secure authentication and user 
 
   **Pro tip!** If you are signed into your Clerk Dashboard, your secret key should become visible by clicking on the eye icon. Otherwise, you can find your keys in the Clerk Dashboard on the [API Keys](https://dashboard.clerk.com/last-active?path=api-keys) page.
 
-  ```env {{ prettier: false, filename: '.env.local' }}
+  ```env {{ filename: '.env.local' }}
   CLERK_PUBLISHABLE_KEY={{pub_key}}
   CLERK_SECRET_KEY={{secret}}
   ```
 
   #### Update redwood.toml
 
-  ```toml {{ prettier: false, filename: 'redwood.toml' }}
+  ```toml {{ filename: 'redwood.toml' }}
   [web]
     includeEnvironmentVariables = ['CLERK_PUBLISHABLE_KEY']
   ```
@@ -46,7 +46,7 @@ Learn how to use Clerk to quickly and easily add secure authentication and user 
 
   The next step is to run a Redwood CLI command to install the required packages and generate some boilerplate code:
 
-  ```sh {{ prettier: false, filename: 'my-redwood-project' }}
+  ```sh {{ filename: 'my-redwood-project' }}
   yarn rw setup auth clerk --force
   ```
 

--- a/docs/references/ruby/available-methods.mdx
+++ b/docs/references/ruby/available-methods.mdx
@@ -9,7 +9,7 @@ The Ruby SDK mirrors the [Backend API](https://clerk.com/docs/reference/backend-
 
 All examples assume you have an instance of the `Clerk::SDK`:
 
-```ruby {{ prettier: false }}
+```ruby
 sdk = Clerk::SDK.new
 ```
 
@@ -19,7 +19,7 @@ The following methods are available for managing [allowlist identifiers](https:/
 
 ### Retrieve the list of allowlist identifiers
 
-```ruby {{ prettier: false }}
+```ruby
 sdk.allowlist_identifiers.all
 ```
 
@@ -27,13 +27,13 @@ sdk.allowlist_identifiers.all
 
 If `notify` is true, an email will be sent to notify the owner of the identifier.
 
-```ruby {{ prettier: false }}
+```ruby
 sdk.allowlist_identifiers.create(identifier: "john@example.com", notify: true)
 ```
 
 ### Delete an allowlist identifier
 
-```ruby {{ prettier: false }}
+```ruby
 sdk.allowlist_identifiers.delete("alid_xyz")
 ```
 
@@ -41,7 +41,7 @@ sdk.allowlist_identifiers.delete("alid_xyz")
 
 ### Toggle allowlist-only sign-ups on/off
 
-```ruby {{ prettier: false }}
+```ruby
 sdk.allowlist.update(restricted_to_allowlist: true)
 ```
 
@@ -51,19 +51,19 @@ The following methods are available for the [`clients`](https://clerk.com/docs/r
 
 ### Retrieve a single client
 
-```ruby {{ prettier: false }}
+```ruby
 sdk.clients.find("client_xyz")
 ```
 
 ### Retrieve the list of clients
 
-```ruby {{ prettier: false }}
+```ruby
 sdk.clients.all
 ```
 
 ### Verify the JWT and return the client
 
-```ruby {{ prettier: false }}
+```ruby
 sdk.clients.verify_token("jwt")
 ```
 
@@ -73,19 +73,19 @@ The following methods are available for managing [sessions](https://clerk.com/do
 
 ### Retrieve a single session
 
-```ruby {{ prettier: false }}
+```ruby
 sdk.sessions.find("sess_xyz")
 ```
 
 ### Retrieve a list of sessions
 
-```ruby {{ prettier: false }}
+```ruby
 sdk.sessions.all
 ```
 
 ### Revoke a session
 
-```ruby {{ prettier: false }}
+```ruby
 sdk.sessions.revoke("sess_xyz")
 ```
 
@@ -93,7 +93,7 @@ sdk.sessions.revoke("sess_xyz")
 
 Verify whether a session with a given ID corresponds to the provided session token. Throws an error if the provided ID is invalid.
 
-```ruby {{ prettier: false }}
+```ruby
 sdk.sessions.verify_token("sess_xyz", "jwt")
 ```
 
@@ -103,24 +103,24 @@ The following methods are available for managing [users](https://clerk.com/docs/
 
 ### Retrieve a list of users
 
-```ruby {{ prettier: false }}
+```ruby
 sdk.users.all
 ```
 
 You can also filter users by email address:
 
-```ruby {{ prettier: false }}
+```ruby
 sdk.users.all(email_address: ["user1@example.com", "user2@example.com"])
 ```
 
 ### Update a user
 
-```ruby {{ prettier: false }}
+```ruby
 sdk.users.update("user_xyz", {first_name: "John"})
 ```
 
 ### Delete a user
 
-```ruby {{ prettier: false }}
+```ruby
 sdk.users.delete("user_xyz")
 ```

--- a/docs/references/ruby/overview.mdx
+++ b/docs/references/ruby/overview.mdx
@@ -16,19 +16,19 @@ description: Learn how to integrate Ruby into your Clerk application.
 
   Add this line to your application's Gemfile.
 
-  ```ruby {{ prettier: false }}
+  ```ruby
   gem 'clerk-sdk-ruby', require: "clerk"
   ```
 
   And then execute:
 
-  ```sh {{ prettier: false, filename: 'terminal' }}
+  ```sh {{ filename: 'terminal' }}
   $ bundle install
   ```
 
   Or install it yourself as:
 
-  ```sh {{ prettier: false, filename: 'terminal' }}
+  ```sh {{ filename: 'terminal' }}
   $ gem install clerk-sdk-ruby
   ```
 
@@ -40,7 +40,7 @@ description: Learn how to integrate Ruby into your Clerk application.
 
   This examples shows how to instantiate an instance of `Clerk::SDK` with your secret key and then send your first user a welcome email.
 
-  ```ruby {{ prettier: false }}
+  ```ruby
   clerk = Clerk::SDK.new(api_key: `{{secret}}`)
 
   # List all users
@@ -73,7 +73,7 @@ description: Learn how to integrate Ruby into your Clerk application.
 
   You can customize each instance of the `Clerk::SDK` object by passing keyword arguments to the constructor:
 
-  ```ruby {{ prettier: false }}
+  ```ruby
   clerk = Clerk::SDK.new(
       api_key: `{{secret}}`,
       base_url: "Y",
@@ -85,7 +85,7 @@ description: Learn how to integrate Ruby into your Clerk application.
 
   If an argument is not provided, the configuration object is looked up, which falls back to the associated environment variable. Here's an example with all supported configuration settings their environment variable equivalents:
 
-  ```ruby {{ prettier: false }}
+  ```ruby
   Clerk.configure do |c|
     c.api_key = `{{secret}}` # if omitted: ENV["CLERK_SECRET_KEY"] - API calls will fail if unset
     c.base_url = "https://..." # if omitted: "https://api.clerk.com/v1/"

--- a/docs/references/ruby/rack-rails.mdx
+++ b/docs/references/ruby/rack-rails.mdx
@@ -13,7 +13,7 @@ The SDK comes with a Rack middleware which lazily loads the Clerk session and us
 
 If you add the gem in a Rails app, the Rack middleware will be included automatically in the middleware stack. For easier access to the Clerk session and user, include the `Clerk::Authenticatable` concern in your controller:
 
-```ruby {{ prettier: false }}
+```ruby
 require "clerk/authenticatable"
 
 class ApplicationController < ActionController::Base
@@ -31,7 +31,7 @@ This gives your controller and views access to the following methods:
 
 If you want to protect a subset of your controllers (for example, if you have an admin section), you can add a `before_filter` like this:
 
-```ruby {{ prettier: false }}
+```ruby
 class AdminsController < ApplicationController
   before_action :require_clerk_session
 


### PR DESCRIPTION
<!--- Add the "deploy-preview" label and add your page previews here -->

> [!IMPORTANT]
> 🔎 Previews:
>
> - https://clerk.com/docs/pr/1404/references/expo/read-session-user-data
> - https://clerk.com/docs/pr/1404/references/gatsby/with-server-auth
> - https://clerk.com/docs/pr/1404/references/go/other-examples
> - https://clerk.com/docs/pr/1404/references/go/overview
> - https://clerk.com/docs/pr/1404/references/go/verifying-sessions
> - https://clerk.com/docs/pr/1404/references/nextjs/auth-middleware
> - https://clerk.com/docs/pr/1404/references/nextjs/auth-object
> - https://clerk.com/docs/pr/1404/references/nextjs/auth
> - https://clerk.com/docs/pr/1404/references/nextjs/build-clerk-props
> - https://clerk.com/docs/pr/1404/references/nextjs/clerk-middleware
> - https://clerk.com/docs/pr/1404/references/nextjs/current-user
> - https://clerk.com/docs/pr/1404/references/nextjs/custom-signup-signin-pages
> - https://clerk.com/docs/pr/1404/references/nextjs/get-auth
> - https://clerk.com/docs/pr/1404/references/nextjs/read-session-data
> - https://clerk.com/docs/pr/1404/references/nextjs/route-handlers
> - https://clerk.com/docs/pr/1404/references/nextjs/server-actions
> - https://clerk.com/docs/pr/1404/references/nextjs/trpc
> - https://clerk.com/docs/pr/1404/references/nextjs/usage-with-older-versions
> - https://clerk.com/docs/pr/1404/references/nodejs/available-methods
> - https://clerk.com/docs/pr/1404/references/nodejs/overview
> - https://clerk.com/docs/pr/1404/references/redwood/overview
> - https://clerk.com/docs/pr/1404/references/ruby/available-methods
> - https://clerk.com/docs/pr/1404/references/ruby/overview
> - https://clerk.com/docs/pr/1404/references/ruby/rack-rails