### PR TITLE
Update custom-signup-signin-pages.mdx

### DIFF
--- a/docs/references/nextjs/custom-signup-signin-pages.mdx
+++ b/docs/references/nextjs/custom-signup-signin-pages.mdx
@@ -75,7 +75,7 @@ If Clerk's prebuilt components don't meet your specific needs or if you require 
   ```tsx {{ prettier: false, filename: 'middleware.ts' }}
   import { clerkMiddleware } from "@clerk/nextjs/server";
 
-  const isPublicRoute = createRouteMatcher(["/sign_in(.*)", "/sign_up(.*)"]);
+  const isPublicRoute = createRouteMatcher(["/sign-in(.*)", "/sign-up(.*)"]);
 
   export default clerkMiddleware((auth, request) => {
     if (!isPublicRoute(request)) {

--- a/docs/references/nextjs/custom-signup-signin-pages.mdx
+++ b/docs/references/nextjs/custom-signup-signin-pages.mdx
@@ -75,7 +75,7 @@ If Clerk's prebuilt components don't meet your specific needs or if you require 
   ```tsx {{ prettier: false, filename: 'middleware.ts' }}
   import { clerkMiddleware } from "@clerk/nextjs/server";
 
-  const isPublicRoute = createRouteMatcher(["/signin(.*)", "/signup(.*)"]);
+  const isPublicRoute = createRouteMatcher(["/sign_in(.*)", "/sign_up(.*)"]);
 
   export default clerkMiddleware((auth, request) => {
     if (!isPublicRoute(request)) {


### PR DESCRIPTION
Fix typo within the createRouteMatcher sample code in custom-signup-sign-page tutorial to correctly match the sign in and sign up page routes proposed by the tutorial. 

<!--- Add the "deploy-preview" label and add your page previews here -->

> [!IMPORTANT]
> 🔎 Previews:
>
> -

<!--- Describe your changes in detail. Why does this change need to happen? Include any links to Slack discussions, Linear comments, etc. -->
I spent hours trying to create custom sign in and sign up pages in my next app and was experiencing an infinite redirect issue when I tried to load my app. It turns out that the route matcher was not working because the sample code in the demo was wrong. This updates the sample code in the demo to correctly match the page route proposed by the demo.

### Explanation:

<!--- How does this PR solve the problem? -->

### This PR:

-
