### PR TITLE
(/clerk-provider) Update info about dynamic rendering

### DIFF
--- a/docs/components/clerk-provider.mdx
+++ b/docs/components/clerk-provider.mdx
@@ -13,9 +13,11 @@ The `<ClerkProvider>` component must be added to your React entrypoint.
 
 <Tabs type="framework" items={["Next.js", "React"]}>
   <Tab>
-    The `<ClerkProvider>` component needs to access headers to authenticate correctly. This means anything wrapped by the provider will be opted into dynamic rendering at request time. If you have static-optimized or ISR pages that you would prefer not to be opted into dynamic rendering, make sure they are not wrapped by `<ClerkProvider>`.
+    By default, the `<ClerkProvider>` component has a server component wrapper in order to access header information. This means anything wrapped by the provider will be opted into dynamic rendering at request time.
 
-    This is easiest to accomplish by ensuring that `<ClerkProvider>` is added further down the tree to wrap route groups that explicitly need authentication instead of having the provider wrap your application root as recommended above. For example, if your project includes a set of landing/marketing pages as well as a dashboard that requires sign in, you would create separate (marketing) and (dashboard) route groups. Adding `<ClerkProvider>` to the `(dashboard)/layout.jsx` layout file will ensure that only those routes are opted into dynamic rendering, allowing the marketing routes to be statically optimized.
+    If you would prefer not to be opted into dynamic rendering, such as for static-optimized or ISR pages, you can either use `<ClerkProvider>` in a client component, or ensure the content is not wrapped by `<ClerkProvider>`. Instead of wrapping your application root with the provider, you can place it further down the tree to wrap route groups that require authentication.
+
+    For example, if your project includes a set of landing/marketing pages and a dashboard that requires sign-in, you can create separate route groups for marketing and dashboard pages. By adding `<ClerkProvider>` to the `(dashboard)/layout.jsx` file, only the dashboard routes will opt into dynamic rendering, while the marketing routes remain statically optimized.
 
     <CodeBlockTabs type="router" options={["App Router", "Pages Router"]}>
       ```tsx {{ prettier: false, filename: 'app/layout.tsx' }}


### PR DESCRIPTION
<!--- Add the "deploy-preview" label and add your page previews here -->

> [!IMPORTANT]
> 🔎 Previews:
>
> - https://clerk.com/docs/pr/1410/components/clerk-provider

<!--- Describe your changes in detail. Why does this change need to happen? Include any links to Slack discussions, Linear comments, etc. -->

### Explanation:

[User feedback ticket](https://linear.app/clerk/issue/DOCS-8960/componentsclerk-provider-add-info-about-dynamic-rendering) reads:
> The docs for this page are extremely lacking and don’t cover how it’s possible to still use ClerkProvider as a client component which doesn’t force dynamic rendering. Needs to be added and explained deeper.

<!--- How does this PR solve the problem? -->

### This PR:

- Updates the information to make usage of the provider clear; adds info on using it in client components
