### PR TITLE
docs(astro): Add multi-framework example for $signInStore and $signUpStore

### DIFF
--- a/docs/references/astro/sign-in-store.mdx
+++ b/docs/references/astro/sign-in-store.mdx
@@ -67,4 +67,4 @@ The possible values for the `status` property of the `SignIn` resource are liste
 
 ### Create a custom sign-in flow
 
-The `$signInStore` store can also be used to build fully custom sign-in flows, if Clerk's pre-built components don't meet your specific needs or if you require more control over the authentication flow. Different sign-in flows include email and password, email and phone codes, email links, and multifactor (MFA). To learn more about using the `$signInStore` store to create custom flows, check out the [custom flow guides](/docs/custom-flows/overview)
+The `$signInStore` store can also be used to build fully custom sign-in flows, if Clerk's pre-built components don't meet your specific needs or if you require more control over the authentication flow. Different sign-in flows include email and password, email and phone codes, email links, and multifactor (MFA). To learn more about using the `$signInStore` store to create custom flows, check out the [custom flow guides.](/docs/custom-flows/overview)

--- a/docs/references/astro/sign-in-store.mdx
+++ b/docs/references/astro/sign-in-store.mdx
@@ -5,7 +5,7 @@ description: Clerk's $signInStore nanostore provides a convenient way to access 
 
 # `$signInStore`
 
-The `$signInStore` store provides a convenient way to access the [`SignIn`](https://clerk.com/docs/references/javascript/sign-in/sign-in) object, which allows you to check the current state of a sign-in. This is also useful for creating a custom sign-in flow.
+The `$signInStore` store provides a convenient way to access the [`SignIn`](/docs/references/javascript/sign-in/sign-in){{ target: '_blank' }} object, which allows you to check the current state of a sign-in. This is also useful for creating a custom sign-in flow.
 
 ## How to use the `$signInStore` store
 

--- a/docs/references/astro/sign-in-store.mdx
+++ b/docs/references/astro/sign-in-store.mdx
@@ -5,7 +5,7 @@ description: Clerk's $signInStore nanostore provides a convenient way to access 
 
 # `$signInStore`
 
-The `$signInStore` store provides a convenient way to access the [`SignIn`](/docs/references/javascript/sign-in/sign-in){{ target: '_blank' }} object, which allows you to check the current state of a sign-in. This is also useful for creating a custom sign-in flow.
+The `$signInStore` store provides a convenient way to access the [`SignIn`](https://clerk.com/docs/references/javascript/sign-in/sign-in) object, which allows you to check the current state of a sign-in. This is also useful for creating a custom sign-in flow.
 
 ## How to use the `$signInStore` store
 
@@ -13,26 +13,58 @@ The `$signInStore` store provides a convenient way to access the [`SignIn`](/doc
 
 The following example demonstrates how to use the `$signInStore` store to check the current state of a sign-in.
 
-```tsx {{ filename: 'sign-in-step.tsx' }}
-import { useStore } from '@nanostores/react'
-import { $signInStore } from '@clerk/astro/client'
+<CodeBlockTabs options={['React', 'Vue', 'Svelte']}>
+  ```tsx {{ prettier: false, filename: 'sign-in-step.tsx' }}
+  import { useStore } from '@nanostores/react';
+  import { $signInStore } from '@clerk/astro/client';
 
-export default function SignInStep() {
-  const signIn = useStore($signInStore)
+  export default function SignInStep() {
+    const signIn = useStore($signInStore);
 
-  if (signIn === undefined) {
-    // Add logic to handle loading state
-    return null
+    if (signIn === undefined) {
+      // Add logic to handle loading state
+      return null;
+    }
+
+    return <div>The current sign in attempt status is {signIn.status}.</div>;
   }
+  ```
 
-  // Logic to handle sign in
+  ```vue {{ prettier: false, filename: 'sign-in-step.vue' }}
+  <script setup>
+  import { useStore } from '@nanostores/vue';
+  import { $signInStore } from '@clerk/astro/client';
 
-  return <div>The current sign in attempt status is {signIn.status}.</div>
-}
-```
+  const signIn = useStore($signInStore);
+  </script>
+
+  <template>
+    <div v-if="signIn === undefined">
+      <!-- Add logic to handle loading state -->
+    </div>
+    <div v-else>
+      <div>The current sign in attempt status is {{ signIn.status }}.</div>
+    </div>
+  </template>
+  ```
+
+  ```svelte {{ prettier: false, filename: 'sign-in-step.svelte' }}
+  <script>
+  // The $ prefix is reserved in Svelte for its own reactivity system.
+  // Alias the imports to avoid conflicts.
+  import { $signInStore as signIn } from '@clerk/astro/client';
+  </script>
+
+  {#if $signIn === undefined}
+      <!-- Add logic to handle loading state -->
+  {:else}
+      <div>The current sign in attempt status is {$signIn.status}.</div>
+  {/if}
+  ```
+</CodeBlockTabs>
 
 The possible values for the `status` property of the `SignIn` resource are listed [here](/docs/references/javascript/sign-in/sign-in#properties).
 
 ### Create a custom sign-in flow
 
-The `$signInStore` store can also be used to build fully custom sign-in flows, if Clerk's pre-built components don't meet your specific needs or if you require more control over the authentication flow. Different sign-in flows include email and password, email and phone codes, email links, and multifactor (MFA). To learn more about using the `$signInStore` store to create custom flows, check out the [custom flow guides](/docs/custom-flows/overview).
+The `$signInStore` store can also be used to build fully custom sign-in flows, if Clerk's pre-built components don't meet your specific needs or if you require more control over the authentication flow. Different sign-in flows include email and password, email and phone codes, email links, and multifactor (MFA). To learn more about using the `$signInStore` store to create custom flows, check out the [custom flow guides](/docs/custom-flows/overview)

--- a/docs/references/astro/sign-in-store.mdx
+++ b/docs/references/astro/sign-in-store.mdx
@@ -15,18 +15,18 @@ The following example demonstrates how to use the `$signInStore` store to check 
 
 <CodeBlockTabs options={['React', 'Vue', 'Svelte']}>
   ```tsx {{ filename: 'sign-in-step.tsx' }}
-  import { useStore } from '@nanostores/react';
-  import { $signInStore } from '@clerk/astro/client';
+  import { useStore } from '@nanostores/react'
+  import { $signInStore } from '@clerk/astro/client'
 
   export default function SignInStep() {
-    const signIn = useStore($signInStore);
+    const signIn = useStore($signInStore)
 
     if (signIn === undefined) {
       // Add logic to handle loading state
-      return null;
+      return null
     }
 
-    return <div>The current sign in attempt status is {signIn.status}.</div>;
+    return <div>The current sign in attempt status is {signIn.status}.</div>
   }
   ```
 

--- a/docs/references/astro/sign-in-store.mdx
+++ b/docs/references/astro/sign-in-store.mdx
@@ -14,7 +14,7 @@ The `$signInStore` store provides a convenient way to access the [`SignIn`](http
 The following example demonstrates how to use the `$signInStore` store to check the current state of a sign-in.
 
 <CodeBlockTabs options={['React', 'Vue', 'Svelte']}>
-  ```tsx {{ prettier: false, filename: 'sign-in-step.tsx' }}
+  ```tsx {{ filename: 'sign-in-step.tsx' }}
   import { useStore } from '@nanostores/react';
   import { $signInStore } from '@clerk/astro/client';
 

--- a/docs/references/astro/sign-in-store.mdx
+++ b/docs/references/astro/sign-in-store.mdx
@@ -30,12 +30,12 @@ The following example demonstrates how to use the `$signInStore` store to check 
   }
   ```
 
-  ```vue {{ prettier: false, filename: 'sign-in-step.vue' }}
+  ```vue {{ filename: 'sign-in-step.vue' }}
   <script setup>
-  import { useStore } from '@nanostores/vue';
-  import { $signInStore } from '@clerk/astro/client';
+  import { useStore } from '@nanostores/vue'
+  import { $signInStore } from '@clerk/astro/client'
 
-  const signIn = useStore($signInStore);
+  const signIn = useStore($signInStore)
   </script>
 
   <template>
@@ -48,17 +48,17 @@ The following example demonstrates how to use the `$signInStore` store to check 
   </template>
   ```
 
-  ```svelte {{ prettier: false, filename: 'sign-in-step.svelte' }}
+  ```svelte {{ filename: 'sign-in-step.svelte' }}
   <script>
-  // The $ prefix is reserved in Svelte for its own reactivity system.
-  // Alias the imports to avoid conflicts.
-  import { $signInStore as signIn } from '@clerk/astro/client';
+    // The $ prefix is reserved in Svelte for its own reactivity system.
+    // Alias the imports to avoid conflicts.
+    import { $signInStore as signIn } from '@clerk/astro/client'
   </script>
 
   {#if $signIn === undefined}
-      <!-- Add logic to handle loading state -->
+    <!-- Add logic to handle loading state -->
   {:else}
-      <div>The current sign in attempt status is {$signIn.status}.</div>
+    <div>The current sign in attempt status is {$signIn.status}.</div>
   {/if}
   ```
 </CodeBlockTabs>

--- a/docs/references/astro/sign-up-store.mdx
+++ b/docs/references/astro/sign-up-store.mdx
@@ -5,7 +5,7 @@ description: Clerk's $signUpStore nanostore provides a convenient way to access 
 
 # `$signUpStore`
 
-The `$signUpStore` store provides a convenient way to access the \[`SignUp`][`SignUp`](/docs/references/javascript/sign-up/sign-up){{ target: '_blank' }} object, which allows you to check the current state of a sign-up. This is also useful for creating a custom sign-up flow.
+The `$signUpStore` store provides a convenient way to access the [`SignUp`](/docs/references/javascript/sign-up/sign-up){{ target: '_blank' }} object, which allows you to check the current state of a sign-up. This is also useful for creating a custom sign-up flow.
 
 ## How to use the `$signUpStore` store
 

--- a/docs/references/astro/sign-up-store.mdx
+++ b/docs/references/astro/sign-up-store.mdx
@@ -30,12 +30,12 @@ The following example demonstrates how to use the `$signUpStore` store to access
   }
   ```
 
-  ```vue {{ prettier: false, filename: 'sign-up-step.vue' }}
+  ```vue {{ filename: 'sign-up-step.vue' }}
   <script setup>
-  import { useStore } from '@nanostores/vue';
-  import { $signUpStore } from '@clerk/astro/client';
+  import { useStore } from '@nanostores/vue'
+  import { $signUpStore } from '@clerk/astro/client'
 
-  const signUp = useStore($signUpStore);
+  const signUp = useStore($signUpStore)
   </script>
 
   <template>
@@ -48,17 +48,17 @@ The following example demonstrates how to use the `$signUpStore` store to access
   </template>
   ```
 
-  ```svelte {{ prettier: false, filename: 'sign-up-step.svelte' }}
+  ```svelte {{ filename: 'sign-up-step.svelte' }}
   <script>
-  // The $ prefix is reserved in Svelte for its own reactivity system.
-  // Alias the imports to avoid conflicts.
-  import { $signUpStore as signUp } from '@clerk/astro/client';
+    // The $ prefix is reserved in Svelte for its own reactivity system.
+    // Alias the imports to avoid conflicts.
+    import { $signUpStore as signUp } from '@clerk/astro/client'
   </script>
 
   {#if $signUp === undefined}
-      <!-- Add logic to handle loading state -->
+    <!-- Add logic to handle loading state -->
   {:else}
-      <div>The current sign-up attempt status is {$signUp.status}.</div>
+    <div>The current sign-up attempt status is {$signUp.status}.</div>
   {/if}
   ```
 </CodeBlockTabs>

--- a/docs/references/astro/sign-up-store.mdx
+++ b/docs/references/astro/sign-up-store.mdx
@@ -5,7 +5,7 @@ description: Clerk's $signUpStore nanostore provides a convenient way to access 
 
 # `$signUpStore`
 
-The `$signUpStore` store provides a convenient way to access the [`SignUp`](/docs/references/javascript/sign-up/sign-up){{ target: '_blank' }} object, which allows you to check the current state of a sign-up. This is also useful for creating a custom sign-up flow.
+The `$signUpStore` store provides a convenient way to access the [`SignUp`](https://clerk.com/docs/references/javascript/sign-up/sign-up) object, which allows you to check the current state of a sign-up. This is also useful for creating a custom sign-up flow.
 
 ## How to use the `$signUpStore` store
 
@@ -13,26 +13,58 @@ The `$signUpStore` store provides a convenient way to access the [`SignUp`](/doc
 
 The following example demonstrates how to use the `$signUpStore` store to access the `SignUp` object and check the current state of a sign-up.
 
-```tsx {{ filename: 'sign-up-step.tsx' }}
-import { useStore } from '@nanostores/react'
-import { $signUpStore } from '@clerk/astro/client'
+<CodeBlockTabs options={['React', 'Vue', 'Svelte']}>
+  ```tsx {{ prettier: false, filename: 'sign-up-step.tsx' }}
+  import { useStore } from '@nanostores/react';
+  import { $signUpStore } from '@clerk/astro/client';
 
-export default function SignUpStep() {
-  const signUp = useStore($signUpStore)
+  export default function SignUpStep() {
+    const signUp = useStore($signUpStore);
 
-  if (signUp === undefined) {
-    // Add logic to handle loading state
-    return null
+    if (signUp === undefined) {
+      // Add logic to handle loading state
+      return null;
+    }
+
+    return <div>The current sign-up attempt status is {signUp.status}.</div>;
   }
+  ```
 
-  // Logic to handle sign up
+  ```vue {{ prettier: false, filename: 'sign-up-step.vue' }}
+  <script setup>
+  import { useStore } from '@nanostores/vue';
+  import { $signUpStore } from '@clerk/astro/client';
 
-  return <div>The current sign-up attempt status is {signUp.status}.</div>
-}
-```
+  const signUp = useStore($signUpStore);
+  </script>
 
-The possible values for the `status` property of the `SignUp` resource are listed [here](/docs/references/javascript/sign-up/sign-up#properties){{ target: '_blank' }}.
+  <template>
+    <div v-if="signUp === undefined">
+      <!-- Add logic to handle loading state -->
+    </div>
+    <div v-else>
+      <div>The current sign-up attempt status is {{ signUp.status }}.</div>
+    </div>
+  </template>
+  ```
+
+  ```svelte {{ prettier: false, filename: 'sign-up-step.svelte' }}
+  <script>
+  // The $ prefix is reserved in Svelte for its own reactivity system.
+  // Alias the imports to avoid conflicts.
+  import { $signUpStore as signUp } from '@clerk/astro/client';
+  </script>
+
+  {#if $signUp === undefined}
+      <!-- Add logic to handle loading state -->
+  {:else}
+      <div>The current sign-up attempt status is {$signUp.status}.</div>
+  {/if}
+  ```
+</CodeBlockTabs>
+
+The possible values for the `status` property of the `SignUp` resource are listed [here](https://clerk.com/docs/references/javascript/sign-up/sign-up#properties).
 
 ### Create a custom sign-up flow
 
-The `$signUpStore` store can also be used to build fully custom sign-up flows, if Clerk's pre-built components don't meet your specific needs or if you require more control over the authentication flow. Different sign-up flows include email and password, email and phone codes, email links, and multifactor (MFA). To learn more about using the `$signUpStore` store to create custom flows, check out the [custom flow guides](/docs/custom-flows/overview).
+The `$signUpStore` store can also be used to build fully custom sign-up flows, if Clerk's pre-built components don't meet your specific needs or if you require more control over the authentication flow. Different sign-up flows include email and password, email and phone codes, email links, and multifactor (MFA). To learn more about using the `$signUpStore` store to create custom flows, check out the [custom flow guides](/docs/custom-flows/overview)

--- a/docs/references/astro/sign-up-store.mdx
+++ b/docs/references/astro/sign-up-store.mdx
@@ -5,7 +5,7 @@ description: Clerk's $signUpStore nanostore provides a convenient way to access 
 
 # `$signUpStore`
 
-The `$signUpStore` store provides a convenient way to access the [`SignUp`](https://clerk.com/docs/references/javascript/sign-up/sign-up) object, which allows you to check the current state of a sign-up. This is also useful for creating a custom sign-up flow.
+The `$signUpStore` store provides a convenient way to access the [`SignUp`][`SignUp`](/docs/references/javascript/sign-up/sign-up){{ target: '_blank' }} object, which allows you to check the current state of a sign-up. This is also useful for creating a custom sign-up flow.
 
 ## How to use the `$signUpStore` store
 

--- a/docs/references/astro/sign-up-store.mdx
+++ b/docs/references/astro/sign-up-store.mdx
@@ -5,7 +5,7 @@ description: Clerk's $signUpStore nanostore provides a convenient way to access 
 
 # `$signUpStore`
 
-The `$signUpStore` store provides a convenient way to access the [`SignUp`][`SignUp`](/docs/references/javascript/sign-up/sign-up){{ target: '_blank' }} object, which allows you to check the current state of a sign-up. This is also useful for creating a custom sign-up flow.
+The `$signUpStore` store provides a convenient way to access the \[`SignUp`][`SignUp`](/docs/references/javascript/sign-up/sign-up){{ target: '_blank' }} object, which allows you to check the current state of a sign-up. This is also useful for creating a custom sign-up flow.
 
 ## How to use the `$signUpStore` store
 
@@ -15,18 +15,18 @@ The following example demonstrates how to use the `$signUpStore` store to access
 
 <CodeBlockTabs options={['React', 'Vue', 'Svelte']}>
   ```tsx {{ filename: 'sign-up-step.tsx' }}
-  import { useStore } from '@nanostores/react';
-  import { $signUpStore } from '@clerk/astro/client';
+  import { useStore } from '@nanostores/react'
+  import { $signUpStore } from '@clerk/astro/client'
 
   export default function SignUpStep() {
-    const signUp = useStore($signUpStore);
+    const signUp = useStore($signUpStore)
 
     if (signUp === undefined) {
       // Add logic to handle loading state
-      return null;
+      return null
     }
 
-    return <div>The current sign-up attempt status is {signUp.status}.</div>;
+    return <div>The current sign-up attempt status is {signUp.status}.</div>
   }
   ```
 

--- a/docs/references/astro/sign-up-store.mdx
+++ b/docs/references/astro/sign-up-store.mdx
@@ -67,4 +67,4 @@ The possible values for the `status` property of the `SignUp` resource are liste
 
 ### Create a custom sign-up flow
 
-The `$signUpStore` store can also be used to build fully custom sign-up flows, if Clerk's pre-built components don't meet your specific needs or if you require more control over the authentication flow. Different sign-up flows include email and password, email and phone codes, email links, and multifactor (MFA). To learn more about using the `$signUpStore` store to create custom flows, check out the [custom flow guides](/docs/custom-flows/overview)
+The `$signUpStore` store can also be used to build fully custom sign-up flows, if Clerk's pre-built components don't meet your specific needs or if you require more control over the authentication flow. Different sign-up flows include email and password, email and phone codes, email links, and multifactor (MFA). To learn more about using the `$signUpStore` store to create custom flows, check out the [custom flow guides.](/docs/custom-flows/overview)

--- a/docs/references/astro/sign-up-store.mdx
+++ b/docs/references/astro/sign-up-store.mdx
@@ -63,7 +63,7 @@ The following example demonstrates how to use the `$signUpStore` store to access
   ```
 </CodeBlockTabs>
 
-The possible values for the `status` property of the `SignUp` resource are listed [here](https://clerk.com/docs/references/javascript/sign-up/sign-up#properties).
+The possible values for the `status` property of the `SignUp` resource are listed [here](/docs/references/javascript/sign-up/sign-up#properties){{ target: '_blank' }}.
 
 ### Create a custom sign-up flow
 

--- a/docs/references/astro/sign-up-store.mdx
+++ b/docs/references/astro/sign-up-store.mdx
@@ -14,7 +14,7 @@ The `$signUpStore` store provides a convenient way to access the [`SignUp`][`Sig
 The following example demonstrates how to use the `$signUpStore` store to access the `SignUp` object and check the current state of a sign-up.
 
 <CodeBlockTabs options={['React', 'Vue', 'Svelte']}>
-  ```tsx {{ prettier: false, filename: 'sign-up-step.tsx' }}
+  ```tsx {{ filename: 'sign-up-step.tsx' }}
   import { useStore } from '@nanostores/react';
   import { $signUpStore } from '@clerk/astro/client';
 


### PR DESCRIPTION
<!--- Add the "deploy-preview" label and add your page previews here -->

> [!IMPORTANT]
> 🔎 Previews:
>
> - https://clerk.com/docs/pr/1435/references/astro/sign-in-store
> - https://clerk.com/docs/pr/1435/references/astro/sign-up-store

<!--- Describe your changes in detail. Why does this change need to happen? Include any links to Slack discussions, Linear comments, etc. -->

### Explanation:

<!--- How does this PR solve the problem? -->

### This PR:

- As one of Astro's key features is its ability to seamlessly integrate components from various frameworks, this PR demonstrates the use of @clerk/astro's `$signInStore` and `$signUpStore` with both Vue and Svelte components.