### PR TITLE
docs(astro): Add multi-framework example for $session and $sessionListStore

### DIFF
--- a/docs/references/astro/session-list-store.mdx
+++ b/docs/references/astro/session-list-store.mdx
@@ -9,24 +9,88 @@ The `$sessionListStore` store returns an array of [`Session`](/docs/references/j
 
 ## How to use the `$sessionListStore` store
 
-The following example demonstrates how to use the `$sessionListStore` store to display the expiration time of the first session in the list.
+The following example demonstrates how to use the `$sessionListStore` to create a basic user button component. This component displays the current session's email address and provides a menu to switch between active sessions or sign out of all accounts.
 
-```tsx {{ filename: 'session-list.tsx' }}
-import { useStore } from '@nanostores/react'
-import { $sessionList } from '@clerk/astro/client'
+<CodeBlockTabs options={['React', 'Vue', 'Svelte']}>
+  ```tsx {{ filename: 'user-button.tsx' }}
+  import { $sessionListStore, $clerkStore } from '@clerk/astro/client'
 
-export default function Home() {
-  const sessions = useStore($sessionList)
+  export default function UserButton() {
+    const sessions = useStore($sessionListStore)
+    const { session, setActive, signOut } = useStore($clerkStore)
 
-  if (sessions === undefined) {
-    // handle loading state
-    return null
+    if (sessions === undefined) {
+      // Handle loading state
+      return <div>Loading sessions...</div>
+    }
+
+    return (
+      <div>
+        <div>{session.user.primaryEmailAddress}</div>
+        <div role="menu">
+          {sessions.map((sess) => (
+            <button role="menuitem" onClick={() => setActive({ session: sess.id })} key={sess.id}>
+              {sess.user.primaryEmailAddress}
+            </button>
+          ))}
+          <button role="menuitem" onClick={() => signOut()}>
+            Sign out of all accounts
+          </button>
+        </div>
+      </div>
+    )
   }
+  ```
 
-  return (
-    <div>
-      <p>Your current session expires at {sessions[0].expireAt}.</p>
+  ```vue {{ filename: 'user-button.vue' }}
+  <script setup>
+  import { useStore } from '@nanostores/vue'
+  import { $sessionListStore, $clerkStore } from '@clerk/astro/client'
+
+  const sessions = useStore($sessionListStore)
+  const clerk = useStore($clerkStore)
+  </script>
+
+  <template>
+    <div v-if="sessions === undefined">Loading sessions...</div>
+    <div v-else>
+      <div>{{ clerk.session.user.primaryEmailAddress }}</div>
+      <div role="menu">
+        <button
+          v-for="sess in sessions"
+          :key="sess.id"
+          role="menuitem"
+          @click="clerk.setActive({ session: sess.id })"
+        >
+          {{ sess.user.primaryEmailAddress }}
+        </button>
+        <button role="menuitem" @click="clerk.signOut">Sign out of all accounts</button>
+      </div>
     </div>
-  )
-}
-```
+  </template>
+  ```
+
+  ```svelte {{ filename: 'session-list.svelte' }}
+  <script>
+    // The $ prefix is reserved in Svelte for its own reactivity system.
+    // Alias the imports to avoid conflicts.
+    import { $sessionListStore as sessions, $clerkStore as clerk } from '@clerk/astro/client'
+  </script>
+
+  {#if $sessions === undefined}
+    <div>Loading sessions...</div>
+  {:else}
+    <div>
+      <div>{$clerk.session.user.primaryEmailAddress}</div>
+      <div role="menu">
+        {#each $sessions as sess (sess.id)}
+          <button role="menuitem" on:click={() => $clerk.setActive({ session: sess.id })}>
+            {sess.user.primaryEmailAddress}
+          </button>
+        {/each}
+        <button role="menuitem" on:click={() => $clerk.signOut()}> Sign out of all accounts </button>
+      </div>
+    </div>
+  {/if}
+  ```
+</CodeBlockTabs>

--- a/docs/references/astro/session-store.mdx
+++ b/docs/references/astro/session-store.mdx
@@ -5,7 +5,7 @@ description: Clerk's $sessionStore nanostore provides a convenient way to access
 
 # `$sessionStore`
 
-The `$sessionStore` store provides a convenient way to access the current user's [`Session`](https://clerk.com/docs/references/javascript/session) object, as well as helpers for setting the active session.
+The `$sessionStore` store provides a convenient way to access the current user's [`Session`](/docs/references/javascript/session){{ target: '_blank' }} object, as well as helpers for setting the active session.
 
 ## How to use the `$sessionStore` store
 

--- a/docs/references/astro/session-store.mdx
+++ b/docs/references/astro/session-store.mdx
@@ -5,33 +5,74 @@ description: Clerk's $sessionStore nanostore provides a convenient way to access
 
 # `$sessionStore`
 
-The `$sessionStore` store provides a convenient way to access the current user's [`Session`](/docs/references/javascript/session){{ target: '_blank' }} object, as well as helpers for setting the active session.
+The `$sessionStore` store provides a convenient way to access the current user's [`Session`](https://clerk.com/docs/references/javascript/session) object, as well as helpers for setting the active session.
 
 ## How to use the `$sessionStore` store
 
 The following example demonstrates how to use the `$sessionStore` store to access the `session` object, which has the `lastActiveAt` property on it. The `lastActiveAt` property is used to display the last active time of the current session to the user.
 
-```tsx {{ filename: 'session.tsx' }}
-import { useStore } from '@nanostores/react'
-import { $sessionStore } from '@clerk/astro/client'
+<CodeBlockTabs options={['React', 'Vue', 'Svelte']}>
+  ```tsx {{ filename: 'session.tsx' }}
+  import { useStore } from '@nanostores/react'
+  import { $sessionStore } from '@clerk/astro/client'
 
-export default function Home() {
+  export default function Session() {
+    const session = useStore($sessionStore)
+
+    if (session === undefined) {
+      // Add logic to handle loading state
+      return null
+    }
+
+    if (session === null) {
+      // Add logic to handle not signed in state
+      return null
+    }
+
+    return (
+      <div>
+        <p>This session has been active since {session.lastActiveAt.toLocaleString()}</p>
+      </div>
+    )
+  }
+  ```
+
+  ```vue {{ filename: 'session.vue' }}
+  <script setup>
+  import { useStore } from '@nanostores/vue'
+  import { $sessionStore } from '@clerk/astro/client'
+
   const session = useStore($sessionStore)
+  </script>
 
-  if (session === undefined) {
-    // Add logic to handle loading state
-    return null
-  }
-
-  if (session === null) {
-    // Add logic to handle not signed in state
-    return null
-  }
-
-  return (
-    <div>
-      <p>This session has been active since {session.lastActiveAt.toLocaleString()}</p>
+  <template>
+    <div v-if="session === undefined">
+      <!-- Add logic to handle loading state -->
     </div>
-  )
-}
-```
+    <div v-else-if="session === null">
+      <!-- Add logic to handle not signed in state -->
+    </div>
+    <div v-else>
+      <p>This session has been active since {{ session.lastActiveAt.toLocaleString() }}</p>
+    </div>
+  </template>
+  ```
+
+  ```svelte {{ filename: 'session.svelte' }}
+  <script>
+    // The $ prefix is reserved in Svelte for its own reactivity system.
+    // Alias the imports to avoid conflicts.
+    import { $sessionStore as session } from '@clerk/astro/client'
+  </script>
+
+  {#if $session === undefined}
+    <!-- Add logic to handle loading state -->
+  {:else if $session === null}
+    <!-- Add logic to handle not signed in state -->
+  {:else}
+    <div>
+      <p>This session has been active since {$session.lastActiveAt.toLocaleString()}</p>
+    </div>
+  {/if}
+  ```
+</CodeBlockTabs>


### PR DESCRIPTION
This is the last PR for multi-framework examples 🙇🏼 

> [!IMPORTANT]
> 🔎 Previews:
>
> - https://clerk.com/docs/pr/1443/references/astro/session-store
> - https://clerk.com/docs/pr/1443/references/astro/session-list-store

<!--- Describe your changes in detail. Why does this change need to happen? Include any links to Slack discussions, Linear comments, etc. -->

### Explanation:

<!--- How does this PR solve the problem? -->

### This PR:

- Demonstrates the use of `@clerk/astro`'s `$sessionStore` and `$sessionListStore` stores in both Vue and Svelte components.
