### PR TITLE
Fix manifest structure

### DIFF
--- a/docs/manifest.json
+++ b/docs/manifest.json
@@ -310,206 +310,161 @@
     ],
     [
       {
+        "title": "Configuration",
         "items": [
           [
             {
-              "title": "Configuration",
+              "title": "Sign-up & Sign-in",
+              "collapse": true,
               "items": [
                 [
                   {
-                    "title": "Sign-up & Sign-in",
-                    "collapse": true,
+                    "title": "Overview",
+                    "href": "/docs/authentication/overview"
+                  },
+                  {
+                    "title": "Configuration",
+                    "items": [
+                      [
+                        {
+                          "title": "Sign-up and sign-in options",
+                          "href": "/docs/authentication/configuration/sign-up-sign-in-options"
+                        },
+                        {
+                          "title": "Session options",
+                          "href": "/docs/authentication/configuration/session-options"
+                        },
+                        {
+                          "title": "Email & SMS templates",
+                          "href": "/docs/authentication/configuration/email-sms-templates"
+                        },
+                        {
+                          "title": "Restrictions",
+                          "href": "/docs/authentication/configuration/restrictions"
+                        }
+                      ]
+                    ]
+                  },
+                  {
+                    "title": "Social Connections",
                     "items": [
                       [
                         {
                           "title": "Overview",
-                          "href": "/docs/authentication/overview"
+                          "href": "/docs/authentication/social-connections/overview"
                         },
                         {
-                          "title": "Configuration",
+                          "title": "Social connections (OAuth)",
+                          "href": "/docs/authentication/social-connections/oauth"
+                        },
+                        {
+                          "title": "Account linking",
+                          "href": "/docs/authentication/social-connections/account-linking"
+                        },
+                        {
+                          "title": "Custom provider",
+                          "href": "/docs/authentication/social-connections/custom-provider"
+                        },
+                        {
+                          "title": "Google",
+                          "href": "/docs/authentication/social-connections/google"
+                        },
+                        {
+                          "title": "Facebook",
+                          "href": "/docs/authentication/social-connections/facebook"
+                        },
+                        {
+                          "title": "Microsoft",
+                          "href": "/docs/authentication/social-connections/microsoft"
+                        },
+                        {
+                          "title": "See all",
+                          "collapse": true,
                           "items": [
                             [
                               {
-                                "title": "Sign-up and sign-in options",
-                                "href": "/docs/authentication/configuration/sign-up-sign-in-options"
+                                "title": "Apple",
+                                "href": "/docs/authentication/social-connections/apple"
                               },
                               {
-                                "title": "Session options",
-                                "href": "/docs/authentication/configuration/session-options"
+                                "title": "Atlassian",
+                                "href": "/docs/authentication/social-connections/atlassian"
                               },
                               {
-                                "title": "Email & SMS templates",
-                                "href": "/docs/authentication/configuration/email-sms-templates"
+                                "title": "Bitbucket",
+                                "href": "/docs/authentication/social-connections/bitbucket"
                               },
                               {
-                                "title": "Restrictions",
-                                "href": "/docs/authentication/configuration/restrictions"
-                              }
-                            ]
-                          ]
-                        },
-                        {
-                          "title": "Social Connections",
-                          "items": [
-                            [
-                              {
-                                "title": "Overview",
-                                "href": "/docs/authentication/social-connections/overview"
+                                "title": "Box",
+                                "href": "/docs/authentication/social-connections/box"
                               },
                               {
-                                "title": "Social connections (OAuth)",
-                                "href": "/docs/authentication/social-connections/oauth"
+                                "title": "Coinbase",
+                                "href": "/docs/authentication/social-connections/coinbase"
                               },
                               {
-                                "title": "Account linking",
-                                "href": "/docs/authentication/social-connections/account-linking"
+                                "title": "Discord",
+                                "href": "/docs/authentication/social-connections/discord"
                               },
                               {
-                                "title": "Custom provider",
-                                "href": "/docs/authentication/social-connections/custom-provider"
+                                "title": "Dropbox",
+                                "href": "/docs/authentication/social-connections/dropbox"
                               },
                               {
-                                "title": "Google",
-                                "href": "/docs/authentication/social-connections/google"
+                                "title": "GitHub",
+                                "href": "/docs/authentication/social-connections/github"
                               },
                               {
-                                "title": "Facebook",
-                                "href": "/docs/authentication/social-connections/facebook"
+                                "title": "GitLab",
+                                "href": "/docs/authentication/social-connections/gitlab"
                               },
                               {
-                                "title": "Microsoft",
-                                "href": "/docs/authentication/social-connections/microsoft"
+                                "title": "HubSpot",
+                                "href": "/docs/authentication/social-connections/hubspot"
                               },
                               {
-                                "title": "See all",
-                                "collapse": true,
-                                "items": [
-                                  [
-                                    {
-                                      "title": "Apple",
-                                      "href": "/docs/authentication/social-connections/apple"
-                                    },
-                                    {
-                                      "title": "Atlassian",
-                                      "href": "/docs/authentication/social-connections/atlassian"
-                                    },
-                                    {
-                                      "title": "Bitbucket",
-                                      "href": "/docs/authentication/social-connections/bitbucket"
-                                    },
-                                    {
-                                      "title": "Box",
-                                      "href": "/docs/authentication/social-connections/box"
-                                    },
-                                    {
-                                      "title": "Coinbase",
-                                      "href": "/docs/authentication/social-connections/coinbase"
-                                    },
-                                    {
-                                      "title": "Discord",
-                                      "href": "/docs/authentication/social-connections/discord"
-                                    },
-                                    {
-                                      "title": "Dropbox",
-                                      "href": "/docs/authentication/social-connections/dropbox"
-                                    },
-                                    {
-                                      "title": "GitHub",
-                                      "href": "/docs/authentication/social-connections/github"
-                                    },
-                                    {
-                                      "title": "GitLab",
-                                      "href": "/docs/authentication/social-connections/gitlab"
-                                    },
-                                    {
-                                      "title": "HubSpot",
-                                      "href": "/docs/authentication/social-connections/hubspot"
-                                    },
-                                    {
-                                      "title": "Line",
-                                      "href": "/docs/authentication/social-connections/line"
-                                    },
-                                    {
-                                      "title": "Linear",
-                                      "href": "/docs/authentication/social-connections/linear"
-                                    },
-                                    {
-                                      "title": "LinkedIn (Deprecated)",
-                                      "href": "/docs/authentication/social-connections/linkedin"
-                                    },
-                                    {
-                                      "title": "LinkedIn",
-                                      "href": "/docs/authentication/social-connections/linkedin-oidc"
-                                    },
-                                    {
-                                      "title": "Notion",
-                                      "href": "/docs/authentication/social-connections/notion"
-                                    },
-                                    {
-                                      "title": "Slack",
-                                      "href": "/docs/authentication/social-connections/slack"
-                                    },
-                                    {
-                                      "title": "Spotify",
-                                      "href": "/docs/authentication/social-connections/spotify"
-                                    },
-                                    {
-                                      "title": "TikTok",
-                                      "href": "/docs/authentication/social-connections/tiktok"
-                                    },
-                                    {
-                                      "title": "Twitter v1",
-                                      "href": "/docs/authentication/social-connections/twitter"
-                                    },
-                                    {
-                                      "title": "X/Twitter v2",
-                                      "href": "/docs/authentication/social-connections/x-twitter"
-                                    },
-                                    {
-                                      "title": "Xero",
-                                      "href": "/docs/authentication/social-connections/xero"
-                                    }
-                                  ]
-                                ]
-                              }
-                            ]
-                          ]
-                        },
-                        {
-                          "title": "SAML",
-                          "items": [
-                            [
-                              {
-                                "title": "Overview",
-                                "href": "/docs/authentication/saml/overview"
+                                "title": "Line",
+                                "href": "/docs/authentication/social-connections/line"
                               },
                               {
-                                "title": "Authentication flows",
-                                "href": "/docs/authentication/saml/authentication-flows"
+                                "title": "Linear",
+                                "href": "/docs/authentication/social-connections/linear"
                               },
                               {
-                                "title": "Account linking",
-                                "href": "/docs/authentication/saml/account-linking"
+                                "title": "LinkedIn (Deprecated)",
+                                "href": "/docs/authentication/social-connections/linkedin"
                               },
                               {
-                                "title": "Azure",
-                                "href": "/docs/authentication/saml/azure"
+                                "title": "LinkedIn",
+                                "href": "/docs/authentication/social-connections/linkedin-oidc"
                               },
                               {
-                                "title": "Google",
-                                "href": "/docs/authentication/saml/google"
+                                "title": "Notion",
+                                "href": "/docs/authentication/social-connections/notion"
                               },
                               {
-                                "title": "Okta",
-                                "href": "/docs/authentication/saml/okta"
+                                "title": "Slack",
+                                "href": "/docs/authentication/social-connections/slack"
                               },
                               {
-                                "title": "Custom provider",
-                                "href": "/docs/authentication/saml/custom-provider"
+                                "title": "Spotify",
+                                "href": "/docs/authentication/social-connections/spotify"
                               },
                               {
-                                "title": "Just-in-Time account provisioning",
-                                "href": "/docs/authentication/saml/jit-provisioning"
+                                "title": "TikTok",
+                                "href": "/docs/authentication/social-connections/tiktok"
+                              },
+                              {
+                                "title": "Twitter v1",
+                                "href": "/docs/authentication/social-connections/twitter"
+                              },
+                              {
+                                "title": "X/Twitter v2",
+                                "href": "/docs/authentication/social-connections/x-twitter"
+                              },
+                              {
+                                "title": "Xero",
+                                "href": "/docs/authentication/social-connections/xero"
                               }
                             ]
                           ]
@@ -518,207 +473,246 @@
                     ]
                   },
                   {
-                    "title": "Users",
-                    "collapse": true,
+                    "title": "SAML",
                     "items": [
                       [
                         {
                           "title": "Overview",
-                          "href": "/docs/users/overview"
+                          "href": "/docs/authentication/saml/overview"
                         },
                         {
-                          "title": "Metadata",
-                          "href": "/docs/users/metadata"
-                        },
-                        { "title": "Invitations", "href": "/docs/users/invitations" },
-                        { "title": "User impersonation", "href": "/docs/users/user-impersonation" },
-                        {
-                          "title": "Delete users",
-                          "href": "/docs/users/deleting-users"
+                          "title": "Authentication flows",
+                          "href": "/docs/authentication/saml/authentication-flows"
                         },
                         {
-                          "title": "Guides",
-                          "items": [
-                            [
-                              {
-                                "title": "Web3 authentication",
-                                "href": "/docs/users/web3"
-                              }
-                            ]
-                          ]
+                          "title": "Account linking",
+                          "href": "/docs/authentication/saml/account-linking"
+                        },
+                        {
+                          "title": "Azure",
+                          "href": "/docs/authentication/saml/azure"
+                        },
+                        {
+                          "title": "Google",
+                          "href": "/docs/authentication/saml/google"
+                        },
+                        {
+                          "title": "Okta",
+                          "href": "/docs/authentication/saml/okta"
+                        },
+                        {
+                          "title": "Custom provider",
+                          "href": "/docs/authentication/saml/custom-provider"
+                        },
+                        {
+                          "title": "Just-in-Time account provisioning",
+                          "href": "/docs/authentication/saml/jit-provisioning"
+                        }
+                      ]
+                    ]
+                  }
+                ]
+              ]
+            },
+            {
+              "title": "Users",
+              "collapse": true,
+              "items": [
+                [
+                  {
+                    "title": "Overview",
+                    "href": "/docs/users/overview"
+                  },
+                  {
+                    "title": "Metadata",
+                    "href": "/docs/users/metadata"
+                  },
+                  { "title": "Invitations", "href": "/docs/users/invitations" },
+                  { "title": "User impersonation", "href": "/docs/users/user-impersonation" },
+                  {
+                    "title": "Delete users",
+                    "href": "/docs/users/deleting-users"
+                  },
+                  {
+                    "title": "Guides",
+                    "items": [
+                      [
+                        {
+                          "title": "Web3 authentication",
+                          "href": "/docs/users/web3"
+                        }
+                      ]
+                    ]
+                  }
+                ]
+              ]
+            },
+            {
+              "title": "Organizations, Roles, and Permissions",
+              "collapse": true,
+              "items": [
+                [
+                  {
+                    "title": "Overview",
+                    "href": "/docs/organizations/overview"
+                  },
+                  {
+                    "title": "Roles and permissions",
+                    "href": "/docs/organizations/roles-permissions"
+                  },
+                  {
+                    "title": "Verified domains",
+                    "href": "/docs/organizations/verified-domains"
+                  },
+                  {
+                    "title": "Guides",
+                    "items": [
+                      [
+                        {
+                          "title": "Create roles and assign permissions",
+                          "href": "/docs/organizations/create-roles-permissions"
+                        },
+                        {
+                          "title": "Verify the active user’s permissions",
+                          "href": "/docs/organizations/verify-user-permissions"
+                        },
+                        {
+                          "title": "Reassign the creator role",
+                          "href": "/docs/organizations/creator-role"
                         }
                       ]
                     ]
                   },
                   {
-                    "title": "Organizations, Roles, and Permissions",
-                    "collapse": true,
+                    "title": "Building custom flows",
                     "items": [
                       [
                         {
-                          "title": "Overview",
-                          "href": "/docs/organizations/overview"
+                          "title": "Using metadata",
+                          "href": "/docs/organizations/metadata"
                         },
                         {
-                          "title": "Roles and permissions",
-                          "href": "/docs/organizations/roles-permissions"
+                          "title": "Create an organization",
+                          "href": "/docs/organizations/creating-organizations"
                         },
                         {
-                          "title": "Verified domains",
-                          "href": "/docs/organizations/verified-domains"
+                          "title": "Update an organization",
+                          "href": "/docs/organizations/updating-organizations"
                         },
                         {
-                          "title": "Guides",
-                          "items": [
-                            [
-                              {
-                                "title": "Create roles and assign permissions",
-                                "href": "/docs/organizations/create-roles-permissions"
-                              },
-                              {
-                                "title": "Verify the active user’s permissions",
-                                "href": "/docs/organizations/verify-user-permissions"
-                              },
-                              {
-                                "title": "Reassign the creator role",
-                                "href": "/docs/organizations/creator-role"
-                              }
-                            ]
-                          ]
+                          "title": "Invite users",
+                          "href": "/docs/organizations/inviting-users"
                         },
                         {
-                          "title": "Building custom flows",
-                          "items": [
-                            [
-                              {
-                                "title": "Using metadata",
-                                "href": "/docs/organizations/metadata"
-                              },
-                              {
-                                "title": "Create an organization",
-                                "href": "/docs/organizations/creating-organizations"
-                              },
-                              {
-                                "title": "Update an organization",
-                                "href": "/docs/organizations/updating-organizations"
-                              },
-                              {
-                                "title": "Invite users",
-                                "href": "/docs/organizations/inviting-users"
-                              },
-                              {
-                                "title": "Manage member roles",
-                                "href": "/docs/organizations/managing-roles"
-                              },
-                              {
-                                "title": "View a user's organization memberships",
-                                "href": "/docs/organizations/viewing-memberships"
-                              },
-                              {
-                                "title": "Manage membership requests",
-                                "href": "/docs/organizations/manage-membership-requests"
-                              },
-                              {
-                                "title": "Switch between organizations",
-                                "href": "/docs/organizations/custom-organization-switcher"
-                              }
-                            ]
-                          ]
+                          "title": "Manage member roles",
+                          "href": "/docs/organizations/managing-roles"
+                        },
+                        {
+                          "title": "View a user's organization memberships",
+                          "href": "/docs/organizations/viewing-memberships"
+                        },
+                        {
+                          "title": "Manage membership requests",
+                          "href": "/docs/organizations/manage-membership-requests"
+                        },
+                        {
+                          "title": "Switch between organizations",
+                          "href": "/docs/organizations/custom-organization-switcher"
+                        }
+                      ]
+                    ]
+                  }
+                ]
+              ]
+            },
+            {
+              "title": "Backend Requests",
+              "collapse": true,
+              "items": [
+                [
+                  {
+                    "title": "Overview",
+                    "href": "/docs/backend-requests/overview"
+                  },
+                  {
+                    "title": "Making requests",
+                    "items": [
+                      [
+                        {
+                          "title": "Same-Origin Requests",
+                          "href": "/docs/backend-requests/making/same-origin"
+                        },
+                        {
+                          "title": "Cross-Origin Requests",
+                          "href": "/docs/backend-requests/making/cross-origin"
+                        },
+                        {
+                          "title": "Customize your session token",
+                          "href": "/docs/backend-requests/making/custom-session-token"
+                        },
+                        {
+                          "title": "JWT Templates",
+                          "href": "/docs/backend-requests/making/jwt-templates"
                         }
                       ]
                     ]
                   },
                   {
-                    "title": "Backend Requests",
-                    "collapse": true,
+                    "title": "Handling requests",
+                    "items": [
+                      [
+                        {
+                          "title": "Node.js & Express",
+                          "href": "/docs/backend-requests/handling/nodejs"
+                        },
+                        {
+                          "title": "Go",
+                          "href": "/docs/backend-requests/handling/go",
+                          "icon": "go"
+                        },
+                        {
+                          "title": "Gatsby",
+                          "href": "/docs/backend-requests/handling/gatsby",
+                          "icon": "gatsby"
+                        },
+                        {
+                          "title": "Ruby / Rails",
+                          "href": "/docs/backend-requests/handling/ruby-rails",
+                          "icon": "ruby"
+                        },
+                        {
+                          "title": "Manual JWT Verification",
+                          "href": "/docs/backend-requests/handling/manual-jwt"
+                        }
+                      ]
+                    ]
+                  },
+                  {
+                    "title": "Versioning",
                     "items": [
                       [
                         {
                           "title": "Overview",
-                          "href": "/docs/backend-requests/overview"
+                          "href": "/docs/backend-requests/versioning/overview"
                         },
                         {
-                          "title": "Making requests",
-                          "items": [
-                            [
-                              {
-                                "title": "Same-Origin Requests",
-                                "href": "/docs/backend-requests/making/same-origin"
-                              },
-                              {
-                                "title": "Cross-Origin Requests",
-                                "href": "/docs/backend-requests/making/cross-origin"
-                              },
-                              {
-                                "title": "Customize your session token",
-                                "href": "/docs/backend-requests/making/custom-session-token"
-                              },
-                              {
-                                "title": "JWT Templates",
-                                "href": "/docs/backend-requests/making/jwt-templates"
-                              }
-                            ]
-                          ]
+                          "title": "Available versions",
+                          "href": "/docs/backend-requests/versioning/available-versions"
+                        }
+                      ]
+                    ]
+                  },
+                  {
+                    "title": "Resources",
+                    "items": [
+                      [
+                        {
+                          "title": "Session tokens",
+                          "href": "/docs/backend-requests/resources/session-tokens"
                         },
                         {
-                          "title": "Handling requests",
-                          "items": [
-                            [
-                              {
-                                "title": "Node.js & Express",
-                                "href": "/docs/backend-requests/handling/nodejs"
-                              },
-                              {
-                                "title": "Go",
-                                "href": "/docs/backend-requests/handling/go",
-                                "icon": "go"
-                              },
-                              {
-                                "title": "Gatsby",
-                                "href": "/docs/backend-requests/handling/gatsby",
-                                "icon": "gatsby"
-                              },
-                              {
-                                "title": "Ruby / Rails",
-                                "href": "/docs/backend-requests/handling/ruby-rails",
-                                "icon": "ruby"
-                              },
-                              {
-                                "title": "Manual JWT Verification",
-                                "href": "/docs/backend-requests/handling/manual-jwt"
-                              }
-                            ]
-                          ]
-                        },
-                        {
-                          "title": "Versioning",
-                          "items": [
-                            [
-                              {
-                                "title": "Overview",
-                                "href": "/docs/backend-requests/versioning/overview"
-                              },
-                              {
-                                "title": "Available versions",
-                                "href": "/docs/backend-requests/versioning/available-versions"
-                              }
-                            ]
-                          ]
-                        },
-                        {
-                          "title": "Resources",
-                          "items": [
-                            [
-                              {
-                                "title": "Session tokens",
-                                "href": "/docs/backend-requests/resources/session-tokens"
-                              },
-                              {
-                                "title": "Rate limits",
-                                "href": "/docs/backend-requests/resources/rate-limits"
-                              }
-                            ]
-                          ]
+                          "title": "Rate limits",
+                          "href": "/docs/backend-requests/resources/rate-limits"
                         }
                       ]
                     ]
@@ -726,835 +720,171 @@
                 ]
               ]
             }
-          ],
+          ]
+        ]
+      }
+    ],
+    [
+      {
+        "title": "Customization",
+        "items": [
           [
             {
-              "title": "Customization",
+              "title": "Account Portal",
+              "collapse": true,
               "items": [
                 [
                   {
-                    "title": "Account Portal",
-                    "collapse": true,
-                    "items": [
-                      [
-                        {
-                          "title": "Overview",
-                          "href": "/docs/customization/account-portal/overview"
-                        },
-                        {
-                          "title": "Getting started",
-                          "href": "/docs/customization/account-portal/getting-started"
-                        },
-                        {
-                          "title": "Advanced Usage",
-                          "items": [
-                            [
-                              {
-                                "title": "Direct links",
-                                "href": "/docs/customization/account-portal/direct-links"
-                              },
-                              {
-                                "title": "User & Organization Pages",
-                                "href": "/docs/customization/account-portal/user-profile-org-profile"
-                              },
-                              {
-                                "title": "Disable Account Portal",
-                                "href": "/docs/customization/account-portal/disable-account-portal"
-                              }
-                            ]
-                          ]
-                        }
-                      ]
-                    ]
+                    "title": "Overview",
+                    "href": "/docs/customization/account-portal/overview"
                   },
                   {
-                    "title": "Appearance Prop",
-                    "collapse": true,
-                    "items": [
-                      [
-                        {
-                          "title": "Overview",
-                          "href": "/docs/customization/overview"
-                        },
-                        {
-                          "title": "Layout",
-                          "href": "/docs/customization/layout"
-                        },
-                        {
-                          "title": "Themes",
-                          "href": "/docs/customization/themes"
-                        },
-                        {
-                          "title": "Variables",
-                          "href": "/docs/customization/variables"
-                        }
-                      ]
-                    ]
-                  },
-                  { "title": "Localization", "href": "/docs/customization/localization" },
-                  {
-                    "title": "Custom Pages",
-                    "collapse": true,
-                    "items": [
-                      [
-                        {
-                          "title": "`<UserProfile />`",
-                          "href": "/docs/customization/user-profile"
-                        },
-                        {
-                          "title": "`<OrganizationProfile />`",
-                          "href": "/docs/customization/organization-profile"
-                        }
-                      ]
-                    ]
-                  },
-                  {
-                    "title": "Custom Menu Items",
-                    "collapse": true,
-                    "items": [
-                      [
-                        {
-                          "title": "`<UserButton />`",
-                          "wrap": false,
-                          "href": "/docs/customization/user-button"
-                        }
-                      ]
-                    ]
-                  },
-                  {
-                    "title": "Elements",
-                    "tag": "(Beta)",
-                    "collapse": true,
-                    "items": [
-                      [
-                        {
-                          "title": "Overview",
-                          "href": "/docs/customization/elements/overview"
-                        },
-                        {
-                          "title": "Guides",
-                          "items": [
-                            [
-                              {
-                                "title": "Build a sign-in flow",
-                                "href": "/docs/customization/elements/guides/sign-in"
-                              },
-                              {
-                                "title": "Build a sign-up flow",
-                                "href": "/docs/customization/elements/guides/sign-up"
-                              },
-                              {
-                                "title": "Styling",
-                                "href": "/docs/customization/elements/guides/styling"
-                              }
-                            ]
-                          ]
-                        },
-                        {
-                          "title": "Examples",
-                          "items": [
-                            [
-                              {
-                                "title": "Sign-in",
-                                "href": "/docs/customization/elements/examples/sign-in"
-                              },
-                              {
-                                "title": "Sign-up",
-                                "href": "/docs/customization/elements/examples/sign-up"
-                              },
-                              {
-                                "title": "Primitives",
-                                "href": "/docs/customization/elements/examples/primitives"
-                              },
-                              {
-                                "title": "shadcn/ui",
-                                "href": "/docs/customization/elements/examples/shadcn-ui"
-                              }
-                            ]
-                          ]
-                        },
-                        {
-                          "title": "Component Reference",
-                          "items": [
-                            [
-                              {
-                                "title": "Common",
-                                "href": "/docs/customization/elements/reference/common"
-                              },
-                              {
-                                "title": "Sign-in",
-                                "href": "/docs/customization/elements/reference/sign-in"
-                              },
-                              {
-                                "title": "Sign-up",
-                                "href": "/docs/customization/elements/reference/sign-up"
-                              }
-                            ]
-                          ]
-                        }
-                      ]
-                    ]
-                  }
-                ]
-              ]
-            }
-          ],
-          [
-            {
-              "title": "Development",
-              "items": [
-                [
-                  {
-                    "title": "Testing",
-                    "collapse": true,
-                    "items": [
-                      [
-                        {
-                          "title": "Overview",
-                          "href": "/docs/testing/overview"
-                        },
-                        {
-                          "title": "Test Emails and Phones",
-                          "href": "/docs/testing/test-emails-and-phones"
-                        },
-                        {
-                          "title": "Testing Frameworks",
-                          "items": [
-                            [
-                              {
-                                "title": "Playwright",
-                                "href": "/docs/testing/playwright"
-                              },
-                              { "title": "Cypress", "href": "/docs/testing/cypress" },
-                              {
-                                "title": "Postman or Insomnia",
-                                "href": "/docs/testing/postman-or-insomnia"
-                              }
-                            ]
-                          ]
-                        }
-                      ]
-                    ]
-                  },
-                  {
-                    "title": "Errors",
-                    "collapse": true,
-                    "items": [
-                      [
-                        {
-                          "title": "Overview",
-                          "href": "/docs/errors/overview"
-                        },
-                        {
-                          "title": "Actor tokens",
-                          "href": "/docs/errors/actor-tokens"
-                        },
-                        {
-                          "title": "Allowlist identifiers",
-                          "href": "/docs/errors/allowlist-identifiers"
-                        },
-                        {
-                          "title": "Application",
-                          "href": "/docs/errors/application"
-                        },
-                        {
-                          "title": "Authentication",
-                          "href": "/docs/errors/authentication"
-                        },
-                        {
-                          "title": "Backup codes",
-                          "href": "/docs/errors/backup-codes"
-                        },
-                        {
-                          "title": "Billing",
-                          "href": "/docs/errors/billing"
-                        },
-                        {
-                          "title": "Billing accounts",
-                          "href": "/docs/errors/billing-accounts"
-                        },
-                        {
-                          "title": "Blocklist identifiers",
-                          "href": "/docs/errors/blocklist-identifiers"
-                        },
-                        {
-                          "title": "Clients",
-                          "href": "/docs/errors/clients"
-                        },
-                        {
-                          "title": "Cookie",
-                          "href": "/docs/errors/cookie"
-                        },
-                        {
-                          "title": "Deprecation",
-                          "href": "/docs/errors/deprecation"
-                        },
-                        {
-                          "title": "Domains",
-                          "href": "/docs/errors/domains"
-                        },
-                        {
-                          "title": "Entitlements",
-                          "href": "/docs/errors/entitlements"
-                        },
-                        {
-                          "title": "Features",
-                          "href": "/docs/errors/features"
-                        },
-                        {
-                          "title": "Identifications",
-                          "href": "/docs/errors/identifications"
-                        },
-                        {
-                          "title": "Passkeys",
-                          "href": "/docs/errors/passkeys"
-                        },
-                        {
-                          "title": "Sign-in",
-                          "href": "/docs/errors/sign-in"
-                        },
-                        {
-                          "title": "Sign-up",
-                          "href": "/docs/errors/sign-up"
-                        },
-                        {
-                          "title": "Sign-in-tokens",
-                          "href": "/docs/errors/sign-in-tokens"
-                        }
-                      ]
-                    ]
-                  },
-                  {
-                    "title": "Troubleshooting",
-                    "collapse": true,
-                    "items": [
-                      [
-                        {
-                          "title": "Overview",
-                          "href": "/docs/troubleshooting/overview"
-                        },
-                        {
-                          "title": "Email Deliverability",
-                          "href": "/docs/troubleshooting/email-deliverability"
-                        },
-                        {
-                          "title": "Script Loading",
-                          "href": "/docs/troubleshooting/script-loading"
-                        },
-                        {
-                          "title": "Help & Support",
-                          "items": [
-                            [
-                              {
-                                "title": "Create a minimal reproduction",
-                                "href": "/docs/troubleshooting/create-a-minimal-reproduction"
-                              },
-                              {
-                                "title": "Community Discord",
-                                "href": "/discord",
-                                "target": "_blank"
-                              },
-                              {
-                                "title": "Contact Support",
-                                "href": "/support",
-                                "target": "_blank"
-                              }
-                            ]
-                          ]
-                        }
-                      ]
-                    ]
-                  },
-                  {
-                    "title": "Upgrade Guides",
-                    "collapse": true,
-                    "items": [
-                      [
-                        {
-                          "title": "Overview",
-                          "href": "/docs/upgrade-guides/overview"
-                        },
-                        {
-                          "title": "Long term support policy",
-                          "href": "/docs/upgrade-guides/long-term-support"
-                        },
-                        {
-                          "title": "Clerk SDK versioning",
-                          "href": "/docs/upgrade-guides/sdk-versioning"
-                        },
-                        {
-                          "title": "Upgrading to Core 2",
-                          "items": [
-                            [
-                              {
-                                "title": "Overview",
-                                "href": "/docs/upgrade-guides/core-2/overview"
-                              },
-                              {
-                                "title": "Component redesign",
-                                "href": "/docs/upgrade-guides/core-2/component-redesign"
-                              },
-                              {
-                                "title": "SDK Guides",
-                                "collapse": true,
-                                "items": [
-                                  [
-                                    {
-                                      "title": "Next.js",
-                                      "href": "/docs/upgrade-guides/core-2/nextjs",
-                                      "icon": "nextjs"
-                                    },
-                                    {
-                                      "title": "Remix",
-                                      "href": "/docs/upgrade-guides/core-2/remix",
-                                      "icon": "remix"
-                                    },
-                                    {
-                                      "title": "Expo",
-                                      "href": "/docs/upgrade-guides/core-2/expo"
-                                    },
-                                    {
-                                      "title": "Fastify",
-                                      "href": "/docs/upgrade-guides/core-2/fastify"
-                                    },
-                                    {
-                                      "title": "React",
-                                      "href": "/docs/upgrade-guides/core-2/react",
-                                      "icon": "react"
-                                    },
-                                    {
-                                      "title": "Node",
-                                      "href": "/docs/upgrade-guides/core-2/node"
-                                    },
-                                    {
-                                      "title": "Backend",
-                                      "href": "/docs/upgrade-guides/core-2/backend"
-                                    },
-                                    {
-                                      "title": "Chrome Extension",
-                                      "href": "/docs/upgrade-guides/core-2/chrome-extension"
-                                    },
-                                    {
-                                      "title": "JavaScript",
-                                      "href": "/docs/upgrade-guides/core-2/javascript",
-                                      "icon": "javascript"
-                                    }
-                                  ]
-                                ]
-                              }
-                            ]
-                          ]
-                        },
-                        {
-                          "title": "Upgrading to Core 1",
-                          "items": [
-                            [
-                              {
-                                "title": "Overview",
-                                "href": "/docs/upgrade-guides/upgrading-from-v2-to-v3"
-                              }
-                            ]
-                          ]
-                        },
-                        {
-                          "title": "Dashboard",
-                          "items": [
-                            [
-                              {
-                                "title": "API Key Changes",
-                                "href": "/docs/upgrade-guides/api-keys"
-                              },
-                              {
-                                "title": "URL-based session syncing",
-                                "href": "/docs/upgrade-guides/url-based-session-syncing"
-                              },
-                              {
-                                "title": "Progressive Sign up",
-                                "href": "/docs/upgrade-guides/progressive-sign-up"
-                              }
-                            ]
-                          ]
-                        }
-                      ]
-                    ]
-                  },
-                  {
-                    "title": "Deployments & Migrations",
-                    "collapse": true,
-                    "items": [
-                      [
-                        {
-                          "title": "Instances / Environments",
-                          "href": "/docs/deployments/environments"
-                        },
-                        {
-                          "title": "Clerk environment variables",
-                          "href": "/docs/deployments/clerk-environment-variables"
-                        },
-                        {
-                          "title": "Deployment",
-                          "items": [
-                            [
-                              {
-                                "title": "Deploy to production",
-                                "href": "/docs/deployments/overview"
-                              },
-                              {
-                                "title": "Deploy to Vercel",
-                                "href": "/docs/deployments/deploy-to-vercel"
-                              },
-                              {
-                                "title": "Set up a staging environment",
-                                "href": "/docs/deployments/set-up-staging"
-                              },
-                              {
-                                "title": "Deploy an Expo app to production",
-                                "href": "/docs/deployments/deploy-expo"
-                              },
-                              {
-                                "title": "Deploy an Astro app to production",
-                                "href": "/docs/deployments/deploy-astro"
-                              },
-                              {
-                                "title": "Set up a preview environment",
-                                "href": "/docs/deployments/set-up-preview-environment"
-                              },
-                              {
-                                "title": "Changing domains",
-                                "href": "/docs/deployments/changing-domains"
-                              }
-                            ]
-                          ]
-                        },
-                        {
-                          "title": "Migrations",
-                          "items": [
-                            [
-                              {
-                                "title": "Migrate to Clerk",
-                                "href": "/docs/deployments/migrate-overview"
-                              },
-                              {
-                                "title": "Migrate from Firebase",
-                                "href": "/docs/deployments/migrate-from-firebase"
-                              },
-                              {
-                                "title": "Migrate from Cognito",
-                                "href": "/docs/deployments/migrate-from-cognito"
-                              },
-                              {
-                                "title": "Exporting user data",
-                                "href": "/docs/deployments/exporting-users"
-                              }
-                            ]
-                          ]
-                        },
-                        {
-                          "title": "Cookie Information",
-                          "items": [
-                            [
-                              {
-                                "title": "Clerk Cookie Information",
-                                "href": "/docs/deployments/clerk-cookies"
-                              }
-                            ]
-                          ]
-                        }
-                      ]
-                    ]
-                  }
-                ]
-              ]
-            }
-          ],
-          [
-            {
-              "title": "Advanced",
-              "items": [
-                [
-                  {
-                    "title": "Integrations",
-                    "collapse": true,
-                    "items": [
-                      [
-                        {
-                          "title": "Overview",
-                          "href": "/docs/integrations/overview"
-                        },
-                        {
-                          "title": "Webhooks",
-                          "items": [
-                            [
-                              {
-                                "title": "Overview",
-                                "href": "/docs/integrations/webhooks/overview"
-                              },
-                              {
-                                "title": "Sync Clerk data to your application with webhooks",
-                                "href": "/docs/integrations/webhooks/sync-data"
-                              },
-                              {
-                                "title": "Handling webhooks with Inngest",
-                                "href": "/docs/integrations/webhooks/inngest"
-                              },
-                              {
-                                "title": "Send webhooks to Loops",
-                                "href": "/docs/integrations/webhooks/loops"
-                              },
-                              {
-                                "title": "Debug your webhooks",
-                                "href": "/docs/integrations/webhooks/debug-your-webhooks"
-                              }
-                            ]
-                          ]
-                        },
-                        {
-                          "title": "Databases",
-                          "items": [
-                            [
-                              {
-                                "title": "Convex",
-                                "href": "/docs/integrations/databases/convex"
-                              },
-                              {
-                                "title": "Fauna",
-                                "href": "/docs/integrations/databases/fauna"
-                              },
-                              {
-                                "title": "Firebase",
-                                "href": "/docs/integrations/databases/firebase"
-                              },
-                              {
-                                "title": "Grafbase",
-                                "href": "/docs/integrations/databases/grafbase"
-                              },
-                              {
-                                "title": "Hasura",
-                                "href": "/docs/integrations/databases/hasura"
-                              },
-                              {
-                                "title": "Nhost",
-                                "href": "/docs/integrations/databases/nhost"
-                              },
-                              {
-                                "title": "Supabase",
-                                "href": "/docs/integrations/databases/supabase"
-                              },
-                              {
-                                "title": "Neon",
-                                "href": "/docs/integrations/databases/neon"
-                              }
-                            ]
-                          ]
-                        },
-                        {
-                          "title": "Analytics",
-                          "items": [
-                            [
-                              {
-                                "title": "Google Analytics",
-                                "href": "/docs/integrations/analytics/google-analytics"
-                              }
-                            ]
-                          ]
-                        }
-                      ]
-                    ]
+                    "title": "Getting started",
+                    "href": "/docs/customization/account-portal/getting-started"
                   },
                   {
                     "title": "Advanced Usage",
-                    "collapse": true,
                     "items": [
                       [
                         {
-                          "title": "Clerk as an OAuth2 Provider",
-                          "href": "/docs/advanced-usage/clerk-idp"
+                          "title": "Direct links",
+                          "href": "/docs/customization/account-portal/direct-links"
                         },
                         {
-                          "title": "Authentication across different domains",
-                          "href": "/docs/advanced-usage/satellite-domains"
+                          "title": "User & Organization Pages",
+                          "href": "/docs/customization/account-portal/user-profile-org-profile"
                         },
                         {
-                          "title": "Proxying the Clerk Frontend API",
-                          "href": "/docs/advanced-usage/using-proxies"
+                          "title": "Disable Account Portal",
+                          "href": "/docs/customization/account-portal/disable-account-portal"
+                        }
+                      ]
+                    ]
+                  }
+                ]
+              ]
+            },
+            {
+              "title": "Appearance Prop",
+              "collapse": true,
+              "items": [
+                [
+                  {
+                    "title": "Overview",
+                    "href": "/docs/customization/overview"
+                  },
+                  {
+                    "title": "Layout",
+                    "href": "/docs/customization/layout"
+                  },
+                  {
+                    "title": "Themes",
+                    "href": "/docs/customization/themes"
+                  },
+                  {
+                    "title": "Variables",
+                    "href": "/docs/customization/variables"
+                  }
+                ]
+              ]
+            },
+            { "title": "Localization", "href": "/docs/customization/localization" },
+            {
+              "title": "Custom Pages",
+              "collapse": true,
+              "items": [
+                [
+                  {
+                    "title": "`<UserProfile />`",
+                    "href": "/docs/customization/user-profile"
+                  },
+                  {
+                    "title": "`<OrganizationProfile />`",
+                    "href": "/docs/customization/organization-profile"
+                  }
+                ]
+              ]
+            },
+            {
+              "title": "Custom Menu Items",
+              "collapse": true,
+              "items": [
+                [
+                  {
+                    "title": "`<UserButton />`",
+                    "wrap": false,
+                    "href": "/docs/customization/user-button"
+                  }
+                ]
+              ]
+            },
+            {
+              "title": "Elements",
+              "tag": "(Beta)",
+              "collapse": true,
+              "items": [
+                [
+                  {
+                    "title": "Overview",
+                    "href": "/docs/customization/elements/overview"
+                  },
+                  {
+                    "title": "Guides",
+                    "items": [
+                      [
+                        {
+                          "title": "Build a sign-in flow",
+                          "href": "/docs/customization/elements/guides/sign-in"
+                        },
+                        {
+                          "title": "Build a sign-up flow",
+                          "href": "/docs/customization/elements/guides/sign-up"
+                        },
+                        {
+                          "title": "Styling",
+                          "href": "/docs/customization/elements/guides/styling"
                         }
                       ]
                     ]
                   },
                   {
-                    "title": "Security & Privacy",
-                    "collapse": true,
+                    "title": "Examples",
                     "items": [
                       [
                         {
-                          "title": "Overview",
-                          "href": "/docs/security/overview"
+                          "title": "Sign-in",
+                          "href": "/docs/customization/elements/examples/sign-in"
                         },
                         {
-                          "title": "Vulnerability disclosure policy",
-                          "href": "/docs/security/vulnerability-disclosure-policy"
+                          "title": "Sign-up",
+                          "href": "/docs/customization/elements/examples/sign-up"
                         },
                         {
-                          "title": "XSS leak protection",
-                          "href": "/docs/security/xss-leak-protection"
+                          "title": "Primitives",
+                          "href": "/docs/customization/elements/examples/primitives"
                         },
                         {
-                          "title": "CSRF protection",
-                          "href": "/docs/security/csrf-protection"
-                        },
-                        {
-                          "title": "CSP Headers",
-                          "href": "/docs/security/clerk-csp"
-                        },
-                        {
-                          "title": "Fixation protection",
-                          "href": "/docs/security/fixation-protection"
-                        },
-                        {
-                          "title": "Password protection and rules",
-                          "href": "/docs/security/password-protection"
-                        },
-                        {
-                          "title": "Clerk Telemetry",
-                          "href": "/docs/telemetry"
-                        },
-                        {
-                          "title": "Protect accounts from attacks",
-                          "items": [
-                            [
-                              {
-                                "title": "Brute force attacks and locking user accounts",
-                                "href": "/docs/security/user-lock-guide"
-                              },
-                              {
-                                "title": "Protect sign ups from bots",
-                                "href": "/docs/security/bot-protection"
-                              },
-                              {
-                                "title": "Customize max sign-in attempts and duration of of user lockout",
-                                "href": "/docs/security/customize-user-lockout"
-                              },
-                              {
-                                "title": "Unlock accounts from the Clerk Dashboard",
-                                "href": "/docs/security/unlock-user-accounts"
-                              },
-                              {
-                                "title": "Programmatically lock and unlock accounts",
-                                "href": "/docs/security/programmatically-lock-user-accounts"
-                              },
-                              {
-                                "title": "Protect email link sign-ins and sign-ups",
-                                "href": "/docs/security/email-link-protection"
-                              }
-                            ]
-                          ]
+                          "title": "shadcn/ui",
+                          "href": "/docs/customization/elements/examples/shadcn-ui"
                         }
                       ]
                     ]
                   },
                   {
-                    "title": "Custom Flows",
-                    "collapse": true,
+                    "title": "Component Reference",
                     "items": [
                       [
                         {
-                          "title": "Overview",
-                          "href": "/docs/custom-flows/overview"
+                          "title": "Common",
+                          "href": "/docs/customization/elements/reference/common"
                         },
                         {
-                          "title": "Error handling",
-                          "href": "/docs/custom-flows/error-handling"
+                          "title": "Sign-in",
+                          "href": "/docs/customization/elements/reference/sign-in"
                         },
                         {
-                          "title": "Authentication",
-                          "items": [
-                            [
-                              {
-                                "title": "Email & password",
-                                "href": "/docs/custom-flows/email-password"
-                              },
-                              {
-                                "title": "Email / SMS OTP",
-                                "href": "/docs/custom-flows/email-sms-otp"
-                              },
-                              {
-                                "title": "Email links",
-                                "href": "/docs/custom-flows/email-links"
-                              },
-                              {
-                                "title": "Email & password + MFA",
-                                "href": "/docs/custom-flows/email-password-mfa"
-                              },
-                              {
-                                "title": "Passkeys",
-                                "href": "/docs/custom-flows/passkeys"
-                              },
-                              {
-                                "title": "Google One Tap",
-                                "href": "/docs/custom-flows/google-one-tap"
-                              },
-                              {
-                                "title": "OAuth connections",
-                                "href": "/docs/custom-flows/oauth-connections"
-                              },
-                              {
-                                "title": "SAML connections",
-                                "href": "/docs/custom-flows/saml-connections"
-                              },
-                              {
-                                "title": "Sign out",
-                                "href": "/docs/custom-flows/sign-out"
-                              },
-                              { "title": "Sign out", "href": "/docs/custom-flows/sign-out" },
-                              {
-                                "title": "Sign-up with application invitations",
-                                "href": "/docs/custom-flows/invitations"
-                              },
-                              {
-                                "title": "Embedded email links",
-                                "href": "/docs/custom-flows/embedded-email-links"
-                              },
-                              {
-                                "title": "Multi-session applications",
-                                "href": "/docs/custom-flows/multi-session-applications"
-                              },
-                              {
-                                "title": "Bot sign-up protection",
-                                "href": "/docs/custom-flows/bot-sign-up-protection"
-                              }
-                            ]
-                          ]
-                        },
-                        {
-                          "title": "Account updates",
-                          "items": [
-                            [
-                              {
-                                "title": "Forgot password",
-                                "href": "/docs/custom-flows/forgot-password"
-                              },
-                              {
-                                "title": "User impersonation",
-                                "href": "/docs/custom-flows/user-impersonation"
-                              },
-                              {
-                                "title": "Add email",
-                                "href": "/docs/custom-flows/add-email"
-                              },
-                              {
-                                "title": "Add phone",
-                                "href": "/docs/custom-flows/add-phone"
-                              },
-                              {
-                                "title": "Manage SMS-based MFA",
-                                "href": "/docs/custom-flows/manage-sms-based-mfa"
-                              },
-                              {
-                                "title": "Manage TOTP-based MFA",
-                                "href": "/docs/custom-flows/manage-totp-based-mfa"
-                              }
-                            ]
-                          ]
+                          "title": "Sign-up",
+                          "href": "/docs/customization/elements/reference/sign-up"
                         }
                       ]
                     ]
@@ -1562,126 +892,249 @@
                 ]
               ]
             }
-          ],
+          ]
+        ]
+      }
+    ],
+    [
+      {
+        "title": "Development",
+        "items": [
           [
             {
-              "title": "SDK References",
+              "title": "Testing",
+              "collapse": true,
               "items": [
                 [
                   {
-                    "title": "Next.js",
-                    "collapse": true,
-                    "icon": "nextjs",
+                    "title": "Overview",
+                    "href": "/docs/testing/overview"
+                  },
+                  {
+                    "title": "Test Emails and Phones",
+                    "href": "/docs/testing/test-emails-and-phones"
+                  },
+                  {
+                    "title": "Testing Frameworks",
+                    "items": [
+                      [
+                        {
+                          "title": "Playwright",
+                          "href": "/docs/testing/playwright"
+                        },
+                        { "title": "Cypress", "href": "/docs/testing/cypress" },
+                        {
+                          "title": "Postman or Insomnia",
+                          "href": "/docs/testing/postman-or-insomnia"
+                        }
+                      ]
+                    ]
+                  }
+                ]
+              ]
+            },
+            {
+              "title": "Errors",
+              "collapse": true,
+              "items": [
+                [
+                  {
+                    "title": "Overview",
+                    "href": "/docs/errors/overview"
+                  },
+                  {
+                    "title": "Actor tokens",
+                    "href": "/docs/errors/actor-tokens"
+                  },
+                  {
+                    "title": "Allowlist identifiers",
+                    "href": "/docs/errors/allowlist-identifiers"
+                  },
+                  {
+                    "title": "Application",
+                    "href": "/docs/errors/application"
+                  },
+                  {
+                    "title": "Authentication",
+                    "href": "/docs/errors/authentication"
+                  },
+                  {
+                    "title": "Backup codes",
+                    "href": "/docs/errors/backup-codes"
+                  },
+                  {
+                    "title": "Billing",
+                    "href": "/docs/errors/billing"
+                  },
+                  {
+                    "title": "Billing accounts",
+                    "href": "/docs/errors/billing-accounts"
+                  },
+                  {
+                    "title": "Blocklist identifiers",
+                    "href": "/docs/errors/blocklist-identifiers"
+                  },
+                  {
+                    "title": "Clients",
+                    "href": "/docs/errors/clients"
+                  },
+                  {
+                    "title": "Cookie",
+                    "href": "/docs/errors/cookie"
+                  },
+                  {
+                    "title": "Deprecation",
+                    "href": "/docs/errors/deprecation"
+                  },
+                  {
+                    "title": "Domains",
+                    "href": "/docs/errors/domains"
+                  },
+                  {
+                    "title": "Entitlements",
+                    "href": "/docs/errors/entitlements"
+                  },
+                  {
+                    "title": "Features",
+                    "href": "/docs/errors/features"
+                  },
+                  {
+                    "title": "Identifications",
+                    "href": "/docs/errors/identifications"
+                  },
+                  {
+                    "title": "Passkeys",
+                    "href": "/docs/errors/passkeys"
+                  },
+                  {
+                    "title": "Sign-in",
+                    "href": "/docs/errors/sign-in"
+                  },
+                  {
+                    "title": "Sign-up",
+                    "href": "/docs/errors/sign-up"
+                  },
+                  {
+                    "title": "Sign-in-tokens",
+                    "href": "/docs/errors/sign-in-tokens"
+                  }
+                ]
+              ]
+            },
+            {
+              "title": "Troubleshooting",
+              "collapse": true,
+              "items": [
+                [
+                  {
+                    "title": "Overview",
+                    "href": "/docs/troubleshooting/overview"
+                  },
+                  {
+                    "title": "Email Deliverability",
+                    "href": "/docs/troubleshooting/email-deliverability"
+                  },
+                  {
+                    "title": "Script Loading",
+                    "href": "/docs/troubleshooting/script-loading"
+                  },
+                  {
+                    "title": "Help & Support",
+                    "items": [
+                      [
+                        {
+                          "title": "Create a minimal reproduction",
+                          "href": "/docs/troubleshooting/create-a-minimal-reproduction"
+                        },
+                        {
+                          "title": "Community Discord",
+                          "href": "/discord",
+                          "target": "_blank"
+                        },
+                        {
+                          "title": "Contact Support",
+                          "href": "/support",
+                          "target": "_blank"
+                        }
+                      ]
+                    ]
+                  }
+                ]
+              ]
+            },
+            {
+              "title": "Upgrade Guides",
+              "collapse": true,
+              "items": [
+                [
+                  {
+                    "title": "Overview",
+                    "href": "/docs/upgrade-guides/overview"
+                  },
+                  {
+                    "title": "Long term support policy",
+                    "href": "/docs/upgrade-guides/long-term-support"
+                  },
+                  {
+                    "title": "Clerk SDK versioning",
+                    "href": "/docs/upgrade-guides/sdk-versioning"
+                  },
+                  {
+                    "title": "Upgrading to Core 2",
                     "items": [
                       [
                         {
                           "title": "Overview",
-                          "href": "/docs/references/nextjs/overview"
+                          "href": "/docs/upgrade-guides/core-2/overview"
                         },
                         {
-                          "title": "Guides",
+                          "title": "Component redesign",
+                          "href": "/docs/upgrade-guides/core-2/component-redesign"
+                        },
+                        {
+                          "title": "SDK Guides",
+                          "collapse": true,
                           "items": [
                             [
                               {
-                                "title": "Read session and user data",
-                                "href": "/docs/references/nextjs/read-session-data"
+                                "title": "Next.js",
+                                "href": "/docs/upgrade-guides/core-2/nextjs",
+                                "icon": "nextjs"
                               },
                               {
-                                "title": "Add custom sign up and sign in pages",
-                                "href": "/docs/references/nextjs/custom-signup-signin-pages"
+                                "title": "Remix",
+                                "href": "/docs/upgrade-guides/core-2/remix",
+                                "icon": "remix"
                               },
                               {
-                                "title": "Integrate Clerk into your app with tRPC",
-                                "href": "/docs/references/nextjs/trpc"
-                              }
-                            ]
-                          ]
-                        },
-                        {
-                          "title": "General References",
-                          "items": [
-                            [
-                              {
-                                "title": "`clerkMiddleware()`",
-                                "wrap": false,
-                                "href": "/docs/references/nextjs/clerk-middleware"
+                                "title": "Expo",
+                                "href": "/docs/upgrade-guides/core-2/expo"
                               },
                               {
-                                "title": "Auth Object",
-                                "href": "/docs/references/nextjs/auth-object"
-                              }
-                            ]
-                          ]
-                        },
-                        {
-                          "title": "App Router References",
-                          "items": [
-                            [
-                              {
-                                "title": "`auth()`",
-                                "wrap": false,
-                                "href": "/docs/references/nextjs/auth"
+                                "title": "Fastify",
+                                "href": "/docs/upgrade-guides/core-2/fastify"
                               },
                               {
-                                "title": "`currentUser()`",
-                                "wrap": false,
-                                "href": "/docs/references/nextjs/current-user"
+                                "title": "React",
+                                "href": "/docs/upgrade-guides/core-2/react",
+                                "icon": "react"
                               },
                               {
-                                "title": "Route Handlers",
-                                "href": "/docs/references/nextjs/route-handlers"
+                                "title": "Node",
+                                "href": "/docs/upgrade-guides/core-2/node"
                               },
                               {
-                                "title": "Server Actions",
-                                "href": "/docs/references/nextjs/server-actions"
-                              }
-                            ]
-                          ]
-                        },
-                        {
-                          "title": "Pages Router References",
-                          "items": [
-                            [
-                              {
-                                "title": "`getAuth()`",
-                                "wrap": false,
-                                "href": "/docs/references/nextjs/get-auth"
+                                "title": "Backend",
+                                "href": "/docs/upgrade-guides/core-2/backend"
                               },
                               {
-                                "title": "`buildClerkProps()`",
-                                "wrap": false,
-                                "href": "/docs/references/nextjs/build-clerk-props"
-                              }
-                            ]
-                          ]
-                        },
-                        {
-                          "title": "Deprecated",
-                          "items": [
-                            [
-                              {
-                                "title": "`authMiddleware()`",
-                                "wrap": false,
-                                "href": "/docs/references/nextjs/auth-middleware"
+                                "title": "Chrome Extension",
+                                "href": "/docs/upgrade-guides/core-2/chrome-extension"
                               },
                               {
-                                "title": "Use Clerk with Next.js 12 and older",
-                                "href": "/docs/references/nextjs/usage-with-older-versions"
-                              }
-                            ]
-                          ]
-                        },
-                        {
-                          "title": "Demo Repositories",
-                          "items": [
-                            [
-                              {
-                                "title": "App Router Demo Repo",
-                                "href": "https://github.com/clerk/clerk-nextjs-demo-app-router"
-                              },
-                              {
-                                "title": "Pages Router Demo Repo",
-                                "href": "https://github.com/clerk/clerk-nextjs-demo-pages-router"
+                                "title": "JavaScript",
+                                "href": "/docs/upgrade-guides/core-2/javascript",
+                                "icon": "javascript"
                               }
                             ]
                           ]
@@ -1690,1234 +1143,412 @@
                     ]
                   },
                   {
-                    "title": "React",
-                    "collapse": true,
-                    "icon": "react",
+                    "title": "Upgrading to Core 1",
                     "items": [
                       [
                         {
                           "title": "Overview",
-                          "href": "/docs/references/react/overview"
-                        },
-                        {
-                          "title": "Guides",
-                          "items": [
-                            [
-                              {
-                                "title": "Add React Router",
-                                "href": "/docs/references/react/add-react-router"
-                              }
-                            ]
-                          ]
-                        },
-                        {
-                          "title": "Client-side Helpers",
-                          "items": [
-                            [
-                              {
-                                "title": "`useUser()`",
-                                "wrap": false,
-                                "href": "/docs/references/react/use-user"
-                              },
-                              {
-                                "title": "`useClerk()`",
-                                "wrap": false,
-                                "href": "/docs/references/react/use-clerk"
-                              },
-                              {
-                                "title": "`useAuth()`",
-                                "wrap": false,
-                                "href": "/docs/references/react/use-auth"
-                              },
-                              {
-                                "title": "`useSignIn()`",
-                                "wrap": false,
-                                "href": "/docs/references/react/use-sign-in"
-                              },
-                              {
-                                "title": "`useSignUp()`",
-                                "wrap": false,
-                                "href": "/docs/references/react/use-sign-up"
-                              },
-                              {
-                                "title": "`useSession()`",
-                                "wrap": false,
-                                "href": "/docs/references/react/use-session"
-                              },
-                              {
-                                "title": "`useSessionList()`",
-                                "wrap": false,
-                                "href": "/docs/references/react/use-session-list"
-                              },
-                              {
-                                "title": "`useOrganization()`",
-                                "wrap": false,
-                                "href": "/docs/references/react/use-organization"
-                              },
-                              {
-                                "title": "`useOrganizationList()`",
-                                "wrap": false,
-                                "href": "/docs/references/react/use-organization-list"
-                              }
-                            ]
-                          ]
+                          "href": "/docs/upgrade-guides/upgrading-from-v2-to-v3"
                         }
                       ]
                     ]
                   },
                   {
-                    "title": "JavaScript",
-                    "collapse": true,
-                    "icon": "javascript",
+                    "title": "Dashboard",
+                    "items": [
+                      [
+                        {
+                          "title": "API Key Changes",
+                          "href": "/docs/upgrade-guides/api-keys"
+                        },
+                        {
+                          "title": "URL-based session syncing",
+                          "href": "/docs/upgrade-guides/url-based-session-syncing"
+                        },
+                        {
+                          "title": "Progressive Sign up",
+                          "href": "/docs/upgrade-guides/progressive-sign-up"
+                        }
+                      ]
+                    ]
+                  }
+                ]
+              ]
+            },
+            {
+              "title": "Deployments & Migrations",
+              "collapse": true,
+              "items": [
+                [
+                  {
+                    "title": "Instances / Environments",
+                    "href": "/docs/deployments/environments"
+                  },
+                  {
+                    "title": "Clerk environment variables",
+                    "href": "/docs/deployments/clerk-environment-variables"
+                  },
+                  {
+                    "title": "Deployment",
+                    "items": [
+                      [
+                        {
+                          "title": "Deploy to production",
+                          "href": "/docs/deployments/overview"
+                        },
+                        {
+                          "title": "Deploy to Vercel",
+                          "href": "/docs/deployments/deploy-to-vercel"
+                        },
+                        {
+                          "title": "Set up a staging environment",
+                          "href": "/docs/deployments/set-up-staging"
+                        },
+                        {
+                          "title": "Deploy an Expo app to production",
+                          "href": "/docs/deployments/deploy-expo"
+                        },
+                        {
+                          "title": "Deploy an Astro app to production",
+                          "href": "/docs/deployments/deploy-astro"
+                        },
+                        {
+                          "title": "Set up a preview environment",
+                          "href": "/docs/deployments/set-up-preview-environment"
+                        },
+                        {
+                          "title": "Changing domains",
+                          "href": "/docs/deployments/changing-domains"
+                        }
+                      ]
+                    ]
+                  },
+                  {
+                    "title": "Migrations",
+                    "items": [
+                      [
+                        {
+                          "title": "Migrate to Clerk",
+                          "href": "/docs/deployments/migrate-overview"
+                        },
+                        {
+                          "title": "Migrate from Firebase",
+                          "href": "/docs/deployments/migrate-from-firebase"
+                        },
+                        {
+                          "title": "Migrate from Cognito",
+                          "href": "/docs/deployments/migrate-from-cognito"
+                        },
+                        {
+                          "title": "Exporting user data",
+                          "href": "/docs/deployments/exporting-users"
+                        }
+                      ]
+                    ]
+                  },
+                  {
+                    "title": "Cookie Information",
+                    "items": [
+                      [
+                        {
+                          "title": "Clerk Cookie Information",
+                          "href": "/docs/deployments/clerk-cookies"
+                        }
+                      ]
+                    ]
+                  }
+                ]
+              ]
+            }
+          ]
+        ]
+      }
+    ],
+    [
+      {
+        "title": "Advanced",
+        "items": [
+          [
+            {
+              "title": "Integrations",
+              "collapse": true,
+              "items": [
+                [
+                  {
+                    "title": "Overview",
+                    "href": "/docs/integrations/overview"
+                  },
+                  {
+                    "title": "Webhooks",
                     "items": [
                       [
                         {
                           "title": "Overview",
-                          "href": "/docs/references/javascript/overview"
+                          "href": "/docs/integrations/webhooks/overview"
                         },
                         {
-                          "title": "Clerk",
-                          "collapse": true,
-                          "items": [
-                            [
-                              {
-                                "title": "Clerk class",
-                                "href": "/docs/references/javascript/clerk/clerk"
-                              },
-                              {
-                                "title": "Organization methods",
-                                "href": "/docs/references/javascript/clerk/organization-methods"
-                              },
-                              {
-                                "title": "Redirect methods",
-                                "href": "/docs/references/javascript/clerk/redirect-methods"
-                              },
-                              {
-                                "title": "BuildURLs",
-                                "href": "/docs/references/javascript/clerk/build-urls"
-                              },
-                              {
-                                "title": "Handle navigation",
-                                "href": "/docs/references/javascript/clerk/handle-navigation"
-                              },
-                              {
-                                "title": "Session methods",
-                                "href": "/docs/references/javascript/clerk/session-methods"
-                              }
-                            ]
-                          ]
+                          "title": "Sync Clerk data to your application with webhooks",
+                          "href": "/docs/integrations/webhooks/sync-data"
                         },
                         {
-                          "title": "User",
-                          "collapse": true,
-                          "items": [
-                            [
-                              {
-                                "title": "User object",
-                                "href": "/docs/references/javascript/user/user"
-                              },
-                              {
-                                "title": "TOTP methods",
-                                "href": "/docs/references/javascript/user/totp"
-                              },
-                              {
-                                "title": "Password management methods",
-                                "href": "/docs/references/javascript/user/password-management"
-                              },
-                              {
-                                "title": "Create metadata methods",
-                                "href": "/docs/references/javascript/user/create-metadata"
-                              }
-                            ]
-                          ]
+                          "title": "Handling webhooks with Inngest",
+                          "href": "/docs/integrations/webhooks/inngest"
                         },
                         {
-                          "title": "Organization",
-                          "collapse": true,
-                          "items": [
-                            [
-                              {
-                                "title": "Organization object",
-                                "href": "/docs/references/javascript/organization/organization"
-                              },
-                              {
-                                "title": "Membership methods",
-                                "href": "/docs/references/javascript/organization/members"
-                              },
-                              {
-                                "title": "Invitation methods",
-                                "href": "/docs/references/javascript/organization/invitations"
-                              },
-                              {
-                                "title": "Domain methods",
-                                "href": "/docs/references/javascript/organization/domains"
-                              },
-                              {
-                                "title": "Membership request methods",
-                                "href": "/docs/references/javascript/organization/membership-request"
-                              }
-                            ]
-                          ]
+                          "title": "Send webhooks to Loops",
+                          "href": "/docs/integrations/webhooks/loops"
                         },
                         {
-                          "title": "Organization Invitation",
-                          "href": "/docs/references/javascript/organization-invitation"
-                        },
-                        {
-                          "title": "Organization Membership",
-                          "href": "/docs/references/javascript/organization-membership"
-                        },
-                        {
-                          "title": "Organization Domain",
-                          "href": "/docs/references/javascript/organization-domain"
-                        },
-                        {
-                          "title": "Organization Membership Request",
-                          "href": "/docs/references/javascript/organization-membership-request"
-                        },
-                        {
-                          "title": "Session",
-                          "href": "/docs/references/javascript/session"
-                        },
-                        {
-                          "title": "SessionWithActivities",
-                          "href": "/docs/references/javascript/session-with-activities"
-                        },
-                        {
-                          "title": "Client",
-                          "href": "/docs/references/javascript/client"
-                        },
-                        {
-                          "title": "ExternalAccount",
-                          "href": "/docs/references/javascript/external-account"
-                        },
-                        {
-                          "title": "Email Address",
-                          "href": "/docs/references/javascript/email-address"
-                        },
-                        {
-                          "title": "Phone Number",
-                          "href": "/docs/references/javascript/phone-number"
-                        },
-                        {
-                          "title": "Sign In",
-                          "collapse": true,
-                          "items": [
-                            [
-                              {
-                                "title": "Sign In",
-                                "href": "/docs/references/javascript/sign-in/sign-in"
-                              },
-                              {
-                                "title": "First Factor",
-                                "href": "/docs/references/javascript/sign-in/first-factor"
-                              },
-                              {
-                                "title": "Second Factor",
-                                "href": "/docs/references/javascript/sign-in/second-factor"
-                              },
-                              {
-                                "title": "AuthenticateWith",
-                                "href": "/docs/references/javascript/sign-in/authenticate-with"
-                              }
-                            ]
-                          ]
-                        },
-                        {
-                          "title": "Sign Up",
-                          "collapse": true,
-                          "items": [
-                            [
-                              {
-                                "title": "Sign Up",
-                                "href": "/docs/references/javascript/sign-up/sign-up"
-                              },
-                              {
-                                "title": "AuthenticateWith",
-                                "href": "/docs/references/javascript/sign-up/authenticate-with"
-                              },
-                              {
-                                "title": "Verification",
-                                "href": "/docs/references/javascript/sign-up/verification"
-                              },
-                              {
-                                "title": "Email Verification",
-                                "href": "/docs/references/javascript/sign-up/email-verification"
-                              },
-                              {
-                                "title": "Phone Verification",
-                                "href": "/docs/references/javascript/sign-up/phone-verification"
-                              },
-                              {
-                                "title": "Web3 Verification",
-                                "href": "/docs/references/javascript/sign-up/web3-verification"
-                              }
-                            ]
-                          ]
-                        },
-                        {
-                          "title": "Web3 Wallet",
-                          "collapse": true,
-                          "items": [
-                            [
-                              {
-                                "title": "Web3 Wallet",
-                                "href": "/docs/references/javascript/web3-wallet/web3-wallet"
-                              },
-                              {
-                                "title": "Verification",
-                                "href": "/docs/references/javascript/web3-wallet/verification"
-                              }
-                            ]
-                          ]
-                        },
-                        {
-                          "title": "Types",
-                          "collapse": true,
-                          "items": [
-                            [
-                              {
-                                "title": "Overview",
-                                "href": "/docs/references/javascript/types/overview"
-                              },
-                              {
-                                "title": "ClerkAPIError",
-                                "href": "/docs/references/javascript/types/clerk-api-error"
-                              },
-                              {
-                                "title": "ClerkPaginatedResponse",
-                                "href": "/docs/references/javascript/types/clerk-paginated-response"
-                              },
-                              {
-                                "title": "CustomPage",
-                                "href": "/docs/references/javascript/types/custom-page"
-                              },
-                              {
-                                "title": "EmailLinkError",
-                                "href": "/docs/references/javascript/types/email-link-error"
-                              },
-                              {
-                                "title": "DeletedObject",
-                                "href": "/docs/references/javascript/types/deleted-object"
-                              },
-                              {
-                                "title": "OAuth types",
-                                "href": "/docs/references/javascript/types/oauth"
-                              },
-                              {
-                                "title": "PasskeyResource",
-                                "href": "/docs/references/javascript/types/passkey-resource"
-                              },
-                              {
-                                "title": "PublicUserData",
-                                "href": "/docs/references/javascript/types/public-user-data"
-                              },
-                              {
-                                "title": "SessionStatus",
-                                "href": "/docs/references/javascript/types/session-status"
-                              },
-                              {
-                                "title": "SignInFirstFactor",
-                                "href": "/docs/references/javascript/types/sign-in-first-factor"
-                              },
-                              {
-                                "title": "SignInSecondFactor",
-                                "href": "/docs/references/javascript/types/sign-in-second-factor"
-                              },
-                              {
-                                "title": "SignInRedirectOptions",
-                                "href": "/docs/references/javascript/types/sign-in-redirect-options"
-                              },
-                              {
-                                "title": "SignUpRedirectOptions",
-                                "href": "/docs/references/javascript/types/sign-up-redirect-options"
-                              },
-                              {
-                                "title": "SignInInitialValues",
-                                "href": "/docs/references/javascript/types/sign-in-initial-values"
-                              },
-                              {
-                                "title": "SignUpInitialValues",
-                                "href": "/docs/references/javascript/types/sign-up-initial-values"
-                              },
-                              {
-                                "title": "RedirectOptions",
-                                "href": "/docs/references/javascript/types/redirect-options"
-                              },
-                              {
-                                "title": "Verification",
-                                "href": "/docs/references/javascript/types/verification"
-                              }
-                            ]
-                          ]
+                          "title": "Debug your webhooks",
+                          "href": "/docs/integrations/webhooks/debug-your-webhooks"
                         }
                       ]
                     ]
                   },
                   {
-                    "title": "Expo",
-                    "collapse": true,
-                    "icon": "expo",
+                    "title": "Databases",
                     "items": [
                       [
                         {
-                          "title": "Overview",
-                          "href": "/docs/references/expo/overview"
+                          "title": "Convex",
+                          "href": "/docs/integrations/databases/convex"
                         },
                         {
-                          "title": "Guides",
-                          "items": [
-                            [
-                              {
-                                "title": "Read session and user data",
-                                "href": "/docs/references/expo/read-session-user-data"
-                              },
-                              {
-                                "title": "Use biometrics with local credentials",
-                                "href": "/docs/references/expo/local-credentials"
-                              }
-                            ]
-                          ]
+                          "title": "Fauna",
+                          "href": "/docs/integrations/databases/fauna"
                         },
                         {
-                          "title": "Hooks",
-                          "items": [
-                            [
-                              {
-                                "title": "useLocalCredentials()",
-                                "href": "/docs/references/expo/use-local-credentials"
-                              }
-                            ]
-                          ]
+                          "title": "Firebase",
+                          "href": "/docs/integrations/databases/firebase"
                         },
                         {
-                          "title": "Web support",
-                          "icon": "route",
-                          "collapse": true,
-                          "items": [
-                            [
-                              {
-                                "title": "Overview",
-                                "href": "/docs/references/expo/web-support/overview"
-                              },
-                              {
-                                "title": "Add custom sign-up and sign-in pages",
-                                "href": "/docs/references/expo/web-support/custom-signup-signin-pages"
-                              }
-                            ]
-                          ]
+                          "title": "Grafbase",
+                          "href": "/docs/integrations/databases/grafbase"
+                        },
+                        {
+                          "title": "Hasura",
+                          "href": "/docs/integrations/databases/hasura"
+                        },
+                        {
+                          "title": "Nhost",
+                          "href": "/docs/integrations/databases/nhost"
+                        },
+                        {
+                          "title": "Supabase",
+                          "href": "/docs/integrations/databases/supabase"
+                        },
+                        {
+                          "title": "Neon",
+                          "href": "/docs/integrations/databases/neon"
                         }
                       ]
                     ]
                   },
                   {
-                    "title": "iOS",
-                    "tag": "(Beta)",
-                    "collapse": true,
-                    "icon": "apple",
+                    "title": "Analytics",
                     "items": [
                       [
                         {
-                          "title": "Overview",
-                          "href": "/docs/references/ios/overview"
+                          "title": "Google Analytics",
+                          "href": "/docs/integrations/analytics/google-analytics"
                         }
                       ]
                     ]
+                  }
+                ]
+              ]
+            },
+            {
+              "title": "Advanced Usage",
+              "collapse": true,
+              "items": [
+                [
+                  {
+                    "title": "Clerk as an OAuth2 Provider",
+                    "href": "/docs/advanced-usage/clerk-idp"
                   },
                   {
-                    "title": "Node.js",
-                    "collapse": true,
-                    "icon": "nodejs",
+                    "title": "Authentication across different domains",
+                    "href": "/docs/advanced-usage/satellite-domains"
+                  },
+                  {
+                    "title": "Proxying the Clerk Frontend API",
+                    "href": "/docs/advanced-usage/using-proxies"
+                  }
+                ]
+              ]
+            },
+            {
+              "title": "Security & Privacy",
+              "collapse": true,
+              "items": [
+                [
+                  {
+                    "title": "Overview",
+                    "href": "/docs/security/overview"
+                  },
+                  {
+                    "title": "Vulnerability disclosure policy",
+                    "href": "/docs/security/vulnerability-disclosure-policy"
+                  },
+                  {
+                    "title": "XSS leak protection",
+                    "href": "/docs/security/xss-leak-protection"
+                  },
+                  {
+                    "title": "CSRF protection",
+                    "href": "/docs/security/csrf-protection"
+                  },
+                  {
+                    "title": "CSP Headers",
+                    "href": "/docs/security/clerk-csp"
+                  },
+                  {
+                    "title": "Fixation protection",
+                    "href": "/docs/security/fixation-protection"
+                  },
+                  {
+                    "title": "Password protection and rules",
+                    "href": "/docs/security/password-protection"
+                  },
+                  {
+                    "title": "Clerk Telemetry",
+                    "href": "/docs/telemetry"
+                  },
+                  {
+                    "title": "Protect accounts from attacks",
                     "items": [
                       [
                         {
-                          "title": "Overview",
-                          "href": "/docs/references/nodejs/overview"
+                          "title": "Brute force attacks and locking user accounts",
+                          "href": "/docs/security/user-lock-guide"
                         },
                         {
-                          "title": "Available methods",
-                          "href": "/docs/references/nodejs/available-methods"
+                          "title": "Protect sign ups from bots",
+                          "href": "/docs/security/bot-protection"
                         },
                         {
-                          "title": "Connect/Express Middleware",
-                          "href": "/docs/backend-requests/handling/nodejs"
+                          "title": "Customize max sign-in attempts and duration of of user lockout",
+                          "href": "/docs/security/customize-user-lockout"
+                        },
+                        {
+                          "title": "Unlock accounts from the Clerk Dashboard",
+                          "href": "/docs/security/unlock-user-accounts"
+                        },
+                        {
+                          "title": "Programmatically lock and unlock accounts",
+                          "href": "/docs/security/programmatically-lock-user-accounts"
+                        },
+                        {
+                          "title": "Protect email link sign-ins and sign-ups",
+                          "href": "/docs/security/email-link-protection"
                         }
                       ]
                     ]
+                  }
+                ]
+              ]
+            },
+            {
+              "title": "Custom Flows",
+              "collapse": true,
+              "items": [
+                [
+                  {
+                    "title": "Overview",
+                    "href": "/docs/custom-flows/overview"
                   },
                   {
-                    "title": "Remix",
-                    "collapse": true,
-                    "icon": "remix",
+                    "title": "Error handling",
+                    "href": "/docs/custom-flows/error-handling"
+                  },
+                  {
+                    "title": "Authentication",
                     "items": [
                       [
                         {
-                          "title": "`<ClerkApp />`",
-                          "wrap": false,
-                          "href": "/docs/references/remix/clerk-app"
+                          "title": "Email & password",
+                          "href": "/docs/custom-flows/email-password"
                         },
                         {
-                          "title": "SPA Mode",
-                          "wrap": false,
-                          "href": "/docs/references/remix/spa-mode"
+                          "title": "Email / SMS OTP",
+                          "href": "/docs/custom-flows/email-sms-otp"
                         },
                         {
-                          "title": "Add custom sign up and sign in pages",
-                          "wrap": true,
-                          "href": "/docs/references/remix/custom-signup-signin-pages"
+                          "title": "Email links",
+                          "href": "/docs/custom-flows/email-links"
                         },
                         {
-                          "title": "Read session and user data",
-                          "wrap": true,
-                          "href": "/docs/references/remix/read-session-data"
-                        }
-                      ]
-                    ]
-                  },
-                  {
-                    "title": "Go",
-                    "collapse": true,
-                    "icon": "go",
-                    "items": [
-                      [
-                        {
-                          "title": "Overview",
-                          "href": "/docs/references/go/overview"
+                          "title": "Email & password + MFA",
+                          "href": "/docs/custom-flows/email-password-mfa"
                         },
                         {
-                          "title": "Verifying sessions",
-                          "href": "/docs/references/go/verifying-sessions"
+                          "title": "Passkeys",
+                          "href": "/docs/custom-flows/passkeys"
                         },
                         {
-                          "title": "Use Clerk Go for Backend API Operations",
-                          "href": "/docs/references/go/other-examples"
+                          "title": "Google One Tap",
+                          "href": "/docs/custom-flows/google-one-tap"
                         },
                         {
-                          "title": "Go SDK repository",
-                          "href": "https://github.com/clerk/clerk-sdk-go"
-                        }
-                      ]
-                    ]
-                  },
-                  {
-                    "title": "Gatsby",
-                    "collapse": true,
-                    "icon": "gatsby",
-                    "items": [
-                      [
-                        {
-                          "title": "`withServerAuth()`",
-                          "wrap": false,
-                          "href": "/docs/references/gatsby/with-server-auth"
-                        }
-                      ]
-                    ]
-                  },
-                  {
-                    "title": "Astro",
-                    "collapse": true,
-                    "icon": "astro",
-                    "items": [
-                      [
-                        { "title": "Overview", "href": "/docs/references/astro/overview" },
-                        {
-                          "title": "UI Frameworks",
-                          "items": [
-                            [
-                              {
-                                "title": "Use Clerk with Astro and React",
-                                "href": "/docs/references/astro/react"
-                              }
-                            ]
-                          ]
-                        },
-                        {
-                          "title": "Guides",
-                          "items": [
-                            [
-                              {
-                                "title": "Migrating from community SDK",
-                                "href": "/docs/references/astro/migrating-from-astro-community-sdk"
-                              },
-                              {
-                                "title": "Read session and user data",
-                                "wrap": false,
-                                "href": "/docs/references/astro/read-session-data"
-                              }
-                            ]
-                          ]
-                        },
-                        {
-                          "title": "General Reference",
-                          "items": [
-                            [
-                              {
-                                "title": "`clerkMiddleware()`",
-                                "wrap": false,
-                                "href": "/docs/references/astro/clerk-middleware"
-                              },
-                              {
-                                "title": "Locals",
-                                "wrap": false,
-                                "href": "/docs/references/astro/locals"
-                              },
-                              {
-                                "title": "Endpoints",
-                                "wrap": false,
-                                "href": "/docs/references/astro/endpoints"
-                              }
-                            ]
-                          ]
-                        },
-                        {
-                          "title": "Client-side Helpers",
-                          "items": [
-                            [
-                              {
-                                "title": "`$authStore`",
-                                "wrap": false,
-                                "href": "/docs/references/astro/auth-store"
-                              },
-                              {
-                                "title": "`$clerkStore`",
-                                "wrap": false,
-                                "href": "/docs/references/astro/clerk-store"
-                              },
-                              {
-                                "title": "`$userStore`",
-                                "wrap": false,
-                                "href": "/docs/references/astro/user-store"
-                              },
-                              {
-                                "title": "`$signInStore`",
-                                "wrap": false,
-                                "href": "/docs/references/astro/sign-in-store"
-                              },
-                              {
-                                "title": "`$signUpStore`",
-                                "wrap": false,
-                                "href": "/docs/references/astro/sign-up-store"
-                              },
-                              {
-                                "title": "`$sessionStore`",
-                                "wrap": false,
-                                "href": "/docs/references/astro/session-store"
-                              },
-                              {
-                                "title": "`$sessionListStore`",
-                                "wrap": false,
-                                "href": "/docs/references/astro/session-list-store"
-                              },
-                              {
-                                "title": "`$organizationStore`",
-                                "wrap": false,
-                                "href": "/docs/references/astro/organization-store"
-                              }
-                            ]
-                          ]
-                        }
-                      ]
-                    ]
-                  },
-                  {
-                    "title": "Ruby / Rails",
-                    "collapse": true,
-                    "icon": "ruby",
-                    "items": [
-                      [
-                        {
-                          "title": "Overview",
-                          "href": "/docs/references/ruby/overview"
-                        },
-                        {
-                          "title": "Available Methods",
-                          "href": "/docs/references/ruby/available-methods"
-                        },
-                        {
-                          "title": "Rack/Rails integration",
-                          "href": "/docs/references/ruby/rack-rails"
-                        },
-                        {
-                          "title": "Ruby SDK repository",
-                          "href": "https://github.com/clerk/clerk-sdk-ruby"
-                        }
-                      ]
-                    ]
-                  },
-                  {
-                    "title": "JS Backend SDK",
-                    "collapse": true,
-                    "icon": "clerk",
-                    "items": [
-                      [
-                        {
-                          "title": "Overview",
-                          "href": "/docs/references/backend/overview"
-                        },
-                        {
-                          "title": "User",
-                          "collapse": true,
-                          "items": [
-                            [
-                              {
-                                "title": "`getUserList()`",
-                                "wrap": false,
-                                "href": "/docs/references/backend/user/get-user-list"
-                              },
-                              {
-                                "title": "`getUser()`",
-                                "wrap": false,
-                                "href": "/docs/references/backend/user/get-user"
-                              },
-                              {
-                                "title": "`getCount()`",
-                                "wrap": false,
-                                "href": "/docs/references/backend/user/get-count"
-                              },
-                              {
-                                "title": "`getOrganizationMembershipList()`",
-                                "wrap": false,
-                                "href": "/docs/references/backend/user/get-organization-membership-list"
-                              },
-                              {
-                                "title": "`getUserOAuthAccessToken()`",
-                                "wrap": false,
-                                "href": "/docs/references/backend/user/get-user-oauth-access-token"
-                              },
-                              {
-                                "title": "`createUser()`",
-                                "wrap": false,
-                                "href": "/docs/references/backend/user/create-user"
-                              },
-                              {
-                                "title": "`verifyPassword()`",
-                                "wrap": false,
-                                "href": "/docs/references/backend/user/verify-password"
-                              },
-                              {
-                                "title": "`banUser()`",
-                                "wrap": false,
-                                "href": "/docs/references/backend/user/ban-user"
-                              },
-                              {
-                                "title": "`unbanUser()`",
-                                "wrap": false,
-                                "href": "/docs/references/backend/user/unban-user"
-                              },
-                              {
-                                "title": "`lockUser()`",
-                                "wrap": false,
-                                "href": "/docs/references/backend/user/lock-user"
-                              },
-                              {
-                                "title": "`unlockUser()`",
-                                "wrap": false,
-                                "href": "/docs/references/backend/user/unlock-user"
-                              },
-                              {
-                                "title": "`updateUser()`",
-                                "wrap": false,
-                                "href": "/docs/references/backend/user/update-user"
-                              },
-                              {
-                                "title": "`updateUserProfileImage()`",
-                                "wrap": false,
-                                "href": "/docs/references/backend/user/update-user-profile-image"
-                              },
-                              {
-                                "title": "`updateUserMetadata()`",
-                                "wrap": false,
-                                "href": "/docs/references/backend/user/update-user-metadata"
-                              },
-                              {
-                                "title": "`deleteUser()`",
-                                "wrap": false,
-                                "href": "/docs/references/backend/user/delete-user"
-                              },
-                              {
-                                "title": "`disableUserMFA()`",
-                                "wrap": false,
-                                "href": "/docs/references/backend/user/disable-user-mfa"
-                              },
-                              {
-                                "title": "`verifyTOTP()`",
-                                "wrap": false,
-                                "href": "/docs/references/backend/user/verify-totp"
-                              }
-                            ]
-                          ]
-                        },
-                        {
-                          "title": "Organization",
-                          "collapse": true,
-                          "items": [
-                            [
-                              {
-                                "title": "`getOrganization()`",
-                                "wrap": false,
-                                "href": "/docs/references/backend/organization/get-organization"
-                              },
-                              {
-                                "title": "`getOrganizationList()`",
-                                "wrap": false,
-                                "href": "/docs/references/backend/organization/get-organization-list"
-                              },
-                              {
-                                "title": "`getOrganizationMembershipList()`",
-                                "wrap": false,
-                                "href": "/docs/references/backend/organization/get-organization-membership-list"
-                              },
-                              {
-                                "title": "`getOrganizationInvitationList()`",
-                                "wrap": false,
-                                "href": "/docs/references/backend/organization/get-organization-invitation-list"
-                              },
-                              {
-                                "title": "`createOrganization()`",
-                                "wrap": false,
-                                "href": "/docs/references/backend/organization/create-organization"
-                              },
-                              {
-                                "title": "`createOrganizationMembership()`",
-                                "wrap": false,
-                                "href": "/docs/references/backend/organization/create-organization-membership"
-                              },
-                              {
-                                "title": "`createOrganizationInvitation()`",
-                                "wrap": false,
-                                "href": "/docs/references/backend/organization/create-organization-invitation"
-                              },
-                              {
-                                "title": "`updateOrganization()`",
-                                "wrap": false,
-                                "href": "/docs/references/backend/organization/update-organization"
-                              },
-                              {
-                                "title": "`updateOrganizationLogo()`",
-                                "wrap": false,
-                                "href": "/docs/references/backend/organization/update-organization-logo"
-                              },
-                              {
-                                "title": "`updateOrganizationMembership()`",
-                                "wrap": false,
-                                "href": "/docs/references/backend/organization/update-organization-membership"
-                              },
-                              {
-                                "title": "`updateOrganizationMetadata()`",
-                                "wrap": false,
-                                "href": "/docs/references/backend/organization/update-organization-metadata"
-                              },
-                              {
-                                "title": "`updateOrganizationMembershipMetadata()`",
-                                "wrap": false,
-                                "href": "/docs/references/backend/organization/update-organization-membership-metadata"
-                              },
-                              {
-                                "title": "`deleteOrganization()`",
-                                "wrap": false,
-                                "href": "/docs/references/backend/organization/delete-organization"
-                              },
-                              {
-                                "title": "`deleteOrganizationMembership()`",
-                                "wrap": false,
-                                "href": "/docs/references/backend/organization/delete-organization-membership"
-                              },
-                              {
-                                "title": "`revokeOrganizationInvitation()`",
-                                "wrap": false,
-                                "href": "/docs/references/backend/organization/revoke-organization-invitation"
-                              }
-                            ]
-                          ]
-                        },
-                        {
-                          "title": "Allowlist Identifiers",
-                          "collapse": true,
-                          "items": [
-                            [
-                              {
-                                "title": "`getAllowlistIdentifierList()`",
-                                "wrap": false,
-                                "href": "/docs/references/backend/allowlist/get-allowlist-identifier-list"
-                              },
-                              {
-                                "title": "`createAllowlistIdentifier()`",
-                                "wrap": false,
-                                "href": "/docs/references/backend/allowlist/create-allowlist-identifier"
-                              },
-                              {
-                                "title": "`deleteAllowlistIdentifier()`",
-                                "wrap": false,
-                                "href": "/docs/references/backend/allowlist/delete-allowlist-identifier"
-                              }
-                            ]
-                          ]
-                        },
-                        {
-                          "title": "Sessions",
-                          "collapse": true,
-                          "items": [
-                            [
-                              {
-                                "title": "`getSession()`",
-                                "wrap": false,
-                                "href": "/docs/references/backend/sessions/get-session"
-                              },
-                              {
-                                "title": "`getSessionList()`",
-                                "wrap": false,
-                                "href": "/docs/references/backend/sessions/get-session-list"
-                              },
-                              {
-                                "title": "`getToken()`",
-                                "wrap": false,
-                                "href": "/docs/references/backend/sessions/get-token"
-                              },
-                              {
-                                "title": "`verifySession()`",
-                                "wrap": false,
-                                "href": "/docs/references/backend/sessions/verify-session"
-                              },
-                              {
-                                "title": "`revokeSession()`",
-                                "wrap": false,
-                                "href": "/docs/references/backend/sessions/revoke-session"
-                              }
-                            ]
-                          ]
-                        },
-                        {
-                          "title": "Client",
-                          "collapse": true,
-                          "items": [
-                            [
-                              {
-                                "title": "`getClient()`",
-                                "wrap": false,
-                                "href": "/docs/references/backend/client/get-client"
-                              },
-                              {
-                                "title": "`getClientList()`",
-                                "wrap": false,
-                                "href": "/docs/references/backend/client/get-client-list"
-                              },
-                              {
-                                "title": "`verifyClient()`",
-                                "wrap": false,
-                                "href": "/docs/references/backend/client/verify-client"
-                              }
-                            ]
-                          ]
-                        },
-                        {
-                          "title": "Invitations",
-                          "collapse": true,
-                          "items": [
-                            [
-                              {
-                                "title": "`getInvitationList()`",
-                                "wrap": false,
-                                "href": "/docs/references/backend/invitations/get-invitation-list"
-                              },
-                              {
-                                "title": "`createInvitation()`",
-                                "wrap": false,
-                                "href": "/docs/references/backend/invitations/create-invitation"
-                              },
-                              {
-                                "title": "`revokeInvitation()`",
-                                "wrap": false,
-                                "href": "/docs/references/backend/invitations/revoke-invitation"
-                              }
-                            ]
-                          ]
-                        },
-                        {
-                          "title": "Redirect Urls",
-                          "collapse": true,
-                          "items": [
-                            [
-                              {
-                                "title": "`getRedirectUrl()`",
-                                "wrap": false,
-                                "href": "/docs/references/backend/redirect-urls/get-redirect-url"
-                              },
-                              {
-                                "title": "`getRedirectUrlList()`",
-                                "wrap": false,
-                                "href": "/docs/references/backend/redirect-urls/get-redirect-url-list"
-                              },
-                              {
-                                "title": "`createRedirectUrl()`",
-                                "wrap": false,
-                                "href": "/docs/references/backend/redirect-urls/create-redirect-url"
-                              },
-                              {
-                                "title": "`deleteRedirectUrl()`",
-                                "wrap": false,
-                                "href": "/docs/references/backend/redirect-urls/delete-redirect-url"
-                              }
-                            ]
-                          ]
-                        },
-                        {
-                          "title": "Email addresses",
-                          "collapse": true,
-                          "items": [
-                            [
-                              {
-                                "title": "`getEmailAddress()`",
-                                "wrap": false,
-                                "href": "/docs/references/backend/email-addresses/get-email-address"
-                              },
-                              {
-                                "title": "`createEmailAddress()`",
-                                "wrap": false,
-                                "href": "/docs/references/backend/email-addresses/create-email-address"
-                              },
-                              {
-                                "title": "`updateEmailAddress()`",
-                                "wrap": false,
-                                "href": "/docs/references/backend/email-addresses/update-email-address"
-                              },
-                              {
-                                "title": "`deleteEmailAddress()`",
-                                "wrap": false,
-                                "href": "/docs/references/backend/email-addresses/delete-email-address"
-                              }
-                            ]
-                          ]
-                        },
-                        {
-                          "title": "Phone numbers",
-                          "collapse": true,
-                          "items": [
-                            [
-                              {
-                                "title": "`getPhoneNumber()`",
-                                "wrap": false,
-                                "href": "/docs/references/backend/phone-numbers/get-phone-number"
-                              },
-                              {
-                                "title": "`createPhoneNumber()`",
-                                "wrap": false,
-                                "href": "/docs/references/backend/phone-numbers/create-phone-number"
-                              },
-                              {
-                                "title": "`updatePhoneNumber()`",
-                                "wrap": false,
-                                "href": "/docs/references/backend/phone-numbers/update-phone-number"
-                              },
-                              {
-                                "title": "`deletePhoneNumber()`",
-                                "wrap": false,
-                                "href": "/docs/references/backend/phone-numbers/delete-phone-number"
-                              }
-                            ]
-                          ]
+                          "title": "OAuth connections",
+                          "href": "/docs/custom-flows/oauth-connections"
                         },
                         {
                           "title": "SAML connections",
-                          "collapse": true,
-                          "items": [
-                            [
-                              {
-                                "title": "`getSamlConnectionList()`",
-                                "wrap": false,
-                                "href": "/docs/references/backend/saml-connections/get-saml-connection-list"
-                              },
-                              {
-                                "title": "`getSamlConnection()`",
-                                "wrap": false,
-                                "href": "/docs/references/backend/saml-connections/get-saml-connection"
-                              },
-                              {
-                                "title": "`createSamlConnection()`",
-                                "wrap": false,
-                                "href": "/docs/references/backend/saml-connections/create-saml-connection"
-                              },
-                              {
-                                "title": "`updateSamlConnection()`",
-                                "wrap": false,
-                                "href": "/docs/references/backend/saml-connections/update-saml-connection"
-                              },
-                              {
-                                "title": "`deleteSamlConnection()`",
-                                "wrap": false,
-                                "href": "/docs/references/backend/saml-connections/delete-saml-connection"
-                              }
-                            ]
-                          ]
+                          "href": "/docs/custom-flows/saml-connections"
                         },
                         {
-                          "title": "Sign-in tokens",
-                          "collapse": true,
-                          "items": [
-                            [
-                              {
-                                "title": "`createSignInToken()`",
-                                "wrap": false,
-                                "href": "/docs/references/backend/sign-in-tokens/create-sign-in-token"
-                              },
-                              {
-                                "title": "`revokeSignInToken()`",
-                                "wrap": false,
-                                "href": "/docs/references/backend/sign-in-tokens/revoke-sign-in-token"
-                              }
-                            ]
-                          ]
+                          "title": "Sign out",
+                          "href": "/docs/custom-flows/sign-out"
+                        },
+                        { "title": "Sign out", "href": "/docs/custom-flows/sign-out" },
+                        {
+                          "title": "Sign-up with application invitations",
+                          "href": "/docs/custom-flows/invitations"
                         },
                         {
-                          "title": "Testing Tokens",
-                          "collapse": true,
-                          "items": [
-                            [
-                              {
-                                "title": "`createTestingToken()`",
-                                "wrap": false,
-                                "href": "/docs/references/backend/testing-tokens/create-testing-token"
-                              }
-                            ]
-                          ]
+                          "title": "Embedded email links",
+                          "href": "/docs/custom-flows/embedded-email-links"
                         },
                         {
-                          "title": "`authenticateRequest()`",
-                          "wrap": false,
-                          "href": "/docs/references/backend/authenticate-request"
+                          "title": "Multi-session applications",
+                          "href": "/docs/custom-flows/multi-session-applications"
                         },
                         {
-                          "title": "`verifyToken()`",
-                          "wrap": false,
-                          "href": "/docs/references/backend/verify-token"
-                        },
-                        {
-                          "title": "Types",
-                          "collapse": true,
-                          "items": [
-                            [
-                              {
-                                "title": "`PaginatedResourceResponse`",
-                                "href": "/docs/references/backend/types/paginated-resource-response"
-                              },
-                              {
-                                "title": "Backend `AllowlistIdentifier` object",
-                                "href": "/docs/references/backend/types/backend-allowlist-identifier"
-                              },
-                              {
-                                "title": "Backend `Client` object",
-                                "href": "/docs/references/backend/types/backend-client"
-                              },
-                              {
-                                "title": "Backend `Invitation` object",
-                                "href": "/docs/references/backend/types/backend-invitation"
-                              },
-                              {
-                                "title": "Backend `Organization` object",
-                                "href": "/docs/references/backend/types/backend-organization"
-                              },
-                              {
-                                "title": "Backend `OrganizationInvitation` object",
-                                "href": "/docs/references/backend/types/backend-organization-invitation"
-                              },
-                              {
-                                "title": "Backend `OrganizationMembership` object",
-                                "href": "/docs/references/backend/types/backend-organization-membership"
-                              },
-                              {
-                                "title": "Backend `Session` object",
-                                "href": "/docs/references/backend/types/backend-session"
-                              },
-                              {
-                                "title": "Backend `RedirectURL` object",
-                                "href": "/docs/references/backend/types/backend-redirect-url"
-                              },
-                              {
-                                "title": "Backend `User` object",
-                                "href": "/docs/references/backend/types/backend-user"
-                              }
-                            ]
-                          ]
+                          "title": "Bot sign-up protection",
+                          "href": "/docs/custom-flows/bot-sign-up-protection"
                         }
                       ]
                     ]
                   },
                   {
-                    "title": "Community SDKs",
-                    "collapse": true,
+                    "title": "Account updates",
                     "items": [
                       [
                         {
-                          "title": "Redwood",
-                          "tag": "Community",
-                          "collapse": true,
-                          "icon": "redwood",
-                          "items": [
-                            [
-                              {
-                                "title": "Overview",
-                                "href": "/docs/references/redwood/overview"
-                              },
-                              {
-                                "title": "Redwood",
-                                "href": "https://redwoodjs.com/docs/auth/clerk",
-                                "icon": "redwood"
-                              }
-                            ]
-                          ]
+                          "title": "Forgot password",
+                          "href": "/docs/custom-flows/forgot-password"
                         },
                         {
-                          "title": "Svelte",
-                          "tag": "Community",
-                          "href": "https://github.com/markjaquith/clerk-sveltekit",
-                          "icon": "svelte"
+                          "title": "User impersonation",
+                          "href": "/docs/custom-flows/user-impersonation"
                         },
                         {
-                          "title": "Vue",
-                          "tag": "Community",
-                          "href": "https://vue-clerk.vercel.app",
-                          "icon": "vue"
+                          "title": "Add email",
+                          "href": "/docs/custom-flows/add-email"
                         },
                         {
-                          "title": "Elysia",
-                          "tag": "Community",
-                          "href": "https://github.com/wobsoriano/elysia-clerk",
-                          "icon": "elysia"
+                          "title": "Add phone",
+                          "href": "/docs/custom-flows/add-phone"
                         },
                         {
-                          "title": "Rust",
-                          "tag": "Community",
-                          "href": "https://github.com/cincinnati-ventures/clerk-rs",
-                          "icon": "rust"
+                          "title": "Manage SMS-based MFA",
+                          "href": "/docs/custom-flows/manage-sms-based-mfa"
                         },
                         {
-                          "title": "Hono",
-                          "tag": "Community",
-                          "href": "https://github.com/honojs/middleware/tree/main/packages/clerk-auth",
-                          "icon": "hono"
-                        },
-                        {
-                          "title": "C#",
-                          "tag": "Community",
-                          "href": "https://github.com/Hawxy/Clerk.Net",
-                          "icon": "c-sharp"
-                        },
-                        {
-                          "title": "Astro",
-                          "tag": "Community",
-                          "href": "https://github.com/panteliselef/astro-with-clerk-auth/blob/main/packages/astro-clerk-auth/README.md",
-                          "icon": "astro"
-                        },
-                        {
-                          "title": "Koa",
-                          "tag": "Community",
-                          "href": "https://github.com/dimkl/clerk-koa/blob/main/README.md",
-                          "icon": "koa"
-                        },
-                        {
-                          "title": "Angular",
-                          "tag": "Community",
-                          "href": "https://github.com/anagstef/ngx-clerk?tab=readme-ov-file#ngx-clerk",
-                          "icon": "angular"
+                          "title": "Manage TOTP-based MFA",
+                          "href": "/docs/custom-flows/manage-totp-based-mfa"
                         }
                       ]
                     ]
@@ -2925,24 +1556,1387 @@
                 ]
               ]
             }
-          ],
+          ]
+        ]
+      }
+    ],
+    [
+      {
+        "title": "SDK References",
+        "items": [
           [
             {
-              "title": "API Reference",
+              "title": "Next.js",
+              "collapse": true,
+              "icon": "nextjs",
               "items": [
                 [
                   {
-                    "title": "Backend API",
-                    "href": "/docs/reference/backend-api",
-                    "target": "_blank"
+                    "title": "Overview",
+                    "href": "/docs/references/nextjs/overview"
                   },
                   {
-                    "title": "Frontend API",
-                    "href": "/docs/reference/frontend-api",
-                    "target": "_blank"
+                    "title": "Guides",
+                    "items": [
+                      [
+                        {
+                          "title": "Read session and user data",
+                          "href": "/docs/references/nextjs/read-session-data"
+                        },
+                        {
+                          "title": "Add custom sign up and sign in pages",
+                          "href": "/docs/references/nextjs/custom-signup-signin-pages"
+                        },
+                        {
+                          "title": "Integrate Clerk into your app with tRPC",
+                          "href": "/docs/references/nextjs/trpc"
+                        }
+                      ]
+                    ]
+                  },
+                  {
+                    "title": "General References",
+                    "items": [
+                      [
+                        {
+                          "title": "`clerkMiddleware()`",
+                          "wrap": false,
+                          "href": "/docs/references/nextjs/clerk-middleware"
+                        },
+                        {
+                          "title": "Auth Object",
+                          "href": "/docs/references/nextjs/auth-object"
+                        }
+                      ]
+                    ]
+                  },
+                  {
+                    "title": "App Router References",
+                    "items": [
+                      [
+                        {
+                          "title": "`auth()`",
+                          "wrap": false,
+                          "href": "/docs/references/nextjs/auth"
+                        },
+                        {
+                          "title": "`currentUser()`",
+                          "wrap": false,
+                          "href": "/docs/references/nextjs/current-user"
+                        },
+                        {
+                          "title": "Route Handlers",
+                          "href": "/docs/references/nextjs/route-handlers"
+                        },
+                        {
+                          "title": "Server Actions",
+                          "href": "/docs/references/nextjs/server-actions"
+                        }
+                      ]
+                    ]
+                  },
+                  {
+                    "title": "Pages Router References",
+                    "items": [
+                      [
+                        {
+                          "title": "`getAuth()`",
+                          "wrap": false,
+                          "href": "/docs/references/nextjs/get-auth"
+                        },
+                        {
+                          "title": "`buildClerkProps()`",
+                          "wrap": false,
+                          "href": "/docs/references/nextjs/build-clerk-props"
+                        }
+                      ]
+                    ]
+                  },
+                  {
+                    "title": "Deprecated",
+                    "items": [
+                      [
+                        {
+                          "title": "`authMiddleware()`",
+                          "wrap": false,
+                          "href": "/docs/references/nextjs/auth-middleware"
+                        },
+                        {
+                          "title": "Use Clerk with Next.js 12 and older",
+                          "href": "/docs/references/nextjs/usage-with-older-versions"
+                        }
+                      ]
+                    ]
+                  },
+                  {
+                    "title": "Demo Repositories",
+                    "items": [
+                      [
+                        {
+                          "title": "App Router Demo Repo",
+                          "href": "https://github.com/clerk/clerk-nextjs-demo-app-router"
+                        },
+                        {
+                          "title": "Pages Router Demo Repo",
+                          "href": "https://github.com/clerk/clerk-nextjs-demo-pages-router"
+                        }
+                      ]
+                    ]
                   }
                 ]
               ]
+            },
+            {
+              "title": "React",
+              "collapse": true,
+              "icon": "react",
+              "items": [
+                [
+                  {
+                    "title": "Overview",
+                    "href": "/docs/references/react/overview"
+                  },
+                  {
+                    "title": "Guides",
+                    "items": [
+                      [
+                        {
+                          "title": "Add React Router",
+                          "href": "/docs/references/react/add-react-router"
+                        }
+                      ]
+                    ]
+                  },
+                  {
+                    "title": "Client-side Helpers",
+                    "items": [
+                      [
+                        {
+                          "title": "`useUser()`",
+                          "wrap": false,
+                          "href": "/docs/references/react/use-user"
+                        },
+                        {
+                          "title": "`useClerk()`",
+                          "wrap": false,
+                          "href": "/docs/references/react/use-clerk"
+                        },
+                        {
+                          "title": "`useAuth()`",
+                          "wrap": false,
+                          "href": "/docs/references/react/use-auth"
+                        },
+                        {
+                          "title": "`useSignIn()`",
+                          "wrap": false,
+                          "href": "/docs/references/react/use-sign-in"
+                        },
+                        {
+                          "title": "`useSignUp()`",
+                          "wrap": false,
+                          "href": "/docs/references/react/use-sign-up"
+                        },
+                        {
+                          "title": "`useSession()`",
+                          "wrap": false,
+                          "href": "/docs/references/react/use-session"
+                        },
+                        {
+                          "title": "`useSessionList()`",
+                          "wrap": false,
+                          "href": "/docs/references/react/use-session-list"
+                        },
+                        {
+                          "title": "`useOrganization()`",
+                          "wrap": false,
+                          "href": "/docs/references/react/use-organization"
+                        },
+                        {
+                          "title": "`useOrganizationList()`",
+                          "wrap": false,
+                          "href": "/docs/references/react/use-organization-list"
+                        }
+                      ]
+                    ]
+                  }
+                ]
+              ]
+            },
+            {
+              "title": "JavaScript",
+              "collapse": true,
+              "icon": "javascript",
+              "items": [
+                [
+                  {
+                    "title": "Overview",
+                    "href": "/docs/references/javascript/overview"
+                  },
+                  {
+                    "title": "Clerk",
+                    "collapse": true,
+                    "items": [
+                      [
+                        {
+                          "title": "Clerk class",
+                          "href": "/docs/references/javascript/clerk/clerk"
+                        },
+                        {
+                          "title": "Organization methods",
+                          "href": "/docs/references/javascript/clerk/organization-methods"
+                        },
+                        {
+                          "title": "Redirect methods",
+                          "href": "/docs/references/javascript/clerk/redirect-methods"
+                        },
+                        {
+                          "title": "BuildURLs",
+                          "href": "/docs/references/javascript/clerk/build-urls"
+                        },
+                        {
+                          "title": "Handle navigation",
+                          "href": "/docs/references/javascript/clerk/handle-navigation"
+                        },
+                        {
+                          "title": "Session methods",
+                          "href": "/docs/references/javascript/clerk/session-methods"
+                        }
+                      ]
+                    ]
+                  },
+                  {
+                    "title": "User",
+                    "collapse": true,
+                    "items": [
+                      [
+                        {
+                          "title": "User object",
+                          "href": "/docs/references/javascript/user/user"
+                        },
+                        {
+                          "title": "TOTP methods",
+                          "href": "/docs/references/javascript/user/totp"
+                        },
+                        {
+                          "title": "Password management methods",
+                          "href": "/docs/references/javascript/user/password-management"
+                        },
+                        {
+                          "title": "Create metadata methods",
+                          "href": "/docs/references/javascript/user/create-metadata"
+                        }
+                      ]
+                    ]
+                  },
+                  {
+                    "title": "Organization",
+                    "collapse": true,
+                    "items": [
+                      [
+                        {
+                          "title": "Organization object",
+                          "href": "/docs/references/javascript/organization/organization"
+                        },
+                        {
+                          "title": "Membership methods",
+                          "href": "/docs/references/javascript/organization/members"
+                        },
+                        {
+                          "title": "Invitation methods",
+                          "href": "/docs/references/javascript/organization/invitations"
+                        },
+                        {
+                          "title": "Domain methods",
+                          "href": "/docs/references/javascript/organization/domains"
+                        },
+                        {
+                          "title": "Membership request methods",
+                          "href": "/docs/references/javascript/organization/membership-request"
+                        }
+                      ]
+                    ]
+                  },
+                  {
+                    "title": "Organization Invitation",
+                    "href": "/docs/references/javascript/organization-invitation"
+                  },
+                  {
+                    "title": "Organization Membership",
+                    "href": "/docs/references/javascript/organization-membership"
+                  },
+                  {
+                    "title": "Organization Domain",
+                    "href": "/docs/references/javascript/organization-domain"
+                  },
+                  {
+                    "title": "Organization Membership Request",
+                    "href": "/docs/references/javascript/organization-membership-request"
+                  },
+                  {
+                    "title": "Session",
+                    "href": "/docs/references/javascript/session"
+                  },
+                  {
+                    "title": "SessionWithActivities",
+                    "href": "/docs/references/javascript/session-with-activities"
+                  },
+                  {
+                    "title": "Client",
+                    "href": "/docs/references/javascript/client"
+                  },
+                  {
+                    "title": "ExternalAccount",
+                    "href": "/docs/references/javascript/external-account"
+                  },
+                  {
+                    "title": "Email Address",
+                    "href": "/docs/references/javascript/email-address"
+                  },
+                  {
+                    "title": "Phone Number",
+                    "href": "/docs/references/javascript/phone-number"
+                  },
+                  {
+                    "title": "Sign In",
+                    "collapse": true,
+                    "items": [
+                      [
+                        {
+                          "title": "Sign In",
+                          "href": "/docs/references/javascript/sign-in/sign-in"
+                        },
+                        {
+                          "title": "First Factor",
+                          "href": "/docs/references/javascript/sign-in/first-factor"
+                        },
+                        {
+                          "title": "Second Factor",
+                          "href": "/docs/references/javascript/sign-in/second-factor"
+                        },
+                        {
+                          "title": "AuthenticateWith",
+                          "href": "/docs/references/javascript/sign-in/authenticate-with"
+                        }
+                      ]
+                    ]
+                  },
+                  {
+                    "title": "Sign Up",
+                    "collapse": true,
+                    "items": [
+                      [
+                        {
+                          "title": "Sign Up",
+                          "href": "/docs/references/javascript/sign-up/sign-up"
+                        },
+                        {
+                          "title": "AuthenticateWith",
+                          "href": "/docs/references/javascript/sign-up/authenticate-with"
+                        },
+                        {
+                          "title": "Verification",
+                          "href": "/docs/references/javascript/sign-up/verification"
+                        },
+                        {
+                          "title": "Email Verification",
+                          "href": "/docs/references/javascript/sign-up/email-verification"
+                        },
+                        {
+                          "title": "Phone Verification",
+                          "href": "/docs/references/javascript/sign-up/phone-verification"
+                        },
+                        {
+                          "title": "Web3 Verification",
+                          "href": "/docs/references/javascript/sign-up/web3-verification"
+                        }
+                      ]
+                    ]
+                  },
+                  {
+                    "title": "Web3 Wallet",
+                    "collapse": true,
+                    "items": [
+                      [
+                        {
+                          "title": "Web3 Wallet",
+                          "href": "/docs/references/javascript/web3-wallet/web3-wallet"
+                        },
+                        {
+                          "title": "Verification",
+                          "href": "/docs/references/javascript/web3-wallet/verification"
+                        }
+                      ]
+                    ]
+                  },
+                  {
+                    "title": "Types",
+                    "collapse": true,
+                    "items": [
+                      [
+                        {
+                          "title": "Overview",
+                          "href": "/docs/references/javascript/types/overview"
+                        },
+                        {
+                          "title": "ClerkAPIError",
+                          "href": "/docs/references/javascript/types/clerk-api-error"
+                        },
+                        {
+                          "title": "ClerkPaginatedResponse",
+                          "href": "/docs/references/javascript/types/clerk-paginated-response"
+                        },
+                        {
+                          "title": "CustomPage",
+                          "href": "/docs/references/javascript/types/custom-page"
+                        },
+                        {
+                          "title": "EmailLinkError",
+                          "href": "/docs/references/javascript/types/email-link-error"
+                        },
+                        {
+                          "title": "DeletedObject",
+                          "href": "/docs/references/javascript/types/deleted-object"
+                        },
+                        {
+                          "title": "OAuth types",
+                          "href": "/docs/references/javascript/types/oauth"
+                        },
+                        {
+                          "title": "PasskeyResource",
+                          "href": "/docs/references/javascript/types/passkey-resource"
+                        },
+                        {
+                          "title": "PublicUserData",
+                          "href": "/docs/references/javascript/types/public-user-data"
+                        },
+                        {
+                          "title": "SessionStatus",
+                          "href": "/docs/references/javascript/types/session-status"
+                        },
+                        {
+                          "title": "SignInFirstFactor",
+                          "href": "/docs/references/javascript/types/sign-in-first-factor"
+                        },
+                        {
+                          "title": "SignInSecondFactor",
+                          "href": "/docs/references/javascript/types/sign-in-second-factor"
+                        },
+                        {
+                          "title": "SignInRedirectOptions",
+                          "href": "/docs/references/javascript/types/sign-in-redirect-options"
+                        },
+                        {
+                          "title": "SignUpRedirectOptions",
+                          "href": "/docs/references/javascript/types/sign-up-redirect-options"
+                        },
+                        {
+                          "title": "SignInInitialValues",
+                          "href": "/docs/references/javascript/types/sign-in-initial-values"
+                        },
+                        {
+                          "title": "SignUpInitialValues",
+                          "href": "/docs/references/javascript/types/sign-up-initial-values"
+                        },
+                        {
+                          "title": "RedirectOptions",
+                          "href": "/docs/references/javascript/types/redirect-options"
+                        },
+                        {
+                          "title": "Verification",
+                          "href": "/docs/references/javascript/types/verification"
+                        }
+                      ]
+                    ]
+                  }
+                ]
+              ]
+            },
+            {
+              "title": "Expo",
+              "collapse": true,
+              "icon": "expo",
+              "items": [
+                [
+                  {
+                    "title": "Overview",
+                    "href": "/docs/references/expo/overview"
+                  },
+                  {
+                    "title": "Guides",
+                    "items": [
+                      [
+                        {
+                          "title": "Read session and user data",
+                          "href": "/docs/references/expo/read-session-user-data"
+                        },
+                        {
+                          "title": "Use biometrics with local credentials",
+                          "href": "/docs/references/expo/local-credentials"
+                        }
+                      ]
+                    ]
+                  },
+                  {
+                    "title": "Hooks",
+                    "items": [
+                      [
+                        {
+                          "title": "useLocalCredentials()",
+                          "href": "/docs/references/expo/use-local-credentials"
+                        }
+                      ]
+                    ]
+                  },
+                  {
+                    "title": "Web support",
+                    "icon": "route",
+                    "collapse": true,
+                    "items": [
+                      [
+                        {
+                          "title": "Overview",
+                          "href": "/docs/references/expo/web-support/overview"
+                        },
+                        {
+                          "title": "Add custom sign-up and sign-in pages",
+                          "href": "/docs/references/expo/web-support/custom-signup-signin-pages"
+                        }
+                      ]
+                    ]
+                  }
+                ]
+              ]
+            },
+            {
+              "title": "iOS",
+              "tag": "(Beta)",
+              "collapse": true,
+              "icon": "apple",
+              "items": [
+                [
+                  {
+                    "title": "Overview",
+                    "href": "/docs/references/ios/overview"
+                  }
+                ]
+              ]
+            },
+            {
+              "title": "Node.js",
+              "collapse": true,
+              "icon": "nodejs",
+              "items": [
+                [
+                  {
+                    "title": "Overview",
+                    "href": "/docs/references/nodejs/overview"
+                  },
+                  {
+                    "title": "Available methods",
+                    "href": "/docs/references/nodejs/available-methods"
+                  },
+                  {
+                    "title": "Connect/Express Middleware",
+                    "href": "/docs/backend-requests/handling/nodejs"
+                  }
+                ]
+              ]
+            },
+            {
+              "title": "Remix",
+              "collapse": true,
+              "icon": "remix",
+              "items": [
+                [
+                  {
+                    "title": "`<ClerkApp />`",
+                    "wrap": false,
+                    "href": "/docs/references/remix/clerk-app"
+                  },
+                  {
+                    "title": "SPA Mode",
+                    "wrap": false,
+                    "href": "/docs/references/remix/spa-mode"
+                  },
+                  {
+                    "title": "Add custom sign up and sign in pages",
+                    "wrap": true,
+                    "href": "/docs/references/remix/custom-signup-signin-pages"
+                  },
+                  {
+                    "title": "Read session and user data",
+                    "wrap": true,
+                    "href": "/docs/references/remix/read-session-data"
+                  }
+                ]
+              ]
+            },
+            {
+              "title": "Go",
+              "collapse": true,
+              "icon": "go",
+              "items": [
+                [
+                  {
+                    "title": "Overview",
+                    "href": "/docs/references/go/overview"
+                  },
+                  {
+                    "title": "Verifying sessions",
+                    "href": "/docs/references/go/verifying-sessions"
+                  },
+                  {
+                    "title": "Use Clerk Go for Backend API Operations",
+                    "href": "/docs/references/go/other-examples"
+                  },
+                  {
+                    "title": "Go SDK repository",
+                    "href": "https://github.com/clerk/clerk-sdk-go"
+                  }
+                ]
+              ]
+            },
+            {
+              "title": "Gatsby",
+              "collapse": true,
+              "icon": "gatsby",
+              "items": [
+                [
+                  {
+                    "title": "`withServerAuth()`",
+                    "wrap": false,
+                    "href": "/docs/references/gatsby/with-server-auth"
+                  }
+                ]
+              ]
+            },
+            {
+              "title": "Astro",
+              "collapse": true,
+              "icon": "astro",
+              "items": [
+                [
+                  { "title": "Overview", "href": "/docs/references/astro/overview" },
+                  {
+                    "title": "UI Frameworks",
+                    "items": [
+                      [
+                        {
+                          "title": "Use Clerk with Astro and React",
+                          "href": "/docs/references/astro/react"
+                        }
+                      ]
+                    ]
+                  },
+                  {
+                    "title": "Guides",
+                    "items": [
+                      [
+                        {
+                          "title": "Migrating from community SDK",
+                          "href": "/docs/references/astro/migrating-from-astro-community-sdk"
+                        },
+                        {
+                          "title": "Read session and user data",
+                          "wrap": false,
+                          "href": "/docs/references/astro/read-session-data"
+                        }
+                      ]
+                    ]
+                  },
+                  {
+                    "title": "General Reference",
+                    "items": [
+                      [
+                        {
+                          "title": "`clerkMiddleware()`",
+                          "wrap": false,
+                          "href": "/docs/references/astro/clerk-middleware"
+                        },
+                        {
+                          "title": "Locals",
+                          "wrap": false,
+                          "href": "/docs/references/astro/locals"
+                        },
+                        {
+                          "title": "Endpoints",
+                          "wrap": false,
+                          "href": "/docs/references/astro/endpoints"
+                        }
+                      ]
+                    ]
+                  },
+                  {
+                    "title": "Client-side Helpers",
+                    "items": [
+                      [
+                        {
+                          "title": "`$authStore`",
+                          "wrap": false,
+                          "href": "/docs/references/astro/auth-store"
+                        },
+                        {
+                          "title": "`$clerkStore`",
+                          "wrap": false,
+                          "href": "/docs/references/astro/clerk-store"
+                        },
+                        {
+                          "title": "`$userStore`",
+                          "wrap": false,
+                          "href": "/docs/references/astro/user-store"
+                        },
+                        {
+                          "title": "`$signInStore`",
+                          "wrap": false,
+                          "href": "/docs/references/astro/sign-in-store"
+                        },
+                        {
+                          "title": "`$signUpStore`",
+                          "wrap": false,
+                          "href": "/docs/references/astro/sign-up-store"
+                        },
+                        {
+                          "title": "`$sessionStore`",
+                          "wrap": false,
+                          "href": "/docs/references/astro/session-store"
+                        },
+                        {
+                          "title": "`$sessionListStore`",
+                          "wrap": false,
+                          "href": "/docs/references/astro/session-list-store"
+                        },
+                        {
+                          "title": "`$organizationStore`",
+                          "wrap": false,
+                          "href": "/docs/references/astro/organization-store"
+                        }
+                      ]
+                    ]
+                  }
+                ]
+              ]
+            },
+            {
+              "title": "Ruby / Rails",
+              "collapse": true,
+              "icon": "ruby",
+              "items": [
+                [
+                  {
+                    "title": "Overview",
+                    "href": "/docs/references/ruby/overview"
+                  },
+                  {
+                    "title": "Available Methods",
+                    "href": "/docs/references/ruby/available-methods"
+                  },
+                  {
+                    "title": "Rack/Rails integration",
+                    "href": "/docs/references/ruby/rack-rails"
+                  },
+                  {
+                    "title": "Ruby SDK repository",
+                    "href": "https://github.com/clerk/clerk-sdk-ruby"
+                  }
+                ]
+              ]
+            },
+            {
+              "title": "JS Backend SDK",
+              "collapse": true,
+              "icon": "clerk",
+              "items": [
+                [
+                  {
+                    "title": "Overview",
+                    "href": "/docs/references/backend/overview"
+                  },
+                  {
+                    "title": "User",
+                    "collapse": true,
+                    "items": [
+                      [
+                        {
+                          "title": "`getUserList()`",
+                          "wrap": false,
+                          "href": "/docs/references/backend/user/get-user-list"
+                        },
+                        {
+                          "title": "`getUser()`",
+                          "wrap": false,
+                          "href": "/docs/references/backend/user/get-user"
+                        },
+                        {
+                          "title": "`getCount()`",
+                          "wrap": false,
+                          "href": "/docs/references/backend/user/get-count"
+                        },
+                        {
+                          "title": "`getOrganizationMembershipList()`",
+                          "wrap": false,
+                          "href": "/docs/references/backend/user/get-organization-membership-list"
+                        },
+                        {
+                          "title": "`getUserOAuthAccessToken()`",
+                          "wrap": false,
+                          "href": "/docs/references/backend/user/get-user-oauth-access-token"
+                        },
+                        {
+                          "title": "`createUser()`",
+                          "wrap": false,
+                          "href": "/docs/references/backend/user/create-user"
+                        },
+                        {
+                          "title": "`verifyPassword()`",
+                          "wrap": false,
+                          "href": "/docs/references/backend/user/verify-password"
+                        },
+                        {
+                          "title": "`banUser()`",
+                          "wrap": false,
+                          "href": "/docs/references/backend/user/ban-user"
+                        },
+                        {
+                          "title": "`unbanUser()`",
+                          "wrap": false,
+                          "href": "/docs/references/backend/user/unban-user"
+                        },
+                        {
+                          "title": "`lockUser()`",
+                          "wrap": false,
+                          "href": "/docs/references/backend/user/lock-user"
+                        },
+                        {
+                          "title": "`unlockUser()`",
+                          "wrap": false,
+                          "href": "/docs/references/backend/user/unlock-user"
+                        },
+                        {
+                          "title": "`updateUser()`",
+                          "wrap": false,
+                          "href": "/docs/references/backend/user/update-user"
+                        },
+                        {
+                          "title": "`updateUserProfileImage()`",
+                          "wrap": false,
+                          "href": "/docs/references/backend/user/update-user-profile-image"
+                        },
+                        {
+                          "title": "`updateUserMetadata()`",
+                          "wrap": false,
+                          "href": "/docs/references/backend/user/update-user-metadata"
+                        },
+                        {
+                          "title": "`deleteUser()`",
+                          "wrap": false,
+                          "href": "/docs/references/backend/user/delete-user"
+                        },
+                        {
+                          "title": "`disableUserMFA()`",
+                          "wrap": false,
+                          "href": "/docs/references/backend/user/disable-user-mfa"
+                        },
+                        {
+                          "title": "`verifyTOTP()`",
+                          "wrap": false,
+                          "href": "/docs/references/backend/user/verify-totp"
+                        }
+                      ]
+                    ]
+                  },
+                  {
+                    "title": "Organization",
+                    "collapse": true,
+                    "items": [
+                      [
+                        {
+                          "title": "`getOrganization()`",
+                          "wrap": false,
+                          "href": "/docs/references/backend/organization/get-organization"
+                        },
+                        {
+                          "title": "`getOrganizationList()`",
+                          "wrap": false,
+                          "href": "/docs/references/backend/organization/get-organization-list"
+                        },
+                        {
+                          "title": "`getOrganizationMembershipList()`",
+                          "wrap": false,
+                          "href": "/docs/references/backend/organization/get-organization-membership-list"
+                        },
+                        {
+                          "title": "`getOrganizationInvitationList()`",
+                          "wrap": false,
+                          "href": "/docs/references/backend/organization/get-organization-invitation-list"
+                        },
+                        {
+                          "title": "`createOrganization()`",
+                          "wrap": false,
+                          "href": "/docs/references/backend/organization/create-organization"
+                        },
+                        {
+                          "title": "`createOrganizationMembership()`",
+                          "wrap": false,
+                          "href": "/docs/references/backend/organization/create-organization-membership"
+                        },
+                        {
+                          "title": "`createOrganizationInvitation()`",
+                          "wrap": false,
+                          "href": "/docs/references/backend/organization/create-organization-invitation"
+                        },
+                        {
+                          "title": "`updateOrganization()`",
+                          "wrap": false,
+                          "href": "/docs/references/backend/organization/update-organization"
+                        },
+                        {
+                          "title": "`updateOrganizationLogo()`",
+                          "wrap": false,
+                          "href": "/docs/references/backend/organization/update-organization-logo"
+                        },
+                        {
+                          "title": "`updateOrganizationMembership()`",
+                          "wrap": false,
+                          "href": "/docs/references/backend/organization/update-organization-membership"
+                        },
+                        {
+                          "title": "`updateOrganizationMetadata()`",
+                          "wrap": false,
+                          "href": "/docs/references/backend/organization/update-organization-metadata"
+                        },
+                        {
+                          "title": "`updateOrganizationMembershipMetadata()`",
+                          "wrap": false,
+                          "href": "/docs/references/backend/organization/update-organization-membership-metadata"
+                        },
+                        {
+                          "title": "`deleteOrganization()`",
+                          "wrap": false,
+                          "href": "/docs/references/backend/organization/delete-organization"
+                        },
+                        {
+                          "title": "`deleteOrganizationMembership()`",
+                          "wrap": false,
+                          "href": "/docs/references/backend/organization/delete-organization-membership"
+                        },
+                        {
+                          "title": "`revokeOrganizationInvitation()`",
+                          "wrap": false,
+                          "href": "/docs/references/backend/organization/revoke-organization-invitation"
+                        }
+                      ]
+                    ]
+                  },
+                  {
+                    "title": "Allowlist Identifiers",
+                    "collapse": true,
+                    "items": [
+                      [
+                        {
+                          "title": "`getAllowlistIdentifierList()`",
+                          "wrap": false,
+                          "href": "/docs/references/backend/allowlist/get-allowlist-identifier-list"
+                        },
+                        {
+                          "title": "`createAllowlistIdentifier()`",
+                          "wrap": false,
+                          "href": "/docs/references/backend/allowlist/create-allowlist-identifier"
+                        },
+                        {
+                          "title": "`deleteAllowlistIdentifier()`",
+                          "wrap": false,
+                          "href": "/docs/references/backend/allowlist/delete-allowlist-identifier"
+                        }
+                      ]
+                    ]
+                  },
+                  {
+                    "title": "Sessions",
+                    "collapse": true,
+                    "items": [
+                      [
+                        {
+                          "title": "`getSession()`",
+                          "wrap": false,
+                          "href": "/docs/references/backend/sessions/get-session"
+                        },
+                        {
+                          "title": "`getSessionList()`",
+                          "wrap": false,
+                          "href": "/docs/references/backend/sessions/get-session-list"
+                        },
+                        {
+                          "title": "`getToken()`",
+                          "wrap": false,
+                          "href": "/docs/references/backend/sessions/get-token"
+                        },
+                        {
+                          "title": "`verifySession()`",
+                          "wrap": false,
+                          "href": "/docs/references/backend/sessions/verify-session"
+                        },
+                        {
+                          "title": "`revokeSession()`",
+                          "wrap": false,
+                          "href": "/docs/references/backend/sessions/revoke-session"
+                        }
+                      ]
+                    ]
+                  },
+                  {
+                    "title": "Client",
+                    "collapse": true,
+                    "items": [
+                      [
+                        {
+                          "title": "`getClient()`",
+                          "wrap": false,
+                          "href": "/docs/references/backend/client/get-client"
+                        },
+                        {
+                          "title": "`getClientList()`",
+                          "wrap": false,
+                          "href": "/docs/references/backend/client/get-client-list"
+                        },
+                        {
+                          "title": "`verifyClient()`",
+                          "wrap": false,
+                          "href": "/docs/references/backend/client/verify-client"
+                        }
+                      ]
+                    ]
+                  },
+                  {
+                    "title": "Invitations",
+                    "collapse": true,
+                    "items": [
+                      [
+                        {
+                          "title": "`getInvitationList()`",
+                          "wrap": false,
+                          "href": "/docs/references/backend/invitations/get-invitation-list"
+                        },
+                        {
+                          "title": "`createInvitation()`",
+                          "wrap": false,
+                          "href": "/docs/references/backend/invitations/create-invitation"
+                        },
+                        {
+                          "title": "`revokeInvitation()`",
+                          "wrap": false,
+                          "href": "/docs/references/backend/invitations/revoke-invitation"
+                        }
+                      ]
+                    ]
+                  },
+                  {
+                    "title": "Redirect Urls",
+                    "collapse": true,
+                    "items": [
+                      [
+                        {
+                          "title": "`getRedirectUrl()`",
+                          "wrap": false,
+                          "href": "/docs/references/backend/redirect-urls/get-redirect-url"
+                        },
+                        {
+                          "title": "`getRedirectUrlList()`",
+                          "wrap": false,
+                          "href": "/docs/references/backend/redirect-urls/get-redirect-url-list"
+                        },
+                        {
+                          "title": "`createRedirectUrl()`",
+                          "wrap": false,
+                          "href": "/docs/references/backend/redirect-urls/create-redirect-url"
+                        },
+                        {
+                          "title": "`deleteRedirectUrl()`",
+                          "wrap": false,
+                          "href": "/docs/references/backend/redirect-urls/delete-redirect-url"
+                        }
+                      ]
+                    ]
+                  },
+                  {
+                    "title": "Email addresses",
+                    "collapse": true,
+                    "items": [
+                      [
+                        {
+                          "title": "`getEmailAddress()`",
+                          "wrap": false,
+                          "href": "/docs/references/backend/email-addresses/get-email-address"
+                        },
+                        {
+                          "title": "`createEmailAddress()`",
+                          "wrap": false,
+                          "href": "/docs/references/backend/email-addresses/create-email-address"
+                        },
+                        {
+                          "title": "`updateEmailAddress()`",
+                          "wrap": false,
+                          "href": "/docs/references/backend/email-addresses/update-email-address"
+                        },
+                        {
+                          "title": "`deleteEmailAddress()`",
+                          "wrap": false,
+                          "href": "/docs/references/backend/email-addresses/delete-email-address"
+                        }
+                      ]
+                    ]
+                  },
+                  {
+                    "title": "Phone numbers",
+                    "collapse": true,
+                    "items": [
+                      [
+                        {
+                          "title": "`getPhoneNumber()`",
+                          "wrap": false,
+                          "href": "/docs/references/backend/phone-numbers/get-phone-number"
+                        },
+                        {
+                          "title": "`createPhoneNumber()`",
+                          "wrap": false,
+                          "href": "/docs/references/backend/phone-numbers/create-phone-number"
+                        },
+                        {
+                          "title": "`updatePhoneNumber()`",
+                          "wrap": false,
+                          "href": "/docs/references/backend/phone-numbers/update-phone-number"
+                        },
+                        {
+                          "title": "`deletePhoneNumber()`",
+                          "wrap": false,
+                          "href": "/docs/references/backend/phone-numbers/delete-phone-number"
+                        }
+                      ]
+                    ]
+                  },
+                  {
+                    "title": "SAML connections",
+                    "collapse": true,
+                    "items": [
+                      [
+                        {
+                          "title": "`getSamlConnectionList()`",
+                          "wrap": false,
+                          "href": "/docs/references/backend/saml-connections/get-saml-connection-list"
+                        },
+                        {
+                          "title": "`getSamlConnection()`",
+                          "wrap": false,
+                          "href": "/docs/references/backend/saml-connections/get-saml-connection"
+                        },
+                        {
+                          "title": "`createSamlConnection()`",
+                          "wrap": false,
+                          "href": "/docs/references/backend/saml-connections/create-saml-connection"
+                        },
+                        {
+                          "title": "`updateSamlConnection()`",
+                          "wrap": false,
+                          "href": "/docs/references/backend/saml-connections/update-saml-connection"
+                        },
+                        {
+                          "title": "`deleteSamlConnection()`",
+                          "wrap": false,
+                          "href": "/docs/references/backend/saml-connections/delete-saml-connection"
+                        }
+                      ]
+                    ]
+                  },
+                  {
+                    "title": "Sign-in tokens",
+                    "collapse": true,
+                    "items": [
+                      [
+                        {
+                          "title": "`createSignInToken()`",
+                          "wrap": false,
+                          "href": "/docs/references/backend/sign-in-tokens/create-sign-in-token"
+                        },
+                        {
+                          "title": "`revokeSignInToken()`",
+                          "wrap": false,
+                          "href": "/docs/references/backend/sign-in-tokens/revoke-sign-in-token"
+                        }
+                      ]
+                    ]
+                  },
+                  {
+                    "title": "Testing Tokens",
+                    "collapse": true,
+                    "items": [
+                      [
+                        {
+                          "title": "`createTestingToken()`",
+                          "wrap": false,
+                          "href": "/docs/references/backend/testing-tokens/create-testing-token"
+                        }
+                      ]
+                    ]
+                  },
+                  {
+                    "title": "`authenticateRequest()`",
+                    "wrap": false,
+                    "href": "/docs/references/backend/authenticate-request"
+                  },
+                  {
+                    "title": "`verifyToken()`",
+                    "wrap": false,
+                    "href": "/docs/references/backend/verify-token"
+                  },
+                  {
+                    "title": "Types",
+                    "collapse": true,
+                    "items": [
+                      [
+                        {
+                          "title": "`PaginatedResourceResponse`",
+                          "href": "/docs/references/backend/types/paginated-resource-response"
+                        },
+                        {
+                          "title": "Backend `AllowlistIdentifier` object",
+                          "href": "/docs/references/backend/types/backend-allowlist-identifier"
+                        },
+                        {
+                          "title": "Backend `Client` object",
+                          "href": "/docs/references/backend/types/backend-client"
+                        },
+                        {
+                          "title": "Backend `Invitation` object",
+                          "href": "/docs/references/backend/types/backend-invitation"
+                        },
+                        {
+                          "title": "Backend `Organization` object",
+                          "href": "/docs/references/backend/types/backend-organization"
+                        },
+                        {
+                          "title": "Backend `OrganizationInvitation` object",
+                          "href": "/docs/references/backend/types/backend-organization-invitation"
+                        },
+                        {
+                          "title": "Backend `OrganizationMembership` object",
+                          "href": "/docs/references/backend/types/backend-organization-membership"
+                        },
+                        {
+                          "title": "Backend `Session` object",
+                          "href": "/docs/references/backend/types/backend-session"
+                        },
+                        {
+                          "title": "Backend `RedirectURL` object",
+                          "href": "/docs/references/backend/types/backend-redirect-url"
+                        },
+                        {
+                          "title": "Backend `User` object",
+                          "href": "/docs/references/backend/types/backend-user"
+                        }
+                      ]
+                    ]
+                  }
+                ]
+              ]
+            },
+            {
+              "title": "Community SDKs",
+              "collapse": true,
+              "items": [
+                [
+                  {
+                    "title": "Redwood",
+                    "tag": "Community",
+                    "collapse": true,
+                    "icon": "redwood",
+                    "items": [
+                      [
+                        {
+                          "title": "Overview",
+                          "href": "/docs/references/redwood/overview"
+                        },
+                        {
+                          "title": "Redwood",
+                          "href": "https://redwoodjs.com/docs/auth/clerk",
+                          "icon": "redwood"
+                        }
+                      ]
+                    ]
+                  },
+                  {
+                    "title": "Svelte",
+                    "tag": "Community",
+                    "href": "https://github.com/markjaquith/clerk-sveltekit",
+                    "icon": "svelte"
+                  },
+                  {
+                    "title": "Vue",
+                    "tag": "Community",
+                    "href": "https://vue-clerk.vercel.app",
+                    "icon": "vue"
+                  },
+                  {
+                    "title": "Elysia",
+                    "tag": "Community",
+                    "href": "https://github.com/wobsoriano/elysia-clerk",
+                    "icon": "elysia"
+                  },
+                  {
+                    "title": "Rust",
+                    "tag": "Community",
+                    "href": "https://github.com/cincinnati-ventures/clerk-rs",
+                    "icon": "rust"
+                  },
+                  {
+                    "title": "Hono",
+                    "tag": "Community",
+                    "href": "https://github.com/honojs/middleware/tree/main/packages/clerk-auth",
+                    "icon": "hono"
+                  },
+                  {
+                    "title": "C#",
+                    "tag": "Community",
+                    "href": "https://github.com/Hawxy/Clerk.Net",
+                    "icon": "c-sharp"
+                  },
+                  {
+                    "title": "Astro",
+                    "tag": "Community",
+                    "href": "https://github.com/panteliselef/astro-with-clerk-auth/blob/main/packages/astro-clerk-auth/README.md",
+                    "icon": "astro"
+                  },
+                  {
+                    "title": "Koa",
+                    "tag": "Community",
+                    "href": "https://github.com/dimkl/clerk-koa/blob/main/README.md",
+                    "icon": "koa"
+                  },
+                  {
+                    "title": "Angular",
+                    "tag": "Community",
+                    "href": "https://github.com/anagstef/ngx-clerk?tab=readme-ov-file#ngx-clerk",
+                    "icon": "angular"
+                  }
+                ]
+              ]
+            }
+          ]
+        ]
+      }
+    ],
+    [
+      {
+        "title": "API Reference",
+        "items": [
+          [
+            {
+              "title": "Backend API",
+              "href": "/docs/reference/backend-api",
+              "target": "_blank"
+            },
+            {
+              "title": "Frontend API",
+              "href": "/docs/reference/frontend-api",
+              "target": "_blank"
             }
           ]
         ]


### PR DESCRIPTION
> [!IMPORTANT]
> 🔎 Previews:
>
> - https://clerk.com/docs/pr/1420

This PR fixes a minor issue with the manifest structure. The current version groups most items together and does not conform to the schema because a `title` property is missing from the object on line 312.

The side effects of the invalid manifest are subtle but it means that most item are grouped in the markup which is probably not what we want, and it also causes minor spacing issues.

In VS Code (and probably other editors) you should be able to see the error inline and in the "Problems" panel:

![CleanShot 2024-08-09 at 11 56 07@2x](https://github.com/user-attachments/assets/1caae682-eb86-426a-af44-49c10f08d5ac)

I may look into validating the manifest schema as part of the Lint GitHub action.

**Before**

```jsonc
{
  "$schema": "./manifest.schema.json",
  "navigation": [
    [
      // first group (with icons)
    ],
    [
      {
        "items": [
          // all other groups except "archived versions"
        ]
      }
    ],
    // ...
  ]
}
```

**After**

```jsonc
{
  "$schema": "./manifest.schema.json",
  "navigation": [
    [
      // first group (with icons)
    ],
    [
      // second group
    ],
    [
      // third group
    ],
    // etc.
  ]
}
```