### PR TITLE
Drop warning for custom OAuth providers

### DIFF
--- a/docs/authentication/social-connections/custom-provider.mdx
+++ b/docs/authentication/social-connections/custom-provider.mdx
@@ -3,9 +3,6 @@ title: OAuth with a custom auth provider
 description: Configure a custom OpenID Connect (OIDC) compatible authentication provider for your Clerk application.
 ---
 
-> [!WARNING]
-> Custom auth providers are in beta. Please [contact support](/contact/support) to get your application whitelisted for this feature.
-
 <TutorialHero
   beforeYouStart={[
     {


### PR DESCRIPTION
Getting ready for GA, this PR removes the warning that prompts users to contact support for access.