### PR TITLE
docs(astro): Add multi-framework example for $organizationStore

### DIFF
--- a/docs/references/astro/organization-store.mdx
+++ b/docs/references/astro/organization-store.mdx
@@ -9,93 +9,248 @@ The `$organizationStore` store is used to retrieve attributes of the currently a
 
 ## How to use the `$organizationStore` store
 
-The following example demonstrates how to use the `$organizationStore` store to access the [`Organization`](/docs/references/javascript/organization/organization){{ target: '_blank' }} object, which allows you to access the current active organization.
+The following example demonstrates how to use the `$organizationStore` store to access the [`Organization`](https://clerk.com/docs/references/javascript/organization/organization) object, which allows you to access the current active organization.
 
-```tsx {{ filename: 'session.tsx' }}
-import { useStore } from '@nanostores/react'
-import { $organizationStore } from '@clerk/astro/client'
+<CodeBlockTabs options={['React', 'Vue', 'Svelte']}>
+  ```tsx {{ prettier: false, filename: 'organization.tsx' }}
+  import { useStore } from '@nanostores/react';
+  import { $organizationStore } from '@clerk/astro/client';
 
-export default function Home() {
-  const organization = useStore($organizationStore)
+  export default function Home() {
+    const organization = useStore($organizationStore);
 
-  if (organization === undefined) {
-    // Add logic to handle loading state
-    return null
+    if (organization === undefined) {
+      // Add logic to handle loading state
+      return null;
+    }
+
+    if(organization === null) {
+      // Add logic to handle no active organization state
+      return null;
+    }
+
+    return (
+      <div>
+        <p>This current organization is {organization.name}</p>
+      </div>
+    )
   }
+  ```
 
-  if (organization === null) {
-    // Add logic to handle no active organization state
-    return null
-  }
+  ```vue {{ prettier: false, filename: 'organization.vue' }}
+  <script setup>
+  import { useStore } from '@nanostores/vue';
+  import { $organizationStore } from '@clerk/astro/client';
 
-  return (
-    <div>
-      <p>This current organization is {organization.name}</p>
+  const organization = useStore($organizationStore);
+  </script>
+
+  <template>
+    <div v-if="organization === undefined">
+      <!-- Add logic to handle loading state -->
     </div>
-  )
-}
-```
+    <div v-else-if="organization === null">
+      <!-- Add logic to handle no active organization state -->
+    </div>
+    <div v-else>
+      <p>This current organization is {{ organization.name }}</p>
+    </div>
+  </template>
+  ```
+
+  ```svelte {{ prettier: false, filename: 'organization.svelte' }}
+  <script>
+  // The $ prefix is reserved in Svelte for its own reactivity system.
+  // Alias the imports to avoid conflicts.
+  import { $organizationStore as organization } from '@clerk/astro/client';
+  </script>
+
+  {#if $organization === undefined}
+    <!-- Add logic to handle loading state -->
+  {:else if $organization === null}
+    <!-- Add logic to handle no active organization state -->
+  {:else}
+    <div>
+      <p>This current organization is {$organization.name}</p>
+    </div>
+  {/if}
+  ```
+</CodeBlockTabs>
 
 ## Paginating data
 
 The following example demonstrates how to implement pagination for organization memberships. The `memberships` state will be populated with the first page of the organization's memberships. When the "Previous page" or "Next page" button is clicked, the `fetchMemberships` function will be called to fetch the previous or next page of memberships.
 
-You can implement this pattern to any Clerk function that returns a [`ClerkPaginatedResponse`](/docs/references/javascript/types/clerk-paginated-response#clerk-paginated-response){{ target: '_blank' }} object.
+You can implement this pattern to any Clerk function that returns a [`ClerkPaginatedResponse`](https://clerk.com/docs/references/javascript/types/clerk-paginated-response#clerk-paginated-response) object.
 
-```tsx {{ filename: 'organization-members.tsx' }}
-import { useState, useEffect } from 'react'
-import { $organizationStore } from '@clerk/astro/client'
-import { useStore } from '@nanostores/react'
+<CodeBlockTabs options={['React', 'Vue', 'Svelte']}>
+  ```tsx {{ prettier: false, filename: 'members.tsx' }}
+  import { useState, useEffect } from 'react';
+  import { $organizationStore } from '@clerk/astro/client'
+  import { useStore } from '@nanostores/react';
 
-export default function OrganizationMembers() {
-  const [memberships, setMemberships] = useState([])
-  const [currentPage, setCurrentPage] = useState(1)
-  const organization = useStore($organizationStore)
+  export default function OrganizationMembers() {
+    const [memberships, setMemberships] = useState([]);
+    const [currentPage, setCurrentPage] = useState(1);
+    const organization = useStore($organizationStore);
 
-  const pageSize = 10
+    const pageSize = 10;
 
-  useEffect(() => {
-    fetchMemberships()
-  }, [currentPage, organization])
+    useEffect(() => {
+      fetchMemberships();
+    }, [currentPage, organization]);
 
-  const fetchMemberships = async () => {
-    if (!organization) {
-      return
+    const fetchMemberships = async () => {
+      if (!organization) {
+        return;
+      }
+
+      const { data } = await organization.getMemberships({
+        initialPage: currentPage,
+        pageSize: 5
+      });
+      setMemberships(data);
+    };
+
+    const fetchPrevious = () => setCurrentPage(currentPage - 1);
+    const fetchNext = () => setCurrentPage(currentPage + 1);
+
+    if (organization === undefined) {
+      // Handle loading state
+      return null;
     }
 
-    const { data } = await organization.getMemberships({
-      initialPage: currentPage,
-      pageSize: 5,
-    })
-    setMemberships(data)
+    if (organization === null) {
+      // Handle no organization state
+      return null;
+    }
+
+    return (
+      <div>
+        <h2>Organization members</h2>
+        <ul>
+          {memberships.map((membership) => (
+            <li key={membership.id}>
+              {membership.publicUserData.firstName} {membership.publicUserData.lastName} &lt;
+              {membership.publicUserData.identifier}&gt; :: {membership.role}
+            </li>
+          ))}
+        </ul>
+        <div>
+          <button onClick={fetchPrevious} disabled={currentPage === 1}>Previous</button>
+          <button onClick={fetchNext}>Next</button>
+        </div>
+      </div>
+    );
+  };
+  ```
+
+  ```vue {{ prettier: false, filename: 'members.vue' }}
+  <script setup>
+  import { useStore } from '@nanostores/vue';
+  import { $organization } from '@clerk/astro/client';
+  import { ref, watchEffect } from 'vue';
+
+  const memberships = ref([]);
+  const currentPage = ref(1);
+  const organization = useStore($organizationStore);
+
+  const pageSize = 10;
+
+  const fetchMemberships = async () => {
+    if (!organization.value) {
+      return;
+    }
+
+    const { data } = await organization.value.getMemberships({
+      initialPage: currentPage.value,
+      pageSize: 5
+    });
+    memberships.value = data;
   }
 
-  const fetchPrevious = () => setCurrentPage(currentPage - 1)
-  const fetchNext = () => setCurrentPage(currentPage + 1)
+  watchEffect(() => {
+    if (!organization.value) {
+      return;
+    }
 
-  if (!organization) {
-    // Handle loading state
-    return null
-  }
+    fetchMemberships();
+  });
 
-  return (
-    <div>
+  const fetchPrevious = () => currentPage.value--;
+  const fetchNext = () => currentPage.value++;
+  </script>
+
+  <template>
+    <div v-if="organization === undefined">
+      <!-- Handle loading state -->
+    </div>
+    <div v-else-if="organization === null">
+      <!-- Handle no organization state -->
+    </div>
+    <div v-else>
       <h2>Organization members</h2>
       <ul>
-        {memberships.map((membership) => (
-          <li key={membership.id}>
-            {membership.publicUserData.firstName} {membership.publicUserData.lastName} &lt;
-            {membership.publicUserData.identifier}&gt; :: {membership.role}
-          </li>
-        ))}
+        <li v-for="membership in memberships" :key="membership.id">
+          {{ membership.publicUserData.firstName }} {{ membership.publicUserData.lastName }}
+          &lt;{{ membership.publicUserData.identifier }}&gt; :: {{ membership.role }}
+        </li>
       </ul>
       <div>
-        <button onClick={fetchPrevious} disabled={currentPage === 1}>
-          Previous
-        </button>
-        <button onClick={fetchNext}>Next</button>
+        <button @click="fetchPrevious" :disabled="currentPage === 1">Previous</button>
+        <button @click="fetchNext">Next</button>
       </div>
     </div>
-  )
-}
-```
+  </template>
+  ```
+
+  ```svelte {{ prettier: false, filename: 'members.svelte' }}
+  <script>
+  // The $ prefix is reserved in Svelte for its own reactivity system.
+  // Alias the imports to avoid conflicts.
+  import { $organizationStore as organization } from '@clerk/astro/client';
+
+  let memberships = [];
+  let currentPage = 1;
+
+  async function fetchMemberships() {
+      if (!$organization) {
+          return;
+      }
+
+      const { data } = await $organization.getMemberships({
+          initialPage: currentPage,
+          pageSize: 5
+      });
+      memberships = data;
+  }
+
+  $: fetchMemberships();
+
+  const fetchPrevious = () => currentPage.value--;
+  const fetchNext = () => currentPage.value++;
+  </script>
+
+  {#if organization === undefined}
+      <!-- Handle loading state -->
+  {:else if organization === null}
+      <!-- Handle no organization state -->
+  {:else}
+      <div>
+          <h2>Organization members</h2>
+          <ul>
+              {#each memberships as membership (membership.id)}
+                  <li>
+                      {membership.publicUserData.firstName} {membership.publicUserData.lastName} &lt;
+                      {membership.publicUserData.identifier}&gt; :: {membership.role}
+                  </li>
+              {/each}
+          </ul>
+          <div>
+              <button on:click={fetchPrevious} disabled={currentPage === 1}>Previous</button>
+              <button on:click={fetchNext}>Next</button>
+          </div>
+      </div>
+  {/if}
+  ```
+</CodeBlockTabs>

--- a/docs/references/astro/organization-store.mdx
+++ b/docs/references/astro/organization-store.mdx
@@ -13,20 +13,20 @@ The following example demonstrates how to use the `$organizationStore` store to 
 
 <CodeBlockTabs options={['React', 'Vue', 'Svelte']}>
   ```tsx {{ filename: 'organization.tsx' }}
-  import { useStore } from '@nanostores/react';
-  import { $organizationStore } from '@clerk/astro/client';
+  import { useStore } from '@nanostores/react'
+  import { $organizationStore } from '@clerk/astro/client'
 
   export default function Home() {
-    const organization = useStore($organizationStore);
+    const organization = useStore($organizationStore)
 
     if (organization === undefined) {
       // Add logic to handle loading state
-      return null;
+      return null
     }
 
-    if(organization === null) {
+    if (organization === null) {
       // Add logic to handle no active organization state
-      return null;
+      return null
     }
 
     return (
@@ -39,10 +39,10 @@ The following example demonstrates how to use the `$organizationStore` store to 
 
   ```vue {{ filename: 'organization.vue' }}
   <script setup>
-  import { useStore } from '@nanostores/vue';
-  import { $organizationStore } from '@clerk/astro/client';
+  import { useStore } from '@nanostores/vue'
+  import { $organizationStore } from '@clerk/astro/client'
 
-  const organization = useStore($organizationStore);
+  const organization = useStore($organizationStore)
   </script>
 
   <template>
@@ -60,9 +60,9 @@ The following example demonstrates how to use the `$organizationStore` store to 
 
   ```svelte {{ filename: 'organization.svelte' }}
   <script>
-  // The $ prefix is reserved in Svelte for its own reactivity system.
-  // Alias the imports to avoid conflicts.
-  import { $organizationStore as organization } from '@clerk/astro/client';
+    // The $ prefix is reserved in Svelte for its own reactivity system.
+    // Alias the imports to avoid conflicts.
+    import { $organizationStore as organization } from '@clerk/astro/client'
   </script>
 
   {#if $organization === undefined}
@@ -85,44 +85,44 @@ You can implement this pattern to any Clerk function that returns a [`ClerkPagin
 
 <CodeBlockTabs options={['React', 'Vue', 'Svelte']}>
   ```tsx {{ filename: 'members.tsx' }}
-  import { useState, useEffect } from 'react';
+  import { useState, useEffect } from 'react'
   import { $organizationStore } from '@clerk/astro/client'
-  import { useStore } from '@nanostores/react';
+  import { useStore } from '@nanostores/react'
 
   export default function OrganizationMembers() {
-    const [memberships, setMemberships] = useState([]);
-    const [currentPage, setCurrentPage] = useState(1);
-    const organization = useStore($organizationStore);
+    const [memberships, setMemberships] = useState([])
+    const [currentPage, setCurrentPage] = useState(1)
+    const organization = useStore($organizationStore)
 
-    const pageSize = 10;
+    const pageSize = 10
 
     useEffect(() => {
-      fetchMemberships();
-    }, [currentPage, organization]);
+      fetchMemberships()
+    }, [currentPage, organization])
 
     const fetchMemberships = async () => {
       if (!organization) {
-        return;
+        return
       }
 
       const { data } = await organization.getMemberships({
         initialPage: currentPage,
-        pageSize: 5
-      });
-      setMemberships(data);
-    };
+        pageSize: 5,
+      })
+      setMemberships(data)
+    }
 
-    const fetchPrevious = () => setCurrentPage(currentPage - 1);
-    const fetchNext = () => setCurrentPage(currentPage + 1);
+    const fetchPrevious = () => setCurrentPage(currentPage - 1)
+    const fetchNext = () => setCurrentPage(currentPage + 1)
 
     if (organization === undefined) {
       // Handle loading state
-      return null;
+      return null
     }
 
     if (organization === null) {
       // Handle no organization state
-      return null;
+      return null
     }
 
     return (
@@ -137,48 +137,50 @@ You can implement this pattern to any Clerk function that returns a [`ClerkPagin
           ))}
         </ul>
         <div>
-          <button onClick={fetchPrevious} disabled={currentPage === 1}>Previous</button>
+          <button onClick={fetchPrevious} disabled={currentPage === 1}>
+            Previous
+          </button>
           <button onClick={fetchNext}>Next</button>
         </div>
       </div>
-    );
-  };
+    )
+  }
   ```
 
   ```vue {{ filename: 'members.vue' }}
   <script setup>
-  import { useStore } from '@nanostores/vue';
-  import { $organization } from '@clerk/astro/client';
-  import { ref, watchEffect } from 'vue';
+  import { useStore } from '@nanostores/vue'
+  import { $organization } from '@clerk/astro/client'
+  import { ref, watchEffect } from 'vue'
 
-  const memberships = ref([]);
-  const currentPage = ref(1);
-  const organization = useStore($organizationStore);
+  const memberships = ref([])
+  const currentPage = ref(1)
+  const organization = useStore($organizationStore)
 
-  const pageSize = 10;
+  const pageSize = 10
 
   const fetchMemberships = async () => {
     if (!organization.value) {
-      return;
+      return
     }
 
     const { data } = await organization.value.getMemberships({
       initialPage: currentPage.value,
-      pageSize: 5
-    });
-    memberships.value = data;
+      pageSize: 5,
+    })
+    memberships.value = data
   }
 
   watchEffect(() => {
     if (!organization.value) {
-      return;
+      return
     }
 
-    fetchMemberships();
-  });
+    fetchMemberships()
+  })
 
-  const fetchPrevious = () => currentPage.value--;
-  const fetchNext = () => currentPage.value++;
+  const fetchPrevious = () => currentPage.value--
+  const fetchNext = () => currentPage.value++
   </script>
 
   <template>
@@ -192,8 +194,9 @@ You can implement this pattern to any Clerk function that returns a [`ClerkPagin
       <h2>Organization members</h2>
       <ul>
         <li v-for="membership in memberships" :key="membership.id">
-          {{ membership.publicUserData.firstName }} {{ membership.publicUserData.lastName }}
-          &lt;{{ membership.publicUserData.identifier }}&gt; :: {{ membership.role }}
+          {{ membership.publicUserData.firstName }} {{ membership.publicUserData.lastName }} &lt;{{
+            membership.publicUserData.identifier
+          }}&gt; :: {{ membership.role }}
         </li>
       </ul>
       <div>
@@ -206,51 +209,52 @@ You can implement this pattern to any Clerk function that returns a [`ClerkPagin
 
   ```svelte {{ filename: 'members.svelte' }}
   <script>
-  // The $ prefix is reserved in Svelte for its own reactivity system.
-  // Alias the imports to avoid conflicts.
-  import { $organizationStore as organization } from '@clerk/astro/client';
+    // The $ prefix is reserved in Svelte for its own reactivity system.
+    // Alias the imports to avoid conflicts.
+    import { $organizationStore as organization } from '@clerk/astro/client'
 
-  let memberships = [];
-  let currentPage = 1;
+    let memberships = []
+    let currentPage = 1
 
-  async function fetchMemberships() {
+    async function fetchMemberships() {
       if (!$organization) {
-          return;
+        return
       }
 
       const { data } = await $organization.getMemberships({
-          initialPage: currentPage,
-          pageSize: 5
-      });
-      memberships = data;
-  }
+        initialPage: currentPage,
+        pageSize: 5,
+      })
+      memberships = data
+    }
 
-  $: fetchMemberships();
+    $: fetchMemberships()
 
-  const fetchPrevious = () => currentPage.value--;
-  const fetchNext = () => currentPage.value++;
+    const fetchPrevious = () => currentPage.value--
+    const fetchNext = () => currentPage.value++
   </script>
 
   {#if organization === undefined}
-      <!-- Handle loading state -->
+    <!-- Handle loading state -->
   {:else if organization === null}
-      <!-- Handle no organization state -->
+    <!-- Handle no organization state -->
   {:else}
+    <div>
+      <h2>Organization members</h2>
+      <ul>
+        {#each memberships as membership (membership.id)}
+          <li>
+            {membership.publicUserData.firstName}
+            {membership.publicUserData.lastName} &lt;
+            {membership.publicUserData.identifier}&gt; :: {membership.role}
+          </li>
+        {/each}
+      </ul>
       <div>
-          <h2>Organization members</h2>
-          <ul>
-              {#each memberships as membership (membership.id)}
-                  <li>
-                      {membership.publicUserData.firstName} {membership.publicUserData.lastName} &lt;
-                      {membership.publicUserData.identifier}&gt; :: {membership.role}
-                  </li>
-              {/each}
-          </ul>
-          <div>
-              <button on:click={fetchPrevious} disabled={currentPage === 1}>Previous</button>
-              <button on:click={fetchNext}>Next</button>
-          </div>
+        <button on:click={fetchPrevious} disabled={currentPage === 1}>Previous</button>
+        <button on:click={fetchNext}>Next</button>
       </div>
+    </div>
   {/if}
   ```
 </CodeBlockTabs>

--- a/docs/references/astro/organization-store.mdx
+++ b/docs/references/astro/organization-store.mdx
@@ -9,7 +9,7 @@ The `$organizationStore` store is used to retrieve attributes of the currently a
 
 ## How to use the `$organizationStore` store
 
-The following example demonstrates how to use the `$organizationStore` store to access the [`Organization`](https://clerk.com/docs/references/javascript/organization/organization) object, which allows you to access the current active organization.
+The following example demonstrates how to use the `$organizationStore` store to access the [`Organization`](/docs/references/javascript/organization/organization){{ target: '_blank' }} object, which allows you to access the current active organization.
 
 <CodeBlockTabs options={['React', 'Vue', 'Svelte']}>
   ```tsx {{ filename: 'organization.tsx' }}

--- a/docs/references/astro/organization-store.mdx
+++ b/docs/references/astro/organization-store.mdx
@@ -81,7 +81,7 @@ The following example demonstrates how to use the `$organizationStore` store to 
 
 The following example demonstrates how to implement pagination for organization memberships. The `memberships` state will be populated with the first page of the organization's memberships. When the "Previous page" or "Next page" button is clicked, the `fetchMemberships` function will be called to fetch the previous or next page of memberships.
 
-You can implement this pattern to any Clerk function that returns a [`ClerkPaginatedResponse`](https://clerk.com/docs/references/javascript/types/clerk-paginated-response#clerk-paginated-response) object.
+You can implement this pattern to any Clerk function that returns a [`ClerkPaginatedResponse`](/docs/references/javascript/types/clerk-paginated-response#clerk-paginated-response){{ target: '_blank' }} object.
 
 <CodeBlockTabs options={['React', 'Vue', 'Svelte']}>
   ```tsx {{ filename: 'members.tsx' }}

--- a/docs/references/astro/organization-store.mdx
+++ b/docs/references/astro/organization-store.mdx
@@ -12,7 +12,7 @@ The `$organizationStore` store is used to retrieve attributes of the currently a
 The following example demonstrates how to use the `$organizationStore` store to access the [`Organization`](https://clerk.com/docs/references/javascript/organization/organization) object, which allows you to access the current active organization.
 
 <CodeBlockTabs options={['React', 'Vue', 'Svelte']}>
-  ```tsx {{ prettier: false, filename: 'organization.tsx' }}
+  ```tsx {{ filename: 'organization.tsx' }}
   import { useStore } from '@nanostores/react';
   import { $organizationStore } from '@clerk/astro/client';
 
@@ -37,7 +37,7 @@ The following example demonstrates how to use the `$organizationStore` store to 
   }
   ```
 
-  ```vue {{ prettier: false, filename: 'organization.vue' }}
+  ```vue {{ filename: 'organization.vue' }}
   <script setup>
   import { useStore } from '@nanostores/vue';
   import { $organizationStore } from '@clerk/astro/client';
@@ -58,7 +58,7 @@ The following example demonstrates how to use the `$organizationStore` store to 
   </template>
   ```
 
-  ```svelte {{ prettier: false, filename: 'organization.svelte' }}
+  ```svelte {{ filename: 'organization.svelte' }}
   <script>
   // The $ prefix is reserved in Svelte for its own reactivity system.
   // Alias the imports to avoid conflicts.
@@ -84,7 +84,7 @@ The following example demonstrates how to implement pagination for organization 
 You can implement this pattern to any Clerk function that returns a [`ClerkPaginatedResponse`](https://clerk.com/docs/references/javascript/types/clerk-paginated-response#clerk-paginated-response) object.
 
 <CodeBlockTabs options={['React', 'Vue', 'Svelte']}>
-  ```tsx {{ prettier: false, filename: 'members.tsx' }}
+  ```tsx {{ filename: 'members.tsx' }}
   import { useState, useEffect } from 'react';
   import { $organizationStore } from '@clerk/astro/client'
   import { useStore } from '@nanostores/react';
@@ -145,7 +145,7 @@ You can implement this pattern to any Clerk function that returns a [`ClerkPagin
   };
   ```
 
-  ```vue {{ prettier: false, filename: 'members.vue' }}
+  ```vue {{ filename: 'members.vue' }}
   <script setup>
   import { useStore } from '@nanostores/vue';
   import { $organization } from '@clerk/astro/client';
@@ -204,7 +204,7 @@ You can implement this pattern to any Clerk function that returns a [`ClerkPagin
   </template>
   ```
 
-  ```svelte {{ prettier: false, filename: 'members.svelte' }}
+  ```svelte {{ filename: 'members.svelte' }}
   <script>
   // The $ prefix is reserved in Svelte for its own reactivity system.
   // Alias the imports to avoid conflicts.


### PR DESCRIPTION
<!--- Add the "deploy-preview" label and add your page previews here -->

> [!IMPORTANT]
> 🔎 Previews:
>
> - https://clerk.com/docs/pr/1438/references/astro/organization-store

<!--- Describe your changes in detail. Why does this change need to happen? Include any links to Slack discussions, Linear comments, etc. -->

### Explanation:

<!--- How does this PR solve the problem? -->

### This PR:

- As one of Astro's key features is its ability to seamlessly integrate components from various frameworks, this PR demonstrates the use of @clerk/astro's `$organizationStore` with both Vue and Svelte components.