### PR TITLE
docs(astro): Add authentication and user components references

### DIFF
--- a/docs/components/authentication/google-one-tap.mdx
+++ b/docs/components/authentication/google-one-tap.mdx
@@ -56,7 +56,7 @@ The following example includes basic implementation of the `<GoogleOneTap />` co
 > [!NOTE]
 > `<GoogleOneTap>` does not render if the user is already signed into your Clerk application, so there's no need to manually check if a user is signed in yourself before rendering it.
 
-<Tabs type="framework" items={["Next.js"]}>
+<Tabs type="framework" items={["Next.js", "Astro"]}>
   <Tab>
     ```tsx {{ filename: 'app/layout.tsx', mark: [2, 11] }}
     import React from 'react'
@@ -75,6 +75,22 @@ The following example includes basic implementation of the `<GoogleOneTap />` co
         </html>
       )
     }
+    ```
+  </Tab>
+
+  <Tab>
+    ```astro {{ filename: 'layouts/Layout.astro' }}
+    ---
+    import { GoogleOneTap } from '@clerk/astro/components'
+    ---
+
+    <html lang="en">
+      <head>
+        <title>Google One Tap with Clerk and Astro</title>
+      </head>
+
+      <GoogleOneTap />
+    </html>
     ```
   </Tab>
 </Tabs>

--- a/docs/components/authentication/sign-in.mdx
+++ b/docs/components/authentication/sign-in.mdx
@@ -88,7 +88,7 @@ All props are optional.
 
 The following example includes basic implementation of the `<SignIn />` component. You can use this as a starting point for your own implementation.
 
-<Tabs type="framework" items={["Next.js", "React", "Remix", "Gatsby"]}>
+<Tabs type="framework" items={["Next.js", "React", "Remix", "Gatsby", "Astro"]}>
   <Tab>
     The following example demonstrates how you can use the `<SignIn />` component on a public page.
 
@@ -146,6 +146,16 @@ The following example includes basic implementation of the `<SignIn />` componen
         </div>
       )
     }
+    ```
+  </Tab>
+
+  <Tab>
+    ```astro {{ filename: 'pages/sign-in.astro' }}
+    ---
+    import { SignIn } from '@clerk/astro/components'
+    ---
+
+    <SignIn path="/sign-in" />
     ```
   </Tab>
 </Tabs>

--- a/docs/components/authentication/sign-up.mdx
+++ b/docs/components/authentication/sign-up.mdx
@@ -88,7 +88,7 @@ All props are optional.
 
 The following example includes basic implementation of the `<SignUp />` component. You can use this as a starting point for your own implementation.
 
-<Tabs type="framework" items={["Next.js", "React", "Remix", "Gatsby"]}>
+<Tabs type="framework" items={["Next.js", "React", "Remix", "Gatsby", "Astro"]}>
   <Tab>
     The following example demonstrates how you can use the `<SignUp />` component on a public page.
 
@@ -146,6 +146,16 @@ The following example includes basic implementation of the `<SignUp />` componen
         </div>
       )
     }
+    ```
+  </Tab>
+
+  <Tab>
+    ```astro {{ filename: 'pages/sign-up.astro' }}
+    ---
+    import { SignUp } from '@clerk/astro/components'
+    ---
+
+    <SignUp path="/sign-up" />
     ```
   </Tab>
 </Tabs>

--- a/docs/components/user/user-button.mdx
+++ b/docs/components/user/user-button.mdx
@@ -94,7 +94,7 @@ All props are optional.
 
 In the following example, `<UserButton />` is mounted inside a header component, which is a common pattern on many websites and applications. When the user is signed in, they will see their avatar and be able to open the popup menu.
 
-<Tabs type="framework" items={["Next.js", "React", "Remix"]}>
+<Tabs type="framework" items={["Next.js", "React", "Remix", "Astro"]}>
   <Tab>
     <CodeBlockTabs type="router" options={["App Router", "Pages Router"]}>
       ```tsx {{ filename: 'layout.tsx' }}
@@ -240,6 +240,18 @@ In the following example, `<UserButton />` is mounted inside a header component,
         </div>
       )
     }
+    ```
+  </Tab>
+
+  <Tab>
+    ```astro {{ filename: 'pages/index.astro' }}
+    ---
+    import { SignedIn, UserButton } from '@clerk/astro/components'
+    ---
+
+    <SignedIn>
+      <UserButton />
+    </SignedIn>
     ```
   </Tab>
 </Tabs>

--- a/docs/components/user/user-profile.mdx
+++ b/docs/components/user/user-profile.mdx
@@ -55,7 +55,7 @@ All props are optional.
 
 ## Usage with frameworks
 
-<Tabs type="framework" items={["Next.js", "React", "Remix"]}>
+<Tabs type="framework" items={["Next.js", "React", "Remix", "Astro"]}>
   <Tab>
     You can embed the `<UserProfile />` component using the [Next.js optional catch-all route](https://nextjs.org/docs/pages/building-your-application/routing/dynamic-routes#optional-catch-all-routes). This allows you to redirect the user inside your application.
 
@@ -95,6 +95,16 @@ All props are optional.
     export default function UserProfilePage() {
       return <UserProfile path="/user" />
     }
+    ```
+  </Tab>
+
+  <Tab>
+    ```astro {{ filename: 'pages/user.astro' }}
+    ---
+    import { UserProfile } from '@clerk/astro/components'
+    ---
+
+    <UserProfile path="/user" />
     ```
   </Tab>
 </Tabs>


### PR DESCRIPTION
<!--- Add the "deploy-preview" label and add your page previews here -->

> [!IMPORTANT]
> 🔎 Previews:
>
> - https://clerk.com/docs/pr/1454/components/user/user-button#usage-with-frameworks
> - https://clerk.com/docs/pr/1454/components/user/user-profile#usage-with-frameworks
> - https://clerk.com/docs/pr/1454/components/authentication/sign-in#usage-with-frameworks
> - https://clerk.com/docs/pr/1454/components/authentication/sign-up#usage-with-frameworks
> - https://clerk.com/docs/pr/1454/components/authentication/google-one-tap#usage-with-frameworks


<!--- Describe your changes in detail. Why does this change need to happen? Include any links to Slack discussions, Linear comments, etc. -->

### Explanation:

<!--- How does this PR solve the problem? -->

### This PR:

- Adds Astro authentication and user components examples to UI components section
