### PR TITLE
Enable Prettier for code blocks with incorrect language or syntax errors

### DIFF
--- a/docs/advanced-usage/satellite-domains.mdx
+++ b/docs/advanced-usage/satellite-domains.mdx
@@ -132,29 +132,22 @@ To access authentication state from a satellite domain, users will be transparen
             > You should set your `CLERK_PUBLISHABLE_KEY` and `CLERK_SECRET_KEY` in your environment variables even if you're using props to configure satellite domains.
 
             <CodeBlockTabs options={["App Router", "Pages Router"]}>
-              ```jsx {{ prettier: false, filename: 'app/layout.tsx' }}
-              import { ClerkProvider } from "@clerk/nextjs";
+              ```tsx {{ filename: 'app/layout.tsx' }}
+              import { ClerkProvider } from '@clerk/nextjs'
 
-              export default function RootLayout({
-                children,
-              }: {
-                children: React.ReactNode;
-              }) {
-                const primarySignInUrl = "/sign-in";
+              export default function RootLayout({ children }: { children: React.ReactNode }) {
+                const primarySignInUrl = '/sign-in'
                 return (
                   <html lang="en">
                     <body>
                       <ClerkProvider signInUrl={primarySignInUrl}>
                         <title>Satellite Next.js app</title>
-                        <meta
-                          name="viewport"
-                          content="width=device-width, initial-scale=1.0"
-                        />
+                        <meta name="viewport" content="width=device-width, initial-scale=1.0" />
                         {children}
                       </ClerkProvider>
                     </body>
                   </html>
-                );
+                )
               }
               ```
 
@@ -180,35 +173,24 @@ To access authentication state from a satellite domain, users will be transparen
           - In the Next project associated with your satellite domain, configure your `<ClerkProvider>` as shown in the following example:
 
             <CodeBlockTabs options={["App Router", "Pages Router"]}>
-              ```jsx {{ prettier: false, filename: 'app/layout.tsx' }}
-              import { ClerkProvider } from "@clerk/nextjs";
+              ```tsx {{ filename: 'app/layout.tsx' }}
+              import { ClerkProvider } from '@clerk/nextjs'
 
-              export default function RootLayout({
-                children,
-              }: {
-                children: React.ReactNode;
-              }) {
-                const primarySignInUrl = "https://primary.dev/sign-in";
+              export default function RootLayout({ children }: { children: React.ReactNode }) {
+                const primarySignInUrl = 'https://primary.dev/sign-in'
                 // Or, in development:
                 // const primarySignInUrl = 'http:localhost:3000/sign-in';
                 return (
                   <html lang="en">
                     <body>
-                      <ClerkProvider
-                        isSatellite
-                        domain={(url) => url.host}
-                        signInUrl={primarySignInUrl}
-                      >
+                      <ClerkProvider isSatellite domain={(url) => url.host} signInUrl={primarySignInUrl}>
                         <title>Satellite Next.js app</title>
-                        <meta
-                          name="viewport"
-                          content="width=device-width, initial-scale=1.0"
-                        />
+                        <meta name="viewport" content="width=device-width, initial-scale=1.0" />
                         {children}
                       </ClerkProvider>
                     </body>
                   </html>
-                );
+                )
               }
               ```
 
@@ -278,41 +260,41 @@ To access authentication state from a satellite domain, users will be transparen
 
           - In the root file associated with your primary domain, you only need to configure the `signInUrl` prop:
 
-            ```js {{ prettier: false, filename: 'root.tsx' }}
+            ```ts {{ filename: 'root.tsx' }}
             export const loader = (args) => {
               return rootAuthLoader(
                 args,
                 ({ request }) => {
-                  const { userId, sessionId, getToken } = request.auth;
+                  const { userId, sessionId, getToken } = request.auth
                   return json({
-                      message: `Hello from the root loader :)`,
-                      ENV: getBrowserEnvironment(),
-                  });
+                    message: `Hello from the root loader :)`,
+                    ENV: getBrowserEnvironment(),
+                  })
                 },
                 {
                   loadUser: true,
                   signInUrl: '/sign-in',
-                } as const
-              );
-            };
+                } as const,
+              )
+            }
 
             export default ClerkApp(App, {
               signInUrl: '/sign-in',
-            });
+            })
             ```
 
           - In the root file associated with your satellite domain, configure `ClerkApp` as shown in the following example:
 
-            ```js {{ prettier: false, filename: 'root.tsx' }}
+            ```ts {{ filename: 'root.tsx' }}
             export const loader = (args) => {
               return rootAuthLoader(
                 args,
                 ({ request }) => {
-                  const { userId, sessionId, getToken } = request.auth;
+                  const { userId, sessionId, getToken } = request.auth
                   return json({
-                      message: `Hello from the root loader :)`,
-                      ENV: getBrowserEnvironment(),
-                  });
+                    message: `Hello from the root loader :)`,
+                    ENV: getBrowserEnvironment(),
+                  })
                 },
                 {
                   loadUser: true,
@@ -320,10 +302,10 @@ To access authentication state from a satellite domain, users will be transparen
                   // Or, in development:
                   // signInUrl: 'http:localhost:3000/sign-in',
                   isSatellite: true,
-                  domain: (url) => url.host
-                } as const
-              );
-            };
+                  domain: (url) => url.host,
+                } as const,
+              )
+            }
 
             export default ClerkApp(App, {
               isSatellite: true,
@@ -331,7 +313,7 @@ To access authentication state from a satellite domain, users will be transparen
               signInUrl: 'https://primary.dev/sign-in',
               // Or, in development:
               // signInUrl: 'http:localhost:3000/sign-in',
-            });
+            })
             ```
         </Tab>
       </Tabs>

--- a/docs/components/control/redirect-to-organizationprofile.mdx
+++ b/docs/components/control/redirect-to-organizationprofile.mdx
@@ -31,25 +31,23 @@ The `<RedirectToOrganizationProfile />` component will navigate to the organizat
   </Tab>
 
   <Tab>
-    ```tsx {{ prettier: false, filename: 'pages/privatepage.tsx' }}
+    ```tsx {{ filename: 'pages/privatepage.tsx' }}
     import {
       ClerkProvider,
       SignedIn,
       SignedOut,
-      RedirectToOrganizationProfile
-    } from "@clerk/clerk-react";
+      RedirectToOrganizationProfile,
+    } from '@clerk/clerk-react'
 
     function PrivatePage() {
       return (
         <ClerkProvider publishableKey={`{{pub_key}}`}>
           <SignedIn>
-            <RedirectToOrganizationProfile/>
+            <RedirectToOrganizationProfile />
           </SignedIn>
-          <SignedOut>
-            Please Sign In
-          </SignedOut>
-        </div>
-      );
+          <SignedOut>Please Sign In</SignedOut>
+        </ClerkProvider>
+      )
     }
     ```
   </Tab>

--- a/docs/components/control/redirect-to-signin.mdx
+++ b/docs/components/control/redirect-to-signin.mdx
@@ -56,28 +56,19 @@ The `<RedirectToSignIn />` component will navigate to the sign in URL which has 
   </CodeBlockTabs>
 
   <Tab>
-    ```tsx {{ prettier: false, filename: 'pages/privatepage.tsx' }}
-    import {
-      ClerkProvider,
-      SignedIn,
-      SignedOut,
-      RedirectToSignIn
-    } from "@clerk/clerk-react";
+    ```tsx {{ filename: 'pages/privatepage.tsx' }}
+    import { ClerkProvider, SignedIn, SignedOut, RedirectToSignIn } from '@clerk/clerk-react'
 
     function PrivatePage() {
       return (
         <ClerkProvider publishableKey={`{{pub_key}}`}>
-          <SignedIn>
-            Content that is displayed to signed in
-            users.
-          </SignedIn>
+          <SignedIn>Content that is displayed to signed in users.</SignedIn>
           <SignedOut>
             <RedirectToSignIn />
           </SignedOut>
-        </div>
-      );
+        </ClerkProvider>
+      )
     }
-
     ```
   </Tab>
 

--- a/docs/components/control/redirect-to-signup.mdx
+++ b/docs/components/control/redirect-to-signup.mdx
@@ -33,54 +33,41 @@ The `<RedirectToSignUp />` component will navigate to the sign up URL which has 
     </Tab>
 
     <Tab>
-      ```tsx {{ prettier: false, filename: 'pages/_app.tsx' }}
-      import {
-        ClerkProvider,
-        SignedIn,
-        SignedOut,
-        RedirectToSignUp,
-      } from "@clerk/nextjs";
-      import { AppProps } from "next/app";
+      ```tsx {{ filename: 'pages/_app.tsx' }}
+      import { ClerkProvider, SignedIn, SignedOut, RedirectToSignUp } from '@clerk/nextjs'
+      import { AppProps } from 'next/app'
 
-      function MyApp({ Component, pageProps } : AppProps) {
+      function MyApp({ Component, pageProps }: AppProps) {
         return (
           <ClerkProvider>
             <SignedIn>
-              <Component {...pageProps />
+              <Component {...pageProps} />
             </SignedIn>
             <SignedOut>
               <RedirectToSignUp />
             </SignedOut>
           </ClerkProvider>
-        );
+        )
       }
 
-      export default MyApp;
+      export default MyApp
       ```
     </Tab>
   </CodeBlockTabs>
 
   <Tab>
-    ```tsx {{ prettier: false, filename: 'pages/privatepage.tsx' }}
-    import {
-      ClerkProvider,
-      SignedIn,
-      SignedOut,
-      RedirectToSignUp
-    } from "@clerk/clerk-react";
+    ```tsx {{ filename: 'pages/privatepage.tsx' }}
+    import { ClerkProvider, SignedIn, SignedOut, RedirectToSignUp } from '@clerk/clerk-react'
 
     function PrivatePage() {
       return (
         <ClerkProvider publishableKey={`{{pub_key}}`}>
-          <SignedIn>
-            Content that is displayed to signed in
-            users.
-          </SignedIn>
+          <SignedIn>Content that is displayed to signed in users.</SignedIn>
           <SignedOut>
             <RedirectToSignUp />
           </SignedOut>
-        </div>
-      );
+        </ClerkProvider>
+      )
     }
     ```
   </Tab>

--- a/docs/components/control/redirect-to-userprofile.mdx
+++ b/docs/components/control/redirect-to-userprofile.mdx
@@ -37,25 +37,18 @@ To configure the User Profile URL:
   </Tab>
 
   <Tab>
-    ```tsx {{ prettier: false, filename: 'pages/privatepage.tsx' }}
-    import {
-      ClerkProvider,
-      SignedIn,
-      SignedOut,
-      RedirectToUserProfile
-    } from "@clerk/clerk-react";
+    ```tsx {{ filename: 'pages/privatepage.tsx' }}
+    import { ClerkProvider, SignedIn, SignedOut, RedirectToUserProfile } from '@clerk/clerk-react'
 
     function PrivatePage() {
       return (
         <ClerkProvider publishableKey={`{{pub_key}}`}>
           <SignedIn>
-            <RedirectToUserProfile/>
+            <RedirectToUserProfile />
           </SignedIn>
-          <SignedOut>
-            Please Sign In
-          </SignedOut>
-        </div>
-      );
+          <SignedOut>Please Sign In</SignedOut>
+        </ClerkProvider>
+      )
     }
     ```
   </Tab>

--- a/docs/components/organization/organization-list.mdx
+++ b/docs/components/organization/organization-list.mdx
@@ -291,15 +291,15 @@ function unmountOrganizationList(node: HTMLDivElement): void
 
 If you would like to prohibit people from using their personal accounts and force them to be part of an organization, the `hidePersonal` property forces your user to join or create an organization in order to continue. For more information on how to hide Personal Accounts and force organizations, see the [dedicated guide](/docs/guides/force-organizations).
 
-```tsx {{ prettier: false, filename: 'organization-portal.tsx' }}
+```tsx {{ filename: 'organization-portal.tsx' }}
 export default function OrganizationListPage() {
   return (
     <OrganizationList
-        hidePersonal={true}
-        {...}
+      hidePersonal={true}
+      // ...
     />
-  );
-};
+  )
+}
 ```
 
 ## Customization

--- a/docs/components/user/user-button.mdx
+++ b/docs/components/user/user-button.mdx
@@ -97,18 +97,12 @@ In the following example, `<UserButton />` is mounted inside a header component,
 <Tabs type="framework" items={["Next.js", "React", "Remix"]}>
   <Tab>
     <CodeBlockTabs type="router" options={["App Router", "Pages Router"]}>
-      ```jsx {{ prettier: false, filename: 'layout.tsx' }}
-      import {
-        ClerkProvider,
-        SignedIn,
-        SignedOut,
-        SignInButton,
-        UserButton,
-      } from "@clerk/nextjs";
+      ```tsx {{ filename: 'layout.tsx' }}
+      import { ClerkProvider, SignedIn, SignedOut, SignInButton, UserButton } from '@clerk/nextjs'
 
       function Header() {
         return (
-          <header style={{ display: "flex", justifyContent: "space-between", padding: 20 }}>
+          <header style={{ display: 'flex', justifyContent: 'space-between', padding: 20 }}>
             <h1>My App</h1>
             <SignedIn>
               {/* Mount the UserButton component */}
@@ -116,10 +110,10 @@ In the following example, `<UserButton />` is mounted inside a header component,
             </SignedIn>
             <SignedOut>
               {/* Signed out users get sign in button */}
-              <SignInButton/>
+              <SignInButton />
             </SignedOut>
           </header>
-        );
+        )
       }
 
       export default function RootLayout({ children }: { children: React.ReactNode }) {
@@ -130,7 +124,7 @@ In the following example, `<UserButton />` is mounted inside a header component,
               {children}
             </ClerkProvider>
           </html>
-        );
+        )
       }
       ```
 

--- a/docs/custom-flows/add-email.mdx
+++ b/docs/custom-flows/add-email.mdx
@@ -23,75 +23,73 @@ The following example demonstrates how to build a custom user interface that all
 
 <Tabs items={["Next.js", "iOS (Beta)"]}>
   <Tab>
-    ```jsx {{ prettier: false, filename: 'app/account/add-email/page.tsx' }}
-    'use client';
+    ```tsx {{ filename: 'app/account/add-email/page.tsx' }}
+    'use client'
 
-    import * as React from 'react';
-    import { useUser } from '@clerk/nextjs';
-    import { EmailAddressResource } from '@clerk/types';
+    import * as React from 'react'
+    import { useUser } from '@clerk/nextjs'
+    import { EmailAddressResource } from '@clerk/types'
 
     export default function Page() {
-      const { isLoaded, user } = useUser();
-      const [email, setEmail] = React.useState('');
-      const [code, setCode] = React.useState('');
-      const [isVerifying, setIsVerifying] = React.useState(false);
-      const [successful, setSuccessful] = React.useState(false);
-      const [emailObj, setEmailObj] = React.useState<
-        EmailAddressResource | undefined
-      >();
+      const { isLoaded, user } = useUser()
+      const [email, setEmail] = React.useState('')
+      const [code, setCode] = React.useState('')
+      const [isVerifying, setIsVerifying] = React.useState(false)
+      const [successful, setSuccessful] = React.useState(false)
+      const [emailObj, setEmailObj] = React.useState<EmailAddressResource | undefined>()
 
-      if (!isLoaded) return null;
+      if (!isLoaded) return null
 
       if (isLoaded && !user?.id) {
-        return <p>You must be logged in to access this page</p>;
+        return <p>You must be logged in to access this page</p>
       }
 
       // Handle addition of the email address
       const handleSubmit = async (e: React.FormEvent) => {
-        e.preventDefault();
+        e.preventDefault()
 
         try {
           // Add an unverified email address to user
-          const res = await user.createEmailAddress({ email });
+          const res = await user.createEmailAddress({ email })
           // Reload user to get updated User object
-          await user.reload();
+          await user.reload()
 
           // Find the email address that was just added
-          const emailAddress = user.emailAddresses.find((a) => a.id === res.id);
+          const emailAddress = user.emailAddresses.find((a) => a.id === res.id)
           // Create a reference to the email address that was just added
-          setEmailObj(emailAddress);
+          setEmailObj(emailAddress)
 
           // Send the user an email with the verification code
-          emailAddress?.prepareVerification({ strategy: 'email_code' });
+          emailAddress?.prepareVerification({ strategy: 'email_code' })
 
           // Set to true to display second form
           // and capture the OTP code
-          setIsVerifying(true);
+          setIsVerifying(true)
         } catch (err) {
           // See https://clerk.com/docs/custom-flows/error-handling
           // for more info on error handling
-          console.error(JSON.stringify(err, null, 2));
+          console.error(JSON.stringify(err, null, 2))
         }
-      };
+      }
 
       // Handle the submission of the verification form
       const verifyCode = async (e: React.FormEvent) => {
-        e.preventDefault();
+        e.preventDefault()
         try {
           // Verify that the code entered matches the code sent to the user
-          const emailVerifyAttempt = await emailObj?.attemptVerification({ code });
+          const emailVerifyAttempt = await emailObj?.attemptVerification({ code })
 
           if (emailVerifyAttempt?.verification.status === 'verified') {
-            setSuccessful(true);
+            setSuccessful(true)
           } else {
             // If the status is not complete, check why. User may need to
             // complete further steps.
-            console.error(JSON.stringify(emailVerifyAttempt, null, 2));
+            console.error(JSON.stringify(emailVerifyAttempt, null, 2))
           }
         } catch (err) {
-          console.error(JSON.stringify(err, null, 2));
+          console.error(JSON.stringify(err, null, 2))
         }
-      };
+      }
 
       // Display a success message if the email was added successfully
       if (successful) {
@@ -99,7 +97,7 @@ The following example demonstrates how to build a custom user interface that all
           <>
             <h1>Email added!</h1>
           </>
-        );
+        )
       }
 
       // Display the verification form to capture the OTP code
@@ -125,7 +123,7 @@ The following example demonstrates how to build a custom user interface that all
               </form>
             </div>
           </>
-        );
+        )
       }
 
       // Display the initial form to capture the email address
@@ -150,7 +148,7 @@ The following example demonstrates how to build a custom user interface that all
             </form>
           </div>
         </>
-      );
+      )
     }
     ```
   </Tab>
@@ -166,12 +164,12 @@ The following example demonstrates how to build a custom user interface that all
       @State private var isVerifying = false
       // Create a reference to the email address that we'll be creating
       @State private var newEmailAddress: EmailAddress?
-      
+
       var body: some View {
         if newEmailAddress?.verification?.status == .verified {
           Text("Email added!")
         }
-        
+
         if isVerifying {
           TextField("Enter code", text: $code)
           Button("Verify") {
@@ -187,19 +185,19 @@ The following example demonstrates how to build a custom user interface that all
     }
 
     extension AddEmailView {
-        
+
       func createEmail(_ email: String) async {
         do {
           guard let user = Clerk.shared.user else { return }
-          
+
           // Add an unverified email address to user
           self.newEmailAddress = try await user.createEmailAddress(email)
-          
+
           guard let newEmailAddress = self.newEmailAddress else { return }
-          
+
           // Send the user an email with the verification code
           try await newEmailAddress.prepareVerification(strategy: .emailCode)
-          
+
           // Set to true to display second form
           // and capture the OTP code
           isVerifying = true
@@ -209,14 +207,14 @@ The following example demonstrates how to build a custom user interface that all
           dump(error)
         }
       }
-        
+
       func verifyCode(_ code: String) async {
         do {
           guard let newEmailAddress else { return }
-          
+
           // Verify that the code entered matches the code sent to the user
           self.newEmailAddress = try await newEmailAddress.attemptVerification(strategy: .emailCode(code: code))
-          
+
           // If the status is not complete, check why. User may need to
           // complete further steps.
           dump(self.newEmailAddress?.verification?.status)

--- a/docs/custom-flows/add-phone.mdx
+++ b/docs/custom-flows/add-phone.mdx
@@ -23,74 +23,72 @@ The following example demonstrates how to build a custom user interface that all
 
 <Tabs items={["Next.js", "iOS (Beta)"]}>
   <Tab>
-    ```jsx {{ prettier: false, filename: 'app/account/add-phone/page.tsx' }}
-    'use client';
+    ```tsx {{ filename: 'app/account/add-phone/page.tsx' }}
+    'use client'
 
-    import * as React from 'react';
-    import { useUser } from '@clerk/nextjs';
-    import { PhoneNumberResource } from '@clerk/types';
+    import * as React from 'react'
+    import { useUser } from '@clerk/nextjs'
+    import { PhoneNumberResource } from '@clerk/types'
 
     export default function Page() {
-      const { isLoaded, user } = useUser();
-      const [phone, setPhone] = React.useState('');
-      const [code, setCode] = React.useState('');
-      const [isVerifying, setIsVerifying] = React.useState(false);
-      const [successful, setSuccessful] = React.useState(false);
-      const [phoneObj, setPhoneObj] = React.useState<
-        PhoneNumberResource | undefined
-      >();
+      const { isLoaded, user } = useUser()
+      const [phone, setPhone] = React.useState('')
+      const [code, setCode] = React.useState('')
+      const [isVerifying, setIsVerifying] = React.useState(false)
+      const [successful, setSuccessful] = React.useState(false)
+      const [phoneObj, setPhoneObj] = React.useState<PhoneNumberResource | undefined>()
 
-      if (!isLoaded) return null;
+      if (!isLoaded) return null
 
       if (isLoaded && !user?.id) {
-        return <p>You must be logged in to access this page</p>;
+        return <p>You must be logged in to access this page</p>
       }
 
       // Handle addition of the phone number
       const handleSubmit = async (e: React.FormEvent) => {
-        e.preventDefault();
+        e.preventDefault()
 
         try {
           // Add unverified phone number to user
-          const res = await user.createPhoneNumber({ phoneNumber: phone });
+          const res = await user.createPhoneNumber({ phoneNumber: phone })
           // Reload user to get updated User object
-          await user.reload();
+          await user.reload()
 
           // Create a reference to the new phone number to use related methods
-          const phoneNumber = user.phoneNumbers.find((a) => a.id === res.id);
-          setPhoneObj(phoneNumber);
+          const phoneNumber = user.phoneNumbers.find((a) => a.id === res.id)
+          setPhoneObj(phoneNumber)
 
           // Send the user an SMS with the verification code
-          phoneNumber?.prepareVerification();
+          phoneNumber?.prepareVerification()
 
           // Set to true to display second form
           // and capture the OTP code
-          setIsVerifying(true);
+          setIsVerifying(true)
         } catch (err) {
           // See https://clerk.com/docs/custom-flows/error-handling
           // for more info on error handling
-          console.error(JSON.stringify(err, null, 2));
+          console.error(JSON.stringify(err, null, 2))
         }
-      };
+      }
 
       // Handle the submission of the verification form
       const verifyCode = async (e: React.FormEvent) => {
-        e.preventDefault();
+        e.preventDefault()
         try {
           // Verify that the provided code matches the code sent to the user
-          const phoneVerifyAttempt = await phoneObj?.attemptVerification({ code });
+          const phoneVerifyAttempt = await phoneObj?.attemptVerification({ code })
 
           if (phoneVerifyAttempt?.verification.status === 'verified') {
-            setSuccessful(true);
+            setSuccessful(true)
           } else {
             // If the status is not complete, check why. User may need to
             // complete further steps.
-            console.error(JSON.stringify(phoneVerifyAttempt, null, 2));
+            console.error(JSON.stringify(phoneVerifyAttempt, null, 2))
           }
         } catch (err) {
-          console.error(JSON.stringify(err, null, 2));
+          console.error(JSON.stringify(err, null, 2))
         }
-      };
+      }
 
       // Display a success message if the phone number was added successfully
       if (successful) {
@@ -98,7 +96,7 @@ The following example demonstrates how to build a custom user interface that all
           <>
             <h1>Phone added</h1>
           </>
-        );
+        )
       }
 
       // Display the verification form to capture the OTP code
@@ -124,7 +122,7 @@ The following example demonstrates how to build a custom user interface that all
               </form>
             </div>
           </>
-        );
+        )
       }
 
       // Display the initial form to capture the phone number
@@ -149,7 +147,7 @@ The following example demonstrates how to build a custom user interface that all
             </form>
           </div>
         </>
-      );
+      )
     }
     ```
   </Tab>
@@ -170,7 +168,7 @@ The following example demonstrates how to build a custom user interface that all
         if newPhoneNumber?.verification?.status == .verified {
           Text("Phone added!")
         }
-          
+
         if isVerifying {
           TextField("Enter code", text: $code)
           Button("Verify") {
@@ -186,19 +184,19 @@ The following example demonstrates how to build a custom user interface that all
     }
 
     extension AddPhoneView {
-        
+
       func createPhone(_ phone: String) async {
         do {
           guard let user = Clerk.shared.user else { return }
-          
+
           // Add an unverified phone number to user
           self.newPhoneNumber = try await user.createPhoneNumber(phone)
-          
+
           guard let newphoneNumber = self.newPhoneNumber else { return }
-          
+
           // Send the user an sms message with the verification code
           try await newphoneNumber.prepareVerification()
-          
+
           // Set to true to display second form
           // and capture the OTP code
           isVerifying = true
@@ -208,14 +206,14 @@ The following example demonstrates how to build a custom user interface that all
           dump(error)
         }
       }
-        
+
       func verifyCode(_ code: String) async {
         do {
           guard let newPhoneNumber else { return }
-          
+
           // Verify that the code entered matches the code sent to the user
           self.newPhoneNumber = try await newPhoneNumber.attemptVerification(code: code)
-          
+
           // If the status is not complete, check why. User may need to
           // complete further steps.
           dump(self.newPhoneNumber?.verification?.status)

--- a/docs/custom-flows/email-links.mdx
+++ b/docs/custom-flows/email-links.mdx
@@ -212,14 +212,9 @@ Clerk provides a highly flexible API that allows you to hook into any of the abo
   }
   ```
 
-  ```jsx {{ prettier: false }}
-  import React from "react";
-  import {
-    BrowserRouter as Router,
-    Routes,
-    Route,
-    useNavigate,
-  } from 'react-router-dom';
+  ```jsx
+  import React from 'react'
+  import { BrowserRouter as Router, Routes, Route, useNavigate } from 'react-router-dom'
   import {
     ClerkProvider,
     ClerkLoaded,
@@ -230,15 +225,15 @@ Clerk provides a highly flexible API that allows you to hook into any of the abo
     useSignUp,
     SignedOut,
     SignedIn,
-  } from '@clerk/clerk-react';
+  } from '@clerk/clerk-react'
 
-  const publishableKey = process.env.REACT_APP_CLERK_PUBLISHABLE_KEY;
+  const publishableKey = process.env.REACT_APP_CLERK_PUBLISHABLE_KEY
 
   function App() {
     return (
       <Router>
         <ClerkProvider publishableKey={publishableKey}>
-          <Switch>
+          <Routes>
             {/* Root path shows sign up page. */}
             <Route
               path="/"
@@ -266,34 +261,33 @@ Clerk provides a highly flexible API that allows you to hook into any of the abo
           </Routes>
         </ClerkProvider>
       </Router>
-    );
+    )
   }
 
   // Render the sign up form.
   // Collect user's email address and send an email link with which
   // they can sign up.
   function SignUpEmailLink() {
-    const [emailAddress, setEmailAddress] = React.useState("");
-    const [expired, setExpired] = React.useState(false);
-    const [verified, setVerified] = React.useState(false);
-    const navigate = useNavigate();
-    const { signUp, isLoaded, setActive } = useSignUp();
+    const [emailAddress, setEmailAddress] = React.useState('')
+    const [expired, setExpired] = React.useState(false)
+    const [verified, setVerified] = React.useState(false)
+    const navigate = useNavigate()
+    const { signUp, isLoaded, setActive } = useSignUp()
 
     if (!isLoaded) {
-      return null;
+      return null
     }
 
-    const { startEmailLinkFlow, cancelEmailLinkFlow } =
-      signUp.createEmailLinkFlow();
+    const { startEmailLinkFlow, cancelEmailLinkFlow } = signUp.createEmailLinkFlow()
 
     async function submit(e) {
-      e.preventDefault();
-      setExpired(false);
-      setVerified(false);
+      e.preventDefault()
+      setExpired(false)
+      setVerified(false)
 
       // Start the sign up flow, by collecting
       // the user's email address.
-      await signUp.create({ emailAddress });
+      await signUp.create({ emailAddress })
 
       // Start the email link flow.
       // Pass your app URL that users will be navigated
@@ -301,117 +295,96 @@ Clerk provides a highly flexible API that allows you to hook into any of the abo
       // email inbox.
       // su will hold the updated sign up object.
       const su = await startEmailLinkFlow({
-        redirectUrl: "https://your-app.domain.com/verification",
-      });
+        redirectUrl: 'https://your-app.domain.com/verification',
+      })
 
       // Check the verification result.
-      const verification = su.verifications.emailAddress;
+      const verification = su.verifications.emailAddress
       if (verification.verifiedFromTheSameClient()) {
-        setVerified(true);
+        setVerified(true)
         // If you're handling the verification result from
         // another route/component, you should return here.
         // See the <EmailLinkVerification/> component as an
         // example below.
         // If you want to complete the flow on this tab,
         // don't return. Check the sign up status instead.
-        return;
-      } else if (verification.status === "expired") {
-        setExpired(true);
+        return
+      } else if (verification.status === 'expired') {
+        setExpired(true)
       }
 
-      if (su.status === "complete") {
+      if (su.status === 'complete') {
         // Sign up is complete, we have a session.
         // Navigate to the after sign up URL.
         setActive({
           session: su.createdSessionId,
-          beforeEmit: () => navigate("/after-sign-up-path"),
-        });
-        return;
+          beforeEmit: () => navigate('/after-sign-up-path'),
+        })
+        return
       }
     }
 
     if (expired) {
-      return (
-        <div>Email link has expired</div>
-      );
+      return <div>Email link has expired</div>
     }
 
     if (verified) {
-      return (
-        <div>Signed in on other tab</div>
-      );
+      return <div>Signed in on other tab</div>
     }
 
     return (
       <form onSubmit={submit}>
-        <input
-          type="email"
-          value={emailAddress}
-          onChange={e => setEmailAddress(e.target.value)}
-        />
-        <button type="submit">
-          Sign up with email link
-        </button>
+        <input type="email" value={emailAddress} onChange={(e) => setEmailAddress(e.target.value)} />
+        <button type="submit">Sign up with email link</button>
       </form>
-    );
+    )
   }
 
   // Handle email link verification results. This is
   // the final step in the email link flow.
   function EmailLinkVerification() {
-    const [
-      verificationStatus,
-      setVerificationStatus,
-    ] = React.useState("loading");
+    const [verificationStatus, setVerificationStatus] = React.useState('loading')
 
-    const { handleEmailLinkVerification } = useClerk();
+    const { handleEmailLinkVerification } = useClerk()
 
     React.useEffect(() => {
       async function verify() {
         try {
           await handleEmailLinkVerification({
-            redirectUrl: "https://redirect-to-pending-sign-up",
-            redirectUrlComplete: "https://redirect-when-sign-up-complete",
-          });
+            redirectUrl: 'https://redirect-to-pending-sign-up',
+            redirectUrlComplete: 'https://redirect-when-sign-up-complete',
+          })
           // If we're not redirected at this point, it means
           // that the flow has completed on another device.
-          setVerificationStatus("verified");
+          setVerificationStatus('verified')
         } catch (err) {
           // Verification has failed.
-          let status = "failed";
+          let status = 'failed'
           if (isEmailLinkError(err) && err.code === EmailLinkErrorCode.Expired) {
-            status = "expired";
+            status = 'expired'
           }
-          setVerificationStatus(status);
+          setVerificationStatus(status)
         }
       }
-      verify();
-    }, []);
+      verify()
+    }, [])
 
-    if (verificationStatus === "loading") {
+    if (verificationStatus === 'loading') {
       return <div>Loading...</div>
     }
 
-    if (verificationStatus === "failed") {
-      return (
-        <div>Email link verification failed</div>
-      );
+    if (verificationStatus === 'failed') {
+      return <div>Email link verification failed</div>
     }
 
-    if (verificationStatus === "expired") {
-      return (
-        <div>Email link expired</div>
-      );
+    if (verificationStatus === 'expired') {
+      return <div>Email link expired</div>
     }
 
-    return (
-      <div>
-        Successfully signed up. Return to the original tab to continue.
-      </div>
-    );
+    return <div>Successfully signed up. Return to the original tab to continue.</div>
   }
 
-  export default App;
+  export default App
   ```
 
   ```js

--- a/docs/custom-flows/email-sms-otp.mdx
+++ b/docs/custom-flows/email-sms-otp.mdx
@@ -38,70 +38,70 @@ This guide will walk you through how to build a custom SMS OTP sign-up and sign-
     <Tab>
       This example is written for Next.js App Router but can be adapted to any React meta framework, such as Remix or Gatsby.
 
-      ```js {{ prettier: false, filename: 'app/sign-up/page.tsx' }}
-      'use client';
+      ```tsx {{ filename: 'app/sign-up/page.tsx' }}
+      'use client'
 
-      import * as React from 'react';
-      import { useSignUp } from '@clerk/nextjs';
-      import { useRouter } from 'next/navigation';
+      import * as React from 'react'
+      import { useSignUp } from '@clerk/nextjs'
+      import { useRouter } from 'next/navigation'
 
       export default function Page() {
-        const { isLoaded, signUp, setActive } = useSignUp();
-        const [verifying, setVerifying] = React.useState(false);
-        const [phone, setPhone] = React.useState('');
-        const [code, setCode] = React.useState('');
-        const router = useRouter();
+        const { isLoaded, signUp, setActive } = useSignUp()
+        const [verifying, setVerifying] = React.useState(false)
+        const [phone, setPhone] = React.useState('')
+        const [code, setCode] = React.useState('')
+        const router = useRouter()
 
         async function handleSubmit(e: React.FormEvent) {
-          e.preventDefault();
+          e.preventDefault()
 
-          if (!isLoaded && !signUp) return null;
+          if (!isLoaded && !signUp) return null
 
           try {
             // Start the sign-up process using the phone number method
             await signUp.create({
               phoneNumber: phone,
-            });
+            })
 
             // Start the verification - a SMS message will be sent to the
             // number with a one-time code
-            await signUp.preparePhoneNumberVerification();
+            await signUp.preparePhoneNumberVerification()
 
             // Set verifying to true to display second form and capture the OTP code
-            setVerifying(true);
+            setVerifying(true)
           } catch (err) {
             // See https://clerk.com/docs/custom-flows/error-handling
             // for more info on error handling
-            console.error('Error:', JSON.stringify(err, null, 2));
+            console.error('Error:', JSON.stringify(err, null, 2))
           }
         }
 
         async function handleVerification(e: React.FormEvent) {
-          e.preventDefault();
+          e.preventDefault()
 
-          if (!isLoaded && !signUp) return null;
+          if (!isLoaded && !signUp) return null
 
           try {
             // Use the code provided by the user and attempt verification
             const signInAttempt = await signUp.attemptPhoneNumberVerification({
               code,
-            });
+            })
 
             // If verification was completed, set the session to active
             // and redirect the user
             if (signInAttempt.status === 'complete') {
-              await setActive({ session: signInAttempt.createdSessionId });
+              await setActive({ session: signInAttempt.createdSessionId })
 
-              router.push('/');
+              router.push('/')
             } else {
               // If the status is not complete, check why. User may need to
               // complete further steps.
-              console.error(signInAttempt);
+              console.error(signInAttempt)
             }
           } catch (err) {
             // See https://clerk.com/docs/custom-flows/error-handling
             // for more info on error handling
-            console.error('Error:', JSON.stringify(err, null, 2));
+            console.error('Error:', JSON.stringify(err, null, 2))
           }
         }
 
@@ -111,16 +111,11 @@ This guide will walk you through how to build a custom SMS OTP sign-up and sign-
               <h1>Verify your phone number</h1>
               <form onSubmit={handleVerification}>
                 <label htmlFor="code">Enter your verification code</label>
-                <input
-                  value={code}
-                  id="code"
-                  name="code"
-                  onChange={(e) => setCode(e.target.value)}
-                />
+                <input value={code} id="code" name="code" onChange={(e) => setCode(e.target.value)} />
                 <button type="submit">Verify</button>
               </form>
             </>
-          );
+          )
         }
 
         return (
@@ -138,7 +133,7 @@ This guide will walk you through how to build a custom SMS OTP sign-up and sign-
               <button type="submit">Continue</button>
             </form>
           </>
-        );
+        )
       }
       ```
     </Tab>
@@ -433,88 +428,86 @@ This guide will walk you through how to build a custom SMS OTP sign-up and sign-
     <Tab>
       This example is written for Next.js App Router but can be adapted to any React meta framework, such as Remix or Gatsby.
 
-      ```jsx {{ prettier: false, filename: 'app/sign-in/page.tsx' }}
-      'use client';
+      ```tsx {{ filename: 'app/sign-in/page.tsx' }}
+      'use client'
 
-      import * as React from 'react';
-      import { useSignIn } from '@clerk/nextjs';
-      import { PhoneCodeFactor, SignInFirstFactor } from '@clerk/types';
-      import { useRouter } from 'next/navigation';
+      import * as React from 'react'
+      import { useSignIn } from '@clerk/nextjs'
+      import { PhoneCodeFactor, SignInFirstFactor } from '@clerk/types'
+      import { useRouter } from 'next/navigation'
 
       export default function Page() {
-        const { isLoaded, signIn, setActive } = useSignIn();
-        const [verifying, setVerifying] = React.useState(false);
-        const [phone, setPhone] = React.useState('');
-        const [code, setCode] = React.useState('');
-        const router = useRouter();
+        const { isLoaded, signIn, setActive } = useSignIn()
+        const [verifying, setVerifying] = React.useState(false)
+        const [phone, setPhone] = React.useState('')
+        const [code, setCode] = React.useState('')
+        const router = useRouter()
 
         async function handleSubmit(e: React.FormEvent) {
-          e.preventDefault();
+          e.preventDefault()
 
-          if (!isLoaded && !signIn) return null;
+          if (!isLoaded && !signIn) return null
 
           try {
             // Start the sign-in process using the phone number method
             const { supportedFirstFactors } = await signIn.create({
               identifier: phone,
-            });
+            })
 
             // Filter the returned array to find the 'phone_code' entry
-            const isPhoneCodeFactor = (
-              factor: SignInFirstFactor
-            ): factor is PhoneCodeFactor => {
-              return factor.strategy === 'phone_code';
-            };
-            const phoneCodeFactor = supportedFirstFactors?.find(isPhoneCodeFactor);
+            const isPhoneCodeFactor = (factor: SignInFirstFactor): factor is PhoneCodeFactor => {
+              return factor.strategy === 'phone_code'
+            }
+            const phoneCodeFactor = supportedFirstFactors?.find(isPhoneCodeFactor)
 
             if (phoneCodeFactor) {
               // Grab the phoneNumberId
-              const { phoneNumberId } = phoneCodeFactor;
+              const { phoneNumberId } = phoneCodeFactor
 
               // Send the OTP code to the user
               await signIn.prepareFirstFactor({
                 strategy: 'phone_code',
                 phoneNumberId,
-              });
+              })
 
               // Set verifying to true to display second form
               // and capture the OTP code
-              setVerifying(true);
+              setVerifying(true)
             }
           } catch (err) {
             // See https://clerk.com/docs/custom-flows/error-handling
             // for more info on error handling
-            console.error('Error:', JSON.stringify(err, null, 2));
+            console.error('Error:', JSON.stringify(err, null, 2))
           }
         }
 
         async function handleVerification(e: React.FormEvent) {
-          e.preventDefault();
+          e.preventDefault()
 
-          if (!isLoaded && !signIn) return null;
+          if (!isLoaded && !signIn) return null
 
           try {
             // Use the code provided by the user and attempt verification
             const signInAttempt = await signIn.attemptFirstFactor({
               strategy: 'phone_code',
               code,
-            });
+            })
 
             // If verification was completed, set the session to active
             // and redirect the user
             if (signInAttempt.status === 'complete') {
-              await setActive({ session: signInAttempt.createdSessionId });
+              await setActive({ session: signInAttempt.createdSessionId })
 
-              router.push('/');
+              router.push('/')
             } else {
               // If the status is not complete, check why. User may need to
               // complete further steps.
-              console.error(signInAttempt);
+              console.error(signInAttempt)
             }
           } catch (err) {
             // See https://clerk.com/docs/custom-flows/error-handling
             // for more info on error handling
-            console.error('Error:', JSON.stringify(err, null, 2));
+            console.error('Error:', JSON.stringify(err, null, 2))
           }
         }
 
@@ -524,16 +517,11 @@ This guide will walk you through how to build a custom SMS OTP sign-up and sign-
               <h1>Verify your phone number</h1>
               <form onSubmit={handleVerification}>
                 <label htmlFor="code">Enter your verification code</label>
-                <input
-                  value={code}
-                  id="code"
-                  name="code"
-                  onChange={(e) => setCode(e.target.value)}
-                />
+                <input value={code} id="code" name="code" onChange={(e) => setCode(e.target.value)} />
                 <button type="submit">Verify</button>
               </form>
             </>
-          );
+          )
         }
 
         return (
@@ -551,7 +539,7 @@ This guide will walk you through how to build a custom SMS OTP sign-up and sign-
               <button type="submit">Continue</button>
             </form>
           </>
-        );
+        )
       }
       ```
     </Tab>

--- a/docs/custom-flows/embedded-email-links.mdx
+++ b/docs/custom-flows/embedded-email-links.mdx
@@ -48,21 +48,21 @@ This guide will teach you how to set this flow up.
   <Tabs items={["Next.js"]}>
     <Tab>
       <CodeBlockTabs options={["App Router", "Pages Router"]}>
-        ```jsx {{ prettier: false, filename: 'app/accept-token/page.jsx' }}
-        "use client";
-        import { useUser, useSignIn } from "@clerk/nextjs";
-        import { useEffect, useState } from "react";
-        import { useSearchParams } from "next/navigation";
+        ```tsx {{ filename: 'app/accept-token/page.tsx' }}
+        'use client'
+        import { useUser, useSignIn } from '@clerk/nextjs'
+        import { useEffect, useState } from 'react'
+        import { useSearchParams } from 'next/navigation'
 
         export default function AcceptToken() {
-          const { signIn, setActive } = useSignIn();
-          const { user } = useUser();
-          const [signInProcessed, setSignInProcessed] = useState<boolean>(false);
-          const signInToken = useSearchParams().get("token");
+          const { signIn, setActive } = useSignIn()
+          const { user } = useUser()
+          const [signInProcessed, setSignInProcessed] = useState<boolean>(false)
+          const signInToken = useSearchParams().get('token')
 
           useEffect(() => {
             if (!signIn || !setActive || !signInToken) {
-              return;
+              return
             }
 
             const createSignIn = async () => {
@@ -70,59 +70,57 @@ This guide will teach you how to set this flow up.
                 // Create a signIn with the token.
                 // Note that you need to use the "ticket" strategy.
                 const res = await signIn.create({
-                  strategy: "ticket",
+                  strategy: 'ticket',
                   ticket: signInToken as string,
-                });
+                })
                 setActive({
                   session: res.createdSessionId,
                   beforeEmit: () => setSignInProcessed(true),
-                });
+                })
               } catch (err) {
-                setSignInProcessed(true);
+                setSignInProcessed(true)
               }
-            };
+            }
 
-            createSignIn();
-          }, [signIn, setActive]);
+            createSignIn()
+          }, [signIn, setActive])
 
           if (!signInToken) {
-            return <div>no token provided</div>;
+            return <div>no token provided</div>
           }
 
           if (!signInProcessed) {
-            return <div>loading</div>;
+            return <div>loading</div>
           }
 
           if (!user) {
-            return <div>error invalid token</div>;
+            return <div>error invalid token</div>
           }
 
-          return <div>Signed in as {user.id}</div>;
+          return <div>Signed in as {user.id}</div>
         }
         ```
 
-        ```jsx {{ prettier: false, filename: 'pages/accept-token.jsx' }}
-        import { InferGetServerSidePropsType, GetServerSideProps } from "next";
-        import { useUser, useSignIn } from "@clerk/nextjs";
-        import { useEffect, useState } from "react";
+        ```tsx {{ filename: 'pages/accept-token.tsx' }}
+        import { InferGetServerSidePropsType, GetServerSideProps } from 'next'
+        import { useUser, useSignIn } from '@clerk/nextjs'
+        import { useEffect, useState } from 'react'
 
         // Grab the query param server side, and pass through props
         export const getServerSideProps: GetServerSideProps = async (context) => {
           return {
             props: { signInToken: context.query.token ? context.query.token : null },
-          };
-        };
+          }
+        }
 
-        const AcceptToken = ({
-          signInToken,
-        }: InferGetServerSidePropsType<typeof getServerSideProps>) => {
-          const { signIn, setActive } = useSignIn();
-          const { user } = useUser();
-          const [signInProcessed, setSignInProcessed] = useState<boolean>(false);
+        const AcceptToken = ({ signInToken }: InferGetServerSidePropsType<typeof getServerSideProps>) => {
+          const { signIn, setActive } = useSignIn()
+          const { user } = useUser()
+          const [signInProcessed, setSignInProcessed] = useState<boolean>(false)
 
           useEffect(() => {
             if (!signIn || !setActive || !signInToken) {
-              return;
+              return
             }
 
             const createSignIn = async () => {
@@ -130,37 +128,37 @@ This guide will teach you how to set this flow up.
                 // Create a signIn with the token.
                 // Note that you need to use the "ticket" strategy.
                 const res = await signIn.create({
-                  strategy: "ticket",
+                  strategy: 'ticket',
                   ticket: signInToken as string,
-                });
+                })
                 setActive({
                   session: res.createdSessionId,
-                  beforeEmit: () => setSignInProcessed(true)
-                });
+                  beforeEmit: () => setSignInProcessed(true),
+                })
               } catch (err) {
-                setSignInProcessed(true);
+                setSignInProcessed(true)
               }
-            };
+            }
 
-            createSignIn();
-          }, [signIn, setActive]);
+            createSignIn()
+          }, [signIn, setActive])
 
           if (!signInToken) {
-            return <div>no token provided</div>;
+            return <div>no token provided</div>
           }
 
           if (!signInProcessed) {
-            return <div>loading</div>;
+            return <div>loading</div>
           }
 
           if (!user) {
-            return <div>error invalid token</div>;
+            return <div>error invalid token</div>
           }
 
-          return <div>Signed in as {user.id}</div>;
-        };
+          return <div>Signed in as {user.id}</div>
+        }
 
-        export default AcceptToken;
+        export default AcceptToken
         ```
       </CodeBlockTabs>
     </Tab>

--- a/docs/custom-flows/error-handling.mdx
+++ b/docs/custom-flows/error-handling.mdx
@@ -20,32 +20,32 @@ The following example uses the [email & password sign-in custom flow](/docs/cust
   <Tab>
     This example is written for Next.js App Router but it can be adapted for any React meta framework, such as Remix or Gatsby.
 
-    ```jsx {{ prettier: false, filename: 'app/sign-in/[[...sign-in]]/page.tsx' }}
-    'use client';
+    ```tsx {{ filename: 'app/sign-in/[[...sign-in]]/page.tsx' }}
+    'use client'
 
-    import * as React from 'react';
-    import { useSignIn } from '@clerk/nextjs';
-    import { useRouter } from 'next/navigation';
-    import { ClerkAPIError } from '@clerk/types';
-    import { isClerkAPIResponseError } from '@clerk/nextjs/errors';
+    import * as React from 'react'
+    import { useSignIn } from '@clerk/nextjs'
+    import { useRouter } from 'next/navigation'
+    import { ClerkAPIError } from '@clerk/types'
+    import { isClerkAPIResponseError } from '@clerk/nextjs/errors'
 
     export default function SignInForm() {
-      const { isLoaded, signIn, setActive } = useSignIn();
-      const [email, setEmail] = React.useState('');
-      const [password, setPassword] = React.useState('');
-      const [errors, setErrors] = React.useState<ClerkAPIError[]>();
+      const { isLoaded, signIn, setActive } = useSignIn()
+      const [email, setEmail] = React.useState('')
+      const [password, setPassword] = React.useState('')
+      const [errors, setErrors] = React.useState<ClerkAPIError[]>()
 
-      const router = useRouter();
+      const router = useRouter()
 
       // Handle the submission of the sign-in form
       const handleSubmit = async (e: React.FormEvent) => {
-        e.preventDefault();
+        e.preventDefault()
 
         // clear any errors that may have occured during previous form submission
-        setErrors(undefined);
+        setErrors(undefined)
 
         if (!isLoaded) {
-          return;
+          return
         }
 
         // Start the sign-in process using the email and password provided
@@ -53,24 +53,24 @@ The following example uses the [email & password sign-in custom flow](/docs/cust
           const completeSignIn = await signIn.create({
             identifier: email,
             password,
-          });
+          })
 
           // This is mainly for debugging while developing.
           if (completeSignIn.status !== 'complete') {
-            console.log(JSON.stringify(completeSignIn, null, 2));
+            console.log(JSON.stringify(completeSignIn, null, 2))
           }
 
           // If sign-in process is complete, set the created session as active
           // and redirect the user
           if (completeSignIn.status === 'complete') {
-            await setActive({ session: completeSignIn.createdSessionId });
-            router.push('/');
+            await setActive({ session: completeSignIn.createdSessionId })
+            router.push('/')
           }
         } catch (err) {
-          if (isClerkAPIResponseError(err)) setErrors(err.errors);
-          console.error(JSON.stringify(err, null, 2));
+          if (isClerkAPIResponseError(err)) setErrors(err.errors)
+          console.error(JSON.stringify(err, null, 2))
         }
-      };
+      }
 
       // Display a form to capture the user's email and password
       return (
@@ -108,7 +108,7 @@ The following example uses the [email & password sign-in custom flow](/docs/cust
             </ul>
           )}
         </>
-      );
+      )
     }
     ```
   </Tab>

--- a/docs/custom-flows/invitations.mdx
+++ b/docs/custom-flows/invitations.mdx
@@ -21,40 +21,40 @@ The following example demonstrates how to create a new sign-up using the invitat
 
 <Tabs items={["Next.js", "JavaScript"]}>
   <Tab>
-    ```jsx {{ prettier: false, filename: 'app/sign-up/[[...sign-up]]/page.tsx' }}
-    'use client';
+    ```tsx {{ filename: 'app/sign-up/[[...sign-up]]/page.tsx' }}
+    'use client'
 
-    import * as React from 'react';
-    import { useSignUp } from '@clerk/nextjs';
-    import { useRouter } from 'next/navigation';
+    import * as React from 'react'
+    import { useSignUp } from '@clerk/nextjs'
+    import { useRouter } from 'next/navigation'
 
     export default function Page() {
-      const { isLoaded, signUp, setActive } = useSignUp();
-      const [firstName, setFirstName] = React.useState('');
-      const [lastName, setLastName] = React.useState('');
-      const router = useRouter();
+      const { isLoaded, signUp, setActive } = useSignUp()
+      const [firstName, setFirstName] = React.useState('')
+      const [lastName, setLastName] = React.useState('')
+      const router = useRouter()
 
       // Get the token from the query parameter
-      const param = '__clerk_ticket';
-      const ticket = new URL(window.location.href).searchParams.get(param);
+      const param = '__clerk_ticket'
+      const ticket = new URL(window.location.href).searchParams.get(param)
 
       // If there is no invitation token, restrict access to the sign-up page
       if (!ticket) {
-        return <p>You need an invitation to sign up for this application.</p>;
+        return <p>You need an invitation to sign up for this application.</p>
       }
 
       // Handle submission of the sign-up form
       const handleSubmit = async (e: React.FormEvent) => {
-        e.preventDefault();
+        e.preventDefault()
 
-        if (!isLoaded) return;
+        if (!isLoaded) return
 
         try {
-          if (!ticket) return null;
+          if (!ticket) return null
 
           // Optional: collect additional user information
-          const firstName = 'John';
-          const lastName = 'Doe';
+          const firstName = 'John'
+          const lastName = 'Doe'
 
           // Create a new sign-up with the supplied invitation token.
           // Make sure you're also passing the ticket strategy.
@@ -65,22 +65,22 @@ The following example demonstrates how to create a new sign-up using the invitat
             ticket,
             firstName,
             lastName,
-          });
+          })
 
           // If verification was completed, set the session to active
           // and redirect the user
           if (signUpAttempt.status === 'complete') {
-            await setActive({ session: signUpAttempt.createdSessionId });
-            router.push('/');
+            await setActive({ session: signUpAttempt.createdSessionId })
+            router.push('/')
           } else {
             // If the status is not complete, check why. User may need to
             // complete further steps.
-            console.error(JSON.stringify(signUpAttempt, null, 2));
+            console.error(JSON.stringify(signUpAttempt, null, 2))
           }
         } catch (err: any) {
-          console.error(JSON.stringify(err, null, 2));
+          console.error(JSON.stringify(err, null, 2))
         }
-      };
+      }
 
       // Display the initial sign-up form to capture optional sign-up info
       return (
@@ -112,7 +112,7 @@ The following example demonstrates how to create a new sign-up using the invitat
             </div>
           </form>
         </>
-      );
+      )
     }
     ```
   </Tab>

--- a/docs/custom-flows/manage-sms-based-mfa.mdx
+++ b/docs/custom-flows/manage-sms-based-mfa.mdx
@@ -36,28 +36,28 @@ One of the options that Clerk supports for MFA is **SMS verification codes**. Th
 
   <Tabs items={["Manage MFA page", "Add phone number page"]}>
     <Tab>
-      ```jsx {{ prettier: false, filename: '/app/account/manage-mfa/page.tsx' }}
-      'use client';
+      ```tsx {{ filename: '/app/account/manage-mfa/page.tsx' }}
+      'use client'
 
-      import * as React from 'react';
-      import { useUser } from '@clerk/nextjs';
-      import { BackupCodeResource, PhoneNumberResource } from '@clerk/types';
-      import Link from 'next/link';
+      import * as React from 'react'
+      import { useUser } from '@clerk/nextjs'
+      import { BackupCodeResource, PhoneNumberResource } from '@clerk/types'
+      import Link from 'next/link'
 
       // Display phone numbers reserved for MFA
       const ManageMfaPhoneNumbers = () => {
-        const { user } = useUser();
+        const { user } = useUser()
 
-        if (!user) return null;
+        if (!user) return null
 
         // Check if any phone numbers are reserved for MFA
         const mfaPhones = user.phoneNumbers
           .filter((ph) => ph.verification.status === 'verified')
           .filter((ph) => ph.reservedForSecondFactor)
-          .sort((ph: PhoneNumberResource) => (ph.defaultSecondFactor ? -1 : 1));
+          .sort((ph: PhoneNumberResource) => (ph.defaultSecondFactor ? -1 : 1))
 
         if (mfaPhones.length === 0) {
-          return <p>There are currently no phone numbers reserved for MFA.</p>;
+          return <p>There are currently no phone numbers reserved for MFA.</p>
         }
 
         return (
@@ -71,62 +71,49 @@ One of the options that Clerk supports for MFA is **SMS verification codes**. Th
                       {phone.phoneNumber} {phone.defaultSecondFactor && '(Default)'}
                     </p>
                     <div>
-                      <button
-                        onClick={() =>
-                          phone.setReservedForSecondFactor({ reserved: false })
-                        }
-                      >
+                      <button onClick={() => phone.setReservedForSecondFactor({ reserved: false })}>
                         Disable for MFA
                       </button>
                     </div>
 
                     {!phone.defaultSecondFactor && (
                       <div>
-                        <button onClick={() => phone.makeDefaultSecondFactor()}>
-                          Make default
-                        </button>
+                        <button onClick={() => phone.makeDefaultSecondFactor()}>Make default</button>
                       </div>
                     )}
 
                     <div>
-                      <button onClick={() => phone.destroy()}>
-                        Remove from account
-                      </button>
+                      <button onClick={() => phone.destroy()}>Remove from account</button>
                     </div>
                   </li>
-                );
+                )
               })}
             </ul>
           </>
-        );
-      };
+        )
+      }
 
       // Display phone numbers that are not reserved for MFA
       const ManageAvailablePhoneNumbers = () => {
-        const { user } = useUser();
+        const { user } = useUser()
 
-        if (!user) return null;
+        if (!user) return null
 
         // Check if any phone numbers aren't reserved for MFA
         const availalableForMfaPhones = user.phoneNumbers
           .filter((ph) => ph.verification.status === 'verified')
-          .filter((ph) => !ph.reservedForSecondFactor);
+          .filter((ph) => !ph.reservedForSecondFactor)
 
         // Reserve a phone number for MFA
         const reservePhoneForMfa = async (phone: PhoneNumberResource) => {
           // Set the phone number as reserved for MFA
-          await phone.setReservedForSecondFactor({ reserved: true });
+          await phone.setReservedForSecondFactor({ reserved: true })
           // Refresh the user information to reflect changes
-          await user.reload();
-        };
+          await user.reload()
+        }
 
         if (availalableForMfaPhones.length === 0) {
-          return (
-            <p>
-              There are currently no verified phone numbers available to be reserved for
-              MFA.
-            </p>
-          );
+          return <p>There are currently no verified phone numbers available to be reserved for MFA.</p>
         }
 
         return (
@@ -139,58 +126,52 @@ One of the options that Clerk supports for MFA is **SMS verification codes**. Th
                   <li key={phone.id} style={{ display: 'flex', gap: '10px' }}>
                     <p>{phone.phoneNumber}</p>
                     <div>
-                      <button onClick={() => reservePhoneForMfa(phone)}>
-                        Use for MFA
-                      </button>
+                      <button onClick={() => reservePhoneForMfa(phone)}>Use for MFA</button>
                     </div>
                     <div>
-                      <button onClick={() => phone.destroy()}>
-                        Remove from account
-                      </button>
+                      <button onClick={() => phone.destroy()}>Remove from account</button>
                     </div>
                   </li>
-                );
+                )
               })}
             </ul>
           </>
-        );
-      };
+        )
+      }
 
       // Generate and display backup codes
       function GenerateBackupCodes() {
-        const { user } = useUser();
-        const [backupCodes, setBackupCodes] = React.useState<
-          BackupCodeResource | undefined
-        >(undefined);
+        const { user } = useUser()
+        const [backupCodes, setBackupCodes] = React.useState<BackupCodeResource | undefined>(undefined)
 
-        const [loading, setLoading] = React.useState(false);
+        const [loading, setLoading] = React.useState(false)
 
         React.useEffect(() => {
           if (backupCodes) {
-            return;
+            return
           }
 
-          setLoading(true);
+          setLoading(true)
           void user
             ?.createBackupCode()
             .then((backupCode: BackupCodeResource) => {
-              setBackupCodes(backupCode);
-              setLoading(false);
+              setBackupCodes(backupCode)
+              setLoading(false)
             })
             .catch((err) => {
               // See https://clerk.com/docs/custom-flows/error-handling
               // for more info on error handling
-              console.error(JSON.stringify(err, null, 2));
-              setLoading(false);
-            });
-        }, []);
+              console.error(JSON.stringify(err, null, 2))
+              setLoading(false)
+            })
+        }, [])
 
         if (loading) {
-          return <p>Loading...</p>;
+          return <p>Loading...</p>
         }
 
         if (!backupCodes) {
-          return <p>There was a problem generating backup codes</p>;
+          return <p>There was a problem generating backup codes</p>
         }
 
         return (
@@ -199,18 +180,18 @@ One of the options that Clerk supports for MFA is **SMS verification codes**. Th
               <li key={index}>{code}</li>
             ))}
           </ol>
-        );
+        )
       }
 
       export default function ManageSMSMFA() {
-        const [showBackupCodes, setShowBackupCodes] = React.useState(false);
+        const [showBackupCodes, setShowBackupCodes] = React.useState(false)
 
-        const { isLoaded, user } = useUser();
+        const { isLoaded, user } = useUser()
 
-        if (!isLoaded) return null;
+        if (!isLoaded) return null
 
         if (!user) {
-          return <p>You must be logged in to access this page</p>;
+          return <p>You must be logged in to access this page</p>
         }
 
         return (
@@ -238,80 +219,78 @@ One of the options that Clerk supports for MFA is **SMS verification codes**. Th
               </>
             )}
           </>
-        );
+        )
       }
       ```
     </Tab>
 
     <Tab>
-      ```jsx {{ prettier: false, filename: '/app/account/add-phone/page.tsx' }}
-      'use client';
+      ```tsx {{ filename: '/app/account/add-phone/page.tsx' }}
+      'use client'
 
-      import * as React from 'react';
-      import { useUser } from '@clerk/nextjs';
-      import { PhoneNumberResource } from '@clerk/types';
+      import * as React from 'react'
+      import { useUser } from '@clerk/nextjs'
+      import { PhoneNumberResource } from '@clerk/types'
 
       export default function Page() {
-        const { isLoaded, user } = useUser();
-        const [phone, setPhone] = React.useState('');
-        const [code, setCode] = React.useState('');
-        const [isVerifying, setIsVerifying] = React.useState(false);
-        const [successful, setSuccessful] = React.useState(false);
-        const [phoneObj, setPhoneObj] = React.useState<
-          PhoneNumberResource | undefined
-        >();
+        const { isLoaded, user } = useUser()
+        const [phone, setPhone] = React.useState('')
+        const [code, setCode] = React.useState('')
+        const [isVerifying, setIsVerifying] = React.useState(false)
+        const [successful, setSuccessful] = React.useState(false)
+        const [phoneObj, setPhoneObj] = React.useState<PhoneNumberResource | undefined>()
 
-        if (!isLoaded) return null;
+        if (!isLoaded) return null
 
         if (!user) {
-          return <p>You must be logged in to access this page</p>;
+          return <p>You must be logged in to access this page</p>
         }
 
         // Handle addition of the phone number
         const handleSubmit = async (e: React.FormEvent) => {
-          e.preventDefault();
+          e.preventDefault()
 
           try {
             // Add unverified phone number to user
-            const res = await user.createPhoneNumber({ phoneNumber: phone });
+            const res = await user.createPhoneNumber({ phoneNumber: phone })
             // Reload user to get updated User object
-            await user.reload();
+            await user.reload()
 
             // Create a reference to the new phone number to use related methods
-            const phoneNumber = user.phoneNumbers.find((a) => a.id === res.id);
-            setPhoneObj(phoneNumber);
+            const phoneNumber = user.phoneNumbers.find((a) => a.id === res.id)
+            setPhoneObj(phoneNumber)
 
             // Send the user an SMS with the verification code
-            phoneNumber?.prepareVerification();
+            phoneNumber?.prepareVerification()
 
             // Set to true to display second form
             // and capture the OTP code
-            setIsVerifying(true);
+            setIsVerifying(true)
           } catch (err) {
             // See https://clerk.com/docs/custom-flows/error-handling
             // for more info on error handling
-            console.error(JSON.stringify(err, null, 2));
+            console.error(JSON.stringify(err, null, 2))
           }
-        };
+        }
 
         // Handle the submission of the verification form
         const verifyCode = async (e: React.FormEvent) => {
-          e.preventDefault();
+          e.preventDefault()
           try {
             // Verify that the provided code matches the code sent to the user
-            const phoneVerifyAttempt = await phoneObj?.attemptVerification({ code });
+            const phoneVerifyAttempt = await phoneObj?.attemptVerification({ code })
 
             if (phoneVerifyAttempt?.verification.status === 'verified') {
-              setSuccessful(true);
+              setSuccessful(true)
             } else {
               // If the status is not complete, check why. User may need to
               // complete further steps.
-              console.error(JSON.stringify(phoneVerifyAttempt, null, 2));
+              console.error(JSON.stringify(phoneVerifyAttempt, null, 2))
             }
           } catch (err) {
-            console.error(JSON.stringify(err, null, 2));
+            console.error(JSON.stringify(err, null, 2))
           }
-        };
+        }
 
         // Display a success message if the phone number was added successfully
         if (successful) {
@@ -319,7 +298,7 @@ One of the options that Clerk supports for MFA is **SMS verification codes**. Th
             <>
               <h1>Phone added</h1>
             </>
-          );
+          )
         }
 
         // Display the verification form to capture the OTP code
@@ -345,7 +324,7 @@ One of the options that Clerk supports for MFA is **SMS verification codes**. Th
                 </form>
               </div>
             </>
-          );
+          )
         }
 
         // Display the initial form to capture the phone number
@@ -370,7 +349,7 @@ One of the options that Clerk supports for MFA is **SMS verification codes**. Th
               </form>
             </div>
           </>
-        );
+        )
       }
       ```
     </Tab>

--- a/docs/custom-flows/saml-connections.mdx
+++ b/docs/custom-flows/saml-connections.mdx
@@ -27,22 +27,22 @@ The following example shows two files:
 <Tabs items={["Next.js"]}>
   <Tab>
     <CodeBlockTabs options={["Sign in page", "SSO callback page"]}>
-      ```jsx {{ prettier: false, filename: 'app/sign-in/page.tsx' }}
-      'use client';
+      ```tsx {{ filename: 'app/sign-in/page.tsx' }}
+      'use client'
 
-      import * as React from 'react';
-      import { useSignIn, useSignUp } from '@clerk/nextjs';
+      import * as React from 'react'
+      import { useSignIn, useSignUp } from '@clerk/nextjs'
 
       export default function OauthSignIn() {
-        const { signIn } = useSignIn();
-        const { signUp } = useSignUp();
+        const { signIn } = useSignIn()
+        const { signUp } = useSignUp()
 
-        if (!signIn || !signUp) return null;
+        if (!signIn || !signUp) return null
 
         const signInWith = (e: React.FormEvent) => {
-          e.preventDefault();
+          e.preventDefault()
 
-          const email = (e.target as HTMLFormElement).email.value;
+          const email = (e.target as HTMLFormElement).email.value
 
           signIn
             .authenticateWithRedirect({
@@ -52,13 +52,13 @@ The following example shows two files:
               redirectUrlComplete: '/',
             })
             .then((res) => {
-              console.log(res);
+              console.log(res)
             })
             .catch((err: any) => {
-              console.log(err.errors);
-              console.error(err, null, 2);
-            });
-        };
+              console.log(err.errors)
+              console.error(err, null, 2)
+            })
+        }
 
         // Render a button for each supported SAML provider
         // you want to add to your app
@@ -67,7 +67,7 @@ The following example shows two files:
             <input type="email" name="email" placeholder="Enter email address" />
             <button>Sign in with SAML</button>
           </form>
-        );
+        )
       }
       ```
 
@@ -96,22 +96,22 @@ The following example shows how to handle these cases in your sign-in flow. The 
 
 <Tabs items={["Next.js"]}>
   <Tab>
-    ```js {{ prettier: false, filename: 'app/sign-in/[[...sign-in]]/page.tsx' }}
-    'use client';
+    ```tsx {{ filename: 'app/sign-in/[[...sign-in]]/page.tsx' }}
+    'use client'
 
-    import * as React from 'react';
-    import { useSignIn, useSignUp } from '@clerk/nextjs';
+    import * as React from 'react'
+    import { useSignIn, useSignUp } from '@clerk/nextjs'
 
     export default function OauthSignIn() {
-      const { signIn } = useSignIn();
-      const { signUp, setActive } = useSignUp();
+      const { signIn } = useSignIn()
+      const { signUp, setActive } = useSignUp()
 
-      if (!signIn || !signUp) return null;
+      if (!signIn || !signUp) return null
 
       const signInWith = (e: React.FormEvent) => {
-        e.preventDefault();
+        e.preventDefault()
 
-        const email = (e.target as HTMLFormElement).email.value;
+        const email = (e.target as HTMLFormElement).email.value
 
         signIn
           .authenticateWithRedirect({
@@ -121,55 +121,53 @@ The following example shows how to handle these cases in your sign-in flow. The 
             redirectUrlComplete: '/',
           })
           .then((res) => {
-            console.log(res);
+            console.log(res)
           })
           .catch((err: any) => {
-            console.log(err.errors);
-            console.error(err, null, 2);
-          });
-      };
+            console.log(err.errors)
+            console.error(err, null, 2)
+          })
+      }
 
       async function handleSignIn(e: React.FormEvent) {
-        if (!signIn || !signUp) return null;
+        if (!signIn || !signUp) return null
 
         // If the user has an account in your application, but does not yet
         // have a SAML account connected to it, you can transfer the SAML
         // account to the existing user account.
         const userExistsButNeedsToSignIn =
           signUp.verifications.externalAccount.status === 'transferable' &&
-          signUp.verifications.externalAccount.error?.code ===
-            'external_account_exists';
+          signUp.verifications.externalAccount.error?.code === 'external_account_exists'
 
         if (userExistsButNeedsToSignIn) {
-          const res = await signIn.create({ transfer: true });
+          const res = await signIn.create({ transfer: true })
 
           if (res.status === 'complete') {
             setActive({
               session: res.createdSessionId,
-            });
+            })
           }
         }
 
         // If the user has a SAML account but does not yet
         // have an account in your app, you can create an account
         // for them using the SAML information.
-        const userNeedsToBeCreated =
-          signIn.firstFactorVerification.status === 'transferable';
+        const userNeedsToBeCreated = signIn.firstFactorVerification.status === 'transferable'
 
         if (userNeedsToBeCreated) {
           const res = await signUp.create({
             transfer: true,
-          });
+          })
 
           if (res.status === 'complete') {
             setActive({
               session: res.createdSessionId,
-            });
+            })
           }
         } else {
           // If the user has an account in your application
           // and has an SAML account connected to it, you can sign them in.
-          signInWith(e);
+          signInWith(e)
         }
       }
 
@@ -180,7 +178,7 @@ The following example shows how to handle these cases in your sign-in flow. The 
           <input type="email" name="email" placeholder="Enter email address" />
           <button>Sign in with SAML</button>
         </form>
-      );
+      )
     }
     ```
   </Tab>

--- a/docs/elements/guides/styling.mdx
+++ b/docs/elements/guides/styling.mdx
@@ -162,7 +162,7 @@ const CustomInput = forwardRef(function CustomInput(props, forwardedRef) {
 
 Classes from an imported CSS module can be applied to most Clerk Elements components with `className`.
 
-```tsx {{ prettier: false, filename: '/app/sign-in/[[...sign-in]]/page.tsx' }}
+```tsx {{ filename: '/app/sign-in/[[...sign-in]]/page.tsx' }}
 'use client'
 
 import * as Clerk from '@clerk/elements/common'
@@ -173,13 +173,17 @@ export default function SignInPage() {
   return (
     <SignIn.Root>
       <SignIn.Step name="start" className={styles.startStep}>
-        <Clerk.Connection name="google" className={styles.provider}>Sign in with Google</Clerk.Connection>
+        <Clerk.Connection name="google" className={styles.provider}>
+          Sign in with Google
+        </Clerk.Connection>
         <Clerk.Field name="identifier">
           <Clerk.Label className={styles.label}>Email</Clerk.Label>
           <Clerk.Input className={styles.input} />
           <Clerk.FieldError className={styles.error} />
         </Clerk.Field>
-        <SignIn.Action submit className={styles.submit}>Continue</SignIn.Action>
+        <SignIn.Action submit className={styles.submit}>
+          Continue
+        </SignIn.Action>
       </SignIn.Step>
       <SignIn.Step name="verifications" className={styles.verificationsStep}>
         <SignIn.Strategy name="email_code">
@@ -188,7 +192,10 @@ export default function SignInPage() {
             <Clerk.Input className={styles.input} />
             <Clerk.FieldError className={styles.error} />
           </Clerk.Field>
-          <SignIn.Action submit className={styles.submit}>Verify</SignIn.Action>
+          <SignIn.Action submit className={styles.submit}>
+            Verify
+          </SignIn.Action>
+        </SignIn.Strategy>
       </SignIn.Step>
     </SignIn.Root>
   )

--- a/docs/elements/reference/common.mdx
+++ b/docs/elements/reference/common.mdx
@@ -340,9 +340,9 @@ The following data attributes are also added to the underlying element:
 
 ### Usage {{ toc: false }}
 
-```tsx {{ prettier: false }}
+```tsx
 <Clerk.Field name="identifier">
-  <Clerk.Label>Email</Label>
+  <Clerk.Label>Email</Clerk.Label>
   <Clerk.Input type="email" />
 </Clerk.Field>
 ```

--- a/docs/guides/force-organizations.mdx
+++ b/docs/guides/force-organizations.mdx
@@ -80,14 +80,14 @@ This guide will be written for Next.js applications using App Router, but the sa
     <Tab>
       The [`auth()`](/docs/references/nextjs/auth) helper function can be used to get the `orgId` from the session _server-side_. If the `orgId` is `null`, then the user does not have an active organization.
 
-      ```tsx {{ prettier: false }}
+      ```tsx
       import { auth } from '@clerk/nextjs/server'
 
       export default function Layout() {
-        const { orgId } = auth();
+        const { orgId } = auth()
 
-        const hasActiveOrg = orgId !== null;
-        ...
+        const hasActiveOrg = orgId !== null
+        // ...
       }
       ```
     </Tab>
@@ -95,15 +95,15 @@ This guide will be written for Next.js applications using App Router, but the sa
     <Tab>
       The [`useAuth()`](/docs/references/react/use-auth) hook can be used to get the `orgId` from the session _client-side_. If the `orgId` is `null`, then the user does not have an active organization.
 
-      ```tsx {{ prettier: false }}
-      "use client"
+      ```tsx
+      'use client'
       import { useAuth } from '@clerk/nextjs'
 
       export default function Layout() {
-        const { orgId } = useAuth();
+        const { orgId } = useAuth()
 
-        const hasActiveOrg = orgId !== null;
-        ...
+        const hasActiveOrg = orgId !== null
+        // ...
       }
       ```
     </Tab>

--- a/docs/integrations/databases/hasura.mdx
+++ b/docs/integrations/databases/hasura.mdx
@@ -69,7 +69,7 @@ To add the JWT secret locally with Hasura Core, you need to set both the `HASURA
 
 `HASURA_GRAPHQL_JWT_SECRET` should be set to a stringified JSON object of the JWT secret which contains the JWKS endpoint as the value of `jwk_url`.
 
-```json {{ prettier: false }}
+```yaml
 HASURA_GRAPHQL_ADMIN_SECRET: myadminsecretkey
 HASURA_GRAPHQL_JWT_SECRET: '{"jwk_url":"https://{{fapi}}/.well-known/jwks.json"}'
 ```
@@ -80,7 +80,7 @@ Replace `<YOUR_FRONTEND_API>` with the Frontend API value. This value can be fou
 
 If you did use a custom signing key, instead of providing the `jwk_url` you need to provide the algorithm type and key in the stringified JSON object as the `HASURA_GRAPHQL_JWT_SECRET` in the Hasura Cloud Env Vars or in the `docker-compose.yml` file.
 
-```json {{ prettier: false }}
+```yaml
 HASURA_GRAPHQL_JWT_SECRET: '{"type": "HS256", "key": "<YOUR_SIGNING_KEY>" }'
 ```
 

--- a/docs/integrations/databases/supabase.mdx
+++ b/docs/integrations/databases/supabase.mdx
@@ -227,20 +227,20 @@ For interacting with the Supabase dashboard, you can either use the **Supabase i
 
   The following example uses the [Next.js SDK](/docs/references/nextjs/overview) to access the [`useUser()`](/docs/references/react/use-user) and [`useSession()`](/docs/references/react/use-session) hooks, but you can adapt this code to work with any React-based Clerk SDK.
 
-  ```jsx {{ prettier: false, filename: 'app/page.tsx' }}
-  'use client';
-  import { useEffect, useState } from 'react';
-  import { useSession, useUser } from '@clerk/nextjs';
-  import { createClient } from '@supabase/supabase-js';
+  ```tsx {{ filename: 'app/page.tsx' }}
+  'use client'
+  import { useEffect, useState } from 'react'
+  import { useSession, useUser } from '@clerk/nextjs'
+  import { createClient } from '@supabase/supabase-js'
 
   export default function Home() {
-    const [tasks, setTasks] = useState<any[]>([]);
-    const [loading, setLoading] = useState(true);
-    const [name, setName] = useState('');
+    const [tasks, setTasks] = useState<any[]>([])
+    const [loading, setLoading] = useState(true)
+    const [name, setName] = useState('')
     // The `useUser()` hook will be used to ensure that Clerk has loaded data about the logged in user
-    const { user } = useUser();
+    const { user } = useUser()
     // The `useSession()` hook will be used to get the Clerk session object
-    const { session } = useSession();
+    const { session } = useSession()
 
     // Create a custom supabase client that injects the Clerk Supabase token into the request headers
     function createClerkSupabaseClient() {
@@ -253,48 +253,48 @@ For interacting with the Supabase dashboard, you can either use the **Supabase i
             fetch: async (url, options = {}) => {
               const clerkToken = await session?.getToken({
                 template: 'supabase',
-              });
+              })
 
               // Insert the Clerk Supabase token into the headers
-              const headers = new Headers(options?.headers);
-              headers.set('Authorization', `Bearer ${clerkToken}`);
+              const headers = new Headers(options?.headers)
+              headers.set('Authorization', `Bearer ${clerkToken}`)
 
               // Now call the default fetch
               return fetch(url, {
                 ...options,
                 headers,
-              });
+              })
             },
           },
-        }
-      );
+        },
+      )
     }
 
     // Create a `client` object for accessing Supabase data using the Clerk token
-    const client = createClerkSupabaseClient();
+    const client = createClerkSupabaseClient()
 
     // This `useEffect` will wait for the User object to be loaded before requesting
     // the tasks for the logged in user
     useEffect(() => {
-      if (!user) return;
+      if (!user) return
 
       async function loadTasks() {
-        setLoading(true);
-        const { data, error } = await client.from('tasks').select();
-        if (!error) setTasks(data);
-        setLoading(false);
+        setLoading(true)
+        const { data, error } = await client.from('tasks').select()
+        if (!error) setTasks(data)
+        setLoading(false)
       }
 
-      loadTasks();
-    }, [user]);
+      loadTasks()
+    }, [user])
 
     async function createTask(e: React.FormEvent<HTMLFormElement>) {
-      e.preventDefault();
+      e.preventDefault()
       // Insert task into the "tasks" database
       await client.from('tasks').insert({
         name,
-      });
-      window.location.reload();
+      })
+      window.location.reload()
     }
 
     return (
@@ -303,9 +303,7 @@ For interacting with the Supabase dashboard, you can either use the **Supabase i
 
         {loading && <p>Loading...</p>}
 
-        {!loading &&
-          tasks.length > 0 &&
-          tasks.map((task: any) => <p>{task.name}</p>)}
+        {!loading && tasks.length > 0 && tasks.map((task: any) => <p>{task.name}</p>)}
 
         {!loading && tasks.length === 0 && <p>No tasks found</p>}
 
@@ -321,7 +319,7 @@ For interacting with the Supabase dashboard, you can either use the **Supabase i
           <button type="submit">Add</button>
         </form>
       </div>
-    );
+    )
   }
   ```
 

--- a/docs/organizations/creating-organizations.mdx
+++ b/docs/organizations/creating-organizations.mdx
@@ -17,21 +17,21 @@ This guide will demonstrate how to use Clerk's API to build a custom flow for cr
 
     This example is written for Next.js App Router but can be adapted for any React meta framework, such as Remix or Gatsby.
 
-    ```jsx {{ prettier: false, filename: 'app/components/CreateOrganization' }}
-    'use client';
+    ```tsx {{ filename: 'app/components/CreateOrganization.tsx' }}
+    'use client'
 
-    import { useOrganizationList } from "@clerk/nextjs";
-    import { FormEventHandler, useState } from "react";
+    import { useOrganizationList } from '@clerk/nextjs'
+    import { FormEventHandler, useState } from 'react'
 
     export default function CreateOrganization() {
-      const { createOrganization } = useOrganizationList();
-      const [organizationName, setOrganizationName] = useState("");
+      const { createOrganization } = useOrganizationList()
+      const [organizationName, setOrganizationName] = useState('')
 
       const handleSubmit: FormEventHandler<HTMLFormElement> = (e) => {
-        e.preventDefault();
-        createOrganization({ name: organizationName });
-        setOrganizationName("");
-      };
+        e.preventDefault()
+        createOrganization({ name: organizationName })
+        setOrganizationName('')
+      }
 
       return (
         <form onSubmit={handleSubmit}>
@@ -43,7 +43,7 @@ This guide will demonstrate how to use Clerk's API to build a custom flow for cr
           />
           <button type="submit">Create organization</button>
         </form>
-      );
+      )
     }
     ```
   </Tab>
@@ -54,8 +54,8 @@ This guide will demonstrate how to use Clerk's API to build a custom flow for cr
     Use the tabs to view the code necessary for the `index.html` and `main.js` files.
 
     <CodeBlockTabs options={["index.html", "main.js"]}>
-      ```js {{ prettier: false, filename: 'index.html' }}
-      <!DOCTYPE html>
+      ```html {{ filename: 'index.html' }}
+      <!doctype html>
       <html lang="en">
         <head>
           <meta charset="UTF-8" />
@@ -72,12 +72,7 @@ This guide will demonstrate how to use Clerk's API to build a custom flow for cr
             <button>Create organization</button>
           </form>
 
-          <script
-            type="module"
-            src="/src/main.js"
-            async
-            crossorigin="anonymous"
-          ></script>
+          <script type="module" src="/src/main.js" async crossorigin="anonymous"></script>
         </body>
       </html>
       ```

--- a/docs/organizations/inviting-users.mdx
+++ b/docs/organizations/inviting-users.mdx
@@ -32,31 +32,31 @@ This guide will demonstrate how to use Clerk's API to build a custom flow for in
 
     This example is written for Next.js App Router but can be adapted for any React meta framework, such as Remix or Gatsby.
 
-    ```jsx {{ prettier: false, filename: 'app/components/InvitationList.tsx' }}
-    "use client"
+    ```tsx {{ filename: 'app/components/InvitationList.tsx' }}
+    'use client'
 
-    import { useOrganization } from '@clerk/nextjs';
-    import { OrganizationCustomRoleKey } from '@clerk/types';
-    import { ChangeEventHandler, useEffect, useRef, useState } from 'react';
+    import { useOrganization } from '@clerk/nextjs'
+    import { OrganizationCustomRoleKey } from '@clerk/types'
+    import { ChangeEventHandler, useEffect, useRef, useState } from 'react'
 
     export const OrgMembersParams = {
       memberships: {
         pageSize: 5,
         keepPreviousData: true,
       },
-    };
+    }
 
     export const OrgInvitationsParams = {
       invitations: {
         pageSize: 5,
         keepPreviousData: true,
       },
-    };
+    }
 
     // Form to invite a new member to the organization.
     export const InviteMember = () => {
       const { isLoaded, organization, invitations } = useOrganization(OrgInvitationsParams)
-      const [emailAddress, setEmailAddress] = useState("")
+      const [emailAddress, setEmailAddress] = useState('')
       const [disabled, setDisabled] = useState(false)
 
       if (!isLoaded || !organization) {
@@ -66,9 +66,7 @@ This guide will demonstrate how to use Clerk's API to build a custom flow for in
       const onSubmit = async (e: React.ChangeEvent<HTMLFormElement>) => {
         e.preventDefault()
 
-        const submittedData = Object.fromEntries(
-          new FormData(e.currentTarget).entries()
-        ) as {
+        const submittedData = Object.fromEntries(new FormData(e.currentTarget).entries()) as {
           email: string | undefined
           role: OrganizationCustomRoleKey | undefined
         }
@@ -83,7 +81,7 @@ This guide will demonstrate how to use Clerk's API to build a custom flow for in
           role: submittedData.role,
         })
         await invitations?.revalidate?.()
-        setEmailAddress("")
+        setEmailAddress('')
         setDisabled(false)
       }
 
@@ -97,7 +95,7 @@ This guide will demonstrate how to use Clerk's API to build a custom flow for in
             onChange={(e) => setEmailAddress(e.target.value)}
           />
           <label>Role</label>
-          <SelectRole fieldName={"role"} />
+          <SelectRole fieldName={'role'} />
           <button type="submit" disabled={disabled}>
             Invite
           </button>
@@ -127,9 +125,7 @@ This guide will demonstrate how to use Clerk's API to build a custom flow for in
           })
           .then((res) => {
             isPopulated.current = true
-            setRoles(
-              res.data.map((roles) => roles.key as OrganizationCustomRoleKey)
-            )
+            setRoles(res.data.map((roles) => roles.key as OrganizationCustomRoleKey))
           })
       }, [organization?.id])
 
@@ -157,10 +153,10 @@ This guide will demonstrate how to use Clerk's API to build a custom flow for in
       const { isLoaded, invitations, memberships } = useOrganization({
         ...OrgInvitationsParams,
         ...OrgMembersParams,
-      });
+      })
 
       if (!isLoaded) {
-        return <>Loading</>;
+        return <>Loading</>
       }
 
       return (
@@ -183,11 +179,8 @@ This guide will demonstrate how to use Clerk's API to build a custom flow for in
                   <td>
                     <button
                       onClick={async () => {
-                        await inv.revoke();
-                        await Promise.all([
-                          memberships?.revalidate,
-                          invitations?.revalidate,
-                        ]);
+                        await inv.revoke()
+                        await Promise.all([memberships?.revalidate, invitations?.revalidate])
                       }}
                     >
                       Revoke
@@ -214,8 +207,8 @@ This guide will demonstrate how to use Clerk's API to build a custom flow for in
             </button>
           </div>
         </>
-      );
-    };
+      )
+    }
     ```
   </Tab>
 

--- a/docs/organizations/managing-roles.mdx
+++ b/docs/organizations/managing-roles.mdx
@@ -21,28 +21,28 @@ This guide will demonstrate how to use Clerk's API to build a custom flow for ma
 
     This example is written for Next.js App Router but can be adapted for any React meta framework, such as Remix or Gatsby.
 
-    ```jsx {{ prettier: false, filename: 'app/components/ManageRoles.tsx' }}
-    'use client';
+    ```tsx {{ filename: 'app/components/ManageRoles.tsx' }}
+    'use client'
 
-    import { useState, useEffect, ChangeEventHandler, useRef } from 'react';
-    import { useOrganization, useUser } from '@clerk/nextjs';
-    import type { OrganizationCustomRoleKey } from '@clerk/types';
+    import { useState, useEffect, ChangeEventHandler, useRef } from 'react'
+    import { useOrganization, useUser } from '@clerk/nextjs'
+    import type { OrganizationCustomRoleKey } from '@clerk/types'
 
     export const OrgMembersParams = {
       memberships: {
         pageSize: 5,
         keepPreviousData: true,
       },
-    };
+    }
 
     // List of organization memberships. Administrators can
     // change member roles or remove members from the organization.
     export const ManageRoles = () => {
-      const { user } = useUser();
-      const { isLoaded, memberships } = useOrganization(OrgMembersParams);
+      const { user } = useUser()
+      const { isLoaded, memberships } = useOrganization(OrgMembersParams)
 
       if (!isLoaded) {
-        return <>Loading</>;
+        return <>Loading</>
       }
 
       return (
@@ -61,8 +61,7 @@ This guide will demonstrate how to use Clerk's API to build a custom flow for ma
               {memberships?.data?.map((mem) => (
                 <tr key={mem.id}>
                   <td>
-                    {mem.publicUserData.identifier}{' '}
-                    {mem.publicUserData.userId === user?.id && '(You)'}
+                    {mem.publicUserData.identifier} {mem.publicUserData.userId === user?.id && '(You)'}
                   </td>
                   <td>{mem.createdAt.toLocaleDateString()}</td>
                   <td>
@@ -71,16 +70,16 @@ This guide will demonstrate how to use Clerk's API to build a custom flow for ma
                       onChange={async (e) => {
                         await mem.update({
                           role: e.target.value as OrganizationCustomRoleKey,
-                        });
-                        await memberships?.revalidate();
+                        })
+                        await memberships?.revalidate()
                       }}
                     />
                   </td>
                   <td>
                     <button
                       onClick={async () => {
-                        await mem.destroy();
-                        await memberships?.revalidate();
+                        await mem.destroy()
+                        await memberships?.revalidate()
                       }}
                     >
                       Remove
@@ -107,38 +106,36 @@ This guide will demonstrate how to use Clerk's API to build a custom flow for ma
             </button>
           </div>
         </>
-      );
-    };
+      )
+    }
 
     type SelectRoleProps = {
-      fieldName?: string;
-      isDisabled?: boolean;
-      onChange?: ChangeEventHandler<HTMLSelectElement>;
-      defaultRole?: string;
-    };
+      fieldName?: string
+      isDisabled?: boolean
+      onChange?: ChangeEventHandler<HTMLSelectElement>
+      defaultRole?: string
+    }
 
     const SelectRole = (props: SelectRoleProps) => {
-      const { fieldName, isDisabled = false, onChange, defaultRole } = props;
-      const { organization } = useOrganization();
-      const [fetchedRoles, setRoles] = useState<OrganizationCustomRoleKey[]>([]);
-      const isPopulated = useRef(false);
+      const { fieldName, isDisabled = false, onChange, defaultRole } = props
+      const { organization } = useOrganization()
+      const [fetchedRoles, setRoles] = useState<OrganizationCustomRoleKey[]>([])
+      const isPopulated = useRef(false)
 
       useEffect(() => {
-        if (isPopulated.current) return;
+        if (isPopulated.current) return
         organization
           ?.getRoles({
             pageSize: 20,
             initialPage: 1,
           })
           .then((res) => {
-            isPopulated.current = true;
-            setRoles(
-              res.data.map((roles) => roles.key as OrganizationCustomRoleKey)
-            );
-          });
-      }, [organization?.id]);
+            isPopulated.current = true
+            setRoles(res.data.map((roles) => roles.key as OrganizationCustomRoleKey))
+          })
+      }, [organization?.id])
 
-      if (fetchedRoles.length === 0) return null;
+      if (fetchedRoles.length === 0) return null
 
       return (
         <select
@@ -154,8 +151,8 @@ This guide will demonstrate how to use Clerk's API to build a custom flow for ma
             </option>
           ))}
         </select>
-      );
-    };
+      )
+    }
     ```
   </Tab>
 

--- a/docs/organizations/updating-organizations.mdx
+++ b/docs/organizations/updating-organizations.mdx
@@ -20,36 +20,36 @@ This guide will demonstrate how to use Clerk's API to build a custom flow for up
 
     This example is written for Next.js App Router but can be adapted for any React meta framework, such as Remix or Gatsby.
 
-    ```jsx {{ prettier: false, filename: 'app/components/UpdateOrganization.tsx' }}
-    'use client';
+    ```tsx {{ filename: 'app/components/UpdateOrganization.tsx' }}
+    'use client'
 
-    import { useState, useEffect } from 'react';
-    import { useRouter } from 'next/navigation';
-    import { useOrganization } from '@clerk/nextjs';
+    import { useState, useEffect } from 'react'
+    import { useRouter } from 'next/navigation'
+    import { useOrganization } from '@clerk/nextjs'
 
     export default function UpdateOrganization() {
-      const [name, setName] = useState('');
-      const router = useRouter();
-      const { organization } = useOrganization();
+      const [name, setName] = useState('')
+      const router = useRouter()
+      const { organization } = useOrganization()
 
       useEffect(() => {
         if (!organization) {
-          return;
+          return
         }
-        setName(organization.name);
-      }, [organization]);
+        setName(organization.name)
+      }, [organization])
 
       if (!organization) {
-        return null;
+        return null
       }
 
       async function submit(e: React.FormEvent<HTMLFormElement>) {
-        e.preventDefault();
+        e.preventDefault()
         try {
-          await organization?.update({ name });
-          router.push(`/organizations/${organization?.id}`);
+          await organization?.update({ name })
+          router.push(`/organizations/${organization?.id}`)
         } catch (err) {
-          console.error(err);
+          console.error(err)
         }
       }
 
@@ -59,17 +59,12 @@ This guide will demonstrate how to use Clerk's API to build a custom flow for up
           <form onSubmit={submit}>
             <div>
               <label htmlFor="name">Name</label>
-              <input
-                id="name"
-                name="name"
-                value={name}
-                onChange={(e) => setName(e.target.value)}
-              />
+              <input id="name" name="name" value={name} onChange={(e) => setName(e.target.value)} />
             </div>
             <button>Update</button>
           </form>
         </div>
-      );
+      )
     }
     ```
   </Tab>

--- a/docs/testing/test-emails-and-phones.mdx
+++ b/docs/testing/test-emails-and-phones.mdx
@@ -79,33 +79,32 @@ Testing email links in E2E suites is an uphill task. We recommend turning on [em
 
 ### Testing sign in via email code
 
-```jsx {{ prettier: false }}
+```tsx
 const testSignInWithEmailCode = async () => {
-  const { signIn } = useSignIn();
+  const { signIn } = useSignIn()
 
-  const emailAddress = "john+clerk_test@example.com";
-  const signInResp = await signIn.create({ identifier: emailAddress });
+  const emailAddress = 'john+clerk_test@example.com'
+  const signInResp = await signIn.create({ identifier: emailAddress })
   const { emailAddressId } = signInResp.supportedFirstFactors.find(
-    (ff) =>
-      ff.strategy === "email_code" && ff.safeIdentifier === emailAddress
-  )! as EmailCodeFactor;
+    (ff) => ff.strategy === 'email_code' && ff.safeIdentifier === emailAddress,
+  )! as EmailCodeFactor
 
   await signIn.prepareFirstFactor({
-    strategy: "email_code",
+    strategy: 'email_code',
     emailAddressId: emailAddressId,
-  });
+  })
 
   const attemptResponse = await signIn.attemptFirstFactor({
-    strategy: "email_code",
-    code: "424242",
-  });
+    strategy: 'email_code',
+    code: '424242',
+  })
 
-  if (attemptResponse.status == "complete") {
-    console.log("success");
+  if (attemptResponse.status == 'complete') {
+    console.log('success')
   } else {
-    console.log("error");
+    console.log('error')
   }
-};
+}
 ```
 
 ### Testing sign up with phone number

--- a/docs/upgrade-guides/core-2/backend.mdx
+++ b/docs/upgrade-guides/core-2/backend.mdx
@@ -716,7 +716,7 @@ As part of this major version, a number of previously deprecated props, arugment
 
     To support the existing roles `admin`, `basic_member`, and `guest_member` apply interface merging using the following snippet:
 
-    ```js {{ prettier: false }}
+    ```ts
     interface ClerkAuthorization {
       permission: ''
       role: 'admin' | 'basic_member' | 'guest_member'

--- a/docs/users/metadata.mdx
+++ b/docs/users/metadata.mdx
@@ -76,7 +76,7 @@ Private metadata is only accessible by the backend, which makes this useful for 
   </Tab>
 
   <Tab>
-    ```ts {{ prettier: false, filename: 'private.go' }}
+    ```go {{ filename: 'private.go' }}
     var client clerk.Client
 
     func addStripeCustomerID(user *clerk.User, stripeCustomerID string) error {
@@ -95,7 +95,7 @@ Private metadata is only accessible by the backend, which makes this useful for 
   </Tab>
 
   <Tab>
-    ```ts {{ prettier: false, filename: 'private.rb' }}
+    ```ruby {{ filename: 'private.rb' }}
     // ruby json example with a private metadata and stripe id
     require 'clerk'
     require 'json'
@@ -176,7 +176,7 @@ You can retrieve the private metadata for a user by using the [`getUser`](/docs/
   </Tab>
 
   <Tab>
-    ```ts {{ prettier: false, filename: 'private.go' }}
+    ```go {{ filename: 'private.go' }}
     var client clerk.Client
 
     func GetUserMetadata(user *clerk.User, stripeCustomerID string) error {
@@ -190,7 +190,7 @@ You can retrieve the private metadata for a user by using the [`getUser`](/docs/
   </Tab>
 
   <Tab>
-    ```ts {{ prettier: false, filename: 'private.rb' }}
+    ```ruby {{ filename: 'private.rb' }}
     // ruby json example with a private metadata and stripe id
     require 'clerk'
     clerk = Clerk::SDK.new(api_key: "your_clerk_secret_key")
@@ -261,7 +261,7 @@ Public metadata is accessible by both the frontend and the backend. This is usef
   </Tab>
 
   <Tab>
-    ```ts {{ prettier: false, filename: 'public.go' }}
+    ```go {{ filename: 'public.go' }}
     var client clerk.Client
 
     func addStripeCustomerID(user *clerk.User, role string) error {
@@ -280,7 +280,7 @@ Public metadata is accessible by both the frontend and the backend. This is usef
   </Tab>
 
   <Tab>
-    ```ts {{ prettier: false, filename: 'public.rb' }}
+    ```ruby {{ filename: 'public.rb' }}
     // ruby json example with a private metadata and stripe id
     require 'clerk'
     require 'json'
@@ -381,7 +381,7 @@ Updating this value overrides the previous value; it does not merge. To perform 
   </Tab>
 
   <Tab>
-    ```ts {{ prettier: false, filename: 'private.go' }}
+    ```go {{ filename: 'private.go' }}
     var client clerk.Client
 
     func addStripeCustomerID(user *clerk.User, stripeCustomerID string) error {
@@ -400,7 +400,7 @@ Updating this value overrides the previous value; it does not merge. To perform 
   </Tab>
 
   <Tab>
-    ```ts {{ prettier: false, filename: 'private.rb' }}
+    ```ruby {{ filename: 'private.rb' }}
     // ruby json example with a private metadata and stripe id
     require 'clerk'
     require 'json'

--- a/docs/users/web3.mdx
+++ b/docs/users/web3.mdx
@@ -64,37 +64,32 @@ export default function Home() {
 
 A new Next.js app using Pages Router comes with a sample API route in `/pages/api/hello.js`. Let's modify it to retrieve the user's Web3 address:
 
-```jsx {{ prettier: false, filename: 'pages/api/hello.ts' }}
-import type { NextApiRequest, NextApiResponse } from "next";
-import { getAuth } from "@clerk/nextjs/server";
-import { clerkClient } from "@clerk/nextjs";
+```ts {{ filename: 'pages/api/hello.ts' }}
+import type { NextApiRequest, NextApiResponse } from 'next'
+import { getAuth } from '@clerk/nextjs/server'
+import { clerkClient } from '@clerk/nextjs'
 
-export default async function handler(
-  req: NextApiRequest,
-  res: NextApiResponse
-) {
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
   try {
-    const { userId } = getAuth(req);
+    const { userId } = getAuth(req)
 
     if (!userId) {
-      return res.status(401).json({ error: "Unauthorized" });
+      return res.status(401).json({ error: 'Unauthorized' })
     }
 
-    const user = userId ? await clerkClient.users.getUser(userId) : null;
+    const user = userId ? await clerkClient.users.getUser(userId) : null
 
     // Retrieve the user's web3Wallet
-    const walletId = user ? user.primaryWeb3WalletId : null;
-    const address = user
-      ? user.web3Wallets.find((wallet) => wallet.id === walletId)
-      : null;
+    const walletId = user ? user.primaryWeb3WalletId : null
+    const address = user ? user.web3Wallets.find((wallet) => wallet.id === walletId) : null
 
-    res.status(200).json({ address: address });
+    res.status(200).json({ address: address })
   } catch (e) {
-    console.log(e);
+    console.log(e)
 
     res.status(500).json({
-      error: "Something went wrong retrieving the web3wallet from Clerk",
-    });
+      error: 'Something went wrong retrieving the web3wallet from Clerk',
+    })
   }
 }
 ```


### PR DESCRIPTION
This PR removes `prettier: false` from some code blocks by first fixing errors, specifically:

- **Incorrect language.** For example some code blocks were set to `js(x)` but contain TS syntax so should be `ts(x)`
- **Syntax errors.** For example missing closing JSX tags