### PR TITLE
docs(astro): Add organization components references

### DIFF
--- a/docs/components/organization/create-organization.mdx
+++ b/docs/components/organization/create-organization.mdx
@@ -64,7 +64,7 @@ All props are optional.
 
 The following example includes a basic implementation of the `<CreateOrganization />` component. You can use this as a starting point for your own implementation.
 
-<Tabs type="framework" items={["Next.js", "React", "Remix"]}>
+<Tabs type="framework" items={["Next.js", "React", "Remix", "Astro"]}>
   <Tab>
     <CodeBlockTabs type="router" options={["App Router", "Pages Router"]}>
       ```jsx {{ filename: '/app/create-organization/[[...create-organization]]/page.tsx' }}
@@ -102,6 +102,16 @@ The following example includes a basic implementation of the `<CreateOrganizatio
     export default function CreateOrganizationPage() {
       return <CreateOrganization path="/create-organization" />
     }
+    ```
+  </Tab>
+
+  <Tab>
+    ```astro {{ filename: '/pages/create-organization.astro' }}
+    ---
+    import { CreateOrganization } from '@clerk/astro/components'
+    ---
+
+    <CreateOrganization path="/create-organization" />
     ```
   </Tab>
 </Tabs>

--- a/docs/components/organization/organization-list.mdx
+++ b/docs/components/organization/organization-list.mdx
@@ -69,7 +69,7 @@ All props are optional.
 
 ## Usage with frameworks
 
-<Tabs type="framework" items={["Next.js", "React", "Remix"]}>
+<Tabs type="framework" items={["Next.js", "React", "Remix", "Astro"]}>
   <Tab>
     <CodeBlockTabs type="router" options={["App Router", "Pages Router"]}>
       ```jsx {{ filename: '/app/discover/page.tsx' }}
@@ -131,6 +131,20 @@ All props are optional.
         />
       )
     }
+    ```
+  </Tab>
+
+  <Tab>
+    ```astro {{ filename: '/pages/discover.astro' }}
+    ---
+    import { OrganizationList } from '@clerk/astro/components'
+    ---
+
+    <OrganizationList
+      afterCreateOrganizationUrl="/organization/:slug"
+      afterSelectPersonalUrl="/user/:id"
+      afterSelectOrganizationUrl="/organization/:slug"
+    />
     ```
   </Tab>
 </Tabs>

--- a/docs/components/organization/organization-profile.mdx
+++ b/docs/components/organization/organization-profile.mdx
@@ -108,7 +108,7 @@ All props are optional.
     import { OrganizationProfile } from '@clerk/astro/components'
     ---
 
-    <OrganizationList path="/organization-profile" />
+    <OrganizationProfile path="/organization-profile" />
     ```
   </Tab>
 </Tabs>

--- a/docs/components/organization/organization-profile.mdx
+++ b/docs/components/organization/organization-profile.mdx
@@ -59,7 +59,7 @@ All props are optional.
 
 ## Usage with frameworks
 
-<Tabs type="framework" items={["Next.js", "React", "Remix"]}>
+<Tabs type="framework" items={["Next.js", "React", "Remix", "Astro"]}>
   <Tab>
     You can embed the `<OrganizationProfile />` component using the [Next.js optional catch-all route](https://nextjs.org/docs/pages/building-your-application/routing/dynamic-routes#optional-catch-all-routes). This allows you to redirect the user inside your application.
 
@@ -99,6 +99,16 @@ All props are optional.
     export default function OrganizationProfilePage() {
       return <OrganizationProfile path="/organization-profile" />
     }
+    ```
+  </Tab>
+
+  <Tab>
+    ```astro {{ filename: '/pages/organization-profile.astro' }}
+    ---
+    import { OrganizationProfile } from '@clerk/astro/components'
+    ---
+
+    <OrganizationList path="/organization-profile" />
     ```
   </Tab>
 </Tabs>

--- a/docs/components/organization/organization-switcher.mdx
+++ b/docs/components/organization/organization-switcher.mdx
@@ -108,7 +108,7 @@ All props below are optional.
 
 ## Usage with frameworks
 
-<Tabs items={["Next.js", "React", "Remix"]}>
+<Tabs items={["Next.js", "React", "Remix", "Astro"]}>
   <Tab>
     <CodeBlockTabs type="router" options={["App Router", "Pages Router"]}>
       ```jsx {{ filename: '/app/organization-switcher/[[...organization-switcher]]/page.tsx' }}
@@ -162,6 +162,16 @@ All props below are optional.
         </div>
       )
     }
+    ```
+  </Tab>
+
+  <Tab>
+    ```astro {{ filename: '/pages/organization-switcher.astro' }}
+    ---
+    import { OrganizationSwitcher } from '@clerk/astro/components'
+    ---
+
+    <OrganizationSwitcher />
     ```
   </Tab>
 </Tabs>


### PR DESCRIPTION
<!--- Add the "deploy-preview" label and add your page previews here -->

> [!IMPORTANT]
> 🔎 Previews:
>
> - https://clerk.com/docs/pr/1453/components/organization/create-organization
> - https://clerk.com/docs/pr/1453/components/organization/organization-switcher
> - https://clerk.com/docs/pr/1453/components/organization/organization-profile
> - https://clerk.com/docs/pr/1453/components/organization/organization-list

<!--- Describe your changes in detail. Why does this change need to happen? Include any links to Slack discussions, Linear comments, etc. -->

### Explanation:

<!--- How does this PR solve the problem? -->

### This PR:

- Adds Astro organization components examples to UI components section
