### PR TITLE
Update TypeScript function definitions

### DIFF
--- a/docs/references/backend/allowlist/create-allowlist-identifier.mdx
+++ b/docs/references/backend/allowlist/create-allowlist-identifier.mdx
@@ -9,8 +9,10 @@ description: Use Clerk's Backend SDK to add a new identifier to the allowlist.
 
 Adds a new identifier to the allowlist.
 
-```tsx {{ prettier: false }}
-function createAllowlistIdentifier: (params: AllowlistIdentifierCreateParams) => Promise<AllowlistIdentifier>;
+```ts
+function createAllowlistIdentifier(
+  params: AllowlistIdentifierCreateParams,
+): Promise<AllowlistIdentifier>
 ```
 
 ## `AllowlistIdentifierCreateParams`

--- a/docs/references/backend/allowlist/delete-allowlist-identifier.mdx
+++ b/docs/references/backend/allowlist/delete-allowlist-identifier.mdx
@@ -9,8 +9,8 @@ description: Use Clerk's Backend SDK to delete an allowlist identifier.
 
 Deletes an [`AllowlistIdentifier`](/docs/references/backend/types/backend-allowlist-identifier).
 
-```tsx {{ prettier: false }}
-function deleteAllowlistIdentifier: (allowlistIdentifierId: string) => Promise<AllowlistIdentifier>;
+```ts
+function deleteAllowlistIdentifier(allowlistIdentifierId: string): Promise<AllowlistIdentifier>
 ```
 
 ## Parameters

--- a/docs/references/backend/allowlist/get-allowlist-identifier-list.mdx
+++ b/docs/references/backend/allowlist/get-allowlist-identifier-list.mdx
@@ -9,8 +9,8 @@ description: Use Clerk's Backend SDK to retrieve a list of allowlist identifiers
 
 Retrieves the list of all allowlist identifiers.
 
-```tsx {{ prettier: false }}
-function getAllowlistIdentifierList: () => Promise<PaginatedResourceResponse<AllowlistIdentifier[]>>;
+```ts
+function getAllowlistIdentifierList(): Promise<PaginatedResourceResponse<AllowlistIdentifier[]>>
 ```
 
 ## Example

--- a/docs/references/backend/authenticate-request.mdx
+++ b/docs/references/backend/authenticate-request.mdx
@@ -9,8 +9,11 @@ description: Use Clerk's Backend SDK to verify a token passed from the frontend.
 
 Authenticates a token passed from the frontend. Networkless if the `jwtKey` is provided. Otherwise, performs a network call to retrieve the JWKS from [Clerk's Backend API](/docs/reference/backend-api/tag/JWKS#operation/GetJWKS).
 
-```tsx {{ prettier: false }}
-function authenticateRequest: (request: Request, options: AuthenticateRequestOptions) => Promise<RequestState>;
+```ts
+function authenticateRequest(
+  request: Request,
+  options: AuthenticateRequestOptions,
+): Promise<RequestState>
 ```
 
 ## Parameters

--- a/docs/references/backend/client/get-client.mdx
+++ b/docs/references/backend/client/get-client.mdx
@@ -9,8 +9,8 @@ description: Use Clerk's Backend SDK to retrieve a single client by its ID.
 
 Retrieves a single [`Client`](/docs/references/javascript/client).
 
-```tsx {{ prettier: false }}
-function getClient: (clientId: string) => Promise<Client>;
+```ts
+function getClient(clientId: string): Promise<Client>
 ```
 
 ## Parameters

--- a/docs/references/backend/client/verify-client.mdx
+++ b/docs/references/backend/client/verify-client.mdx
@@ -9,8 +9,8 @@ description: Use Clerk's Backend SDK to retrieve a client for a given session to
 
 Verifies the [`Client`](/docs/references/javascript/client) in the provided token.
 
-```tsx {{ prettier: false }}
-function verifyClient: (token: string) => Promise<Client>;
+```ts
+function verifyClient(token: string): Promise<Client>
 ```
 
 ## Parameters

--- a/docs/references/backend/domains/delete-domain.mdx
+++ b/docs/references/backend/domains/delete-domain.mdx
@@ -7,8 +7,8 @@ description: Use Clerk's Backend SDK to delete a satellite domain for the instan
 
 Deletes a satellite domain for the instance. It is currently not possible to delete the instance's primary domain.
 
-```tsx {{ prettier: false }}
-function deleteDomain: (id: string) => Promise<User>;
+```ts
+function deleteDomain(id: string): Promise<User>
 ```
 
 ## Parameters

--- a/docs/references/backend/email-addresses/create-email-address.mdx
+++ b/docs/references/backend/email-addresses/create-email-address.mdx
@@ -9,8 +9,8 @@ description: Use Clerk's Backend SDK to create an email address for the specifie
 
 Creates an [`EmailAddress`](/docs/references/javascript/email-address) for the specified user.
 
-```tsx {{ prettier: false }}
-function createEmailAddress: (params: CreateEmailAddressParams) => Promise<EmailAddress>;
+```ts
+function createEmailAddress(params: CreateEmailAddressParams): Promise<EmailAddress>
 ```
 
 ## `CreateEmailAddressParams`

--- a/docs/references/backend/email-addresses/delete-email-address.mdx
+++ b/docs/references/backend/email-addresses/delete-email-address.mdx
@@ -9,8 +9,8 @@ description: Use Clerk's Backend SDK to delete an email address.
 
 Deletes an [`EmailAddress`](/docs/references/javascript/email-address).
 
-```tsx {{ prettier: false }}
-function deleteEmailAddress: (emailAddressId: string) => Promise<EmailAddress>;
+```ts
+function deleteEmailAddress(emailAddressId: string): Promise<EmailAddress>
 ```
 
 ## Parameters

--- a/docs/references/backend/email-addresses/get-email-address.mdx
+++ b/docs/references/backend/email-addresses/get-email-address.mdx
@@ -9,8 +9,8 @@ description: Use Clerk's Backend SDK to retrieve a single email address by its I
 
 Retrieves a single [`EmailAddress`](/docs/references/javascript/email-address).
 
-```tsx {{ prettier: false }}
-function getEmailAddress: (emailAddressId: string) => Promise<EmailAddress>;
+```ts
+function getEmailAddress(emailAddressId: string): Promise<EmailAddress>
 ```
 
 ## Parameters

--- a/docs/references/backend/email-addresses/update-email-address.mdx
+++ b/docs/references/backend/email-addresses/update-email-address.mdx
@@ -9,8 +9,11 @@ description: Use Clerk's Backend SDK to update an email address.
 
 Updates an [`EmailAddress`](/docs/references/javascript/email-address).
 
-```tsx {{ prettier: false }}
-function updateEmailAddress: (emailAddressId: string, params: UpdateEmailAddressParams) => Promise<EmailAddress>;
+```ts
+function updateEmailAddress(
+  emailAddressId: string,
+  params: UpdateEmailAddressParams,
+): Promise<EmailAddress>
 ```
 
 ## `UpdateEmailAddressParams`

--- a/docs/references/backend/invitations/create-invitation.mdx
+++ b/docs/references/backend/invitations/create-invitation.mdx
@@ -11,8 +11,8 @@ Creates a new [`Invitation`](/docs/references/backend/types/backend-invitation) 
 
 If an email address has already been invited or already exists in your application, trying to create a new invitation will return an error. To bypass this error and create a new invitation anyways, set `ignoreExisting` to `true`.
 
-```tsx {{ prettier: false }}
-function createInvitation: (params: CreateParams) => Promise<Invitation>;
+```ts
+function createInvitation(params: CreateParams): Promise<Invitation>
 ```
 
 ## `CreateParams`

--- a/docs/references/backend/invitations/get-invitation-list.mdx
+++ b/docs/references/backend/invitations/get-invitation-list.mdx
@@ -9,8 +9,10 @@ description: Use Clerk's Backend SDK to retrieve a list of non-revoked invitatio
 
 Retrieves a list of non-revoked invitations for your application, sorted by descending creation date.
 
-```tsx {{ prettier: false }}
-function getInvitationList: (params: GetInvitationListParams) => Promise<PaginatedResourceResponse<Invitation[]>>;
+```ts
+function getInvitationList(
+  params: GetInvitationListParams,
+): Promise<PaginatedResourceResponse<Invitation[]>>
 ```
 
 ## `GetInvitationListParams`

--- a/docs/references/backend/invitations/revoke-invitation.mdx
+++ b/docs/references/backend/invitations/revoke-invitation.mdx
@@ -13,8 +13,8 @@ Revoking an invitation makes the invitation email link unusable. However, it doe
 
 Only active (i.e. non-revoked) invitations can be revoked.
 
-```tsx {{ prettier: false }}
-function revokeInvitation: (invitationId: string) => Promise<Invitation>;
+```ts
+function revokeInvitation(invitationId: string): Promise<Invitation>
 ```
 
 ## Parameters

--- a/docs/references/backend/organization/create-organization-invitation.mdx
+++ b/docs/references/backend/organization/create-organization-invitation.mdx
@@ -9,8 +9,10 @@ description: Use Clerk's Backend SDK to create an invitation for new users to jo
 
 Creates an [`OrganizationInvitation`](/docs/references/backend/types/backend-organization-invitation) for new users to join an organization.
 
-```tsx {{ prettier: false }}
-function createOrganizationInvitation: (params: CreateOrganizationInvitationParams) => Promise<OrganizationInvitation>;
+```ts
+function createOrganizationInvitation(
+  params: CreateOrganizationInvitationParams,
+): Promise<OrganizationInvitation>
 ```
 
 ## `CreateOrganizationInvitationParams`

--- a/docs/references/backend/organization/create-organization-membership.mdx
+++ b/docs/references/backend/organization/create-organization-membership.mdx
@@ -9,8 +9,10 @@ description: Use Clerk's Backend SDK to create a membership to an organization f
 
 Creates a membership to an organization for a user directly (circumventing the need for an invitation).
 
-```tsx {{ prettier: false }}
-function createOrganizationMembership: (params: CreateOrganizationMembershipParams) => Promise<OrganizationMembership>;
+```ts
+function createOrganizationMembership(
+  params: CreateOrganizationMembershipParams,
+): Promise<OrganizationMembership>
 ```
 
 ## `CreateOrganizationMembershipParams`

--- a/docs/references/backend/organization/create-organization.mdx
+++ b/docs/references/backend/organization/create-organization.mdx
@@ -9,8 +9,8 @@ description: Use Clerk's Backend SDK to create an organization.
 
 Creates an [`Organization`](/docs/references/backend/types/backend-organization).
 
-```tsx {{ prettier: false }}
-function createOrganization: (params: CreateParams) => Promise<Organization>;
+```ts
+function createOrganization(params: CreateParams): Promise<Organization>
 ```
 
 ## `CreateParams`

--- a/docs/references/backend/organization/delete-organization-logo.mdx
+++ b/docs/references/backend/organization/delete-organization-logo.mdx
@@ -7,8 +7,8 @@ description: Use Clerk's Backend SDK to delete an organization's logo.
 
 Deletes an organization's logo.
 
-```tsx {{ prettier: false }}
-function deleteOrganizationLogo: (organizationId: string) => Promise<Organization>;
+```ts
+function deleteOrganizationLogo(organizationId: string): Promise<Organization>
 ```
 
 ## Parameters

--- a/docs/references/backend/organization/delete-organization-membership.mdx
+++ b/docs/references/backend/organization/delete-organization-membership.mdx
@@ -9,8 +9,10 @@ description: Use Clerk's Backend SDK to remove a user from the specified organiz
 
 Removes a user from the specified organization.
 
-```tsx {{ prettier: false }}
-function getOrganizationList: (params: DeleteOrganizationMembershipParams) => Promise<OrganizationMembership>;
+```ts
+function getOrganizationList(
+  params: DeleteOrganizationMembershipParams,
+): Promise<OrganizationMembership>
 ```
 
 ## `DeleteOrganizationMembershipParams`

--- a/docs/references/backend/organization/delete-organization.mdx
+++ b/docs/references/backend/organization/delete-organization.mdx
@@ -9,8 +9,8 @@ description: Use Clerk's Backend SDK to delete an organization.
 
 Deletes an [`Organization`](/docs/references/backend/types/backend-organization)
 
-```tsx {{ prettier: false }}
-function deleteOrganization: (organizationId: string) => Promise<Organization>;
+```ts
+function deleteOrganization(organizationId: string): Promise<Organization>
 ```
 
 ## Parameters

--- a/docs/references/backend/organization/get-organization-invitation-list.mdx
+++ b/docs/references/backend/organization/get-organization-invitation-list.mdx
@@ -9,8 +9,10 @@ description: Use Clerk's Backend SDK to retrieve a list of organization invitati
 
 Retrieves a list of organization invitations.
 
-```tsx {{ prettier: false }}
-function getOrganizationInvitationList: (params: GetOrganizationInvitationListParams) => Promise<PaginatedResourceResponse<OrganizationInvitation[]>>;
+```ts
+function getOrganizationInvitationList(
+  params: GetOrganizationInvitationListParams,
+): Promise<PaginatedResourceResponse<OrganizationInvitation[]>>
 ```
 
 ## `GetOrganizationInvitationListParams`

--- a/docs/references/backend/organization/get-organization-invitation.mdx
+++ b/docs/references/backend/organization/get-organization-invitation.mdx
@@ -9,8 +9,10 @@ description: Use Clerk's Backend SDK to retrieve an organization invitation.
 
 Retrieves an [`OrganizationInvitation`](/docs/references/backend/types/backend-organization-invitation).
 
-```tsx {{ prettier: false }}
-function getOrganizationInvitation: (params: GetOrganizationInvitationParams) => Promise<OrganizationInvitation>;
+```ts
+function getOrganizationInvitation(
+  params: GetOrganizationInvitationParams,
+): Promise<OrganizationInvitation>
 ```
 
 ## `GetOrganizationInvitationParams`

--- a/docs/references/backend/organization/get-organization-list.mdx
+++ b/docs/references/backend/organization/get-organization-list.mdx
@@ -9,8 +9,10 @@ description: Use Clerk's Backend SDK to retrieve a list of organizations.
 
 Retrieves a list of organizations.
 
-```tsx {{ prettier: false }}
-function getOrganizationList: (params: GetOrganizationListParams) => Promise<PaginatedResourceResponse<Organization[]>>;
+```ts
+function getOrganizationList(
+  params: GetOrganizationListParams,
+): Promise<PaginatedResourceResponse<Organization[]>>
 ```
 
 ## `GetOrganizationListParams`

--- a/docs/references/backend/organization/get-organization-membership-list.mdx
+++ b/docs/references/backend/organization/get-organization-membership-list.mdx
@@ -9,8 +9,10 @@ description: Use Clerk's Backend SDK to retrieve a list of memberships for an or
 
 Retrieves a list of memberships for an organization.
 
-```tsx {{ prettier: false }}
-function getOrganizationMembershipList: (params: GetOrganizationMembershipListParams) => Promise<PaginatedResourceResponse<OrganizationMembership[]>>;
+```ts
+function getOrganizationMembershipList(
+  params: GetOrganizationMembershipListParams,
+): Promise<PaginatedResourceResponse<OrganizationMembership[]>>
 ```
 
 ## `GetOrganizationMembershipListParams`

--- a/docs/references/backend/organization/get-organization.mdx
+++ b/docs/references/backend/organization/get-organization.mdx
@@ -9,8 +9,8 @@ description: Use Clerk's Backend SDK to retrieve a single organization.
 
 Retrieves a single [`Organization`](/docs/references/backend/types/backend-organization).
 
-```tsx {{ prettier: false }}
-function getOrganization: (params: GetOrganizationParams) => Promise<Organization>;
+```ts
+function getOrganization(params: GetOrganizationParams): Promise<Organization>
 ```
 
 ## `GetOrganizationParams`

--- a/docs/references/backend/organization/revoke-organization-invitation.mdx
+++ b/docs/references/backend/organization/revoke-organization-invitation.mdx
@@ -9,8 +9,10 @@ description: Use Clerk's Backend SDK to revoke an organization invitation from a
 
 Revokes an [`OrganizationInvitation`](/docs/references/backend/types/backend-organization-invitation) from a user for the specified organization.
 
-```tsx {{ prettier: false }}
-function revokeOrganizationInvitation: (params: RevokeOrganizationInvitationParams) => Promise<OrganizationInvitation>;
+```ts
+function revokeOrganizationInvitation(
+  params: RevokeOrganizationInvitationParams,
+): Promise<OrganizationInvitation>
 ```
 
 ## `RevokeOrganizationInvitationParams`

--- a/docs/references/backend/organization/update-organization-logo.mdx
+++ b/docs/references/backend/organization/update-organization-logo.mdx
@@ -9,8 +9,11 @@ description: Use Clerk's Backend SDK to update an organization's logo.
 
 Updates the organization's logo.
 
-```tsx {{ prettier: false }}
-function updateOrganizationLogo: (organizationId: string, params: UpdateLogoParams) => Promise<Organization>;
+```ts
+function updateOrganizationLogo(
+  organizationId: string,
+  params: UpdateLogoParams,
+): Promise<Organization>
 ```
 
 ## `UpdateLogoParams`

--- a/docs/references/backend/organization/update-organization-membership-metadata.mdx
+++ b/docs/references/backend/organization/update-organization-membership-metadata.mdx
@@ -9,8 +9,10 @@ description: Use Clerk's Backend SDK to update the metadata associated with a us
 
 Update the metadata attributes of an [`OrganizationMembership`](/docs/references/backend/types/backend-organization-membership) by merging existing values with the provided parameters. Metadata values will be updated via a "deep" merge - "deep" means that any nested JSON objects will be merged as well. You can remove metadata keys at any level by setting their value to `null`.
 
-```tsx {{ prettier: false }}
-function updateOrganizationMembershipMetadata: (params: UpdateOrganizationMembershipMetadataParams) => Promise<OrganizationMembership>;
+```ts
+function updateOrganizationMembershipMetadata(
+  params: UpdateOrganizationMembershipMetadataParams,
+): Promise<OrganizationMembership>
 ```
 
 ## `UpdateOrganizationMembershipMetadataParams`

--- a/docs/references/backend/organization/update-organization-membership.mdx
+++ b/docs/references/backend/organization/update-organization-membership.mdx
@@ -9,8 +9,10 @@ description: Use Clerk's Backend SDK to update a user's organization membership.
 
 Updates a user's [`OrganizationMembership`](/docs/references/backend/types/backend-organization-membership). Currently, only the role can be updated.
 
-```tsx {{ prettier: false }}
-function updateOrganizationMembership: (params: UpdateOrganizationMembershipParams) => Promise<OrganizationMembership>;
+```ts
+function updateOrganizationMembership(
+  params: UpdateOrganizationMembershipParams,
+): Promise<OrganizationMembership>
 ```
 
 ## `UpdateOrganizationMembershipParams`

--- a/docs/references/backend/organization/update-organization-metadata.mdx
+++ b/docs/references/backend/organization/update-organization-metadata.mdx
@@ -9,8 +9,11 @@ description: Use Clerk's Backend SDK to update the metadata associated with a gi
 
 Updates the metadata attributes of an [`Organization`](/docs/references/backend/types/backend-organization) by merging existing values with the provided parameters. Metadata values will be updated via a "deep" merge - "deep" meaning that any nested JSON objects will be merged as well. You can remove metadata keys at any level by setting their value to `null`.
 
-```tsx {{ prettier: false }}
-function updateOrganizationMetadata: (organizationId: string, params: UpdateOrganizationMetadataParams) => Promise<Organization>;
+```ts
+function updateOrganizationMetadata(
+  organizationId: string,
+  params: UpdateOrganizationMetadataParams,
+): Promise<Organization>
 ```
 
 ## `UpdateOrganizationMetadataParams`

--- a/docs/references/backend/organization/update-organization.mdx
+++ b/docs/references/backend/organization/update-organization.mdx
@@ -7,8 +7,8 @@ description: Use Clerk's Backend SDK to update an organization's name.
 
 Updates an [`Organization`](/docs/references/backend/types/backend-organization).
 
-```tsx {{ prettier: false }}
-function updateOrganization: (params: UpdateOrganizationParams) => Promise<Organization>;
+```ts
+function updateOrganization(params: UpdateOrganizationParams): Promise<Organization>
 ```
 
 ## `UpdateOrganizationParams`

--- a/docs/references/backend/phone-numbers/create-phone-number.mdx
+++ b/docs/references/backend/phone-numbers/create-phone-number.mdx
@@ -9,8 +9,8 @@ description: Use Clerk's Backend SDK to create a phone number for the specified 
 
 Creates a [`PhoneNumber`](/docs/references/javascript/phone-number) for the specified user.
 
-```tsx {{ prettier: false }}
-function createPhoneNumber: (params: CreatePhoneNumberParams) => Promise<PhoneNumber>;
+```ts
+function createPhoneNumber(params: CreatePhoneNumberParams): Promise<PhoneNumber>
 ```
 
 ## `CreatePhoneNumberParams`

--- a/docs/references/backend/phone-numbers/delete-phone-number.mdx
+++ b/docs/references/backend/phone-numbers/delete-phone-number.mdx
@@ -9,8 +9,8 @@ description: Use Clerk's Backend SDK to delete a phone number.
 
 Deletes a [`PhoneNumber`](/docs/references/javascript/phone-number).
 
-```tsx {{ prettier: false }}
-function deletePhoneNumber: (phoneNumberId: string) => Promise<PhoneNumber>;
+```ts
+function deletePhoneNumber(phoneNumberId: string): Promise<PhoneNumber>
 ```
 
 ## Parameters

--- a/docs/references/backend/phone-numbers/get-phone-number.mdx
+++ b/docs/references/backend/phone-numbers/get-phone-number.mdx
@@ -9,8 +9,8 @@ description: Use Clerk's Backend SDK to retrieve a single phone number by its ID
 
 Retrieves a single [`PhoneNumber`](/docs/references/javascript/phone-number).
 
-```tsx {{ prettier: false }}
-function getPhoneNumber: (phoneNumberId: string) => Promise<PhoneNumber>;
+```ts
+function getPhoneNumber(phoneNumberId: string): Promise<PhoneNumber>
 ```
 
 ## Parameters

--- a/docs/references/backend/phone-numbers/update-phone-number.mdx
+++ b/docs/references/backend/phone-numbers/update-phone-number.mdx
@@ -9,8 +9,11 @@ description: Use Clerk's Backend SDK to update a phone number.
 
 Updates a [`PhoneNumber`](/docs/references/javascript/phone-number).
 
-```tsx {{ prettier: false }}
-function updatePhoneNumber: (phoneNumberId: string, params: UpdatePhoneNumberParams) => Promise<PhoneNumber>;
+```ts
+function updatePhoneNumber(
+  phoneNumberId: string,
+  params: UpdatePhoneNumberParams,
+): Promise<PhoneNumber>
 ```
 
 ## `UpdatePhoneNumberParams`

--- a/docs/references/backend/redirect-urls/create-redirect-url.mdx
+++ b/docs/references/backend/redirect-urls/create-redirect-url.mdx
@@ -9,8 +9,8 @@ description: Use Clerk's Backend SDK to create a redirect URL.
 
 Creates a [`RedirectUrl`](/docs/references/backend/types/backend-redirect-url).
 
-```tsx {{ prettier: false }}
-function createRedirectUrl: (params: CreateRedirectUrlParams) => Promise<RedirectUrl>;
+```ts
+function createRedirectUrl(params: CreateRedirectUrlParams): Promise<RedirectUrl>
 ```
 
 ## `CreateRedirectUrlParams`

--- a/docs/references/backend/redirect-urls/delete-redirect-url.mdx
+++ b/docs/references/backend/redirect-urls/delete-redirect-url.mdx
@@ -9,8 +9,8 @@ description: Use Clerk's Backend SDK to delete a redirect URL.
 
 Deletes a [`RedirectUrl`](/docs/references/backend/types/backend-redirect-url).
 
-```tsx {{ prettier: false }}
-function deleteRedirectUrl: (redirectUrlId: string) => Promise<RedirectUrl>;
+```ts
+function deleteRedirectUrl(redirectUrlId: string): Promise<RedirectUrl>
 ```
 
 ## Parameters

--- a/docs/references/backend/redirect-urls/get-redirect-url.mdx
+++ b/docs/references/backend/redirect-urls/get-redirect-url.mdx
@@ -9,8 +9,8 @@ description: Use Clerk's Backend SDK to retrieve a single redirect URL by its ID
 
 Retrieves a single [`RedirectUrl`](/docs/references/backend/types/backend-redirect-url).
 
-```tsx {{ prettier: false }}
-function getRedirectUrl: (redirectUrlId: string) => Promise<RedirectUrl>;
+```ts
+function getRedirectUrl(redirectUrlId: string): Promise<RedirectUrl>
 ```
 
 ## Parameters

--- a/docs/references/backend/saml-connections/create-saml-connection.mdx
+++ b/docs/references/backend/saml-connections/create-saml-connection.mdx
@@ -7,8 +7,8 @@ description: Use Clerk's Backend SDK to create a SAML connection.
 
 Creates a new [`SamlConnection`](/docs/references/backend/types/saml-connection).
 
-```tsx {{ prettier: false }}
-function createSamlConnection: (params: CreateSamlConnectionParams) => Promise<SamlConnection>;
+```ts
+function createSamlConnection(params: CreateSamlConnectionParams): Promise<SamlConnection>
 ```
 
 ## `CreateSamlConnectionParams`

--- a/docs/references/backend/saml-connections/delete-saml-connection.mdx
+++ b/docs/references/backend/saml-connections/delete-saml-connection.mdx
@@ -7,8 +7,8 @@ description: Use Clerk's Backend SDK to delete a SAML connection.
 
 Deletes a [`SamlConnection`](/docs/references/backend/types/saml-connection) by its ID.
 
-```tsx {{ prettier: false }}
-function deleteSamlConnection: (samlConnectionId: string) => Promise<Organization>;
+```ts
+function deleteSamlConnection(samlConnectionId: string): Promise<Organization>
 ```
 
 ## Parameters

--- a/docs/references/backend/saml-connections/get-saml-connection-list.mdx
+++ b/docs/references/backend/saml-connections/get-saml-connection-list.mdx
@@ -7,8 +7,8 @@ description: Use Clerk's Backend SDK to retrieve the list of SAML connections fo
 
 Retrieves the list of SAML connections for an instance.
 
-```tsx {{ prettier: false }}
-function getSamlConnectionList: (params: SamlConnectionListParams = {}) => Promise<SamlConnection[]>;
+```ts
+function getSamlConnectionList(params: SamlConnectionListParams = {}): Promise<SamlConnection[]>
 ```
 
 ## `SamlConnectionListParams`

--- a/docs/references/backend/saml-connections/get-saml-connection.mdx
+++ b/docs/references/backend/saml-connections/get-saml-connection.mdx
@@ -7,8 +7,8 @@ description: Use Clerk's Backend SDK to retrieve a SAML connection.
 
 Retrieves a [`SamlConnection`](/docs/references/backend/types/saml-connection) by its ID.
 
-```tsx {{ prettier: false }}
-function getSamlConnection: (samlConnectionId: string) => Promise<SamlConnection>;
+```ts
+function getSamlConnection(samlConnectionId: string): Promise<SamlConnection>
 ```
 
 ## `GetOrganizationParams`

--- a/docs/references/backend/saml-connections/update-saml-connection.mdx
+++ b/docs/references/backend/saml-connections/update-saml-connection.mdx
@@ -7,8 +7,11 @@ description: Use Clerk's Backend SDK to update a SAML connection.
 
 Updates a [`SamlConnection`](/docs/references/backend/types/saml-connection) by its ID.
 
-```tsx {{ prettier: false }}
-function updateSamlConnection: (samlConnectionId: string, params: UpdateSamlConnectionParams = {}) => Promise<Organization>;
+```ts
+function updateSamlConnection(
+  samlConnectionId: string,
+  params: UpdateSamlConnectionParams = {},
+): Promise<Organization>
 ```
 
 ## `UpdateSamlConnectionParams`

--- a/docs/references/backend/sessions/get-session-list.mdx
+++ b/docs/references/backend/sessions/get-session-list.mdx
@@ -9,8 +9,10 @@ description: Use Clerk's Backend SDK to retrieve a list of sessions.
 
 Retrieves a list of sessions.
 
-```tsx {{ prettier: false }}
-function getSessionList: (queryParams: SessionListParams) => Promise<PaginatedResourceResponse<Session[]>>;
+```ts
+function getSessionList(
+  queryParams: SessionListParams,
+): Promise<PaginatedResourceResponse<Session[]>>
 ```
 
 ## `SessionListParams`

--- a/docs/references/backend/sessions/get-session.mdx
+++ b/docs/references/backend/sessions/get-session.mdx
@@ -9,8 +9,8 @@ description: Use Clerk's Backend SDK to retrieve a single session by its ID.
 
 Retrieves a single [`Session`](/docs/references/backend/types/backend-session).
 
-```tsx {{ prettier: false }}
-function getSession: (sessionId: string) => Promise<Session>;
+```ts
+function getSession(sessionId: string): Promise<Session>
 ```
 
 ## Parameters

--- a/docs/references/backend/sessions/get-token.mdx
+++ b/docs/references/backend/sessions/get-token.mdx
@@ -9,8 +9,8 @@ description: Use Clerk's Backend SDK to retrieve a token for a JWT Template that
 
 Retrieves a token for a JWT Template that is defined in the Clerk Dashboard on the **[JWT Templates](https://dashboard.clerk.com/last-active?path=jwt-templates)** page.
 
-```js {{ prettier: false }}
-function getToken: (sessionId: string, template: string) => Promise<Token>;
+```ts
+function getToken(sessionId: string, template: string): Promise<Token>
 ```
 
 ## Parameters

--- a/docs/references/backend/sessions/revoke-session.mdx
+++ b/docs/references/backend/sessions/revoke-session.mdx
@@ -11,8 +11,8 @@ Revokes a [`Session`](/docs/references/backend/types/backend-session).
 
 User will be signed out from the particular client the referred to.
 
-```tsx {{ prettier: false }}
-function revokeSession: (sessionId: string) => Promise<Session>;
+```ts
+function revokeSession(sessionId: string): Promise<Session>
 ```
 
 ## Parameters

--- a/docs/references/backend/sign-in-tokens/create-sign-in-token.mdx
+++ b/docs/references/backend/sign-in-tokens/create-sign-in-token.mdx
@@ -7,8 +7,8 @@ description: Use Clerk's Backend SDK to create a new sign-in token for a given u
 
 Creates a new sign-in token and associates it with the given user. By default, sign-in tokens expire in 30 days. You can optionally supply a different duration in seconds using the `expires_in_seconds` property.
 
-```tsx {{ prettier: false }}
-function createSignInToken: (params: CreateSignInTokensParams) => Promise<SignInToken>;
+```ts
+function createSignInToken(params: CreateSignInTokensParams): Promise<SignInToken>
 ```
 
 ## `CreateSignInTokenParams`

--- a/docs/references/backend/sign-in-tokens/revoke-sign-in-token.mdx
+++ b/docs/references/backend/sign-in-tokens/revoke-sign-in-token.mdx
@@ -7,8 +7,8 @@ description: Use Clerk's Backend SDK to revoke a pending sign-in token.
 
 Revokes a pending sign-in token.
 
-```tsx {{ prettier: false }}
-function revokeSignInToken: (signInTokenId: string) => Promise<SignInToken>;
+```ts
+function revokeSignInToken(signInTokenId: string): Promise<SignInToken>
 ```
 
 ## Parameters

--- a/docs/references/backend/testing-tokens/create-testing-token.mdx
+++ b/docs/references/backend/testing-tokens/create-testing-token.mdx
@@ -7,8 +7,8 @@ description: Use Clerk's Backend SDK to create a testing token for the instance.
 
 Creates a Testing Token for the instance. **It only works on development instances.**
 
-```tsx {{ prettier: false }}
-function createTestingToken: () => Promise<TestingToken>;
+```ts
+function createTestingToken(): Promise<TestingToken>
 ```
 
 ## Example

--- a/docs/references/backend/user/ban-user.mdx
+++ b/docs/references/backend/user/ban-user.mdx
@@ -9,8 +9,8 @@ description: Use Clerk's Backend SDK to mark a given user as banned.
 
 Marks the given [`User`](/docs/references/backend/types/backend-user) as banned, which means that all their sessions are revoked and they are not allowed to sign in again.
 
-```tsx {{ prettier: false }}
-function banUser: (userId: string) => Promise<User>;
+```ts
+function banUser(userId: string): Promise<User>
 ```
 
 ## Parameters

--- a/docs/references/backend/user/create-user.mdx
+++ b/docs/references/backend/user/create-user.mdx
@@ -15,8 +15,8 @@ Any email address and phone number created using this method will be automatical
 
 A rate limit rule of 20 requests per 10 seconds is applied to this endpoint.
 
-```tsx {{ prettier: false }}
-function createUser: (params: CreateUserParams) => Promise<User>;
+```ts
+function createUser(params: CreateUserParams): Promise<User>
 ```
 
 ## `CreateUserParams`

--- a/docs/references/backend/user/delete-user.mdx
+++ b/docs/references/backend/user/delete-user.mdx
@@ -9,8 +9,8 @@ description: Use Clerk's Backend SDK to delete a user.
 
 Deletes a [`User`](/docs/references/backend/types/backend-user) given a valid ID.
 
-```tsx {{ prettier: false }}
-function deleteUser: (userId: string) => Promise<User>;
+```ts
+function deleteUser(userId: string): Promise<User>
 ```
 
 ## Parameters

--- a/docs/references/backend/user/disable-user-mfa.mdx
+++ b/docs/references/backend/user/disable-user-mfa.mdx
@@ -9,8 +9,8 @@ description: Use Clerk's Backend SDK to disable all of a user's MFA methods at o
 
 Disable all of a user's MFA methods (e.g. OTP sent via SMS, TOTP on their authenticator app) at once.
 
-```tsx {{ prettier: false }}
-function disableUserMFA: (userId: string) => Promise<User>;
+```ts
+function disableUserMFA(userId: string): Promise<User>
 ```
 
 ## Parameters

--- a/docs/references/backend/user/get-count.mdx
+++ b/docs/references/backend/user/get-count.mdx
@@ -9,8 +9,8 @@ description: Use Clerk's Backend SDK to retrieve the total number of users.
 
 Retrieves the total number of users.
 
-```tsx {{ prettier: false }}
-function getCount: (params: UserCountParams) => Promise<number>;
+```ts
+function getCount(params: UserCountParams): Promise<number>
 ```
 
 ## `UserCountParams`

--- a/docs/references/backend/user/get-organization-membership-list.mdx
+++ b/docs/references/backend/user/get-organization-membership-list.mdx
@@ -9,8 +9,10 @@ description: Use Clerk's Backend SDK to retrieve a list of organization membersh
 
 Retrieves a list of organization memberships for a given user.
 
-```tsx {{ prettier: false }}
-function getOrganizationMembershipList: (params: GetOrganizationMembershipListParams) => Promise<PaginatedResourceResponse<OrganizationMembership[]>>;
+```ts
+function getOrganizationMembershipList(
+  params: GetOrganizationMembershipListParams,
+): Promise<PaginatedResourceResponse<OrganizationMembership[]>>
 ```
 
 ## `GetOrganizationMembershipListParams`

--- a/docs/references/backend/user/get-user-oauth-access-token.mdx
+++ b/docs/references/backend/user/get-user-oauth-access-token.mdx
@@ -9,8 +9,11 @@ description: Use Clerk's Backend SDK to retrieve the corresponding OAuth access 
 
 Retrieve the corresponding OAuth access token for a user that has previously authenticated with a particular OAuth provider.
 
-```tsx {{ prettier: false }}
-function getUserOauthAccessToken: (userId: string, provider: `oauth_${OAuthProvider}`) => Promise<OauthAccessToken[]>;
+```ts
+function getUserOauthAccessToken(
+  userId: string,
+  provider: `oauth_${OAuthProvider}`,
+): Promise<OauthAccessToken[]>
 ```
 
 ## Parameters

--- a/docs/references/backend/user/get-user.mdx
+++ b/docs/references/backend/user/get-user.mdx
@@ -9,8 +9,8 @@ description: Use Clerk's Backend SDK to retrieve a single user by their ID.
 
 Retrieves a single [`User`](/docs/references/backend/types/backend-user) by their ID, if the ID is valid.
 
-```tsx {{ prettier: false }}
-function getUser: (userId: string) => Promise<User>;
+```ts
+function getUser(userId: string): Promise<User>
 ```
 
 ## Parameters

--- a/docs/references/backend/user/lock-user.mdx
+++ b/docs/references/backend/user/lock-user.mdx
@@ -11,8 +11,8 @@ Marks the given [`User`](/docs/references/backend/types/backend-user) as locked,
 
 By default, lockout duration is 1 hour, but it can be configured in the application's [**Attack Protection**](https://dashboard.clerk.com/last-active?path=user-authentication/attack-protection) settings. For more details, see the [dedicated guide for customizing **Attack Protection** settings](/docs/security/customize-user-lockout).
 
-```tsx {{ prettier: false }}
-function lockUser: (userId: string) => Promise<User>;
+```ts
+function lockUser(userId: string): Promise<User>
 ```
 
 ## Parameters

--- a/docs/references/backend/user/unban-user.mdx
+++ b/docs/references/backend/user/unban-user.mdx
@@ -9,8 +9,8 @@ description: Use Clerk's Backend SDK to remove the ban mark from a user.
 
 Removes the ban mark from the given [`User`](/docs/references/backend/types/backend-user).
 
-```tsx {{ prettier: false }}
-function unbanUser: (userId: string) => Promise<User>;
+```ts
+function unbanUser(userId: string): Promise<User>
 ```
 
 ## Parameters

--- a/docs/references/backend/user/unlock-user.mdx
+++ b/docs/references/backend/user/unlock-user.mdx
@@ -9,8 +9,8 @@ description: Use Clerk's Backend SDK to remove a sign-in lock from a user.
 
 Removes a sign-in lock from the given [`User`](/docs/references/backend/types/backend-user).
 
-```tsx {{ prettier: false }}
-function unlockUser: (userId: string) => Promise<User>;
+```ts
+function unlockUser(userId: string): Promise<User>
 ```
 
 ## Parameters

--- a/docs/references/backend/user/update-user-metadata.mdx
+++ b/docs/references/backend/user/update-user-metadata.mdx
@@ -11,8 +11,8 @@ Updates the metadata associated with the specified user by merging existing valu
 
 A "deep" merge will be performed - "deep" means that any nested JSON objects will be merged as well. You can remove metadata keys at any level by setting their value to `null`.
 
-```tsx {{ prettier: false }}
-function updateUserMetadata: (userId: string, params: UpdateUserMetadataParams) => Promise<User>;
+```ts
+function updateUserMetadata(userId: string, params: UpdateUserMetadataParams): Promise<User>
 ```
 
 ## `UpdateUserMetadataParams`

--- a/docs/references/backend/user/update-user-profile-image.mdx
+++ b/docs/references/backend/user/update-user-profile-image.mdx
@@ -9,8 +9,8 @@ description: Use Clerk's Backend SDK to update a user's profile image.
 
 Updates a user's profile image.
 
-```tsx {{ prettier: false }}
-function updateUserProfileImage: (userId: string, params: { file: Blob | File }) => Promise<User>;
+```ts
+function updateUserProfileImage(userId: string, params: { file: Blob | File }): Promise<User>
 ```
 
 ## Example

--- a/docs/references/backend/user/update-user.mdx
+++ b/docs/references/backend/user/update-user.mdx
@@ -9,8 +9,8 @@ description: Use Clerk's Backend SDK to update a user.
 
 Updates a [`User`](/docs/references/backend/types/backend-user).
 
-```tsx {{ prettier: false }}
-function updateUser: (userId: string, params: UpdateUserParams) => Promise<User>;
+```ts
+function updateUser(userId: string, params: UpdateUserParams): Promise<User>
 ```
 
 ## `UpdateUserParams`

--- a/docs/references/backend/user/verify-password.mdx
+++ b/docs/references/backend/user/verify-password.mdx
@@ -9,8 +9,8 @@ description: Use Clerk's Backend SDK to check that the user's password matches t
 
 Check that the user's password matches the supplied input. Useful for custom auth flows and re-verification.
 
-```tsx {{ prettier: false }}
-function verifyPassword: (params: VerifyPasswordParams) => Promise<{ verified: true }>;
+```ts
+function verifyPassword(params: VerifyPasswordParams): Promise<{ verified: true }>
 ```
 
 ## `VerifyPasswordParams`

--- a/docs/references/backend/user/verify-totp.mdx
+++ b/docs/references/backend/user/verify-totp.mdx
@@ -9,8 +9,8 @@ description: Use Clerk's Backend SDK to verify a TOTP or backup code for a user.
 
 Verify that the provided TOTP or backup code is valid for the user. Verifying a backup code will result it in being consumed (i.e. it will become invalid). Useful for custom auth flows and re-verification.
 
-```tsx {{ prettier: false }}
-function verifyTOTP: (params: VerifyTOTPParams) => Promise<{ verified: true; code_type: 'totp' }>;
+```ts
+function verifyTOTP(params: VerifyTOTPParams): Promise<{ verified: true; code_type: 'totp' }>
 ```
 
 ## `verifyTOTPParams`

--- a/docs/references/backend/verify-token.mdx
+++ b/docs/references/backend/verify-token.mdx
@@ -12,8 +12,11 @@ description: Use Clerk's Backend SDK to verify a token signature.
 
 Verifies a Clerk-generated token signature. Networkless if the `jwtKey` is provided. Otherwise, performs a network call to retrieve the JWKS from [Clerk's Backend API](/docs/reference/backend-api/tag/JWKS#operation/GetJWKS).
 
-```js {{ prettier: false }}
-function verifyToken: (token: string, options: VerifyTokenOptions) => Promise<JwtReturnType<JwtPayload, TokenVerificationError>>;
+```ts
+function verifyToken(
+  token: string,
+  options: VerifyTokenOptions,
+): Promise<JwtReturnType<JwtPayload, TokenVerificationError>>
 ```
 
 ## Parameters

--- a/docs/references/javascript/organization-domain.mdx
+++ b/docs/references/javascript/organization-domain.mdx
@@ -115,8 +115,8 @@ The `OrganizationDomain` object is the model around an organization domain.
 
 Deletes the organization domain and removes it from the organization.
 
-```typescript {{ prettier: false }}
-function delete: () => Promise<void>;
+```ts {{ prettier: false }}
+function delete(): Promise<void>
 ```
 
 ## `prepareAffiliationVerification()`

--- a/docs/references/javascript/organization/domains.mdx
+++ b/docs/references/javascript/organization/domains.mdx
@@ -17,8 +17,8 @@ The following examples assume:
 
 Creates a new domain for the currently active organization.
 
-```typescript {{ prettier: false }}
-function createDomain: (domainName: string) => Promise<OrganizationDomainResource>;
+```ts
+function createDomain(domainName: string): Promise<OrganizationDomainResource>
 ```
 
 ### Parameters

--- a/docs/references/javascript/organization/membership-request.mdx
+++ b/docs/references/javascript/organization/membership-request.mdx
@@ -17,8 +17,10 @@ The following examples assume:
 
 Retrieve the list of membership requests for the currently active organization.
 
-```typescript {{ prettier: false }}
-function getMembershipRequests: (params?: GetMembershipRequestParams) => Promise<ClerkPaginatedResponse<OrganizationMembershipRequestResource>>;
+```ts
+function getMembershipRequests(
+  params?: GetMembershipRequestParams,
+): Promise<ClerkPaginatedResponse<OrganizationMembershipRequestResource>>
 ```
 
 ### `GetMembershipRequestParams`

--- a/docs/references/javascript/organization/organization.mdx
+++ b/docs/references/javascript/organization/organization.mdx
@@ -482,8 +482,8 @@ function setLogo(params: SetOrganizationLogoParams): Promise<Organization>
 
 Returns a paginated list of roles in the organization.
 
-```typescript {{ prettier: false }}
-function getRoles: (params?: GetRolesParams) => Promise<ClerkPaginatedResponse<RoleResource>>;
+```ts
+function getRoles(params?: GetRolesParams): Promise<ClerkPaginatedResponse<RoleResource>>
 ```
 
 #### `GetRolesParams`

--- a/docs/references/javascript/session.mdx
+++ b/docs/references/javascript/session.mdx
@@ -244,8 +244,8 @@ try {
 
 Checks if the user is authorized for the specified role or permission.
 
-```typescript {{ prettier: false }}
-function checkAuthorization(param: CheckAuthorizationParams) => boolean;
+```ts
+function checkAuthorization(param: CheckAuthorizationParams): boolean
 ```
 
 #### `CheckAuthorizationParams`

--- a/docs/references/javascript/sign-in/authenticate-with.mdx
+++ b/docs/references/javascript/sign-in/authenticate-with.mdx
@@ -106,8 +106,8 @@ function authenticateWithWeb3(params: AuthenticateWithWeb3Params): Promise<SignI
 
 Starts a sign-in flow that allows a user to choose a passkey to sign into their account with.
 
-```typescript {{ prettier: false }}
-function authenticateWithPasskey: (params?: AuthenticateWithPasskeyParams) => Promise<SignInResource>;
+```ts
+function authenticateWithPasskey(params?: AuthenticateWithPasskeyParams): Promise<SignInResource>
 ```
 
 Learn more:

--- a/docs/references/javascript/types/passkey-resource.mdx
+++ b/docs/references/javascript/types/passkey-resource.mdx
@@ -24,8 +24,8 @@ An interface that describes a passkey associated with a user response.
 
 Updates the name of the associated passkey for the signed-in user.
 
-```typescript {{ prettier: false }}
-  function update: (params: { name: string }) => Promise<PasskeyResource>;
+```ts
+function update(params: { name: string }): Promise<PasskeyResource>
 ```
 
 For an example of how to use these methods, see the [Passkeys custom flows documentation](/docs/custom-flows/passkeys#rename-user-passkeys).
@@ -34,8 +34,8 @@ For an example of how to use these methods, see the [Passkeys custom flows docum
 
 Deletes the associated passkey for the signed-in user.
 
-```typescript {{ prettier: false }}
-  function delete: () => Promise<DeletedObject>;
+```ts {{ prettier: false }}
+function delete(): Promise<DeletedObject>
 ```
 
 Learn more:

--- a/docs/references/javascript/user/create-metadata.mdx
+++ b/docs/references/javascript/user/create-metadata.mdx
@@ -16,8 +16,8 @@ Adds an email address for the user. A new [`EmailAddress`][email-ref] will be cr
 > [!WARNING]
 > **Email address** must be enabled as an identifier in your Clerk settings for this method to work. See the [Identifiers](/docs/authentication/configuration/sign-up-sign-in-options#identifiers) section to learn more.
 
-```typescript {{ prettier: false }}
-function createEmailAddress: (params: CreateEmailAddressParams) => Promise<EmailAddress>;
+```ts
+function createEmailAddress(params: CreateEmailAddressParams): Promise<EmailAddress>
 ```
 
 ### `CreateEmailAddressParams`
@@ -104,8 +104,8 @@ Adds a phone number for the user. A new [`PhoneNumber`][phone-ref] will be creat
 > [!WARNING]
 > **Phone number** must be enabled as an identifier in your Clerk settings for this method to work. See the [Identifiers](/docs/authentication/configuration/sign-up-sign-in-options#identifiers) section to learn more.
 
-```typescript {{ prettier: false }}
-function createPhoneNumber: (params: CreatePhoneNumberParams) => Promise<PhoneNumber>;
+```ts
+function createPhoneNumber(params: CreatePhoneNumberParams): Promise<PhoneNumber>
 ```
 
 ### `CreatePhoneNumberParams`
@@ -192,8 +192,8 @@ Adds a web3 wallet for the user. A new [`Web3Wallet<`][web3-ref] will be created
 > [!WARNING]
 > A Web3 provider must be enabled in your Clerk settings for this method to work. See the [Web3 authentication](/docs/authentication/configuration/sign-up-sign-in-options#web3-authentication) section to learn more.
 
-```typescript {{ prettier: false }}
-function createWeb3Wallet: (params: CreateWeb3WalletParams) => Promise<Web3Wallet>;
+```ts
+function createWeb3Wallet(params: CreateWeb3WalletParams): Promise<Web3Wallet>
 ```
 
 ### `CreateWeb3WalletParams`
@@ -280,8 +280,8 @@ Adds an external account for the user. A new [`ExternalAccount`][exacc-ref] will
 > [!WARNING]
 > The social provider that you want to connect to must be enabled in your Clerk settings for this method to work. See the [Social connections (OAuth)](/docs/authentication/configuration/sign-up-sign-in-options#social-connections-o-auth) section to learn more.
 
-```typescript {{ prettier: false }}
-function createExternalAccount: (params: CreateExternalAccountParams) => Promise<ExternalAccount>;
+```ts
+function createExternalAccount(params: CreateExternalAccountParams): Promise<ExternalAccount>
 ```
 
 ### `CreateExternalAccountParams`

--- a/docs/references/javascript/user/password-management.mdx
+++ b/docs/references/javascript/user/password-management.mdx
@@ -13,8 +13,8 @@ The following examples assume that you have followed the [quickstart](/docs/quic
 
 Updates the user's password. Passwords must be at least 8 characters long.
 
-```typescript {{ prettier: false }}
-function updatePassword: (params: UpdateUserPasswordParams) => Promise<User>;
+```ts
+function updatePassword(params: UpdateUserPasswordParams): Promise<User>
 ```
 
 ### `UpdateUserPasswordParams`
@@ -161,8 +161,8 @@ function updatePassword: (params: UpdateUserPasswordParams) => Promise<User>;
 
 Removes the user's password.
 
-```typescript {{ prettier: false }}
-function removePassword: (params: RemoveUserPasswordParams) => Promise<User>;
+```ts
+function removePassword(params: RemoveUserPasswordParams): Promise<User>
 ```
 
 ### `RemoveUserPasswordParams`

--- a/docs/references/javascript/user/user.mdx
+++ b/docs/references/javascript/user/user.mdx
@@ -275,8 +275,8 @@ Updates the user's attributes. Use this method to save information you collected
 
 The appropriate settings must be enabled in the Clerk Dashboard for the user to be able to update their attributes. For example, if you want to use the `update({ firstName })` method, you must enable the **Name** setting. It can be found in the the Clerk Dashboard under **User & Authentication > Email, Phone, Username > [Personal information](https://dashboard.clerk.com/last-active?path=user-authentication/email-phone-username).**
 
-```js {{ prettier: false }}
-function update: (params: UpdateUserParams) => Promise<User>;
+```ts
+function update(params: UpdateUserParams): Promise<User>
 ```
 
 #### `UpdateUserParams`
@@ -398,8 +398,8 @@ In the following example, the user's first name is updated to "Test".
 
 Deletes the current user.
 
-```js {{ prettier: false }}
-function delete: () => Promise<void>;
+```ts {{ prettier: false }}
+function delete(): Promise<void>
 ```
 
 #### Example
@@ -466,8 +466,8 @@ function delete: () => Promise<void>;
 
 Adds the user's profile image or replaces it if one already exists. This method will upload an image and associate it with the user.
 
-```js {{ prettier: false }}
-function setProfileImage: (params: SetProfileImageParams) => Promise<ImageResource>;
+```ts
+function setProfileImage(params: SetProfileImageParams): Promise<ImageResource>
 ```
 
 #### `SetProfileImageParams`
@@ -613,8 +613,8 @@ function setProfileImage: (params: SetProfileImageParams) => Promise<ImageResour
 
 Reloads the user's data from Clerk's API. This method is useful when you want to refresh the user's data after performing some form of mutation.
 
-```js {{ prettier: false }}
-function reload: (p?: ClerkResourceReloadParams) => Promise<this>;
+```ts
+function reload(p?: ClerkResourceReloadParams): Promise<this>
 ```
 
 #### `ClerkResourceReloadParams`
@@ -664,8 +664,8 @@ function reload: (p?: ClerkResourceReloadParams) => Promise<this>;
 
 Retrieves all **active** sessions for this user. This method uses a cache so a network request will only be triggered only once.
 
-```js {{ prettier: false }}
-function getSessions: () => Promise<SessionWithActivities[]>;
+```ts
+function getSessions(): Promise<SessionWithActivities[]>
 ```
 
 #### Returns
@@ -738,8 +738,8 @@ function getSessions: () => Promise<SessionWithActivities[]>;
 
 Creates a passkey for the signed-in user.
 
-```typescript {{ prettier: false }}
-  function createPasskey: () => Promise<PasskeyResource>;
+```ts
+function createPasskey(): Promise<PasskeyResource>
 ```
 
 Learn more:
@@ -755,8 +755,10 @@ For an example of how to use this method, see the [Passkeys custom flows documen
 
 A check whether or not the given resource is the primary identifier for the user.
 
-```js {{ prettier: false }}
-function isPrimaryIdentification: (ident: EmailAddressResource | PhoneNumberResource | Web3WalletResource) => boolean;
+```ts
+function isPrimaryIdentification(
+  ident: EmailAddressResource | PhoneNumberResource | Web3WalletResource,
+): boolean
 ```
 
 #### Parameters
@@ -772,8 +774,10 @@ function isPrimaryIdentification: (ident: EmailAddressResource | PhoneNumberReso
 
 Retrieves a list of organization invitations for the user.
 
-```js {{ prettier: false }}
-function getOrganizationInvitations: (params?: GetUserOrganizationInvitationsParams) => Promise<ClerkPaginatedResponse<UserOrganizationInvitation>>;
+```ts
+function getOrganizationInvitations(
+  params?: GetUserOrganizationInvitationsParams,
+): Promise<ClerkPaginatedResponse<UserOrganizationInvitation>>
 ```
 
 ### `GetUserOrganizationInvitationsParams`
@@ -869,8 +873,10 @@ function getOrganizationInvitations: (params?: GetUserOrganizationInvitationsPar
 
 Retrieves a list of organization suggestions for the user.
 
-```js {{ prettier: false }}
-function getOrganizationSuggestions: (params?: GetUserOrganizationSuggestionsParams) => Promise<ClerkPaginatedResponse<OrganizationSuggestion>>;
+```ts
+function getOrganizationSuggestions(
+  params?: GetUserOrganizationSuggestionsParams,
+): Promise<ClerkPaginatedResponse<OrganizationSuggestion>>
 ```
 
 ### `GetUserOrganizationSuggestionsParams`
@@ -966,8 +972,10 @@ function getOrganizationSuggestions: (params?: GetUserOrganizationSuggestionsPar
 
 Retrieves a list of organization memberships for the user.
 
-```js {{ prettier: false }}
-function getOrganizationMemberships: (params?: GetUserOrganizationMembershipParams) => Promise<ClerkPaginatedResponse<OrganizationMembershipResource>>;
+```ts
+function getOrganizationMemberships(
+  params?: GetUserOrganizationMembershipParams,
+): Promise<ClerkPaginatedResponse<OrganizationMembershipResource>>
 ```
 
 ### `GetUserOrganizationMembershipParams`

--- a/docs/references/nextjs/auth-object.mdx
+++ b/docs/references/nextjs/auth-object.mdx
@@ -110,8 +110,8 @@ You can use `has()` anywhere Clerk returns an [`Auth`](/docs/references/nextjs/a
 
 `has()` has the following function signature:
 
-```typescript {{ prettier: false }}
-function has(isAuthorizedParams: CheckAuthorizationParamsWithCustomPermissions) => boolean;
+```ts
+function has(isAuthorizedParams: CheckAuthorizationParamsWithCustomPermissions): boolean
 ```
 
 #### `CheckAuthorizationParamsWithCustomPermissions`


### PR DESCRIPTION
This is a super small thing but it seems like this is not syntactically valid TypeScript:

```ts
function deleteDomain: (id: string) => Promise<User>
//                   ^ SyntaxError: '(' expected.
```

Whereas this is:

```ts
function deleteDomain(id: string): Promise<User>
```

Updating all of these allows us to remove `prettier: false` and let Prettier do its thing with these snippets! 💅 

> [!NOTE]
> The `delete` snippets are _technically_ invalid because `delete` is a reserved word, so we need to keep `prettier: false` for these