### PR TITLE
Replace tables with `<Properties>`

### DIFF
--- a/docs/components/authentication/google-one-tap.mdx
+++ b/docs/components/authentication/google-one-tap.mdx
@@ -213,9 +213,12 @@ function authenticateWithGoogleOneTap(
 
 #### `AuthenticateWithGoogleOneTapParams`
 
-| Name | Type | Desciption |
-| - | - | - |
-| `token?` | string | A Google authentication token from Google identity services. |
+<Properties>
+  - `token?`
+  - `string`
+
+  A Google authentication token from Google identity services.
+</Properties>
 
 #### `authenticateWithGoogleOneTap()` usage
 
@@ -282,11 +285,26 @@ See [`authenticateWithGoogleOneTap()` usage](#authenticate-with-google-one-tap-u
 
 #### `handleGoogleOneTapCallback()` params
 
-| Name | Type | Desciption |
-| - | - | - |
-| `signInOrUp` | [`SignInResource`](/docs/references/javascript/sign-in/sign-in) \| [`SignUpResource`](/docs/references/javascript/sign-up/sign-up) | The `SignIn` or `SignUp` object returned from `authenticateWithGoogleOneTap()`. |
-| `params` | [`HandleOAuthCallbackParams`](/docs/references/javascript/clerk/handle-navigation#handle-o-auth-callback-params) | An object containing redirect URLs. Useful if you want to set URLs specific to Google One Tap. Otherwise, consider using [environment variables](/docs/deployments/clerk-environment-variables) to set redirect URLs. |
-| `customNavigate?` | `(to: string) => Promise<unknown>` | Allows you to define a custom navigation function. |
+<Properties>
+  - `signInOrUp`
+  - <code>[SignInResource](/docs/references/javascript/sign-in/sign-in) | [SignUpResource](/docs/references/javascript/sign-up/sign-up)</code>
+
+  The `SignIn` or `SignUp` object returned from `authenticateWithGoogleOneTap()`.
+
+  ---
+
+  - `params`
+  - [`HandleOAuthCallbackParams`](/docs/references/javascript/clerk/handle-navigation#handle-o-auth-callback-params)
+
+  An object containing redirect URLs. Useful if you want to set URLs specific to Google One Tap. Otherwise, consider using [environment variables](/docs/deployments/clerk-environment-variables) to set redirect URLs.
+
+  ---
+
+  - `customNavigate?`
+  - `(to: string) => Promise<unknown>`
+
+  Allows you to define a custom navigation function.
+</Properties>
 
 ## Limitations
 

--- a/docs/components/authentication/sign-in.mdx
+++ b/docs/components/authentication/sign-in.mdx
@@ -314,7 +314,7 @@ function openSignIn(props?: SignInProps): void
   - `props?`
   - [`SignInProps`](#properties)
 
-  The properties to pass to the `<SignIn />` component
+  The properties to pass to the `<SignIn />` component.
 </Properties>
 
 #### `openSignIn()` usage

--- a/docs/components/authentication/sign-in.mdx
+++ b/docs/components/authentication/sign-in.mdx
@@ -310,9 +310,12 @@ function openSignIn(props?: SignInProps): void
 
 #### `openSignIn()` params
 
-| Name | Type | Desciption |
-| - | - | - |
-| `props?` | [`SignInProps`](#properties) | The properties to pass to the `<SignIn />` component |
+<Properties>
+  - `props?`
+  - [`SignInProps`](#properties)
+
+  The properties to pass to the `<SignIn />` component
+</Properties>
 
 #### `openSignIn()` usage
 

--- a/docs/custom-flows/overview.mdx
+++ b/docs/custom-flows/overview.mdx
@@ -37,11 +37,23 @@ The `SignUp` object will show **the state of the current sign-up** in the `statu
 
 If you need further help on where things are and what you need to do next, you can also consult the `required_fields`, `optional_fields`, and `missingFields` properties.
 
-| Name | Description |
-| - | - |
-| `requiredFields` | All fields that must be collected before the `SignUp` converts into a `User`. |
-| `optionalFields` | All fields that can be collected, but are not necessary to convert the `SignUp` into a `User`. |
-| `missingFields` | A subset of `requiredFields`. It contains all fields that still need to be collected before a `SignUp` can be converted into a `User`. Note that this property will be updated dynamically. As you add more fields to the `SignUp`, they will be removed. Once this property is empty, your `SignUp` will automatically convert into a `User`. |
+<Properties>
+  - `requiredFields`
+
+  All fields that must be collected before the `SignUp` converts into a `User`.
+
+  ---
+
+  - `optionalFields`
+
+  All fields that can be collected, but are not necessary to convert the `SignUp` into a `User`.
+
+  ---
+
+  - `missingFields`
+
+  A subset of `requiredFields`. It contains all fields that still need to be collected before a `SignUp` can be converted into a `User`. Note that this property will be updated dynamically. As you add more fields to the `SignUp`, they will be removed. Once this property is empty, your `SignUp` will automatically convert into a `User`.
+</Properties>
 
 #### Verified fields
 
@@ -49,10 +61,17 @@ Some properties of the `SignUp`, such as `emailAddress` and `phoneNumber`, must 
 
 The `SignUp` object will show **the state of verification** in the following properties:
 
-| Name | Description |
-| - | - |
-| `unverifiedFields` | A list of all [`User`](/docs/references/javascript/user/user) attributes that need to be verified and are pending verification. This is a list that gets updated dynamically. When verification for all required fields has been successfully completed, this value will become an empty array. |
-| `verifications` | An object that describes the current state of verification for the [`SignUp`](/docs/references/javascript/sign-in/sign-in). There are currently three different keys: `email_address`, `phone_number`, and `external_account`. |
+<Properties>
+  - `unverifiedFields`
+
+  A list of all [`User`](/docs/references/javascript/user/user) attributes that need to be verified and are pending verification. This is a list that gets updated dynamically. When verification for all required fields has been successfully completed, this value will become an empty array.
+
+  ---
+
+  - `verifications`
+
+  An object that describes the current state of verification for the [`SignUp`](/docs/references/javascript/sign-in/sign-in). There are currently three different keys: `email_address`, `phone_number`, and `external_account`.
+</Properties>
 
 ### Sign-in flow
 

--- a/docs/references/backend/types/paginated-resource-response.mdx
+++ b/docs/references/backend/types/paginated-resource-response.mdx
@@ -9,10 +9,19 @@ An interface that describes the response of a method that returns a paginated li
 
 ## Properties
 
-| Properties | Type | Description |
-| - | - | - |
-| `data` | `T[]` | An array that contains the fetched data. |
-| `totalCount` | `number` | The total count of data that exist remotely. |
+<Properties>
+  - `data`
+  - `T[]`
+
+  An array that contains the fetched data.
+
+  ---
+
+  - `totalCount`
+  - `number`
+
+  The total count of data that exist remotely.
+</Properties>
 
 ## Returns
 

--- a/docs/references/javascript/clerk/clerk.mdx
+++ b/docs/references/javascript/clerk/clerk.mdx
@@ -98,14 +98,35 @@ function addListener(listener: (emission: Resources) => void): UnsubscribeCallba
 
 #### `Resources`
 
-| Name | Type |
-| - | - |
-| `client` | [`Client`][client-ref] |
-| `session` | [`Session`][session-ref] \| `null` \| `undefined` |
-| `user` | [`User`][user-ref] \| `null` \| `undefined` |
-| `organization` | [`Organization`][organization-ref] \| `null` \| `undefined` |
-| `lastOrganizationInvitation` | [`OrganizationInvitation`](/docs/references/javascript/organization-invitation) \| `null` \| `undefined` |
-| `lastOrganizationMember` | [`OrganizationMembership`](/docs/references/javascript/organization-membership) \| `null` \| `undefined` |
+<Properties>
+  - `client`
+  - [`Client`][client-ref]
+
+  ---
+
+  - `session`
+  - <code>[Session][session-ref] | null | undefined</code>
+
+  ---
+
+  - `user`
+  - <code>[User][user-ref] | null | undefined</code>
+
+  ---
+
+  - `organization`
+  - <code>[Organization][organization-ref] | null | undefined</code>
+
+  ---
+
+  - `lastOrganizationInvitation`
+  - <code>[OrganizationInvitation](/docs/references/javascript/organization-invitation) | null | undefined</code>
+
+  ---
+
+  - `lastOrganizationMember`
+  - <code>[OrganizationMembership](/docs/references/javascript/organization-membership) | null | undefined</code>
+</Properties>
 
 > [!NOTE]
 > Note the following about `User` and `Session`:

--- a/docs/references/nextjs/get-auth.mdx
+++ b/docs/references/nextjs/get-auth.mdx
@@ -12,10 +12,19 @@ The `getAuth()` helper retrieves the authentication state, allowing you to prote
 
 ## Parameters
 
-| Name | Description |
-| - | - |
-| `req` | The Next.js request object. |
-| `opts?` | An optional object that can be used to configure the behavior of the `getAuth()` function. It accepts the following properties: <ul><li>`secretKey?`: A string that represents the secret key used to sign the session token. If not provided, the secret key is retrieved from the environment variable `CLERK_SECRET_KEY`.</li></ul> |
+<Properties>
+  - `req`
+
+  The Next.js request object.
+
+  ---
+
+  - `opts?`
+
+  An optional object that can be used to configure the behavior of the `getAuth()` function. It accepts the following properties:
+
+  - `secretKey?`: A string that represents the secret key used to sign the session token. If not provided, the secret key is retrieved from the environment variable `CLERK_SECRET_KEY`.
+</Properties>
 
 ## Returns
 


### PR DESCRIPTION
<!--- Add the "deploy-preview" label and add your page previews here -->

> [!IMPORTANT]
> 🔎 Previews:
>
> - https://clerk.com/docs/pr/1449/components/authentication/google-one-tap
> - https://clerk.com/docs/pr/1449/components/authentication/sign-in
> - https://clerk.com/docs/pr/1449/custom-flows/overview
> - https://clerk.com/docs/pr/1449/references/javascript/clerk/clerk
> - https://clerk.com/docs/pr/1449/references/nextjs/get-auth
> - https://clerk.com/docs/pr/1449/references/backend/types/paginated-resource-response

This PR replaces HTML tables with the `<Properties>` component, where I think it's appropriate. These tables were not caught by the initial codemod (#1341) for various reasons:

- "Description" is spelt incorrectly
- The table doesn't contain a "Type" column
- The table doesn't contain a "Description" column