### PR TITLE
fix: Add callout for 'use client' directive

### DIFF
--- a/docs/customization/organization-profile.mdx
+++ b/docs/customization/organization-profile.mdx
@@ -21,6 +21,9 @@ This guide includes examples for both use cases. You can select one of the follo
 
 For the sake of this guide, examples are written for Next.js App Router, but they are supported by any React meta framework, such as Remix or Gatsby.
 
+> [!IMPORTANT]
+> If your app is rendered with [React Server Components](https://react.dev/reference/rsc/server-components) by default, you'll need to add the [`use client` directive](https://react.dev/reference/rsc/use-client) when using `<OrganizationProfile />`.
+
 ## Add a custom page to `<OrganizationProfile />`
 
 Custom pages can be rendered inside the `<OrganizationProfile />` component and provide a way to incorporate app-specific settings or additional functionality.

--- a/docs/customization/user-button.mdx
+++ b/docs/customization/user-button.mdx
@@ -14,6 +14,9 @@ There are two types of custom menu items available:
 - `<UserButton.Action>` - A menu item that triggers an action when clicked.
 - `<UserButton.Link>` - A menu item that navigates to a page when clicked.
 
+> [!IMPORTANT]
+> If your app is rendered with [React Server Components](https://react.dev/reference/rsc/server-components) by default, you'll need to add the [`use client` directive](https://react.dev/reference/rsc/use-client) when using `<UserButton />`.
+
 ## `<UserButton.Action>`
 
 Custom actions can be rendered inside the `<UserButton />` component using the `<UserButton.Action />` component. This component is useful for adding actions like opening a chat or triggering a modal.

--- a/docs/customization/user-profile.mdx
+++ b/docs/customization/user-profile.mdx
@@ -21,6 +21,9 @@ This guide includes examples for both use cases. You can select one of the follo
 
 For the sake of this guide, examples are written for Next.js App Router, but they are supported by any React meta framework, such as Remix or Gatsby.
 
+> [!IMPORTANT]
+> If your app is rendered with [React Server Components](https://react.dev/reference/rsc/server-components) by default, you'll need to add the [`use client` directive](https://react.dev/reference/rsc/use-client) when using `<UserProfile />`.
+
 ## Add a custom page to `<UserProfile />`
 
 Custom pages can be rendered inside the `<UserProfile />` component and provide a way to incorporate app-specific settings or additional functionality.


### PR DESCRIPTION
> [!IMPORTANT]
> 🔎 Previews:
>
> - https://clerk.com/docs/pr/1430/customization/user-profile
> - https://clerk.com/docs/pr/1430/customization/organization-profile
> - https://clerk.com/docs/pr/1430/customization/user-button

This PR stems from https://github.com/clerk/javascript/issues/3925 where it wasn't clear that one needs to add the 'use client' directive with these components.
