### PR TITLE
Add nextjs example to proxy config

### DIFF
--- a/docs/advanced-usage/using-proxies.mdx
+++ b/docs/advanced-usage/using-proxies.mdx
@@ -104,7 +104,7 @@ When using a proxy, all requests to the Frontend API will be made through your d
     </Tab>
 
     <Tab>
-      ```ts {{ filename: 'middleware.ts' }}
+      ```ts {{ prettier: false, filename: 'middleware.ts' }}
         import { NextResponse } from "next/server";
         import { clerkMiddleware } from "@clerk/nextjs/server";
 

--- a/docs/advanced-usage/using-proxies.mdx
+++ b/docs/advanced-usage/using-proxies.mdx
@@ -39,7 +39,7 @@ When using a proxy, all requests to the Frontend API will be made through your d
 
   #### Example configuration
 
-  <Tabs items={["Nginx", "Cloudflare Workers"]}>
+  <Tabs items={["Nginx", "Cloudflare Workers", "Next.js"]}>
     <Tab>
       ```nginx {{ prettier: false, filename: 'nginx.conf' }}
       http {
@@ -101,6 +101,43 @@ When using a proxy, all requests to the Frontend API will be made through your d
           }
         ```
       </CodeBlockTabs>
+    </Tab>
+
+    <Tab>
+      ```ts {{ filename: 'middleware.ts' }}
+        import { NextResponse } from "next/server";
+        import { clerkMiddleware } from "@clerk/nextjs/server";
+
+        export default clerkMiddleware((auth, request) => {
+          if (request.url.match("__clerk")) {
+            const proxyHeaders = new Headers(request.headers);
+            proxyHeaders.set("Clerk-Proxy-Url", "https://app.dev/__clerk");
+            proxyHeaders.set("Clerk-Secret-Key", process.env.CLERK_SECRET_KEY || "");
+            proxyHeaders.set("X-Forwarded-For", request.ip || "");
+
+            const proxyUrl = new URL(request.url);
+            proxyUrl.host = "frontend-api.clerk.dev";
+            proxyUrl.protocol = "https";
+            proxyUrl.pathname = proxyUrl.pathname.replace("/__clerk", "");
+
+            return NextResponse.rewrite(proxyUrl, {
+              request: {
+                headers: proxyHeaders,
+              },
+            });
+          }
+        });
+
+        export const config = {
+          matcher: [
+            // Skip Next.js internals and all static files, unless found in search params
+            "/((?!_next|[^?]*\\.(?:html?|css|js(?!on)|jpe?g|webp|png|gif|svg|ttf|woff2?|ico|csv|docx?|xlsx?|zip|webmanifest)).*)",
+            // Always run for API routes AND anything passed through the proxy
+            "/(api|trpc|__clerk)(.*)",
+          ],
+        };
+
+      ```
     </Tab>
   </Tabs>
 

--- a/docs/advanced-usage/using-proxies.mdx
+++ b/docs/advanced-usage/using-proxies.mdx
@@ -111,7 +111,7 @@ When using a proxy, all requests to the Frontend API will be made through your d
         export default clerkMiddleware((auth, request) => {
           if (request.url.match("__clerk")) {
             const proxyHeaders = new Headers(request.headers);
-            proxyHeaders.set("Clerk-Proxy-Url", "https://app.dev/__clerk");
+            proxyHeaders.set("Clerk-Proxy-Url", process.env.NEXT_PUBLIC_CLERK_PROXY_URL || "");
             proxyHeaders.set("Clerk-Secret-Key", process.env.CLERK_SECRET_KEY || "");
             proxyHeaders.set("X-Forwarded-For", request.ip || "");
 

--- a/docs/advanced-usage/using-proxies.mdx
+++ b/docs/advanced-usage/using-proxies.mdx
@@ -113,7 +113,11 @@ When using a proxy, all requests to the Frontend API will be made through your d
             const proxyHeaders = new Headers(request.headers);
             proxyHeaders.set("Clerk-Proxy-Url", process.env.NEXT_PUBLIC_CLERK_PROXY_URL || "");
             proxyHeaders.set("Clerk-Secret-Key", process.env.CLERK_SECRET_KEY || "");
-            proxyHeaders.set("X-Forwarded-For", request.ip || "");
+            if (request.ip) {
+              proxyHeaders.set("X-Forwarded-For", request.ip);
+            } else {
+              proxyHeaders.set("X-Forwarded-For", request.headers.get('X-Forwarded-For') || '');
+            }
 
             const proxyUrl = new URL(request.url);
             proxyUrl.host = "frontend-api.clerk.dev";

--- a/docs/authentication/configuration/session-options.mdx
+++ b/docs/authentication/configuration/session-options.mdx
@@ -42,6 +42,9 @@ By default, this setting is enabled with a default value of 7 days for all newly
 1. Toggle on **Maximum lifetime**.
 1. Set your desired duration.
 
+> [!NOTE]
+> Unfortunately, Safari will clear Clerk's session cookie every 7 days as an effect of their [CNAME cloaking ITP policy](https://webkit.org/blog/11338/cname-cloaking-and-bounce-tracking-defense/). This will cause users to be signed out weekly, even if session lifetime is set to a longer duration. The only current workaround to this issue is to [proxy FAPI](/docs/advanced-usage/using-proxies).
+
 ## Multi-session applications
 
 A multi-session application is an application that allows multiple accounts to be signed in from the same browser at the same time. The user can switch from one account to another seamlessly. Each account is independent from the rest and has access to different resources.

--- a/docs/authentication/configuration/session-options.mdx
+++ b/docs/authentication/configuration/session-options.mdx
@@ -43,7 +43,7 @@ By default, this setting is enabled with a default value of 7 days for all newly
 1. Set your desired duration.
 
 > [!NOTE]
-> Unfortunately, Safari will clear Clerk's session cookie every 7 days as an effect of their [CNAME cloaking ITP policy](https://webkit.org/blog/11338/cname-cloaking-and-bounce-tracking-defense/). This will cause users to be signed out weekly, even if session lifetime is set to a longer duration. The only current workaround to this issue is to [proxy FAPI](/docs/advanced-usage/using-proxies).
+> Safari will clear Clerk's session cookie every 7 days as an effect of their [CNAME cloaking ITP policy](https://webkit.org/blog/11338/cname-cloaking-and-bounce-tracking-defense/). This will cause users to be signed out weekly, even if session lifetime is set to a longer duration. The only current workaround to this issue is to [proxy FAPI](/docs/advanced-usage/using-proxies).
 
 ## Multi-session applications
 


### PR DESCRIPTION
<!--- Add the "deploy-preview" label and add your page previews here -->

> [!IMPORTANT]
> 🔎 Previews:
>
> - https://clerk.com/docs/pr/1423/advanced-usage/using-proxies#example-configuration

Adds an example of how to configure proxying with a pure nextjs app, using middleware.
