### PR TITLE
docs(astro): Add multi-framework example for $userStore 

### DIFF
--- a/docs/references/astro/user-store.mdx
+++ b/docs/references/astro/user-store.mdx
@@ -164,7 +164,7 @@ For more information on the `update()` method, see the [`User` reference.](/docs
 
 The following example demonstrates how to use the `$userStore` store to reload the current user's data on the client side.
 
-For more information on the `reload()` method, see the [`User` reference.](https://clerk.com/docs/references/javascript/user/user#reload)
+For more information on the `reload()` method, see the [`User` reference.](/docs/references/javascript/user/user#reload){{ target: '_blank' }}
 
 <CodeBlockTabs options={['React', 'Vue', 'Svelte']}>
   ```tsx {{ filename: 'user.tsx' }}

--- a/docs/references/astro/user-store.mdx
+++ b/docs/references/astro/user-store.mdx
@@ -55,9 +55,9 @@ For more information, see the [`User` reference.](https://clerk.com/docs/referen
 
   ```svelte {{ filename: 'user.svelte' }}
   <script>
-  // The $ prefix is reserved in Svelte for its own reactivity system.
-  // Alias the imports to avoid conflicts.
-  import { $userStore as user } from '@clerk/astro/client';
+    // The $ prefix is reserved in Svelte for its own reactivity system.
+    // Alias the imports to avoid conflicts.
+    import { $userStore as user } from '@clerk/astro/client'
   </script>
 
   {#if $user === undefined}
@@ -138,16 +138,16 @@ For more information on the `update()` method, see the [`User` reference.](https
 
   ```svelte {{ filename: 'user.svelte' }}
   <script>
-  // The $ prefix is reserved in Svelte for its own reactivity system.
-  // Alias the imports to avoid conflicts.
-  import { $userStore as user } from '@clerk/astro/client';
+    // The $ prefix is reserved in Svelte for its own reactivity system.
+    // Alias the imports to avoid conflicts.
+    import { $userStore as user } from '@clerk/astro/client'
 
-  const updateUser = async () => {
-    await $user.update({
-      firstName: "John",
-      lastName: "Doe",
-    });
-  };
+    const updateUser = async () => {
+      await $user.update({
+        firstName: 'John',
+        lastName: 'Doe',
+      })
+    }
   </script>
 
   {#if $user === undefined}
@@ -238,33 +238,33 @@ For more information on the `reload()` method, see the [`User` reference.](https
 
   ```svelte {{ filename: 'user.svelte' }}
   <script>
-  // The $ prefix is reserved in Svelte for its own reactivity system.
-  // Alias the imports to avoid conflicts.
-  import { useStore } from '@nanostores/svelte';
-  import { $userStore as userStore } from '@clerk/astro/client';
+    // The $ prefix is reserved in Svelte for its own reactivity system.
+    // Alias the imports to avoid conflicts.
+    import { useStore } from '@nanostores/svelte'
+    import { $userStore as userStore } from '@clerk/astro/client'
 
-  const user = useStore(userStore);
+    const user = useStore(userStore)
 
-  const updateUser = async () => {
-    if ($user) {
-      try {
-        // Update data via an API endpoint
-        const response = await fetch("/api/updateMetadata");
-        const updateMetadata = await response.json();
+    const updateUser = async () => {
+      if ($user) {
+        try {
+          // Update data via an API endpoint
+          const response = await fetch('/api/updateMetadata')
+          const updateMetadata = await response.json()
 
-        // Check if the update was successful
-        if (updateMetadata.message !== "success") {
-          throw new Error("Error updating");
+          // Check if the update was successful
+          if (updateMetadata.message !== 'success') {
+            throw new Error('Error updating')
+          }
+
+          // If the update was successful, reload the user data
+          await $user.reload()
+        } catch (error) {
+          console.error('Failed to update metadata:', error)
+          // Handle the error appropriately
         }
-
-        // If the update was successful, reload the user data
-        await $user.reload();
-      } catch (error) {
-        console.error("Failed to update metadata:", error);
-        // Handle the error appropriately
       }
     }
-  };
   </script>
 
   {#if $user === undefined}

--- a/docs/references/astro/user-store.mdx
+++ b/docs/references/astro/user-store.mdx
@@ -74,7 +74,7 @@ For more information, see the [`User` reference.](/docs/references/javascript/us
 
 The following example demonstrates how to use the `$userStore` store to update the current user's data on the client side.
 
-For more information on the `update()` method, see the [`User` reference.](https://clerk.com/docs/references/javascript/user/user#update)
+For more information on the `update()` method, see the [`User` reference.](/docs/references/javascript/user/user#update){{ target: '_blank' }}
 
 <CodeBlockTabs options={['React', 'Vue', 'Svelte']}>
   ```tsx {{ filename: 'user.tsx' }}

--- a/docs/references/astro/user-store.mdx
+++ b/docs/references/astro/user-store.mdx
@@ -5,7 +5,7 @@ description: The $userStore store provides a convenient way to access current us
 
 # `$userStore`
 
-The `$userStore` store provides a convenient way to access current [`User`](https://clerk.com/docs/references/javascript/user/user) data and helper methods for managing the active user.
+The `$userStore` store provides a convenient way to access current [`User`](/docs/references/javascript/user/user){{ target: '_blank' }} data and helper methods for managing the active user.
 
 ## How to use the `$userStore` store
 

--- a/docs/references/astro/user-store.mdx
+++ b/docs/references/astro/user-store.mdx
@@ -13,7 +13,7 @@ The `$userStore` store provides a convenient way to access current [`User`](http
 
 The following example demonstrates how to use the `$userStore` store to access the `User` object. It returns `undefined` while Clerk is still loading and `null` if the user is not signed in.
 
-For more information, see the [`User` reference.](https://clerk.com/docs/references/javascript/user/user#user-object)
+For more information, see the [`User` reference.](/docs/references/javascript/user/user#user-object){{ target: '_blank' }}
 
 <CodeBlockTabs options={['React', 'Vue', 'Svelte']}>
   ```tsx {{ filename: 'user.tsx' }}

--- a/docs/references/astro/user-store.mdx
+++ b/docs/references/astro/user-store.mdx
@@ -5,7 +5,7 @@ description: The $userStore store provides a convenient way to access current us
 
 # `$userStore`
 
-The `$userStore` store provides a convenient way to access current [`User`](/docs/references/javascript/user/user){{ target: '_blank' }} data and helper methods for managing the active user.
+The `$userStore` store provides a convenient way to access current [`User`](https://clerk.com/docs/references/javascript/user/user) data and helper methods for managing the active user.
 
 ## How to use the `$userStore` store
 
@@ -13,84 +13,202 @@ The `$userStore` store provides a convenient way to access current [`User`](/doc
 
 The following example demonstrates how to use the `$userStore` store to access the `User` object. It returns `undefined` while Clerk is still loading and `null` if the user is not signed in.
 
-For more information, see the [`User` reference.](/docs/references/javascript/user/user#user-object){{ target: '_blank' }}
+For more information, see the [`User` reference.](https://clerk.com/docs/references/javascript/user/user#user-object)
 
-```tsx {{ filename: 'user.tsx' }}
-import { useStore } from '@nanostores/react'
-import { $userStore } from '@clerk/astro/client'
+<CodeBlockTabs options={['React', 'Vue', 'Svelte']}>
+  ```tsx {{ filename: 'user.tsx' }}
+  import { useStore } from '@nanostores/react'
+  import { $userStore } from '@clerk/astro/client'
 
-export default function User() {
-  const user = useStore($userStore)
+  export default function User() {
+    const user = useStore($userStore)
 
-  if (user === undefined) {
-    // Handle loading state however you like
-    return null
-  }
+    if (user === undefined) {
+      // Handle loading state however you like
+      return null
+    }
 
-  if (user) {
+    if (user === null) {
+      return <div>Not signed in</div>
+    }
+
     return <div>Hello {user.fullName}!</div>
   }
+  ```
 
-  return <div>Not signed in</div>
-}
-```
+  ```vue {{ filename: 'user.vue' }}
+  <script setup>
+  import { useStore } from '@nanostores/vue'
+  import { $userStore } from '@clerk/astro/client'
+
+  const user = useStore($userStore)
+  </script>
+
+  <template>
+    <div v-if="user === undefined">
+      <!-- Handle loading state however you like -->
+    </div>
+    <div v-else-if="user === null">Not signed in</div>
+    <div v-else>Hello {{ user.fullName }}!</div>
+  </template>
+  ```
+
+  ```svelte {{ filename: 'user.svelte' }}
+  <script>
+  // The $ prefix is reserved in Svelte for its own reactivity system.
+  // Alias the imports to avoid conflicts.
+  import { $userStore as user } from '@clerk/astro/client';
+  </script>
+
+  {#if $user === undefined}
+    <!-- Handle loading state however you like -->
+  {:else if $user === null}
+    <div>Not signed in</div>
+  {:else}
+    <div>Hello {$user.fullName}!</div>
+  {/if}
+  ```
+</CodeBlockTabs>
 
 ### Update the current user data
 
 The following example demonstrates how to use the `$userStore` store to update the current user's data on the client side.
 
-For more information on the `update()` method, see the [`User` reference.](/docs/references/javascript/user/user#update){{ target: '_blank' }}
+For more information on the `update()` method, see the [`User` reference.](https://clerk.com/docs/references/javascript/user/user#update)
 
-```tsx {{ filename: 'user.tsx' }}
-import { useStore } from '@nanostores/react'
-import { $userStore } from '@clerk/astro/client'
+<CodeBlockTabs options={['React', 'Vue', 'Svelte']}>
+  ```tsx {{ filename: 'user.tsx' }}
+  import { useStore } from '@nanostores/react'
+  import { $userStore } from '@clerk/astro/client'
 
-export default function User() {
+  export default function User() {
+    const user = useStore($userStore)
+
+    if (user === undefined) {
+      // Handle loading state however you like
+      return null
+    }
+
+    if (user === null) return null
+
+    const updateUser = async () => {
+      await user.update({
+        firstName: 'John',
+        lastName: 'Doe',
+      })
+    }
+
+    return (
+      <>
+        <button onClick={updateUser}>Click me to update your name</button>
+        <p>user.firstName: {user?.firstName}</p>
+        <p>user.lastName: {user?.lastName}</p>
+      </>
+    )
+  }
+  ```
+
+  ```vue {{ filename: 'user.vue' }}
+  <script setup>
+  import { useStore } from '@nanostores/vue'
+  import { $userStore } from '@clerk/astro/client'
+
   const user = useStore($userStore)
 
-  if (user === undefined) {
-    // Handle loading state however you like
-    return null
-  }
-
-  if (user === null) return null
-
   const updateUser = async () => {
-    await user.update({
+    await user.value.update({
       firstName: 'John',
       lastName: 'Doe',
     })
   }
+  </script>
 
-  return (
-    <>
-      <button onClick={updateUser}>Click me to update your name</button>
-      <p>user.firstName: {user?.firstName}</p>
-      <p>user.lastName: {user?.lastName}</p>
-    </>
-  )
-}
-```
+  <template>
+    <div v-if="user === undefined">
+      <!-- Handle loading state however you like -->
+    </div>
+
+    <div v-else-if="user !== null">
+      <button @click="updateUser">Click me to update your name</button>
+      <p>user.firstName: {{ user.firstName }}</p>
+      <p>user.lastName: {{ user.lastName }}</p>
+    </div>
+  </template>
+  ```
+
+  ```svelte {{ filename: 'user.svelte' }}
+  <script>
+  // The $ prefix is reserved in Svelte for its own reactivity system.
+  // Alias the imports to avoid conflicts.
+  import { $userStore as user } from '@clerk/astro/client';
+
+  const updateUser = async () => {
+    await $user.update({
+      firstName: "John",
+      lastName: "Doe",
+    });
+  };
+  </script>
+
+  {#if $user === undefined}
+    <!-- Handle loading state however you like -->
+  {:else if $user !== null}
+    <button on:click={updateUser}>Click me to update your name</button>
+    <p>user.firstName: {$user.firstName}</p>
+    <p>user.lastName: {$user.lastName}</p>
+  {/if}
+  ```
+</CodeBlockTabs>
 
 ### Reload user data
 
 The following example demonstrates how to use the `$userStore` store to reload the current user's data on the client side.
 
-For more information on the `reload()` method, see the [`User` reference.](/docs/references/javascript/user/user#reload){{ target: '_blank' }}
+For more information on the `reload()` method, see the [`User` reference.](https://clerk.com/docs/references/javascript/user/user#reload)
 
-```tsx {{ filename: 'user.tsx' }}
-import { useStore } from '@nanostores/react'
-import { $userStore } from '@clerk/astro/client'
+<CodeBlockTabs options={['React', 'Vue', 'Svelte']}>
+  ```tsx {{ filename: 'user.tsx' }}
+  import { useStore } from '@nanostores/react'
+  import { $userStore } from '@clerk/astro/client'
 
-export default function User() {
-  const user = useStore($userStore)
+  export default function User() {
+    const user = useStore($userStore)
 
-  if (user === undefined) {
-    // Handle loading state however you like
-    return null
+    if (user === undefined) {
+      // Handle loading state however you like
+      return null
+    }
+
+    if (user === null) return null
+
+    const updateUser = async () => {
+      // Update data via an API endpoint
+      const updateMetadata = await fetch('/api/updateMetadata')
+
+      // Check if the update was successful
+      if (updateMetadata.message !== 'success') {
+        throw new Error('Error updating')
+      }
+
+      // If the update was successful, reload the user data
+      await user.reload()
+    }
+
+    return (
+      <>
+        <button onClick={updateUser}>Click me to update your metadata</button>
+        <p>user role: {user?.publicMetadata.role}</p>
+      </>
+    )
   }
+  ```
 
-  if (user === null) return null
+  ```vue {{ filename: 'user.vue' }}
+  <script setup>
+  import { useStore } from '@nanostores/vue'
+  import { $userStore } from '@clerk/astro/client'
+
+  const user = useStore($userStore)
 
   const updateUser = async () => {
     // Update data via an API endpoint
@@ -102,14 +220,58 @@ export default function User() {
     }
 
     // If the update was successful, reload the user data
-    await user.reload()
+    await user.value.reload()
   }
+  </script>
 
-  return (
-    <>
-      <button onClick={updateUser}>Click me to update your metadata</button>
-      <p>user role: {user?.publicMetadata.role}</p>
-    </>
-  )
-}
-```
+  <template>
+    <div v-if="user === undefined">
+      <!-- Handle loading state however you like -->
+    </div>
+
+    <div v-else-if="user !== null">
+      <button @click="updateUser">Click me to update your metadata</button>
+      <p>user role: {{ user?.publicMetadata.role }}</p>
+    </div>
+  </template>
+  ```
+
+  ```svelte {{ filename: 'user.svelte' }}
+  <script>
+  // The $ prefix is reserved in Svelte for its own reactivity system.
+  // Alias the imports to avoid conflicts.
+  import { useStore } from '@nanostores/svelte';
+  import { $userStore as userStore } from '@clerk/astro/client';
+
+  const user = useStore(userStore);
+
+  const updateUser = async () => {
+    if ($user) {
+      try {
+        // Update data via an API endpoint
+        const response = await fetch("/api/updateMetadata");
+        const updateMetadata = await response.json();
+
+        // Check if the update was successful
+        if (updateMetadata.message !== "success") {
+          throw new Error("Error updating");
+        }
+
+        // If the update was successful, reload the user data
+        await $user.reload();
+      } catch (error) {
+        console.error("Failed to update metadata:", error);
+        // Handle the error appropriately
+      }
+    }
+  };
+  </script>
+
+  {#if $user === undefined}
+    <!-- Handle loading state however you like -->
+  {:else if $user !== null}
+    <button on:click={updateUser}>Click me to update your metadata</button>
+    <p>user role: {$user.publicMetadata?.role}</p>
+  {/if}
+  ```
+</CodeBlockTabs>


### PR DESCRIPTION
<!--- Add the "deploy-preview" label and add your page previews here -->

> [!IMPORTANT]
> 🔎 Previews:
>
> - https://clerk.com/docs/pr/1441/references/astro/user-store

<!--- Describe your changes in detail. Why does this change need to happen? Include any links to Slack discussions, Linear comments, etc. -->

### Explanation:

<!--- How does this PR solve the problem? -->

### This PR:

- Demonstrates the use of `@clerk/astro`'s `$userStore` store in both Vue and Svelte components.
