### PR TITLE
Replace `<Images>` with standard Markdown syntax

### DIFF
--- a/docs/advanced-usage/clerk-idp.mdx
+++ b/docs/advanced-usage/clerk-idp.mdx
@@ -8,7 +8,7 @@ description: Learn how to use Clerk to facilitate Single Sign-On (SSO) with othe
 
 Clerk can be configured as an identity provider to facilitate Single Sign-On (SSO) with other clients that support the OAuth 2.0 protocol. With this feature, your users can sign in with your Clerk application on other websites to authorize sharing of their user info.
 
-<Images width={2279} height={1135} src="/docs/images/advance/clerk-idp-flow.svg" alt="Clerk IDP Flow" />
+![Clerk IDP Flow](/docs/images/advance/clerk-idp-flow.svg)
 
 <Steps>
   ### Retrieve callback URL from the client application

--- a/docs/authentication/saml/account-linking.mdx
+++ b/docs/authentication/saml/account-linking.mdx
@@ -14,12 +14,7 @@ In the following sections, we'll look at the different scenarios that can occur 
 > [!NOTE]
 > Email addresses from SAML providers are considered verified by default.
 
-<Images
-  width={2400}
-  height={1754}
-  src="/docs/images/authentication/account-linking-flow-saml.webp"
-  alt="Flow chart of the SAML SSO account linking process in various scenarios."
-/>
+![Flow chart of the SAML SSO account linking process in various scenarios.](/docs/images/authentication/account-linking-flow-saml.webp)
 
 ### Email is verified in Clerk
 

--- a/docs/authentication/social-connections/account-linking.mdx
+++ b/docs/authentication/social-connections/account-linking.mdx
@@ -11,12 +11,7 @@ When a user attempts to sign in or sign up, Clerk first checks the email address
 
 In the following sections, we'll look at the different scenarios that can occur during this process and explain how Clerk handles each one.
 
-<Images
-  width={2400}
-  height={1942}
-  src="/docs/images/authentication/account-linking-flow-oauth.webp"
-  alt="Flow chart of the account linking process in various scenarios"
-/>
+![Flow chart of the account linking process in various scenarios](/docs/images/authentication/account-linking-flow-oauth.webp)
 
 ### Email address is verified in both OAuth and Clerk
 
@@ -32,12 +27,7 @@ For instances that allow account creation without email verification at sign-up,
 
 To allow unverified email addresses for your instance, navigate to the [Email, Phone, Username](https://dashboard.clerk.com/last-active?path=user-authentication/email-phone-username) page in the Clerk Dashboard. Click on the settings cog icon next to "Email address" and uncheck the "Verify at sign-up" toggle.
 
-<Images
-  width={2500}
-  height={2000}
-  src="/docs/images/authentication/account-linking-verify-at-sign-up.webp"
-  alt="Verify at sign-up toggle in the Clerk Dashboard"
-/>
+![Verify at sign-up toggle in the Clerk Dashboard](/docs/images/authentication/account-linking-verify-at-sign-up.webp)
 
 Clerk initiates the email verification process at the outset. Upon successful email verification, regardless of the method, additional steps may be taken to validate existing connections or passwords. This is done to ensure the user's account remains secure.
 

--- a/docs/authentication/social-connections/box.mdx
+++ b/docs/authentication/social-connections/box.mdx
@@ -27,21 +27,11 @@ First, you need to create a new OAuth2 Box app. You can find this option in your
 
 You need to choose an app name and then click **Create application**.
 
-<Images
-  width={1920}
-  height={821}
-  src="/docs/images/authentication-providers/box/adding-name-and-creating-application.jpg"
-  alt="Adding a name and creating the application"
-/>
+![Adding a name and creating the application](/docs/images/authentication-providers/box/adding-name-and-creating-application.jpg)
 
 In the Clerk Dashboard, go to **User & Authentication > [Social Connections](https://dashboard.clerk.com/last-active?path=user-authentication/social-connections)** and enable Box. In the modal that opened, ensure **Use custom credentials** is enabled and copy **Authorized redirect URI**. Make sure the value matches the **Redirect URIs**, as shown below.
 
-<Images
-  width={1916}
-  height={820}
-  src="/docs/images/authentication-providers/box/verifying-values-on-configuration-page.jpg"
-  alt="Verifying the values on the configuration page"
-/>
+![Verifying the values on the configuration page](/docs/images/authentication-providers/box/verifying-values-on-configuration-page.jpg)
 
 Copy the **Client ID** and **Client secret** as shown in the above image. Go back to the Clerk Dashboard and paste them into the respective fields.
 

--- a/docs/authentication/social-connections/coinbase.mdx
+++ b/docs/authentication/social-connections/coinbase.mdx
@@ -27,21 +27,11 @@ First, you need to create a new OAuth2 Coinbase app. You can find this option in
 
 You need to set all the required fields and the corresponding **Permitted Redirect URIs**. Under **Advanced Settings**, make sure to also select **Reuse Existing Tokens** for **Previously-Authorized Users** so that your users won't get notified everytime they sign in with their Coinbase account. Then, click **Create application**.
 
-<Images
-  width={1301}
-  height={1647}
-  src="/docs/images/authentication-providers/coinbase/creating-application.jpg"
-  alt="Creating application"
-/>
+![Creating application](/docs/images/authentication-providers/coinbase/creating-application.jpg)
 
 In the Clerk Dashboard, go to **User & Authentication > [Social Connections](https://dashboard.clerk.com/last-active?path=user-authentication/social-connections)** and enable Coinbase. In the modal that opened, ensure **Use custom credentials** is enabled and copy **Authorized redirect URI**. Make sure the value matches the **Redirect URIs**, as shown below.
 
-<Images
-  width={1303}
-  height={1027}
-  src="/docs/images/authentication-providers/coinbase/copying-values-from-box-dashboard.jpg"
-  alt="Copying the Client ID and Client Secret from the Box dashboard"
-/>
+![Copying the Client ID and Client Secret from the Box dashboard](/docs/images/authentication-providers/coinbase/copying-values-from-box-dashboard.jpg)
 
 Copy the **Client ID** and **Client secret** as shown in the above image. Go back to the Clerk Dashboard and paste them into the respective fields.
 

--- a/docs/authentication/social-connections/dropbox.mdx
+++ b/docs/authentication/social-connections/dropbox.mdx
@@ -25,12 +25,7 @@ For production instances, you will need to generate your own Client ID and Clien
 
 First, you need to register a new OAuth Dropbox app at the [Dropbox App Console](https://www.dropbox.com/developers/apps).
 
-<Images
-  width={1905}
-  height={836}
-  src="/docs/images/authentication-providers/dropbox/creating-new-application.jpg"
-  alt="Creating a new application"
-/>
+![Creating a new application](/docs/images/authentication-providers/dropbox/creating-new-application.jpg)
 
 First you need to choose the API type, the App's type of access and to set a name for your new application. You also need to add the **OAuth Redirect URLs.**
 
@@ -38,11 +33,6 @@ In the Clerk Dashboard, go to **User & Authentication > [Social Connections](htt
 
 Once all the above are complete, copy the **Client ID** and **Client Secret.** Go back to the Clerk Dashboard and paste them into the respective fields.
 
-<Images
-  width={1902}
-  height={1042}
-  src="/docs/images/authentication-providers/dropbox/copying-values-from-dropbox-dashboard.jpg"
-  alt="Copying values from the Dropbox dashboard"
-/>
+![Copying values from the Dropbox dashboard](/docs/images/authentication-providers/dropbox/copying-values-from-dropbox-dashboard.jpg)
 
 Don't forget to click **Apply** in the Clerk dashboard. Congratulations! Social connection with Dropbox is now configured for your instance.

--- a/docs/authentication/social-connections/google.mdx
+++ b/docs/authentication/social-connections/google.mdx
@@ -66,12 +66,7 @@ Please make sure your production application always uses a corresponding Google 
 
 ### Block email subaddresses
 
-<Images
-  width={3024}
-  height={1652}
-  src="/docs/images/authentication-providers/google/google-block-email-subaddresses.webp"
-  alt="Block email subaddresses enabled for Google social connection."
-/>
+![Block email subaddresses enabled for Google social connection.](/docs/images/authentication-providers/google/google-block-email-subaddresses.webp)
 
 In the Clerk Dashboard configuration screen, you also have an option to block email subaddresses. With this setting on, any Google account with an email address that contains the characters `+`, `=` or `#` will not be able to sign in, sign up, or be added to existing accounts. By default, this setting will be enabled for new Google social connections.
 

--- a/docs/authentication/social-connections/line.mdx
+++ b/docs/authentication/social-connections/line.mdx
@@ -28,12 +28,7 @@ For production instances, you will need to generate your own Client ID and Clien
 
 First, you need to create a new provider. Fill in a name and click **Create**.
 
-<Images
-  width={1909}
-  height={779}
-  src="/docs/images/authentication-providers/line/creating-new-provider.jpg"
-  alt="Creating a new provider"
-/>
+![Creating a new provider](/docs/images/authentication-providers/line/creating-new-provider.jpg)
 
 The next step is to create a new **LINE Login channel**. You will have to select the provider you created before, the region to provide your LINE service, a channel name, and description and finally select **Web app** as the **App type**.
 
@@ -43,11 +38,6 @@ You also need to add the **OAuth Redirect URLs.** In the Clerk Dashboard, go to 
 
 Once all the above are complete, copy the **Channel ID** and **Channel secret.** Go back to the Clerk Dashboard and paste them into the respective fields.
 
-<Images
-  width={1908}
-  height={782}
-  src="/docs/images/authentication-providers/line/pasting-value-into-line-dashboard.jpg"
-  alt="Pasting value into LINE dashboard"
-/>
+![Pasting value into LINE dashboard](/docs/images/authentication-providers/line/pasting-value-into-line-dashboard.jpg)
 
 Don't forget to click **Apply** in the Clerk dashboard. Congratulations! Social connection with LINE is now configured for your instance.

--- a/docs/authentication/social-connections/linear.mdx
+++ b/docs/authentication/social-connections/linear.mdx
@@ -27,21 +27,11 @@ First, you need to create a new OAuth Linear app. Navigate on your **Settings > 
 
 To fill the Callback URLs field, you need the **Authorized redirect URI** from Clerk. In the Clerk Dashboard, go to **User & Authentication > [Social Connections](https://dashboard.clerk.com/last-active?path=user-authentication/social-connections)** and enable Linear. In the modal that opened, ensure **Use custom credentials** is enabled and copy **Authorized redirect URI**. Paste this value in the Callback URLs field of your Linear application.
 
-<Images
-  width={1399}
-  height={885}
-  src="/docs/images/authentication-providers/linear/creating-new-application.jpg"
-  alt="Creating a new application"
-/>
+![Creating a new application](/docs/images/authentication-providers/linear/creating-new-application.jpg)
 
 When you have filled all the necessary info, click **Create**. Congratulations, you have successfully created your Linear OAuth application.
 
-<Images
-  width={1065}
-  height={596}
-  src="/docs/images/authentication-providers/linear/copying-values-from-linear-dashboard.jpg"
-  alt="Copying values from the Linear dashboard"
-/>
+![Copying values from the Linear dashboard](/docs/images/authentication-providers/linear/copying-values-from-linear-dashboard.jpg)
 
 Copy the **Client ID** and **Client secret** as shown in the above image from the **Basic Information** menu of your app. Go back to the Clerk Dashboard and paste them into the respective fields.
 

--- a/docs/authentication/social-connections/notion.mdx
+++ b/docs/authentication/social-connections/notion.mdx
@@ -25,30 +25,15 @@ For production instances, you will need to generate your own Client ID and Clien
 
 First, you need to create a new OAuth Notion app.
 
-<Images
-  width={1148}
-  height={1480}
-  src="/docs/images/authentication-providers/notion/creating-a-new-integration.jpg"
-  alt="Creating a new integration"
-/>
+![Creating a new integration](/docs/images/authentication-providers/notion/creating-a-new-integration.jpg)
 
 You need to set a name, a logo, and associate a Notion workspace with it. Make sure you are also requesting the user email address along with the other information and click **Submit**.
 
-<Images
-  width={1177}
-  height={2165}
-  src="/docs/images/authentication-providers/notion/configuring-integration.jpg"
-  alt="Configuring integration"
-/>
+![Configuring integration](/docs/images/authentication-providers/notion/configuring-integration.jpg)
 
 In the Clerk Dashboard, go to **User & Authentication > [Social Connections](https://dashboard.clerk.com/last-active?path=user-authentication/social-connections)**. From the list of OAuth vendors, toggle on the Notion option. In the modal that opened, ensure **Use custom credentials** is enabled and copy **Authorized redirect URI**. Paste the value into the **Redirect URIs**, as shown below, after changing the integration type to **Public**. Fill any other information required from Notion and click Submit.
 
-<Images
-  width={1173}
-  height={766}
-  src="/docs/images/authentication-providers/notion/copying-values-from-notion-dashboard.jpg"
-  alt="Copying values from the Notion dashboard"
-/>
+![Copying values from the Notion dashboard](/docs/images/authentication-providers/notion/copying-values-from-notion-dashboard.jpg)
 
 Copy the **Client ID** and **Client secret** as shown in the above image. Go back to the Clerk Dashboard and paste them into the respective fields.
 

--- a/docs/authentication/social-connections/oauth.mdx
+++ b/docs/authentication/social-connections/oauth.mdx
@@ -120,12 +120,7 @@ When signed in, a user can connect to further OAuth providers as well. There is 
 
 When using Clerk's [Account Portal](/docs/customization/account-portal//overview) pages, users can see which providers they have already connected to and which ones they can still connect to on their [User Profile](/docs/customization/account-portal//user-profile-org-profile#user-profile) page.
 
-<Images
-  width={3024}
-  height={1654}
-  src="/docs/images/authentication/connect-account.webp"
-  alt="The User Profile page in the Account Portal. There is a red arrow pointing to the 'Connect account' button in the 'Connected accounts' section."
-/>
+![The User Profile page in the Account Portal. There is a red arrow pointing to the 'Connect account' button in the 'Connected accounts' section.](/docs/images/authentication/connect-account.webp)
 
 If you are using Clerk's [prebuilt components](/docs/components/overview), you can use the [`<UserProfile/>`](/docs/components/user/user-profile) component to allow users to connect to further OAuth providers.
 

--- a/docs/authentication/social-connections/slack.mdx
+++ b/docs/authentication/social-connections/slack.mdx
@@ -28,21 +28,11 @@ For production instances, you will need to generate your own Client ID and Clien
 
 First, you need to create a new OAuth Slack app. On the main [Slack apps page](https://api.slack.com/apps), click on **Create new app**. On the modal that pops up, choose **From scratch,** enter your application name and choose a Slack workspace to associate with it.
 
-<Images
-  width={1917}
-  height={833}
-  src="/docs/images/authentication-providers/slack/creating-new-application.jpg"
-  alt="Creating a new application"
-/>
+![Creating a new application](/docs/images/authentication-providers/slack/creating-new-application.jpg)
 
 In the Clerk Dashboard, go to **User & Authentication > [Social Connections](https://dashboard.clerk.com/last-active?path=user-authentication/social-connections)** and enable Slack. In the modal that opened, ensure **Use custom credentials** is enabled and copy **Authorized redirect URI**. Navigate to **OAuth & Permissions > Redirect URLs** and paste the value to add a new record.
 
-<Images
-  width={1906}
-  height={900}
-  src="/docs/images/authentication-providers/slack/copying-values-from-slack-dashboard.jpg"
-  alt="Copying values from the Slack dashboard"
-/>
+![Copying values from the Slack dashboard](/docs/images/authentication-providers/slack/copying-values-from-slack-dashboard.jpg)
 
 Copy the **Client ID** and **Client secret** as shown in the above image from the Basic Information menu of your app. Go back to the Clerk Dashboard and paste them into the respective fields.
 

--- a/docs/authentication/social-connections/spotify.mdx
+++ b/docs/authentication/social-connections/spotify.mdx
@@ -19,21 +19,11 @@ Clerk does not currently support preconfigured shared OAuth credentials for Spot
 
   To create a new OAuth Spotify app, go to the [Spotify Developer portal](https://developer.spotify.com/) and sign in. Once signed in, navigate to the [Dashboard](https://developer.spotify.com/dashboard/). Click on either of the **Create app** buttons.
 
-  <Images
-    width={3024}
-    height={1654}
-    src="/docs/images/authentication-providers/spotify/create-application.webp"
-    alt="The Spotify Developer Dashboard. A red arrow points to both 'Create app' buttons."
-  />
+  ![The Spotify Developer Dashboard. A red arrow points to both 'Create app' buttons.](/docs/images/authentication-providers/spotify/create-application.webp)
 
   Once redirected to the application creation form, you need to set an **App name**, **App description**, and **Redirect URI**. **Website** is optional.
 
-  <Images
-    width={2490}
-    height={1294}
-    src="/docs/images/authentication-providers/spotify/new-app-form.webp"
-    alt="The 'Create app' form in the Spotify Developer Dashboard."
-  />
+  ![The 'Create app' form in the Spotify Developer Dashboard.](/docs/images/authentication-providers/spotify/new-app-form.webp)
 
   ### Spotify + your Clerk app
 
@@ -41,21 +31,11 @@ Clerk does not currently support preconfigured shared OAuth credentials for Spot
 
   In the Clerk Dashboard, go to **User & Authentication > [Social Connections](https://dashboard.clerk.com/last-active?path=user-authentication/social-connections)**. From the list of OAuth vendors, toggle on the Spotify option.
 
-  <Images
-    width={3024}
-    height={1650}
-    src="/docs/images/authentication-providers/spotify/enable-spotify.webp"
-    alt="The 'Social connections' page in the Clerk Dashboard. A red arrow is pointing to the Spotify toggle."
-  />
+  ![The 'Social connections' page in the Clerk Dashboard. A red arrow is pointing to the Spotify toggle.](/docs/images/authentication-providers/spotify/enable-spotify.webp)
 
   In the modal that opened, copy **Authorized redirect URI**. Keep this modal and page open.
 
-  <Images
-    width={2490}
-    height={1394}
-    src="/docs/images/authentication-providers/spotify/redirect-uri.webp"
-    alt="The Spotify settings modal in the Clerk Dashboard. A red arrow is pointing to the 'Redirect URI' copy button."
-  />
+  ![The Spotify settings modal in the Clerk Dashboard. A red arrow is pointing to the 'Redirect URI' copy button.](/docs/images/authentication-providers/spotify/redirect-uri.webp)
 
   ### Configure Spotify application
 
@@ -65,24 +45,14 @@ Clerk does not currently support preconfigured shared OAuth credentials for Spot
 
   Once your Spotify app is created, you'll be redirected to the app dashboard. From there, navigate to **Settings**.
 
-  <Images
-    width={3024}
-    height={1650}
-    src="/docs/images/authentication-providers/spotify/settings.webp"
-    alt="The Spotify Developer Dashboard for a specific application. A red arrow points to the 'Settings' button."
-  />
+  ![The Spotify Developer Dashboard for a specific application. A red arrow points to the 'Settings' button.](/docs/images/authentication-providers/spotify/settings.webp)
 
   Copy the **Client ID** and **Client Secret**. Go back to the Clerk Dashboard, where the modal should still be open, and paste these values into the respective fields.
 
   > [!NOTE]
   > If the modal or page is not still open, go to the Clerk Dashboard and navigate to **User & Authentication > [Social Connections](https://dashboard.clerk.com/last-active?path=user-authentication/social-connections)**. Click on the settings cog icon next to the Spotify option. You can now paste the **Client ID** and **Client Secret** into their respective fields.
 
-  <Images
-    width={3024}
-    height={1650}
-    src="/docs/images/authentication-providers/spotify/copying-values-from-spotify.webp"
-    alt="The 'Basic information' tab of the Spotify application's settings. A red arrow points to the 'Client ID' and 'Client Secret'."
-  />
+  ![The 'Basic information' tab of the Spotify application's settings. A red arrow points to the 'Client ID' and 'Client Secret'.](/docs/images/authentication-providers/spotify/copying-values-from-spotify.webp)
 
   ### Finished 🎉
 

--- a/docs/authentication/social-connections/x-twitter.mdx
+++ b/docs/authentication/social-connections/x-twitter.mdx
@@ -43,34 +43,19 @@ Clerk does not currently support preconfigured shared OAuth credentials for X/Tw
 
   In the modal that opened, copy the **Authorized redirect URI**. Keep this modal and page open.
 
-  <Images
-    width={1512}
-    height={982}
-    src="/docs/images/authentication-providers/x-twitter/redirect-uri.webp"
-    alt="The X/Twitter settings modal in the Clerk Dashboard. An arrow marked '1' is pointing to the 'Redirect URI' copy button."
-  />
+  ![The X/Twitter settings modal in the Clerk Dashboard. An arrow marked '1' is pointing to the 'Redirect URI' copy button.](/docs/images/authentication-providers/x-twitter/redirect-uri.webp)
 
   ### Set the Authorized Redirect URI in your X/Twitter application
 
   Navigate back to the X/Twitter Developer portal. On the application settings screen, scroll down to the **User authentication settings** section and select **Set up**.
 
-  <Images
-    width={1512}
-    height={982}
-    src="/docs/images/authentication-providers/x-twitter/set-up-user-authentication-settings.webp"
-    alt="The X/Twitter set up user authentication settings page. An arrow marked '1' is pointing to the 'Set up' button."
-  />
+  ![The X/Twitter set up user authentication settings page. An arrow marked '1' is pointing to the 'Set up' button.](/docs/images/authentication-providers/x-twitter/set-up-user-authentication-settings.webp)
 
   In the next screen, you'll be presented with the **User authentication settings** page. Under **App permissions**, you can choose the permissions you want to request from the user. For this tutorial, we'll be using the **Read** permission. Under **Type of App**, select **Web App, Automated App or Bot**.
 
   Under **App info**, in the **Callback URI / Redirect URL** input, paste the **Authorized Redirect URI** value you copied from the Clerk Dashboard in the last step. Your app's settings should like similar to the ones below. Fill any other required fields, such as the **Website URL**, and select **Save**.
 
-  <Images
-    width={1512}
-    height={982}
-    src="/docs/images/authentication-providers/x-twitter/fill-user-authentication-settings.webp"
-    alt="The X/Twitter user authentication settings page. An arrow marked '1' is pointing to the 'type of app' input. An arrow marked '2' is pointing to the 'Callback URI / Redirect URL' input. An arrow marked '3' is pointing to required website URL input."
-  />
+  ![The X/Twitter user authentication settings page. An arrow marked '1' is pointing to the 'type of app' input. An arrow marked '2' is pointing to the 'Callback URI / Redirect URL' input. An arrow marked '3' is pointing to required website URL input.](/docs/images/authentication-providers/x-twitter/fill-user-authentication-settings.webp)
 
   ### Set the Client ID and Client Secret in your Clerk Dashboard
 
@@ -81,12 +66,7 @@ Clerk does not currently support preconfigured shared OAuth credentials for X/Tw
   > [!NOTE]
   > If the modal or page is not still open, go to the Clerk Dashboard and navigate to **User & Authentication > [Social Connections](https://dashboard.clerk.com/last-active?path=user-authentication/social-connections)**. Click on the settings cog icon next to the X/Twitter option. You can now paste the **Client ID** and **Client Secret** into their respective fields.
 
-  <Images
-    width={1512}
-    height={982}
-    src="/docs/images/authentication-providers/x-twitter/paste-credentials.webp"
-    alt="The X/Twitter settings modal in the Clerk Dashboard. An arrow marked '1' is pointing to the 'Client ID' input. An arrow marked '2' is pointing to the 'Client Secret' input."
-  />
+  ![The X/Twitter settings modal in the Clerk Dashboard. An arrow marked '1' is pointing to the 'Client ID' input. An arrow marked '2' is pointing to the 'Client Secret' input.](/docs/images/authentication-providers/x-twitter/paste-credentials.webp)
 
   ### Finished 🎉
 

--- a/docs/authentication/social-connections/xero.mdx
+++ b/docs/authentication/social-connections/xero.mdx
@@ -25,21 +25,11 @@ For production instances, you will need to generate your own Client ID and Clien
 
 First, you need to create a new OAuth2 Xero app. Click New App and fill all the required information such as the App Name, your company URL, the redirect URL, choose Web App as integration type, and then click **Create app**.
 
-<Images
-  width={1904}
-  height={981}
-  src="/docs/images/authentication-providers/xero/creating-new-application.jpg"
-  alt="Creating a new application"
-/>
+![Creating a new application](/docs/images/authentication-providers/xero/creating-new-application.jpg)
 
 In the Clerk Dashboard, go to **User & Authentication > [Social Connections](https://dashboard.clerk.com/last-active?path=user-authentication/social-connections)** and enable Xero. In the modal that opened, ensure **Use custom credentials** is enabled and copy **Authorized redirect URI**. Make sure the value matches the **Redirect URIs**, as shown below.
 
-<Images
-  width={1909}
-  height={824}
-  src="/docs/images/authentication-providers/xero/copying-values-from-xero-dashboard.jpg"
-  alt="Copying values from the Xero dashboard"
-/>
+![Copying values from the Xero dashboard](/docs/images/authentication-providers/xero/copying-values-from-xero-dashboard.jpg)
 
 Copy the **Client ID** and **Client secret** as shown in the above image. Go back to the Clerk Dashboard and paste them into the respective fields.
 

--- a/docs/backend-requests/making/custom-session-token.mdx
+++ b/docs/backend-requests/making/custom-session-token.mdx
@@ -25,12 +25,7 @@ This guide will show you how to customize a session token to include additional 
 
   The following example adds the `fullName` and `primaryEmail` claims to the session token.
 
-  <Images
-    src="/docs/images/advance/session-tokens/custom-session-example.png"
-    width={3024}
-    height={1748}
-    alt="Clerk Dashboard showing the custom claim modal"
-  />
+  ![Clerk Dashboard showing the custom claim modal](/docs/images/advance/session-tokens/custom-session-example.png)
 
   ### Use the custom claims in your application
 

--- a/docs/components/authentication/sign-in.mdx
+++ b/docs/components/authentication/sign-in.mdx
@@ -3,12 +3,7 @@ title: '`<SignIn />` component'
 description: Clerk's <SignIn /> component renders a UI for signing in users.
 ---
 
-<Images
-  width={460}
-  height={576}
-  src="/docs/images/ui-components/sign-in.svg"
-  alt="Clerk's <SignIn /> component renders a UI for signing in users."
-/>
+![Clerk's \<SignIn /> component renders a UI for signing in users.](/docs/images/ui-components/sign-in.svg)
 
 The `<SignIn />` component renders a UI for signing in users. The functionality of the `<SignIn />` component is controlled by the instance settings you specify in your [Clerk Dashboard](https://dashboard.clerk.com), such as [sign-in and sign-up options](/docs/authentication/configuration/sign-up-sign-in-options) and [social connections](/docs/authentication/social-connections/overview). You can further customize your `<SignIn />` component by passing additional [properties](#properties) at the time of rendering.
 

--- a/docs/components/authentication/sign-up.mdx
+++ b/docs/components/authentication/sign-up.mdx
@@ -3,12 +3,7 @@ title: '`<SignUp />` component'
 description: Clerk's <SignUp /> component renders a UI for signing up users.
 ---
 
-<Images
-  width={460}
-  height={900}
-  src="/docs/images/ui-components/sign-up.svg"
-  alt="Clerk's <SignUp /> component renders a UI for signing up users."
-/>
+![Clerk's \<SignUp /> component renders a UI for signing up users.](/docs/images/ui-components/sign-up.svg)
 
 The `<SignUp />` component renders a UI for signing up users. The functionality of the `<SignUp />` component is controlled by the instance settings you specify in your [Clerk Dashboard](https://dashboard.clerk.com), such as [sign-in and sign-up options](/docs/authentication/configuration/sign-up-sign-in-options) and [social connections](/docs/authentication/social-connections/overview). You can further customize your `<SignUp />` component by passing additional [properties](#properties) at the time of rendering.
 

--- a/docs/components/organization/create-organization.mdx
+++ b/docs/components/organization/create-organization.mdx
@@ -3,12 +3,7 @@ title: '`<CreateOrganization />` component'
 description: Clerk's <CreateOrganization /> component is used to render an organization creation UI that allows users to create brand new organizations within your application.
 ---
 
-<Images
-  width={492}
-  height={502}
-  src="/docs/images/ui-components/create-organization.svg"
-  alt="Clerk's <CreateOrganization /> component renders an organization creation UI that allows users to create brand new organizations within your application."
-/>
+![Clerk's \<CreateOrganization /> component renders an organization creation UI that allows users to create brand new organizations within your application.](/docs/images/ui-components/create-organization.svg)
 
 The `<CreateOrganization />` component is used to render an organization creation UI that allows users to create brand new organizations within your application.
 

--- a/docs/components/organization/organization-list.mdx
+++ b/docs/components/organization/organization-list.mdx
@@ -3,12 +3,7 @@ title: '`<OrganizationList />` component'
 description: Clerk's <OrganizationList /> component is used to display organization related memberships, invitations, and suggestions for the user.
 ---
 
-<Images
-  width={460}
-  height={602}
-  src="/docs/images/ui-components/organization-list.svg"
-  alt="Clerk's <OrganizationList /> component is used to display organization related memberships, invitations, and suggestions for the user."
-/>
+![Clerk's \<OrganizationList /> component is used to display organization related memberships, invitations, and suggestions for the user.](/docs/images/ui-components/organization-list.svg)
 
 The `<OrganizationList />` component is used to display organization related memberships, [invitations, and suggestions](/docs/organizations/overview#automatic-invitations-and-suggestions) for the user.
 

--- a/docs/components/organization/organization-profile.mdx
+++ b/docs/components/organization/organization-profile.mdx
@@ -3,12 +3,7 @@ title: '`<OrganizationProfile />` component'
 description: Clerks <OrganizationProfile /> component is used to render a beautiful, full-featured organization management UI that allows users to manage their organization profile and security settings.
 ---
 
-<Images
-  width={940}
-  height={764}
-  src="/docs/images/ui-components/organization-profile.svg"
-  alt="Clerk's <OrganizationProfile /> component renders a full-featured organization management UI that allows users to manage their organization profile and security settings."
-/>
+![Clerk's \<OrganizationProfile /> component renders a full-featured organization management UI that allows users to manage their organization profile and security settings.](/docs/images/ui-components/organization-profile.svg)
 
 The `<OrganizationProfile />` component is used to render a beautiful, full-featured organization management UI that allows users to manage their organization profile and security settings.
 

--- a/docs/components/organization/organization-switcher.mdx
+++ b/docs/components/organization/organization-switcher.mdx
@@ -3,12 +3,7 @@ title: '`<OrganizationSwitcher />` component'
 description: Clerk's <OrganizationSwitcher /> component is used to enable the ability to switch between available organizations the user may be part of in your application.
 ---
 
-<Images
-  width={436}
-  height={389}
-  src="/docs/images/ui-components/organization-switcher.svg"
-  alt="Clerk's <OrganizationSwitcher /> component is used to enable the ability to switch between available organizations the user may be part of in your application."
-/>
+![Clerk's \<OrganizationSwitcher /> component is used to enable the ability to switch between available organizations the user may be part of in your application.](/docs/images/ui-components/organization-switcher.svg)
 
 The `<OrganizationSwitcher />` component allows a user to switch between their account types - their personal account and their joined organizations. This component is useful for applications that have a multi-tenant architecture, where users can be part of multiple organizations.
 

--- a/docs/components/user/user-button.mdx
+++ b/docs/components/user/user-button.mdx
@@ -3,12 +3,7 @@ title: '`<UserButton />` component'
 description: Clerk's <UserButton /> component is used to render the familiar user button UI popularized by Google.
 ---
 
-<Images
-  width={436}
-  height={485}
-  src="/docs/images/ui-components/user-button.svg"
-  alt="Clerk's <UserButton /> component renders the familiar user button UI popularized by Google."
-/>
+![Clerk's \<UserButton /> component renders the familiar user button UI popularized by Google.](/docs/images/ui-components/user-button.svg)
 
 The `<UserButton />` component is used to render the familiar user button UI popularized by Google.
 

--- a/docs/components/user/user-profile.mdx
+++ b/docs/components/user/user-profile.mdx
@@ -3,12 +3,7 @@ title: '`<UserProfile />` component'
 description: Clerk's <UserProfile /> component is used to render a beautiful, full-featured account management UI that allows users to manage their profile and security settings.
 ---
 
-<Images
-  width={940}
-  height={764}
-  src="/docs/images/ui-components/user-profile.svg"
-  alt="Clerk's <UserProfile /> component renders a full-featured account management UI that allows users to manage their profile and security settings."
-/>
+![Clerk's \<UserProfile /> component renders a full-featured account management UI that allows users to manage their profile and security settings.](/docs/images/ui-components/user-profile.svg)
 
 The `<UserProfile />` component is used to render a beautiful, full-featured account management UI that allows users to manage their profile and security settings.
 

--- a/docs/customization/account-portal/overview.mdx
+++ b/docs/customization/account-portal/overview.mdx
@@ -5,7 +5,7 @@ description: The Account Portal offers a comprehensive solution for managing use
 
 The Account Portal in Clerk is a powerful feature that allows you to streamline the sign-in, sign-up, and profile management experience for your users, without having to build your own components or host your own pages.
 
-<Images width={992} height={296} src="/docs/images/account-portal/account_portal_splash.png" alt="Account Portal" />
+![Account Portal](/docs/images/account-portal/account_portal_splash.png)
 
 ## Why use the Account Portal?
 
@@ -17,12 +17,7 @@ However, if you require more precise customization or prefer having your applica
 
 The Account Portal uses Clerk's [prebuilt components](/docs/components/overview), which are embedded into dedicated pages hosted on Clerk servers.
 
-<Images
-  width={1200}
-  height={350}
-  src="/docs/images/account-portal/account_portal_how_it_works.png"
-  alt="Account Portal"
-/>
+![Account Portal](/docs/images/account-portal/account_portal_how_it_works.png)
 
 After a user has finished their flow in an Account Portal page, Clerk automatically redirects them back to your application along with the required authentication context. This way, users are automatically redirected to and from your application for a seamless experience.
 

--- a/docs/customization/account-portal/user-profile-org-profile.mdx
+++ b/docs/customization/account-portal/user-profile-org-profile.mdx
@@ -11,12 +11,7 @@ You can use Clerk's Control Components to navigate your users to the appropriate
 
 The User Profile page is full-featured account management UI that allows users to manage their profile and security settings.
 
-<Images
-  width={3248}
-  height={1716}
-  src="/docs/images/account-portal/account_portal_user_profile.png"
-  alt="User Profile in Account Portal"
-/>
+![User Profile in Account Portal](/docs/images/account-portal/account_portal_user_profile.png)
 
 Redirect your authenticated users to their User Profile page using the [`<RedirectToUserProfile/>`](/docs/components/control/redirect-to-userprofile) control component.
 
@@ -24,12 +19,7 @@ Redirect your authenticated users to their User Profile page using the [`<Redire
 
 The Organization Profile page is a beautiful, full-featured organization management UI that allows users to manage their organization profile and security settings.
 
-<Images
-  width={3248}
-  height={1716}
-  src="/docs/images/account-portal/account_portal_org_profile.png"
-  alt="Organization Profile in Account Portal"
-/>
+![Organization Profile in Account Portal](/docs/images/account-portal/account_portal_org_profile.png)
 
 Redirect your authenticated users to their Organization Profile page using the [`<RedirectToOrganizationProfile/>`](/docs/components/control/redirect-to-organizationprofile) control component.
 
@@ -37,11 +27,6 @@ Redirect your authenticated users to their Organization Profile page using the [
 
 The Create Organization page is a UI that allows users to create brand new organizations within your application.
 
-<Images
-  width={3248}
-  height={1716}
-  src="/docs/images/account-portal/account_portal_create_org.png"
-  alt="Create Organization flow in Account Portal"
-/>
+![Create Organization flow in Account Portal](/docs/images/account-portal/account_portal_create_org.png)
 
 Redirect your authenticated users to the Create Organization flow using the [`<RedirectToCreateOrganization/>`](/docs/components/control/redirect-to-createorganization) control component.

--- a/docs/customization/themes.mdx
+++ b/docs/customization/themes.mdx
@@ -15,33 +15,25 @@ Clerk currently offers four pre-built themes:
 Applied by default when no other theme is provided.
 
 <div style={{padding: "1rem 0", filter: "drop-shadow(rgba(0, 0, 0, 0.16) 0px 12px 24px)"}}>
-  <Images width={400} height={510} src="/docs/images/themes/default.svg" alt="A sign-in form with a light theme" />
+  ![A sign-in form with a light theme](/docs/images/themes/default.svg)
 </div>
 
 ## "Dark" theme
 
 <div style={{padding: "1rem 0", filter: "drop-shadow(rgba(0, 0, 0, 0.16) 0px 12px 24px)"}}>
-  <Images width={400} height={510} src="/docs/images/themes/dark.svg" alt="A sign-in form with a dark theme" />
+  ![A sign-in form with a dark theme](/docs/images/themes/dark.svg)
 </div>
 
 ## "Shades of purple" theme
 
 <div style={{padding: "1rem 0", filter: "drop-shadow(rgba(0, 0, 0, 0.16) 0px 12px 24px)"}}>
-  <Images
-    style={{maxWidth: "400px", height: "auto"}}
-    src="/docs/images/themes/shades_of_purple.png"
-    alt="A sign-in form with a purple and yellow theme"
-  />
+  ![A sign-in form with a purple and yellow theme](/docs/images/themes/shades_of_purple.png){{ style: { maxWidth: '400px' } }}
 </div>
 
 ## "Neobrutalism" theme
 
 <div style={{padding: "1rem 0", filter: "drop-shadow(rgba(0, 0, 0, 0.16) 0px 12px 24px)"}}>
-  <Images
-    style={{maxWidth: "400px", height: "auto"}}
-    src="/docs/images/themes/neobrutalism.png"
-    alt="A sign-in form with a neobrutalist red theme"
-  />
+  ![A sign-in form with a neobrutalist red theme](/docs/images/themes/neobrutalism.png){{ style: { maxWidth: '400px' } }}
 </div>
 
 ## Usage

--- a/docs/guides/basic-rbac.mdx
+++ b/docs/guides/basic-rbac.mdx
@@ -23,12 +23,7 @@ In the Clerk Dashboard, navigate to [**Sessions**](https://dashboard.clerk.com/l
 }
 ```
 
-<Images
-  width={2494}
-  height={1400}
-  src="/docs/images/guides/basic-rbac/customize-session-token.webp"
-  alt="The Sessions page in the Clerk Dashboard with the 'Customize session token' modal opened. The modal has a text field with the JSON 'metadata': '{{user.public_metadata}}'."
-/>
+![The Sessions page in the Clerk Dashboard with the 'Customize session token' modal opened. The modal has a text field with the JSON 'metadata': '\{\{user.public\_metadata}}'.](/docs/images/guides/basic-rbac/customize-session-token.webp)
 
 > [!CAUTION]
 > The entire session token has a limit of 4kb of data. Exceeding this size can have adverse effects, including a possible infinite redirect loop for users who exceed this size in Next.js applications.
@@ -60,12 +55,7 @@ Later, you will add a basic admin tool to change the user's role, but for now, l
 }
 ```
 
-<Images
-  width={2494}
-  height={1400}
-  src="/docs/images/guides/basic-rbac/edit-public-metadata.webp"
-  alt="The Users page in the Clerk Dashboard with the 'Edit public metadata' modal open. The modal has a text field with the JSON 'role': 'admin'."
-/>
+![The Users page in the Clerk Dashboard with the 'Edit public metadata' modal open. The modal has a text field with the JSON 'role': 'admin'.](/docs/images/guides/basic-rbac/edit-public-metadata.webp)
 
 ## Create an admin dashboard and protect it
 

--- a/docs/integrations/analytics/google-analytics.mdx
+++ b/docs/integrations/analytics/google-analytics.mdx
@@ -12,21 +12,11 @@ To enable the integration, you will need to provide Clerk with the required Goog
 
 To get started, go to the Clerk Dashboard and navigate to the **[Integrations](https://dashboard.clerk.com/last-active?path=integrations)** page. Turn on the Google Analytics integration.
 
-<Images
-  width={3024}
-  height={1648}
-  src="/docs/images/integrations/google/integrations.webp"
-  alt="The Integrations page in the Clerk Dashboard. A red arrow points to the toggle next to 'Google Analytics'."
-/>
+![The Integrations page in the Clerk Dashboard. A red arrow points to the toggle next to 'Google Analytics'.](/docs/images/integrations/google/integrations.webp)
 
 Once enabled, you will be presented with a form to enter the required Google Analytics configuration attributes.
 
-<Images
-  width={2488}
-  height={1398}
-  src="/docs/images/integrations/google/configuration-settings.webp"
-  alt="The Google Analytics configuration form in the Clerk Dashboard."
-/>
+![The Google Analytics configuration form in the Clerk Dashboard.](/docs/images/integrations/google/configuration-settings.webp)
 
 ## Configuration
 
@@ -40,32 +30,17 @@ To send events to Google Analytics servers, Clerk uses the [Measurement Protocol
 
 - **API Secret**: An API secret generated in the Google Analytics UI. To create a new secret, navigate to **Admin → Data Streams → choose your stream → Measurement Protocol → Create**.
 
-<Images
-  width={2488}
-  height={1398}
-  src="/docs/images/integrations/google/api-secret.gif"
-  alt="A gif showing how to access the API secret in the Google Analytics UI."
-/>
+![A gif showing how to access the API secret in the Google Analytics UI.](/docs/images/integrations/google/api-secret.gif)
 
 - **Measurement ID**: The measurement ID associated with the data stream sending data to your Google Analytics 4 property. The format is **G-XXXXXXX** and can be found in the Google Analytics UI under **Admin → Data Streams → choose your stream → Measurement ID**.
 
-<Images
-  width={2488}
-  height={1398}
-  src="/docs/images/integrations/google/measurement-id.gif"
-  alt="A gif showing how to access the measurement ID in the Google Analytics UI."
-/>
+![A gif showing how to access the measurement ID in the Google Analytics UI.](/docs/images/integrations/google/measurement-id.gif)
 
 #### Universal Analytics
 
 - **Tracking ID**: The tracking ID is a string composed of your account number and the property index and is used to send data to the correct Google Analytics property. The format is **UA-YYYYYY-Z** and can be found in the Google Analytics UI under **Admin → Tracking Info → Tracking Code**.
 
-<Images
-  width={2836}
-  height={1061}
-  src="/docs/images/integrations/google/tracking-id.webp"
-  alt="A gif showing how to access the measurement ID in the Google Analytics UI."
-/>
+![A gif showing how to access the measurement ID in the Google Analytics UI.](/docs/images/integrations/google/tracking-id.webp)
 
 ### Include Clerk user ID
 

--- a/docs/integrations/databases/convex.mdx
+++ b/docs/integrations/databases/convex.mdx
@@ -35,30 +35,15 @@ This tutorial assumes that you have already [set up a Clerk application](/docs/q
 
   In the Clerk Dashboard, navigate to the [JWT Templates](https://dashboard.clerk.com/last-active?path=jwt-templates)page. Select the **New template** button to create a new template based on Convex.
 
-  <Images
-    width={3024}
-    height={1648}
-    src="/docs/images/integrations/convex/jwt-templates.webp"
-    alt="The JWT Templates page in the Clerk Dashboard. The 'New template' button was clicked, and a pop up titled 'New JWT template' is shown. The 'Convex' template is hovered over."
-  />
+  ![The JWT Templates page in the Clerk Dashboard. The 'New template' button was clicked, and a pop up titled 'New JWT template' is shown. The 'Convex' template is hovered over.](/docs/images/integrations/convex/jwt-templates.webp)
 
   Once the Convex template is created, you will be redirected to the template's page. You can now configure the template to your needs.
 
-  <Images
-    width={3024}
-    height={1648}
-    src="/docs/images/integrations/convex/create-template.webp"
-    alt="The 'Create new template' page of the JWT Templates page in the Clerk Dashboard."
-  />
+  ![The 'Create new template' page of the JWT Templates page in the Clerk Dashboard.](/docs/images/integrations/convex/create-template.webp)
 
   The Convex template will pre-populate the default audience (`aud`) claim required by Convex. You can include additional claims as necessary. [Shortcodes](/docs/backend-requests/making/jwt-templates#shortcodes) are available to make adding dynamic user values easy.
 
-  <Images
-    width={3024}
-    height={1648}
-    src="/docs/images/integrations/convex/template-shortcodes.webp"
-    alt="The 'Create new template' page of the JWT Templates page in the Clerk Dashboard. The page is scrolled down to the 'Claims' section."
-  />
+  ![The 'Create new template' page of the JWT Templates page in the Clerk Dashboard. The page is scrolled down to the 'Claims' section.](/docs/images/integrations/convex/template-shortcodes.webp)
 
   By default, Clerk will sign the JWT with a private key automatically generated for your application, which is what most developers use for Convex. If you so choose, you can customize this key.
 
@@ -66,12 +51,7 @@ This tutorial assumes that you have already [set up a Clerk application](/docs/q
 
   The next step is to configure Convex with the issuer domain provided by Clerk. From your Clerk **JWT template** screen, find the **Issuer** input and click to **Copy** the URL.
 
-  <Images
-    width={3024}
-    height={1648}
-    src="/docs/images/integrations/convex/template-issuer.webp"
-    alt="The 'Create new template' page of the JWT Templates page in the Clerk Dashboard. There is a red box surrounding the 'Issuer' section."
-  />
+  ![The 'Create new template' page of the JWT Templates page in the Clerk Dashboard. There is a red box surrounding the 'Issuer' section.](/docs/images/integrations/convex/template-issuer.webp)
 
   In your `convex` folder, add an `auth.config.js` file with the following configuration:
 

--- a/docs/integrations/databases/fauna.mdx
+++ b/docs/integrations/databases/fauna.mdx
@@ -7,21 +7,11 @@ The first step is to create a new Clerk application from your Clerk Dashboard if
 
 After your Clerk application has been created, in the Clerk Dashboard, navigate to the **[API keys](https://dashboard.clerk.com/last-active?path=api-keys)** page and copy your **Publishable key**.
 
-<Images
-  width={3024}
-  height={1648}
-  src="/docs/images/integrations/publishable-key.webp"
-  alt="The API keys page in the Clerk Dashboard. There is a red arrow pointing to the copy button next to the 'Publishable key'."
-/>
+![The API keys page in the Clerk Dashboard. There is a red arrow pointing to the copy button next to the 'Publishable key'.](/docs/images/integrations/publishable-key.webp)
 
 The next step is to head over to the Fauna database that you want Clerk-authenticated users to access. Click on the **Security** link on the left-hand navigation and then the **Providers** tab.
 
-<Images
-  width={3024}
-  height={1648}
-  src="/docs/images/integrations/fauna/security-providers.webp"
-  alt="The Security page in the Fauna dashboard. The Providers tab is the active tab."
-/>
+![The Security page in the Fauna dashboard. The Providers tab is the active tab.](/docs/images/integrations/fauna/security-providers.webp)
 
 Click the **New Access Provider** button.
 
@@ -36,23 +26,13 @@ Assuming you didn’t use a custom signing key, set the **JWKS endpoint** field 
 
 You can find this URL in the Clerk Dashboard on the **[API keys](https://dashboard.clerk.com/last-active?path=api-keys)** page. Scroll down and click on **Advanced**. In the **JWT public key** section, copy the **JWKS URL**.
 
-<Images
-  width={3024}
-  height={1648}
-  src="/docs/images/integrations/jwks-url.webp"
-  alt="The API Keys page in the Clerk Dashboard. A red box outlines the 'Advanced' drop down button. A red arrow is pointing to the copy button next to 'JWKS URL' in the 'JWT public key' section."
-/>
+![The API Keys page in the Clerk Dashboard. A red box outlines the 'Advanced' drop down button. A red arrow is pointing to the copy button next to 'JWKS URL' in the 'JWT public key' section.](/docs/images/integrations/jwks-url.webp)
 
 The last part is to select a role that will be assigned to authenticated users. The [Role](https://docs.fauna.com/fauna/current/cookbook/advanced/security/user-roles) defines the access privileges and domain-specific security rules. You can specify multiple roles if necessary.
 
 The completed provider form should resemble the following:
 
-<Images
-  width={3024}
-  height={1648}
-  src="/docs/images/integrations/fauna/new-access-provider.webp"
-  alt="The 'New access provider' form in Fauna."
-/>
+![The 'New access provider' form in Fauna.](/docs/images/integrations/fauna/new-access-provider.webp)
 
 Before clicking the **Save** button, copy the **Audience URL** and then go ahead and save.
 
@@ -60,30 +40,15 @@ Before clicking the **Save** button, copy the **Audience URL** and then go ahead
 
 In the Clerk Dashboard, navigate to the **[JWT Templates](https://dashboard.clerk.com/last-active?path=jwt-templates)** page. Click on the **New template** button to create a new template based on Fauna.
 
-<Images
-  width={3024}
-  height={1648}
-  src="/docs/images/integrations/fauna/jwt-templates.webp"
-  alt="The JWT Templates page in the Clerk Dashboard. The 'New template' button was clicked, and a pop up titled 'New JWT template' is shown. The 'Fauna' template is hovered over."
-/>
+![The JWT Templates page in the Clerk Dashboard. The 'New template' button was clicked, and a pop up titled 'New JWT template' is shown. The 'Fauna' template is hovered over.](/docs/images/integrations/fauna/jwt-templates.webp)
 
 Once the Convex template is created, you will be redirected to the template's page. You can now configure the template to your needs.
 
-<Images
-  width={3024}
-  height={1648}
-  src="/docs/images/integrations/fauna/create-template.webp"
-  alt="The 'Create new template' page of the JWT Templates page in the Clerk Dashboard."
-/>
+![The 'Create new template' page of the JWT Templates page in the Clerk Dashboard.](/docs/images/integrations/fauna/create-template.webp)
 
 Scroll down to the **Claims** section and set the `aud` claim to the **Audience URL** you copied from Fauna. The URL format should be `https://db.fauna.com/db/<YOUR_FAUNA_DB_ID>`.
 
-<Images
-  width={3024}
-  height={1648}
-  src="/docs/images/integrations/fauna/template-shortcodes.webp"
-  alt="The 'Create new template' page of the JWT Templates page in the Clerk Dashboard. The page is scrolled down to the 'Claims' section."
-/>
+![The 'Create new template' page of the JWT Templates page in the Clerk Dashboard. The page is scrolled down to the 'Claims' section.](/docs/images/integrations/fauna/template-shortcodes.webp)
 
 You can include additional claims if you’d like, but `aud` is the only required one. [Shortcodes](/docs/backend-requests/making/jwt-templates#shortcodes) are available to make adding dynamic user values easy.
 

--- a/docs/integrations/databases/grafbase.mdx
+++ b/docs/integrations/databases/grafbase.mdx
@@ -7,44 +7,24 @@ The first step is to create a new Clerk application from your Clerk Dashboard if
 
 After your Clerk application has been created, go to the Clerk Dashboard and navigate to the **[JWT Templates](https://dashboard.clerk.com/last-active?path=jwt-templates)** page. Click on the **New template** button to create a new template based on Grafbase.
 
-<Images
-  width={3024}
-  height={1652}
-  src="/docs/images/integrations/grafbase/jwt-template.webp"
-  alt="The JWT Templates page in the Clerk Dashboard. The 'New template' button was clicked, and a pop up titled 'New JWT template' is shown. The 'Grafbase' template is hovered over."
-/>
+![The JWT Templates page in the Clerk Dashboard. The 'New template' button was clicked, and a pop up titled 'New JWT template' is shown. The 'Grafbase' template is hovered over.](/docs/images/integrations/grafbase/jwt-template.webp)
 
 Once the Grafbase template is created, you will be redirected to the template's page. You can now configure the template to your needs.
 
-<Images
-  width={3024}
-  height={1652}
-  src="/docs/images/integrations/grafbase/create-template.webp"
-  alt="The 'Create new template' page of the JWT Templates page in the Clerk Dashboard."
-/>
+![The 'Create new template' page of the JWT Templates page in the Clerk Dashboard.](/docs/images/integrations/grafbase/create-template.webp)
 
 The Grafbase template will pre-populate the default claims required by Grafbase. You can include additional claims as necessary. [Shortcodes](/docs/backend-requests/making/jwt-templates#shortcodes) are available to make adding dynamic user values easy.
 
 > [!NOTE]
 > If your GraphQL API restricts access based on groups, you’ll need to specify the users groups in the `groups` claim.
 
-<Images
-  width={3024}
-  height={1652}
-  src="/docs/images/integrations/grafbase/template-shortcodes.webp"
-  alt="The 'Create new template' page of the JWT Templates page in the Clerk Dashboard. The page is scrolled down to the 'Claims' section."
-/>
+![The 'Create new template' page of the JWT Templates page in the Clerk Dashboard. The page is scrolled down to the 'Claims' section.](/docs/images/integrations/grafbase/template-shortcodes.webp)
 
 ## Configure Grafbase
 
 The next step is to configure Grafbase with the issuer domain provided by Clerk. From your Clerk **JWT template** screen, find the **Issuer** input and click to **Copy** the URL.
 
-<Images
-  width={3024}
-  height={1652}
-  src="/docs/images/integrations/grafbase/template-issuer.webp"
-  alt="The 'Create new template' page of the JWT Templates page in the Clerk Dashboard. There is a red box surrounding the 'Issuer' section."
-/>
+![The 'Create new template' page of the JWT Templates page in the Clerk Dashboard. There is a red box surrounding the 'Issuer' section.](/docs/images/integrations/grafbase/template-issuer.webp)
 
 ### Signed in user authentication
 

--- a/docs/integrations/databases/hasura.mdx
+++ b/docs/integrations/databases/hasura.mdx
@@ -7,30 +7,15 @@ The first step is to create a new Clerk application from your Clerk Dashboard if
 
 After your Clerk application has been created, go to the Clerk Dashboard and navigate to the **[JWT Templates](https://dashboard.clerk.com/last-active?path=jwt-templates)** page. Click on the **New template** button to create a new template based on Hasura.
 
-<Images
-  width={3024}
-  height={1652}
-  src="/docs/images/integrations/hasura/jwt-template.webp"
-  alt="The JWT Templates page in the Clerk Dashboard. The 'New template' button was clicked, and a pop up titled 'New JWT template' is shown. The 'Hasura' template is hovered over."
-/>
+![The JWT Templates page in the Clerk Dashboard. The 'New template' button was clicked, and a pop up titled 'New JWT template' is shown. The 'Hasura' template is hovered over.](/docs/images/integrations/hasura/jwt-template.webp)
 
 Once the Hasura template is created, you will be redirected to the template's page. You can now configure the template to your needs.
 
-<Images
-  width={3024}
-  height={1652}
-  src="/docs/images/integrations/hasura/create-template.webp"
-  alt="The 'Create new template' page of the JWT Templates page in the Clerk Dashboard."
-/>
+![The 'Create new template' page of the JWT Templates page in the Clerk Dashboard.](/docs/images/integrations/hasura/create-template.webp)
 
 The Hasura template will pre-populate the default claims required by Hasura. You can include additional claims as necessary. [Shortcodes](/docs/backend-requests/making/jwt-templates#shortcodes) are available to make adding dynamic user values easy.
 
-<Images
-  width={3024}
-  height={1652}
-  src="/docs/images/integrations/hasura/template-shortcodes.webp"
-  alt="The 'Create new template' page of the JWT Templates page in the Clerk Dashboard. The page is scrolled down to the 'Claims' section."
-/>
+![The 'Create new template' page of the JWT Templates page in the Clerk Dashboard. The page is scrolled down to the 'Claims' section.](/docs/images/integrations/hasura/template-shortcodes.webp)
 
 By default, Clerk will sign the JWT with a private key automatically generated for your application, which is what most developers use for Hasura. If you so choose, you can customize this key.
 
@@ -40,12 +25,7 @@ The next step is to provide Hasura with the public keys used to verify the JWT i
 
 You can find this URL in the Clerk Dashboard on the **[API keys](https://dashboard.clerk.com/last-active?path=api-keys)** page. Scroll down and click on **Advanced**. In the **JWT public key** section, copy the **JWKS URL**.
 
-<Images
-  width={3024}
-  height={1648}
-  src="/docs/images/integrations/jwks-url.webp"
-  alt="The API Keys page in the Clerk Dashboard. A red box outlines the 'Advanced' drop down button. A red arrow is pointing to the copy button next to 'JWKS URL' in the 'JWT public key' section."
-/>
+![The API Keys page in the Clerk Dashboard. A red box outlines the 'Advanced' drop down button. A red arrow is pointing to the copy button next to 'JWKS URL' in the 'JWT public key' section.](/docs/images/integrations/jwks-url.webp)
 
 You can set up your project either with Hasura Cloud or you can [run the Hasura GraphQL engine locally using Docker Compose](https://hasura.io/docs/latest/graphql/core/getting-started/docker-simple.html#docker-simple).
 

--- a/docs/integrations/databases/nhost.mdx
+++ b/docs/integrations/databases/nhost.mdx
@@ -7,30 +7,15 @@ The first step is to create a new Clerk application from your Clerk Dashboard if
 
 After your Clerk application has been created, go to the Clerk Dashboard and navigate to the **[JWT Templates](https://dashboard.clerk.com/last-active?path=jwt-templates)** page. Click on the **New template** button to create a new template based on Nhost.
 
-<Images
-  width={3024}
-  height={1652}
-  src="/docs/images/integrations/nhost/jwt-template.webp"
-  alt="The JWT Templates page in the Clerk Dashboard. The 'New template' button was clicked, and a pop up titled 'New JWT template' is shown. The 'Nhost' template is hovered over."
-/>
+![The JWT Templates page in the Clerk Dashboard. The 'New template' button was clicked, and a pop up titled 'New JWT template' is shown. The 'Nhost' template is hovered over.](/docs/images/integrations/nhost/jwt-template.webp)
 
 Once the Nhost template is created, you will be redirected to the template's page. You can now configure the template to your needs.
 
-<Images
-  width={3024}
-  height={1652}
-  src="/docs/images/integrations/nhost/create-template.webp"
-  alt="The 'Create new template' page of the JWT Templates page in the Clerk Dashboard."
-/>
+![The 'Create new template' page of the JWT Templates page in the Clerk Dashboard.](/docs/images/integrations/nhost/create-template.webp)
 
 The Nhost template will pre-populate the default claims required by Nhost and Hasura. You can include additional claims as necessary. [Shortcodes](/docs/backend-requests/making/jwt-templates#shortcodes) are available to make adding dynamic user values easy.
 
-<Images
-  width={3024}
-  height={1652}
-  src="/docs/images/integrations/nhost/template-shortcodes.webp"
-  alt="The 'Create new template' page of the JWT Templates page in the Clerk Dashboard. The page is scrolled down to the 'Claims' section."
-/>
+![The 'Create new template' page of the JWT Templates page in the Clerk Dashboard. The page is scrolled down to the 'Claims' section.](/docs/images/integrations/nhost/template-shortcodes.webp)
 
 ## Configure Nhost
 
@@ -38,21 +23,11 @@ The next step is to provide Nhost with the public keys used to verify the JWT is
 
 You can find this URL in the Clerk Dashboard on the **[API keys](https://dashboard.clerk.com/last-active?path=api-keys)** page. Scroll down and click on **Advanced**. In the **JWT public key** section, copy the **JWKS URL**.
 
-<Images
-  width={3024}
-  height={1648}
-  src="/docs/images/integrations/jwks-url.webp"
-  alt="The API Keys page in the Clerk Dashboard. A red box outlines the 'Advanced' drop down button. A red arrow is pointing to the copy button next to 'JWKS URL' in the 'JWT public key' section."
-/>
+![The API Keys page in the Clerk Dashboard. A red box outlines the 'Advanced' drop down button. A red arrow is pointing to the copy button next to 'JWKS URL' in the 'JWT public key' section.](/docs/images/integrations/jwks-url.webp)
 
 From your Nhost dashboard, navigate to **Settings** --> **Environment variables**.
 
-<Images
-  width={1889}
-  height={1192}
-  src="/docs/images/integrations/nhost/nhost-env-var.webp"
-  alt="The Environment variables page in the Nhost dashboard."
-/>
+![The Environment variables page in the Nhost dashboard.](/docs/images/integrations/nhost/nhost-env-var.webp)
 
 Next to the **NOHST\_JWT\_SECRET**, click the **Edit** button and paste in the **JWKS URL** that you copied from the Clerk Dashboard.
 

--- a/docs/integrations/webhooks/inngest.mdx
+++ b/docs/integrations/webhooks/inngest.mdx
@@ -18,48 +18,23 @@ To follow this guide, you need an Inngest account (free tier is enough) and have
 
 To create an Inngest webhook endpoint and add it to your Clerk account, open the [Webhooks](https://dashboard.clerk.com/last-active?path=webhooks) page at the Clerk dashboard. Next, select the **Add Endpoint** button.
 
-<Images
-  width={2578}
-  height={1652}
-  src="/docs/images/integrations/inngest/webhook-page.webp"
-  alt="The Webhooks page in the Clerk Dashboard. A red arrow points to the button for Add Endpoint."
-/>
+![The Webhooks page in the Clerk Dashboard. A red arrow points to the button for Add Endpoint.](/docs/images/integrations/inngest/webhook-page.webp)
 
 On the next page, select the **Transformation template** tab and the **Inngest** template, then click on the **Connect to Inngest** button.
 
-<Images
-  width={1906}
-  height={1376}
-  src="/docs/images/integrations/inngest/webhook-transformation-template.webp"
-  alt="The Webhooks page in the Clerk Dashboard showing the Inngest transformation template. Red arrows point to the Transformation Template tab, the Inngest template, and the Connect to Inngest button."
-/>
+![The Webhooks page in the Clerk Dashboard showing the Inngest transformation template. Red arrows point to the Transformation Template tab, the Inngest template, and the Connect to Inngest button.](/docs/images/integrations/inngest/webhook-transformation-template.webp)
 
 A popup window will appear to complete the setup. Select **Approve** to create the webhook.
 
-<Images
-  width={1194}
-  height={1520}
-  src="/docs/images/integrations/inngest/inngest-permissions-dialog.webp"
-  alt="The Inngest permissions popup window showing the Approve button."
-/>
+![The Inngest permissions popup window showing the Approve button.](/docs/images/integrations/inngest/inngest-permissions-dialog.webp)
 
 After the popup window disappears, the Webhooks page will now display **Connected** with the webhook URL underneath. There is one more step to complete setup.
 
-<Images
-  width={1880}
-  height={1448}
-  src="/docs/images/integrations/inngest/webhook-endpoint-connected.webp"
-  alt="The Webhooks page in the Clerk Dashboard showing a connected Inngest account. A red arrow points to the Connected button."
-/>
+![The Webhooks page in the Clerk Dashboard showing a connected Inngest account. A red arrow points to the Connected button.](/docs/images/integrations/inngest/webhook-endpoint-connected.webp)
 
 To complete the setup, scroll down and select **Create**.
 
-<Images
-  width={1906}
-  height={1376}
-  src="/docs/images/integrations/inngest/webhook-create.webp"
-  alt="The Webhooks page in the Clerk Dashboard showing the end of the page to create a new endpoint. A red arrow points to the Create button."
-/>
+![The Webhooks page in the Clerk Dashboard showing the end of the page to create a new endpoint. A red arrow points to the Create button.](/docs/images/integrations/inngest/webhook-create.webp)
 
 You'll be redirected to the new endpoint. In your Inngest dashboard, you will see a new webhook created in your account's [production environment](https://app.inngest.com/env/production/manage/webhooks).
 
@@ -67,12 +42,7 @@ You'll be redirected to the new endpoint. In your Inngest dashboard, you will se
 
 After setup, as webhook events are sent from Clerk to Inngest, new `clerk` events will appear in your [Inngest dashboard](https://app.inngest.com/env/production/events). Event names will be the prefixed `clerk/` followed by the event name. See [webhook events](/docs/integrations/webhooks/overview#supported-webhook-events) for a full list.
 
-<Images
-  width={1052}
-  height={860}
-  src="/docs/images/integrations/inngest/inngest-clerk-events.webp"
-  alt="The Events page in the Inngest Dashboard showing a list of Clerk events."
-/>
+![The Events page in the Inngest Dashboard showing a list of Clerk events.](/docs/images/integrations/inngest/inngest-clerk-events.webp)
 
 ## Creating a function to sync a new user to a database
 
@@ -176,30 +146,15 @@ In your browser open [http://localhost:8288](http://localhost:8288) to see the I
 
 To quickly get events to test within Dev Server, you can select any individual event from the **Events** tab then select the **Send to Dev Server**.
 
-<Images
-  width={2142}
-  height={1246}
-  src="/docs/images/integrations/inngest/inngest-send-to-dev-server.webp"
-  alt="The Inngest Dashboard showing an individual event payload. Red arrows point to the Events tab and the Send to Dev Server button."
-/>
+![The Inngest Dashboard showing an individual event payload. Red arrows point to the Events tab and the Send to Dev Server button.](/docs/images/integrations/inngest/inngest-send-to-dev-server.webp)
 
 You'll now see the event in the Inngest Dev Server's **Stream** tab alongside any functions that it triggered.
 
-<Images
-  width={1328}
-  height={670}
-  src="/docs/images/integrations/inngest/inngest-dev-server.webp"
-  alt="The Inngest Dev Server showing the Stream tab. The forwarded event is visible in the stream."
-/>
+![The Inngest Dev Server showing the Stream tab. The forwarded event is visible in the stream.](/docs/images/integrations/inngest/inngest-dev-server.webp)
 
 From here you can select the event, replay it to re-run any functions or edit and replay to edit the event payload to test different types of events.
 
-<Images
-  width={1170}
-  height={1114}
-  src="/docs/images/integrations/inngest/inngest-replay-event.webp"
-  alt="The Inngest Dev Server showing the forwarded event payload. A red arrow points to the Replay button."
-/>
+![The Inngest Dev Server showing the forwarded event payload. A red arrow points to the Replay button.](/docs/images/integrations/inngest/inngest-replay-event.webp)
 
 ## Conclusion
 

--- a/docs/security/customize-user-lockout.mdx
+++ b/docs/security/customize-user-lockout.mdx
@@ -13,7 +13,7 @@ Clerk provides an Account Lockout feature in order to protect user credentials a
 1. To change the duration, under **Lockout duration,** select **Time limit**. Then, select the unit of time (minutes/hours/days/years) and enter the number of units you want lockouts to last.
 1. Select **Save changes** to apply your settings.
 
-<Images width={1512} height={914} src="/docs/images/security/userlock_custom-attempts-and-duration.webp" alt=" " />
+![](/docs/images/security/userlock_custom-attempts-and-duration.webp)
 
 ## Lock a user account forever until an admin unlocks the account
 
@@ -21,4 +21,4 @@ Clerk provides an Account Lockout feature in order to protect user credentials a
 1. Under **Lockout duration,** select **Indefinite Lockout**.
 1. Select **Save changes** to apply your settings.
 
-<Images width={1512} height={914} src="/docs/images/security/userlock_indefinite.webp" alt=" " />
+![](/docs/images/security/userlock_indefinite.webp)

--- a/docs/security/email-link-protection.mdx
+++ b/docs/security/email-link-protection.mdx
@@ -15,12 +15,7 @@ Disabling this protection means that your users are vulnerable to the scenario a
 
 With same device and browser protection on, users will see the following warning if an email link for sign-in or sign-up was opened on a different device or browser:
 
-<Images
-  width={1512}
-  height={914}
-  src="/docs/images/security/email-link_require-same-client.webp"
-  alt="Error message displayed if email link is opened in a different device or browser if email link same device/browser protection is enabled"
-/>
+![Error message displayed if email link is opened in a different device or browser if email link same device/browser protection is enabled](/docs/images/security/email-link_require-same-client.webp)
 
 To configure this security setting, navigate to the [Clerk Dashboard](https://dashboard.clerk.com/last-active?path=user-authentication/email-phone-username) and in the navigation sidebar, select **Email, Phone, Username**. This protection can be enabled for **sign-ins** and **sign-ups** in two ways.
 

--- a/docs/security/unlock-user-accounts.mdx
+++ b/docs/security/unlock-user-accounts.mdx
@@ -13,7 +13,7 @@ Users with admin roles can override lockouts through the Clerk Dashboard.
 1. Open the admin menu by selecting the icon that looks like three stacked dots.
 1. Select **Unlock** to unlock the user account.
 
-<Images width={1512} height={914} src="/docs/images/security/userlock_dashboard.webp" alt=" " />
+![](/docs/images/security/userlock_dashboard.webp)
 
 Alternatively, you can unlock a user's account on their profile page.
 
@@ -22,4 +22,4 @@ Alternatively, you can unlock a user's account on their profile page.
 1. Click on the user's row to be taken to their profile page.
 1. Scroll to the **Unlock user** section, and select **Unlock user**.
 
-<Images width={1512} height={914} src="/docs/images/security/userlock_profile.webp" alt=" " />
+![](/docs/images/security/userlock_profile.webp)

--- a/docs/security/user-lock-guide.mdx
+++ b/docs/security/user-lock-guide.mdx
@@ -35,12 +35,7 @@ Clerk measures the following actions as part of Account Lockout:
 
 When a user exceeds the maximum sign-in attempts, the Clerk [`<SignIn />`](/docs/components/authentication/sign-in) component will inform them of how long they have been locked out for and to contact support for more information.
 
-<Images
-  width={1512}
-  height={914}
-  src="/docs/images/security/userlock_login.png"
-  alt="The Clerk component sign-in form with a red alert stating 'Your account is locked. You will be able to try again in 59 minutes. For more information, please contact support.'"
-/>
+![The Clerk component sign-in form with a red alert stating 'Your account is locked. You will be able to try again in 59 minutes. For more information, please contact support.'](/docs/images/security/userlock_login.png)
 
 > [!NOTE]
 > Currently, users cannot unlock their own account or submit a request to the admin to be unlocked ("self-service unlock"). This is an upcoming feature, so please check Clerk's [changelog](/blog){{ target: '_blank' }} periodically to find out when it is available. Until then, you can [programmatically lock and unlock user accounts with a custom flow](/docs/security/programmatically-lock-user-accounts).

--- a/docs/testing/postman-or-insomnia.mdx
+++ b/docs/testing/postman-or-insomnia.mdx
@@ -11,21 +11,11 @@ The standard token issued by Clerk expires after 60 seconds. Clerk SDKs handle r
 
 You will want to create a long-lived [JWT Template](/docs/backend-requests/making/jwt-templates) to be used in Postman or Insomnia. To do so, go to the Clerk Dashboard and navigate to the **[JWT Templates](https://dashboard.clerk.com/last-active?path=jwt-templates)** page. Click on the **New template** button and select the **Blank** template.
 
-<Images
-  src="/docs/images/testing/blank-jwt-template.webp"
-  width={3024}
-  height={1654}
-  alt="The JWT Template page in the Clerk Dashboard. The 'New template' button was clicked, in the modal that opened, the 'Blank' template is hovered over."
-/>
+![The JWT Template page in the Clerk Dashboard. The 'New template' button was clicked, in the modal that opened, the 'Blank' template is hovered over.](/docs/images/testing/blank-jwt-template.webp)
 
 Give your template a unique name, such as _'testing-template'_. Set the **Token Lifetime** to a value that suits your needs, or use the maximum of 315360000 seconds (10 years). If you added custom claims to the normal session token, then you should add the same claims to your JWT Template.
 
-<Images
-  src="/docs/images/testing/testing-template.webp"
-  width={2492}
-  height={1400}
-  alt="Creating a JWT Template in the Clerk Dashboard"
-/>
+![Creating a JWT Template in the Clerk Dashboard](/docs/images/testing/testing-template.webp)
 
 ## Fetch long-lived token
 
@@ -35,12 +25,7 @@ Visit your frontend that is using the same Clerk Application and instance that y
 await window.Clerk.session.getToken({ template: '<the template name you chose above>' })
 ```
 
-<Images
-  src="/docs/images/testing/get-token-from-console.webp"
-  width={1075}
-  height={479}
-  alt="The Dev Tools Console with the command 'await window.Clerk.session.getToken()' entered. The token is logged to the console."
-/>
+![The Dev Tools Console with the command 'await window.Clerk.session.getToken()' entered. The token is logged to the console.](/docs/images/testing/get-token-from-console.webp)
 
 ## Using Postman or Insomnia
 
@@ -48,59 +33,29 @@ await window.Clerk.session.getToken({ template: '<the template name you chose ab
   <Tab>
     Open Postman and create a new request.
 
-    <Images
-      src="/docs/images/testing/postman-new-request.webp"
-      width={2552}
-      height={1592}
-      alt="The Postman app with a red arrow pointing at the plus icon in the top left corner."
-    />
+    ![The Postman app with a red arrow pointing at the plus icon in the top left corner.](/docs/images/testing/postman-new-request.webp)
 
     Configure Postman with the method and URL for the API Route you want to test. This example uses the `POST` method and the `/api/protected-route` route.
 
-    <Images
-      src="/docs/images/testing/postman-configure-request.webp"
-      width={2552}
-      height={1592}
-      alt="The Postman app with a red box around the method and URL field."
-    />
+    ![The Postman app with a red box around the method and URL field.](/docs/images/testing/postman-configure-request.webp)
 
     Navigate to the **Authorization** tab and for token type, select **Bearer Token**. Paste the token you copied from the console as the Bearer Token. Your request will now authenticate as the user you created the token with.
 
-    <Images
-      src="/docs/images/testing/postman-bearer-token.webp"
-      width={2552}
-      height={1592}
-      alt="The Postman app with the first red arrow pointing at the Authorization tab, the second red arrow pointing at the token type with 'Bearer token' chosen, and a third red arrow pointing at the token field with the token pasted in."
-    />
+    ![The Postman app with the first red arrow pointing at the Authorization tab, the second red arrow pointing at the token type with 'Bearer token' chosen, and a third red arrow pointing at the token field with the token pasted in.](/docs/images/testing/postman-bearer-token.webp)
   </Tab>
 
   <Tab>
     Open Insomnia and create a new request.
 
-    <Images
-      src="/docs/images/testing/insomnia-new-request.webp"
-      width={2552}
-      height={1430}
-      alt="The Insomnia app with a red arrow pointing at the 'New HTTP Request' button."
-    />
+    ![The Insomnia app with a red arrow pointing at the 'New HTTP Request' button.](/docs/images/testing/insomnia-new-request.webp)
 
     Configure Insomnia with the method and URL for the API Route you want to test. This example uses the `POST` method and the `/api/protected-route` route.
 
-    <Images
-      src="/docs/images/testing/insomnia-configure-request.webp"
-      width={2552}
-      height={1430}
-      alt="The Insomnia app with a red box around the method and URL field."
-    />
+    ![The Insomnia app with a red box around the method and URL field.](/docs/images/testing/insomnia-configure-request.webp)
 
     Navigate to the **Auth** tab and click on **Auth** again to show a menu of auth types. Choose the **Bearer token** option. Paste the token you copied from the console. Your request will now authenticate as the user you created the token with.
 
-    <Images
-      src="/docs/images/testing/insomnia-bearer-token.webp"
-      width={2552}
-      height={1430}
-      alt="The Insomnia app with the first red arrow pointing at the Auth tab which has been switched to the 'Bearer token' option. The second red arrow points at the token field with the token pasted in."
-    />
+    ![The Insomnia app with the first red arrow pointing at the Auth tab which has been switched to the 'Bearer token' option. The second red arrow points at the token field with the token pasted in.](/docs/images/testing/insomnia-bearer-token.webp)
   </Tab>
 </Tabs>
 

--- a/docs/testing/test-emails-and-phones.mdx
+++ b/docs/testing/test-emails-and-phones.mdx
@@ -34,12 +34,7 @@ Every development instance has "test mode" enabled by default. If you need to us
 
 To enable test mode via the Clerk Dashboard, navigate to the **Settings** page in the Clerk Dashboard. In the **Enable test mode** section, ensure the toggle is toggled on.
 
-<Images
-  width={756}
-  height={412.5}
-  src="/docs/images/testing/enable-test-mode.webp"
-  alt="The 'Enable test mode' section of the Settings page in the Clerk Dashboard. There is a red arrow pointing to the toggled, which is toggled on."
-/>
+![The 'Enable test mode' section of the Settings page in the Clerk Dashboard. There is a red arrow pointing to the toggled, which is toggled on.](/docs/images/testing/enable-test-mode.webp)
 
 ## How to use test mode
 

--- a/docs/troubleshooting/create-a-minimal-reproduction.mdx
+++ b/docs/troubleshooting/create-a-minimal-reproduction.mdx
@@ -33,12 +33,7 @@ The best way to create a minimal reproduction is to start fresh, with a minimal 
 
   In the example below, you can see options for cloning the [Clerk Next.js App Router](https://github.com/clerk/clerk-nextjs-app-quickstart) repository.
 
-  <Images
-    width={3024}
-    height={1654}
-    src="/docs/images/troubleshooting/how-to-clone.webp"
-    alt="The 'clerk-nextjs-app-quickstart' repository page with the 'Code' button clicked on and its drop down menu is opened. There is a red arrow pointing to the 'Code' button."
-  />
+  ![The 'clerk-nextjs-app-quickstart' repository page with the 'Code' button clicked on and its drop down menu is opened. There is a red arrow pointing to the 'Code' button.](/docs/images/troubleshooting/how-to-clone.webp)
 
   ### Create a Clerk application
 


### PR DESCRIPTION
This PR replaces the old `Images` component with standard Markdown image syntax:

```diff
- <Images width={2279} height={1135} src="/docs/images/advance/clerk-idp-flow.svg" alt="Clerk IDP Flow" />
+ ![Clerk IDP Flow](/docs/images/advance/clerk-idp-flow.svg)
```