### PR TITLE
docs(errors): adding form error codes and rate limit error codes

### DIFF
--- a/docs/errors/forms.mdx
+++ b/docs/errors/forms.mdx
@@ -1,0 +1,75 @@
+---
+title: Form errors
+description: An index of Clerk errors related to forms.
+type: reference
+---
+
+# Forms Errors
+
+An index of Clerk errors related to forms.
+
+## `FormPasswordLengthTooShortCode`
+
+Signifies an error when the password is invalid because it is too short.
+
+```json {{ prettier: false }}
+{
+	"shortMessage": "Passwords must be %d characters or more.", 
+ "code": "form_password_length_too_short"
+}
+```
+
+## `FormInvalidPasswordLengthTooLong`
+
+Signifies an error when the password is invalid because it is too long.
+
+```json {{ prettier: false }}
+{
+	"shortMessage": "Passwords must be less than %d characters.", 
+ "code": "form_password_length_too_long"
+}
+```
+
+## `FormPasswordIncorrectCode`
+
+Signifies an error when the given password is incorrect.
+
+```json {{ prettier: false }}
+{
+	"shortMessage": "Password is incorrect. Try again, or use another method.", 
+ "code": "form_password_incorrect"
+}
+```
+
+## `FormIdentifierNotFoundCode`
+
+Signifies an error when a required identifier is not found.
+
+```json {{ prettier: false }}
+{
+	"shortMessage": "Couldn't find your account.", 
+ "code": "form_identifier_not_found"
+}
+```
+
+## `FormIdentifierExistsCode`
+
+Signifies an error when given identifier already exists.
+
+```json {{ prettier: false }}
+{
+	"shortMessage": "That %s is taken. Please try another.", 
+ "code": "form_identifier_exists"
+}
+```
+
+## `FormIdentifierNotFoundCode`
+
+Signifies an error when a required identifier is not found.
+
+```json {{ prettier: false }}
+{
+	"shortMessage": "Couldn't find your account.", 
+ "code": "form_identifier_not_found"
+}
+```

--- a/docs/errors/rate-limits.mdx
+++ b/docs/errors/rate-limits.mdx
@@ -1,0 +1,29 @@
+---
+title: Rate limit errors
+description: An index of Clerk errors related to rate limits.
+type: reference
+---
+
+# Rate Limit Errors
+
+An index of Clerk errors related to rate limits.
+
+## `TooManyRequests`
+
+```json {{ prettier: false }}
+{
+	"shortMessage": "Too many requests", 	
+ 	"longMessage":  "Too many requests, retry later",  	
+ 	"code":  "too_many_requests"
+}
+```
+
+## `VerificationCodeTooManyRequestsCode`
+
+```json {{ prettier: false }}
+{
+	"shortMessage": "Too many verification code requests",
+	"longMessage":  "Too many verification code requests. Please wait at least 30 seconds to receive your code before trying again.",
+ 	"code":  "verification_code_too_many_requests"
+}
+```

--- a/docs/manifest.json
+++ b/docs/manifest.json
@@ -999,12 +999,20 @@
                     "href": "/docs/errors/features"
                   },
                   {
+                    "title": "Forms",
+                    "href": "/docs/errors/forms"
+                  },
+                  {
                     "title": "Identifications",
                     "href": "/docs/errors/identifications"
                   },
                   {
                     "title": "Passkeys",
                     "href": "/docs/errors/passkeys"
+                  },
+                  {
+                    "title": "Rate Limits",
+                    "href": "/docs/errors/rate-limits"
                   },
                   {
                     "title": "Sign-in",


### PR DESCRIPTION
<!--- Add the "deploy-preview" label and add your page previews here -->

> [!IMPORTANT]
> 🔎 Previews:
>
> -

<!--- Describe your changes in detail. Why does this change need to happen? Include any links to Slack discussions, Linear comments, etc. -->

### Explanation:

We are missing several error codes within our docs, however, these were recently requested by a client.

<!--- How does this PR solve the problem? -->

### This PR:

- Added missing error codes for forms and rate limits - fixes https://linear.app/clerk/issue/DOCS-9033/adding-missing-error-codes-to-docs-pages