### PR TITLE
Remove "Community" tag from nav items under "Community SDKs"

### DIFF
--- a/docs/manifest.json
+++ b/docs/manifest.json
@@ -2876,7 +2876,6 @@
                 [
                   {
                     "title": "Redwood",
-                    "tag": "Community",
                     "collapse": true,
                     "icon": "redwood",
                     "items": [
@@ -2895,55 +2894,46 @@
                   },
                   {
                     "title": "Svelte",
-                    "tag": "Community",
                     "href": "https://github.com/markjaquith/clerk-sveltekit",
                     "icon": "svelte"
                   },
                   {
                     "title": "Vue",
-                    "tag": "Community",
                     "href": "https://vue-clerk.vercel.app",
                     "icon": "vue"
                   },
                   {
                     "title": "Elysia",
-                    "tag": "Community",
                     "href": "https://github.com/wobsoriano/elysia-clerk",
                     "icon": "elysia"
                   },
                   {
                     "title": "Rust",
-                    "tag": "Community",
                     "href": "https://github.com/cincinnati-ventures/clerk-rs",
                     "icon": "rust"
                   },
                   {
                     "title": "Hono",
-                    "tag": "Community",
                     "href": "https://github.com/honojs/middleware/tree/main/packages/clerk-auth",
                     "icon": "hono"
                   },
                   {
                     "title": "C#",
-                    "tag": "Community",
                     "href": "https://github.com/Hawxy/Clerk.Net",
                     "icon": "c-sharp"
                   },
                   {
                     "title": "Astro",
-                    "tag": "Community",
                     "href": "https://github.com/panteliselef/astro-with-clerk-auth/blob/main/packages/astro-clerk-auth/README.md",
                     "icon": "astro"
                   },
                   {
                     "title": "Koa",
-                    "tag": "Community",
                     "href": "https://github.com/dimkl/clerk-koa/blob/main/README.md",
                     "icon": "koa"
                   },
                   {
                     "title": "Angular",
-                    "tag": "Community",
                     "href": "https://github.com/anagstef/ngx-clerk?tab=readme-ov-file#ngx-clerk",
                     "icon": "angular"
                   }


### PR DESCRIPTION
<!--- Add the "deploy-preview" label and add your page previews here -->

> [!IMPORTANT]
> 🔎 Previews:
>
> - https://clerk.com/docs/pr/1456

The sub-items don't need to be tagged with "Community" since they are nested under the "Community SDKs" item.

| Before | After |
| - | - |
| ![CleanShot 2024-08-15 at 13 43 42@2x](https://github.com/user-attachments/assets/f7c25ee5-9e02-4dfe-97aa-c8cfeb8d8b2a) | ![CleanShot 2024-08-15 at 13 44 18@2x](https://github.com/user-attachments/assets/02d2cdc4-b37a-4e68-8b3c-255ebd47d20d) |