### PR TITLE
Fix Ruby comment syntax

### DIFF
--- a/docs/users/metadata.mdx
+++ b/docs/users/metadata.mdx
@@ -96,7 +96,7 @@ Private metadata is only accessible by the backend, which makes this useful for 
 
   <Tab>
     ```ruby {{ filename: 'private.rb' }}
-    // ruby json example with a private metadata and stripe id
+    # ruby json example with a private metadata and stripe id
     require 'clerk'
     require 'json'
 
@@ -191,7 +191,7 @@ You can retrieve the private metadata for a user by using the [`getUser`](/docs/
 
   <Tab>
     ```ruby {{ filename: 'private.rb' }}
-    // ruby json example with a private metadata and stripe id
+    # ruby json example with a private metadata and stripe id
     require 'clerk'
     clerk = Clerk::SDK.new(api_key: "your_clerk_secret_key")
     clerk.users.getUser("user_xyz")
@@ -281,7 +281,7 @@ Public metadata is accessible by both the frontend and the backend. This is usef
 
   <Tab>
     ```ruby {{ filename: 'public.rb' }}
-    // ruby json example with a private metadata and stripe id
+    # ruby json example with a private metadata and stripe id
     require 'clerk'
     require 'json'
 
@@ -401,7 +401,7 @@ Updating this value overrides the previous value; it does not merge. To perform 
 
   <Tab>
     ```ruby {{ filename: 'private.rb' }}
-    // ruby json example with a private metadata and stripe id
+    # ruby json example with a private metadata and stripe id
     require 'clerk'
     require 'json'
 


### PR DESCRIPTION
This PR updates Ruby code snippets to use the correct syntax for single-line comments