### PR TITLE
Fix syntax errors in higher order component code snippets

### DIFF
--- a/docs/upgrade-guides/core-2/nextjs.mdx
+++ b/docs/upgrade-guides/core-2/nextjs.mdx
@@ -1115,39 +1115,39 @@ As part of this major version, a number of previously deprecated props, arugment
   <AccordionPanel>
     The `WithSession` higher order component has been removed. If you would still like to use this function in the way its implemented, it can be created quickly using Clerk's [custom hooks](/docs/references/react/overview). An example of how to do so is below:
 
-    ```js {{ prettier: false }}
+    ```js
     export const WithSession = ({ children }) => {
-      const session = useSession();
-      if (typeof children !== 'function') throw new Error();
+      const session = useSession()
+      if (typeof children !== 'function') throw new Error()
 
-      return {children(session)};
-    };
+      return children(session)
+    }
     ```
   </AccordionPanel>
 
   <AccordionPanel>
     The `WithClerk` higher order component has been removed. If you would still like to use this function in the way its implemented, it can be created quickly using Clerk's [custom hooks](/docs/references/react/overview). An example of how to do so is below:
 
-    ```js {{ prettier: false }}
+    ```js
     export const WithClerk = ({ children }) => {
-      const clerk = useClerk();
-      if (typeof children !== 'function') throw new Error();
+      const clerk = useClerk()
+      if (typeof children !== 'function') throw new Error()
 
-      return {children(clerk)};
-    };
+      return children(clerk)
+    }
     ```
   </AccordionPanel>
 
   <AccordionPanel>
     The `WithUser` higher order component has been removed. If you would still like to use this function in the way its implemented, it can be created quickly using Clerk's [custom hooks](/docs/references/react/overview). An example of how to do so is below:
 
-    ```js {{ prettier: false }}
+    ```js
     export const WithUser = ({ children }) => {
-      const user = useUser();
-      if (typeof children !== 'function') throw new Error();
+      const user = useUser()
+      if (typeof children !== 'function') throw new Error()
 
-      return {children(user)};
-    };
+      return children(user)
+    }
     ```
   </AccordionPanel>
 

--- a/docs/upgrade-guides/core-2/react.mdx
+++ b/docs/upgrade-guides/core-2/react.mdx
@@ -642,39 +642,39 @@ As part of this major version, a number of previously deprecated props, arugment
   <AccordionPanel>
     The `WithSession` higher order component has been removed. If you would still like to use this function in the way its implemented, it can be created quickly using Clerk's [custom hooks](/docs/references/react/overview). An example of how to do so is below:
 
-    ```js {{ prettier: false }}
+    ```js
     export const WithSession = ({ children }) => {
-      const session = useSession();
-      if (typeof children !== 'function') throw new Error();
+      const session = useSession()
+      if (typeof children !== 'function') throw new Error()
 
-      return {children(session)};
-    };
+      return children(session)
+    }
     ```
   </AccordionPanel>
 
   <AccordionPanel>
     The `WithClerk` higher order component has been removed. If you would still like to use this function in the way its implemented, it can be created quickly using Clerk's [custom hooks](/docs/references/react/overview). An example of how to do so is below:
 
-    ```js {{ prettier: false }}
+    ```js
     export const WithClerk = ({ children }) => {
-      const clerk = useClerk();
-      if (typeof children !== 'function') throw new Error();
+      const clerk = useClerk()
+      if (typeof children !== 'function') throw new Error()
 
-      return {children(clerk)};
-    };
+      return children(clerk)
+    }
     ```
   </AccordionPanel>
 
   <AccordionPanel>
     The `WithUser` higher order component has been removed. If you would still like to use this function in the way its implemented, it can be created quickly using Clerk's [custom hooks](/docs/references/react/overview). An example of how to do so is below:
 
-    ```js {{ prettier: false }}
+    ```js
     export const WithUser = ({ children }) => {
-      const user = useUser();
-      if (typeof children !== 'function') throw new Error();
+      const user = useUser()
+      if (typeof children !== 'function') throw new Error()
 
-      return {children(user)};
-    };
+      return children(user)
+    }
     ```
   </AccordionPanel>
 


### PR DESCRIPTION
<!--- Add the "deploy-preview" label and add your page previews here -->

> [!IMPORTANT]
> 🔎 Previews:
>
> - https://clerk.com/docs/pr/1432/docs/upgrade-guides/core-2/nextjs
> - https://clerk.com/docs/pr/1432/docs/upgrade-guides/core-2/react

<!--- Describe your changes in detail. Why does this change need to happen? Include any links to Slack discussions, Linear comments, etc. -->

### Explanation:

<!--- How does this PR solve the problem? -->

### This PR:

- Fixes syntax errors in higher order component code snippets
  ```diff
  - return {children(session)};
  + return children(session)
  ```
- Enables Prettier for these snippets now that they are valid and can be formatted