### PR TITLE
fixing link to staging-alternatives in staging doc

### DIFF
--- a/docs/deployments/set-up-staging.mdx
+++ b/docs/deployments/set-up-staging.mdx
@@ -14,7 +14,7 @@ It is important to note that when you use a separate Clerk application for your 
 
 The following steps will help you set up a new Clerk application with a staging-specific domain:
 
-1. **Acquire a separate domain** - This domain will be used for your staging environment. _This cannot be a subdomain_ of the domain used in your production environment. For example, if your production domain is `my-site.com`, you could use `my-site-staging.com`. If you do not want to use a new domain, see [the instructions for using a subdomain](#use-a-subdomain).
+1. **Acquire a separate domain** - This domain will be used for your staging environment. _This cannot be a subdomain_ of the domain used in your production environment. For example, if your production domain is `my-site.com`, you could use `my-site-staging.com`. If you do not want to use a new domain, see [the instructions for using a subdomain](/docs/deployments/staging-alternatives).
 1. **Create a new Clerk app** - Your staging environment will connect to this app instead of your main Clerk application. See [the Clerk quickstart guide](/docs/quickstarts/setup-clerk) to learn how to create a Clerk app.
 1. **Deploy and configure your staging app's production instance** - Using production API keys will make your staging app more secure. Follow the [Deploy to production](/docs/deployments/overview) guide to do so.
 1. **Contact Clerk support to upgrade your staging app for free** - If you are on a Pro, Enterprise, or Startup plan, Clerk will fully upgrade your staging app for free.


### PR DESCRIPTION
<!--- Add the "deploy-preview" label and add your page previews here -->

> [!IMPORTANT]
> 🔎 Previews:
>
> - https://clerk.com/docs/pr/1444/deployments/set-up-staging

The link to using subdomains for staging deployments was broken and edited to point to the correct page.

@alexisintech -- I noticed that the `staging-alternatives.mdx` page was not in the sidebar/manifest. I believe this was intentional since this is not a recommended solution but I wanted to mention it in case it should be added.
