### PR TITLE
Update custom-signup-signin-pages.mdx

### DIFF
--- a/docs/references/nextjs/custom-signup-signin-pages.mdx
+++ b/docs/references/nextjs/custom-signup-signin-pages.mdx
@@ -75,7 +75,7 @@ If Clerk's prebuilt components don't meet your specific needs or if you require 
   ```tsx {{ prettier: false, filename: 'middleware.ts' }}
   import { clerkMiddleware } from "@clerk/nextjs/server";
 
-  const isPublicRoute = createRouteMatcher(["/signin(.*)", "/signup(.*)"]);
+  const isPublicRoute = createRouteMatcher(["/sign-in(.*)", "/sign-up(.*)"]);
 
   export default clerkMiddleware((auth, request) => {
     if (!isPublicRoute(request)) {


### PR DESCRIPTION
Fixed the url route

<!--- Add the "deploy-preview" label and add your page previews here -->

> [!IMPORTANT]
> 🔎 Previews:
>
Before: 
![image](https://github.com/user-attachments/assets/5e9a55f8-c663-44b2-9c84-30c2c8633a55)

After:
![image](https://github.com/user-attachments/assets/a8b7c275-ef0f-4c89-9830-72334f6a462e)


### Explanation:

The tutorial guide suggests creating a folder named `[[...sign-in]]` and setting `NEXT_PUBLIC_CLERK_SIGN_IN_URL=/sign-in` as an env variable, but the routes in `createRouteMatcher` is incorrect `(/signin(.*))`.

