### PR TITLE
Update CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,6 +8,8 @@ Clerk's documentation content is written in a variation of markdown called [MDX]
 
 Clerk's documentation uses [`mdx-annotations`](https://www.npmjs.com/package/mdx-annotations) which provides a consistent way to apply props to markdown elements. This is utilized for various features such as [controlling image quality](#images-and-static-assets) and [defining code block line highlights](#highlighting).
 
+MDX files ([including any code blocks](#prettier-integration)) are formatted using [a custom Prettier plugin](https://github.com/clerk/clerk-docs/blob/main/prettier-mdx.mjs). It is recommended to enable "format on save" (or similar) in your code editor, but the formatter can also be run manually on all files using `npm run format`.
+
 ## Project setup
 
 1.  Fork and clone the repo
@@ -358,7 +360,9 @@ https://github.com/clerk/clerk-docs/assets/2615508/c1f3fc23-5581-481c-a89c-10c6a
 
 #### Prettier integration
 
-Code within code blocks is automatically formatted by Prettier when the containing MDX file is formatted. Formatting can be disabled for a code block by setting the `prettier` prop to `false`:
+Code within code blocks is automatically formatted by Prettier when the containing MDX file is formatted. Formatting errors may occur due to invalid syntax and these will cause the "Lint" GitHub action to fail and prevent pull requests from being merged. This is a deliberate tool to help prevent syntax errors from finding their way into code examples.
+
+Formatting can be disabled for a code block by setting the `prettier` prop to `false`, but this should only be used when absolutely necessary:
 
 ````mdx
 ```tsx {{ prettier: false }}
@@ -366,7 +370,7 @@ Code within code blocks is automatically formatted by Prettier when the containi
 ```
 ````
 
-["prettier-ignore" comments](https://prettier.io/docs/en/ignore.html) are also supported to ignore _parts_ of a code block:
+["prettier-ignore" comments](https://prettier.io/docs/en/ignore.html) are also supported to ignore _parts_ of a code block. This is preferred over the `prettier` prop where possible:
 
 ````mdx
 ```tsx

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -218,7 +218,7 @@ description: Some brief, but effective description of the page's content.
 ---
 ```
 
-- **`title`** - The title of the page. Used to populate the HTML `<title>` tag
+- **`title`** - The title of the page. Used to populate the HTML `<title>` tag and the h1 of the page. Supports markdown e.g. ``title: '`<SignUp>`'``
 - **`description`** - The description of the page. Used to populate a page's `<meta name="description">` tag
 
 These fields should be present on every documentation page.
@@ -227,7 +227,9 @@ These fields should be present on every documentation page.
 
 Headings should be nested by their rank. Headings with an equal or higher rank start a new section, headings with a lower rank start new subsections that are part of the higher ranked section. Please see the [Web Accessibility Initiative documentation](https://www.w3.org/WAI/tutorials/page-structure/headings/) for more information.
 
-Headings should be written in sentence-casing, where only the first word of the heading is capitalized. E.g. "This is a heading".
+Headings should be written in **sentence-casing**, where only the first word of the heading is capitalized. E.g. "This is a heading".
+
+h1's are not necessary and are considered tech-debt, as the `title` property in the [frontmatter](#file-metadata) will set the h1.
 
 `h2` and `h3` headings are automatically included in the table of contents. You can control this behaviour by using the `toc` prop:
 


### PR DESCRIPTION
MDX files are formatted using prettier. Codeblocks can opt out of prettier formatting by passing {{ prettier: false }}

MDX files no longer need an explicit h1. The `title` in the frontmatter supports markdown, and will render the h1.