### PR TITLE
docs: add step to custom sign up pages and routes about adding routes to be ignored by middleware

### DIFF
--- a/docs/references/nextjs/custom-signup-signin-pages.mdx
+++ b/docs/references/nextjs/custom-signup-signin-pages.mdx
@@ -62,9 +62,15 @@ If Clerk's prebuilt components don't meet your specific needs or if you require 
     ```
   </CodeBlockTabs>
 
-  ### Add custom /sign-in and /sign-up routes to middleware
+  ### Make the sign-up and sign-in routes public
 
-  `clerkMiddleware()` does not explicitly make `/sign-in` and `/sign-up` routes public, so we need to be sure they will be public for people to access the custom routes to sign in and sign up. In your `middleware.ts` file, update the following code to explicitly allow the `sign-in` and `sign-up` pages to be public. This will allow users to access the custom sign-in and sign-up pages, while still protecting the rest of your application's routes.
+  By default, `clerkMiddleware()` makes all routes public. This step is specifically for Next.js applications that have configured `clerkMiddleware()` to make [all routes protected](/docs/references/nextjs/clerk-middleware#protect-all-routes). If you have not configured `clerkMiddleware()` to protect all routes, you can skip this step.
+
+  To make the sign-up and sign-in routes public:
+
+  - Navigate to your `middleware.ts` file.
+  - Create a new [route matcher](/docs/references/nextjs/clerk-middleware#create-route-matcher) that matches the sign-up and sign-in routes.
+  - Create a check to see if the current route is a public route. If it is not a public route, use [`auth().protect()`](/docs/references/nextjs/auth#protect) to protect the route.
 
   ```tsx {{ prettier: false, filename: 'middleware.ts' }}
   import { clerkMiddleware } from "@clerk/nextjs/server";

--- a/docs/references/nextjs/custom-signup-signin-pages.mdx
+++ b/docs/references/nextjs/custom-signup-signin-pages.mdx
@@ -62,6 +62,22 @@ If Clerk's prebuilt components don't meet your specific needs or if you require 
     ```
   </CodeBlockTabs>
 
+  ### Add custom routes to middleware
+
+  `clerkMiddleware()` does not make routes public by default, so we need to make them public for people to access the custom routes to sign in and sign up. In your `middleware.ts` file, update the following code to allow the `sign-in` and `sign-up` pages to be public.
+
+  ```tsx {{ prettier: false, filename: 'middleware.ts' }}
+  import { clerkMiddleware } from "@clerk/nextjs/server";
+
+  const isPublicRoute = createRouteMatcher(["/signin(.*)", "/signup(.*)"]);
+
+  export default clerkMiddleware((auth, request) => {
+    if (!isPublicRoute(request)) {
+      auth().protect();
+    }
+  });
+  ```
+
   ### Update your environment variables
 
   In the previous steps, a `path` prop is passed to the `<SignIn />` and `<SignUp />` components. This is because the components need to know which route they are originally mounted on.

--- a/docs/references/nextjs/custom-signup-signin-pages.mdx
+++ b/docs/references/nextjs/custom-signup-signin-pages.mdx
@@ -62,9 +62,9 @@ If Clerk's prebuilt components don't meet your specific needs or if you require 
     ```
   </CodeBlockTabs>
 
-  ### Add custom routes to middleware
+  ### Add custom /sign-in and /sign-up routes to middleware
 
-  `clerkMiddleware()` does not make routes public by default, so we need to make them public for people to access the custom routes to sign in and sign up. In your `middleware.ts` file, update the following code to allow the `sign-in` and `sign-up` pages to be public.
+  `clerkMiddleware()` does not explicitly make `/sign-in` and `/sign-up` routes public, so we need to be sure they will be public for people to access the custom routes to sign in and sign up. In your `middleware.ts` file, update the following code to explicitly allow the `sign-in` and `sign-up` pages to be public. This will allow users to access the custom sign-in and sign-up pages, while still protecting the rest of your application's routes.
 
   ```tsx {{ prettier: false, filename: 'middleware.ts' }}
   import { clerkMiddleware } from "@clerk/nextjs/server";


### PR DESCRIPTION
<!--- Add the "deploy-preview" label and add your page previews here -->

> [!IMPORTANT]
> 🔎 Previews:
>
> - https://clerk.com/docs/pr/1412

<!--- Describe your changes in detail. Why does this change need to happen? Include any links to Slack discussions, Linear comments, etc. -->

### Explanation:

`clerkMiddleware()` does not make routes public, so if a customer is making most/all routes private they can mistakenly make the sign in and up routes private. Customers following this guide and then making all/most routes public run into private auth routes.

<!--- How does this PR solve the problem? -->

### This PR:

- Adds step to custom sign up pages and routes about adding routes to be ignored by middleware
