### PR TITLE
docs(astro): Add multi-framework example for $authStore and $clerkStore

### DIFF
--- a/docs/references/astro/auth-store.mdx
+++ b/docs/references/astro/auth-store.mdx
@@ -50,32 +50,32 @@ The following example demonstrates how to use the `$authStore` store to access t
 
 <CodeBlockTabs options={['React', 'Vue', 'Svelte']}>
   ```tsx {{ filename: 'components/external-data.tsx' }}
-  import { useStore } from '@nanostores/react';
-  import { $authStore } from '@clerk/astro/client';
+  import { useStore } from '@nanostores/react'
+  import { $authStore } from '@clerk/astro/client'
 
   export default function ExternalData() {
-    const { userId } = useStore($authStore);
+    const { userId } = useStore($authStore)
 
     if (userId === undefined) {
       // Handle loading state however you like
-      return <div>Loading...</div>;
+      return <div>Loading...</div>
     }
 
     if (userId === null) {
       // Handle signed out state however you like
-      return <div>Sign in to view this page</div>;
+      return <div>Sign in to view this page</div>
     }
 
-    return <div>...</div>;
+    return <div>...</div>
   }
   ```
 
   ```vue {{ filename: 'components/external-data.vue' }}
   <script setup>
-  import { useStore } from '@nanostores/vue';
-  import { $authStore } from '@clerk/astro/client';
+  import { useStore } from '@nanostores/vue'
+  import { $authStore } from '@clerk/astro/client'
 
-  const auth = useStore($authStore);
+  const auth = useStore($authStore)
   </script>
 
   <template>
@@ -87,9 +87,9 @@ The following example demonstrates how to use the `$authStore` store to access t
 
   ```svelte {{ filename: 'components/external-data.svelte' }}
   <script>
-  // The $ prefix is reserved in Svelte for its own reactivity system.
-  // Alias the imports to avoid conflicts.
-  import { $authStore as auth } from '@clerk/astro/client';
+    // The $ prefix is reserved in Svelte for its own reactivity system.
+    // Alias the imports to avoid conflicts.
+    import { $authStore as auth } from '@clerk/astro/client'
   </script>
 
   {#if $auth.userId === undefined}

--- a/docs/references/astro/auth-store.mdx
+++ b/docs/references/astro/auth-store.mdx
@@ -49,7 +49,7 @@ The `$authStore` store provides a convenient way to access the current auth stat
 The following example demonstrates how to use the `$authStore` store to access the current auth state. It uses `userId` to detect if the user is signed in.
 
 <CodeBlockTabs options={['React', 'Vue', 'Svelte']}>
-  ```tsx {{ prettier: false, filename: 'components/external-data.tsx' }}
+  ```tsx {{ filename: 'components/external-data.tsx' }}
   import { useStore } from '@nanostores/react';
   import { $authStore } from '@clerk/astro/client';
 
@@ -70,7 +70,7 @@ The following example demonstrates how to use the `$authStore` store to access t
   }
   ```
 
-  ```vue {{ prettier: false, filename: 'components/external-data.vue' }}
+  ```vue {{ filename: 'components/external-data.vue' }}
   <script setup>
   import { useStore } from '@nanostores/vue';
   import { $authStore } from '@clerk/astro/client';
@@ -85,7 +85,7 @@ The following example demonstrates how to use the `$authStore` store to access t
   </template>
   ```
 
-  ```svelte {{ prettier: false, filename: 'components/external-data.svelte' }}
+  ```svelte {{ filename: 'components/external-data.svelte' }}
   <script>
   // The $ prefix is reserved in Svelte for its own reactivity system.
   // Alias the imports to avoid conflicts.

--- a/docs/references/astro/auth-store.mdx
+++ b/docs/references/astro/auth-store.mdx
@@ -9,13 +9,40 @@ The `$authStore` store provides a convenient way to access the current auth stat
 
 ## `$authStore.get()` returns
 
-| Name | Type | Description |
-| - | - | - |
-| `userId` | `string` | The current user's ID. |
-| `sessionId` | `string` | The current user's session ID. |
-| `orgId` | `string` | The current user's active organization ID. |
-| `orgRole` | `string` | The current user's active organization role. |
-| `orgSlug` | `string` | The current user's active organization slug. |
+<Properties>
+  - `userId`
+  - `string`
+
+  The current user's ID.
+
+  ---
+
+  - `sessionId`
+  - `string`
+
+  The current user's session ID.
+
+  ---
+
+  - `orgId`
+  - `string`
+
+  The current user's active organization ID.
+
+  ---
+
+  - `orgRole`
+  - `string`
+
+  The current user's active organization role.
+
+  ---
+
+  - `orgSlug`
+  - `string`
+
+  The current user's active organization slug.
+</Properties>
 
 ## How to use the `$authStore` store
 

--- a/docs/references/astro/auth-store.mdx
+++ b/docs/references/astro/auth-store.mdx
@@ -9,74 +9,68 @@ The `$authStore` store provides a convenient way to access the current auth stat
 
 ## `$authStore.get()` returns
 
-<Properties>
-  - `userId`
-  - `string`
-
-  The current user's ID.
-
-  ---
-
-  - `sessionId`
-  - `string`
-
-  The current user's session ID.
-
-  ---
-
-  - `orgId`
-  - `string`
-
-  The current user's active organization ID.
-
-  ---
-
-  - `orgRole`
-  - `string`
-
-  The current user's active organization role.
-
-  ---
-
-  - `orgSlug`
-  - `string`
-
-  The current user's active organization slug.
-</Properties>
+| Name | Type | Description |
+| - | - | - |
+| `userId` | `string` | The current user's ID. |
+| `sessionId` | `string` | The current user's session ID. |
+| `orgId` | `string` | The current user's active organization ID. |
+| `orgRole` | `string` | The current user's active organization role. |
+| `orgSlug` | `string` | The current user's active organization slug. |
 
 ## How to use the `$authStore` store
 
-The following example demonstrates how to use the `$authStore` store to access the current auth state. It uses `userId` to detect if the user is signed in and the [`getToken()`](/docs/references/javascript/session#get-token){{ target: '_blank' }} method to retrieve a session token for fetching data from an external resource.
+The following example demonstrates how to use the `$authStore` store to access the current auth state. It uses `userId` to detect if the user is signed in.
 
-```tsx {{ filename: 'components/external-data.tsx' }}
-import { useStore } from '@nanostores/react'
-import { $authStore, $sessionStore } from '@clerk/astro/client'
+<CodeBlockTabs options={['React', 'Vue', 'Svelte']}>
+  ```tsx {{ prettier: false, filename: 'components/external-data.tsx' }}
+  import { useStore } from '@nanostores/react';
+  import { $authStore } from '@clerk/astro/client';
 
-export default function ExternalData() {
-  const { userId } = useStore($authStore)
-  const session = useStore($sessionStore)
+  export default function ExternalData() {
+    const { userId } = useStore($authStore);
 
-  if (userId === undefined) {
-    // Handle loading state however you like
-    return <div>Loading...</div>
-  }
-
-  if (userId === null) {
-    // Handle signed out state however you like
-    return <div>Sign in to view this page</div>
-  }
-
-  const fetchDataFromExternalResource = async () => {
-    if (!session) {
-      // Handle session loading state
-      return
+    if (userId === undefined) {
+      // Handle loading state however you like
+      return <div>Loading...</div>;
     }
 
-    const token = await session.getToken()
-    // Add logic to fetch your data
-    return data
-  }
+    if (userId === null) {
+      // Handle signed out state however you like
+      return <div>Sign in to view this page</div>;
+    }
 
-  return <div>...</div>
-}
-```
+    return <div>...</div>;
+  }
+  ```
+
+  ```vue {{ prettier: false, filename: 'components/external-data.vue' }}
+  <script setup>
+  import { useStore } from '@nanostores/vue';
+  import { $authStore } from '@clerk/astro/client';
+
+  const auth = useStore($authStore);
+  </script>
+
+  <template>
+    <div v-if="auth.userId === undefined">Loading...</div>
+    <div v-else-if="auth.userId === null">Sign in to view this page</div>
+    <div v-else>...</div>
+  </template>
+  ```
+
+  ```svelte {{ prettier: false, filename: 'components/external-data.svelte' }}
+  <script>
+  // The $ prefix is reserved in Svelte for its own reactivity system.
+  // Alias the imports to avoid conflicts.
+  import { $authStore as auth } from '@clerk/astro/client';
+  </script>
+
+  {#if $auth.userId === undefined}
+    <div>Loading...</div>
+  {:else if $auth.userId === null}
+    <div>Sign in to view this page</div>
+  {:else}
+    <div>...</div>
+  {/if}
+  ```
+</CodeBlockTabs>

--- a/docs/references/astro/clerk-store.mdx
+++ b/docs/references/astro/clerk-store.mdx
@@ -13,7 +13,7 @@ The `$clerkStore` store provides a convenient way to access the [`Clerk`](https:
 ## How to use the `$clerkStore` store
 
 <CodeBlockTabs options={['React', 'Vue', 'Svelte']}>
-  ```tsx {{ prettier: false, filename: 'components/sign-in.tsx' }}
+  ```tsx {{ filename: 'components/sign-in.tsx' }}
   import { useStore } from '@nanostores/react';
   import { $clerkStore } from '@clerk/astro/client';
 
@@ -24,7 +24,7 @@ The `$clerkStore` store provides a convenient way to access the [`Clerk`](https:
   };
   ```
 
-  ```vue {{ prettier: false, filename: 'components/sign-in.vue' }}
+  ```vue {{ filename: 'components/sign-in.vue' }}
   <script setup>
   import { useStore } from '@nanostores/vue';
   import { $clerkStore } from '@clerk/astro/client';
@@ -39,7 +39,7 @@ The `$clerkStore` store provides a convenient way to access the [`Clerk`](https:
   </template>
   ```
 
-  ```svelte {{ prettier: false, filename: 'components/sign-in.svelte' }}
+  ```svelte {{ filename: 'components/sign-in.svelte' }}
   <script>
   // The $ prefix is reserved in Svelte for its own reactivity system.
   // Alias the imports to avoid conflicts.

--- a/docs/references/astro/clerk-store.mdx
+++ b/docs/references/astro/clerk-store.mdx
@@ -5,7 +5,7 @@ description: Clerk's $clerkStore nanostore provides a convenient way to access t
 
 # `$clerkStore`
 
-The `$clerkStore` store provides a convenient way to access the [`Clerk`](https://clerk.com/docs/references/javascript/clerk/clerk) object. This provides access to some methods that are not available in other stores.
+The `$clerkStore` store provides a convenient way to access the [`Clerk`](/docs/references/javascript/clerk/clerk){{ target: '_blank' }} object. This provides access to some methods that are not available in other stores.
 
 > [!WARNING]
 > This is intended to be used for advanced use cases, like building a completely custom OAuth flow or as an escape hatch for getting access to the `Clerk` object.

--- a/docs/references/astro/clerk-store.mdx
+++ b/docs/references/astro/clerk-store.mdx
@@ -14,24 +14,24 @@ The `$clerkStore` store provides a convenient way to access the [`Clerk`](https:
 
 <CodeBlockTabs options={['React', 'Vue', 'Svelte']}>
   ```tsx {{ filename: 'components/sign-in.tsx' }}
-  import { useStore } from '@nanostores/react';
-  import { $clerkStore } from '@clerk/astro/client';
+  import { useStore } from '@nanostores/react'
+  import { $clerkStore } from '@clerk/astro/client'
 
   export default function SignIn() {
-    const clerk = useStore($clerkStore);
+    const clerk = useStore($clerkStore)
 
-    return <button onClick={() => clerk.openSignIn()}>Sign in</button>;
-  };
+    return <button onClick={() => clerk.openSignIn()}>Sign in</button>
+  }
   ```
 
   ```vue {{ filename: 'components/sign-in.vue' }}
   <script setup>
-  import { useStore } from '@nanostores/vue';
-  import { $clerkStore } from '@clerk/astro/client';
+  import { useStore } from '@nanostores/vue'
+  import { $clerkStore } from '@clerk/astro/client'
 
-  const clerk = useStore($clerkStore);
+  const clerk = useStore($clerkStore)
 
-  const openSignIn = () => clerk.value.openSignIn();
+  const openSignIn = () => clerk.value.openSignIn()
   </script>
 
   <template>
@@ -41,9 +41,9 @@ The `$clerkStore` store provides a convenient way to access the [`Clerk`](https:
 
   ```svelte {{ filename: 'components/sign-in.svelte' }}
   <script>
-  // The $ prefix is reserved in Svelte for its own reactivity system.
-  // Alias the imports to avoid conflicts.
-  import { $clerkStore as clerk } from '@clerk/astro/client';
+    // The $ prefix is reserved in Svelte for its own reactivity system.
+    // Alias the imports to avoid conflicts.
+    import { $clerkStore as clerk } from '@clerk/astro/client'
   </script>
 
   <button on:click={() => $clerk.openSignIn()}>Sign in</button>

--- a/docs/references/astro/clerk-store.mdx
+++ b/docs/references/astro/clerk-store.mdx
@@ -5,20 +5,47 @@ description: Clerk's $clerkStore nanostore provides a convenient way to access t
 
 # `$clerkStore`
 
-The `$clerkStore` store provides a convenient way to access the [`Clerk`](/docs/references/javascript/clerk/clerk){{ target: '_blank' }} object. This provides access to some methods that are not available in other stores.
+The `$clerkStore` store provides a convenient way to access the [`Clerk`](https://clerk.com/docs/references/javascript/clerk/clerk) object. This provides access to some methods that are not available in other stores.
 
 > [!WARNING]
 > This is intended to be used for advanced use cases, like building a completely custom OAuth flow or as an escape hatch for getting access to the `Clerk` object.
 
 ## How to use the `$clerkStore` store
 
-```tsx {{ filename: 'components/sign-in.tsx' }}
-import { useStore } from '@nanostores/react'
-import { $clerkStore } from '@clerk/astro/client'
+<CodeBlockTabs options={['React', 'Vue', 'Svelte']}>
+  ```tsx {{ prettier: false, filename: 'components/sign-in.tsx' }}
+  import { useStore } from '@nanostores/react';
+  import { $clerkStore } from '@clerk/astro/client';
 
-export default function Home() {
-  const clerk = useStore($clerkStore)
+  export default function SignIn() {
+    const clerk = useStore($clerkStore);
 
-  return <button onClick={() => clerk.openSignIn({})}>Sign in</button>
-}
-```
+    return <button onClick={() => clerk.openSignIn()}>Sign in</button>;
+  };
+  ```
+
+  ```vue {{ prettier: false, filename: 'components/sign-in.vue' }}
+  <script setup>
+  import { useStore } from '@nanostores/vue';
+  import { $clerkStore } from '@clerk/astro/client';
+
+  const clerk = useStore($clerkStore);
+
+  const openSignIn = () => clerk.value.openSignIn();
+  </script>
+
+  <template>
+    <button @click="openSignIn">Sign in</button>
+  </template>
+  ```
+
+  ```svelte {{ prettier: false, filename: 'components/sign-in.svelte' }}
+  <script>
+  // The $ prefix is reserved in Svelte for its own reactivity system.
+  // Alias the imports to avoid conflicts.
+  import { $clerkStore as clerk } from '@clerk/astro/client';
+  </script>
+
+  <button on:click={() => $clerk.openSignIn()}>Sign in</button>
+  ```
+</CodeBlockTabs>


### PR DESCRIPTION
<!--- Add the "deploy-preview" label and add your page previews here -->

> [!IMPORTANT]
> 🔎 Previews:
>
> - https://clerk.com/docs/pr/1434/references/astro/auth-store
> - https://clerk.com/docs/pr/1434/references/astro/clerk-store

<!--- Describe your changes in detail. Why does this change need to happen? Include any links to Slack discussions, Linear comments, etc. -->

### Explanation:

<!--- How does this PR solve the problem? -->

### This PR:

- As one of Astro's key features is its ability to seamlessly integrate components from various frameworks, this PR demonstrates the use of @clerk/astro's `$authStore` and `$clerkStore` with both Vue and Svelte components.
