### PR TITLE
fix: Update handshake in SDK Development spec

### DIFF
--- a/docs/references/sdk/backend-only.mdx
+++ b/docs/references/sdk/backend-only.mdx
@@ -159,38 +159,4 @@ You can manually create a wrapper library around the [BAPI OpenAPI](https://cler
 
   app.get('/path', requireAuth(), hasPermission())
   ```
-
-  ### Add handshake support
-
-  Inside your Clerk middleware, add checks for the `headers` on the `requestState`. Apply these headers to the `Response` and handle any existing `location` headers (e.g. redirects).
-
-  ```ts {{ filename: 'clerk-middleware.ts', mark: [[9, 20]] }}
-  import { clerkClient as defaultClerkClient } from './client.ts'
-
-  const clerkMiddleware = (options) => {
-    return async (context, next) => {
-      const clerkClient = options.clerkClient || defaultClerkClient
-
-      const requestState = await clerkClient.authenticateRequest(context.req)
-
-      if (requestState.headers) {
-        // This adds observability headers to the res
-        requestState.headers.forEach((value, key) => context.res.headers.append(key, value))
-
-        const locationHeader = requestState.headers.get('location')
-
-        if (locationHeader) {
-          return context.redirect(locationHeader, 307)
-        } else if (requestState.status === 'handshake') {
-          throw new Error('Clerk: unexpected handshake without redirect')
-        }
-      }
-
-      context.set('clerkAuth', requestState.toAuth())
-      context.set('clerk', clerkClient)
-
-      await next()
-    }
-  }
-  ```
 </Steps>

--- a/docs/references/sdk/fullstack.mdx
+++ b/docs/references/sdk/fullstack.mdx
@@ -25,5 +25,43 @@ A fullstack SDK combines the [frontend-only SDK](/docs/references/sdk/frontend-o
 
 Please check out the respective [frontend-only SDK](/docs/references/sdk/frontend-only) and [backend-only SDK](/docs/references/sdk/backend-only) implementation instructions.
 
+In addition to these instructions, you'll need to go through the following steps to support all required features.
+
 > [!NOTE]
 > If you're looking for a real-world example, have a look at [`@clerk/nextjs`](https://github.com/clerk/javascript/tree/main/packages/nextjs).
+
+<Steps>
+  ### Add handshake support
+
+  Inside your Clerk middleware, add checks for the `headers` on the `requestState`. Apply these headers to the `Response` and handle any existing `location` headers (e.g. redirects).
+
+  ```ts {{ filename: 'clerk-middleware.ts', mark: [[9, 20]] }}
+  import { clerkClient as defaultClerkClient } from './client.ts'
+
+  const clerkMiddleware = (options) => {
+    return async (context, next) => {
+      const clerkClient = options.clerkClient || defaultClerkClient
+
+      const requestState = await clerkClient.authenticateRequest(context.req)
+
+      if (requestState.headers) {
+        // This adds observability headers to the res
+        requestState.headers.forEach((value, key) => context.res.headers.append(key, value))
+
+        const locationHeader = requestState.headers.get('location')
+
+        if (locationHeader) {
+          return context.redirect(locationHeader, 307)
+        } else if (requestState.status === 'handshake') {
+          throw new Error('Clerk: unexpected handshake without redirect')
+        }
+      }
+
+      context.set('clerkAuth', requestState.toAuth())
+      context.set('clerk', clerkClient)
+
+      await next()
+    }
+  }
+  ```
+</Steps>

--- a/docs/references/sdk/types.mdx
+++ b/docs/references/sdk/types.mdx
@@ -14,7 +14,7 @@ Take a look at your framework and check which type it enables. Then place your S
 | SDK Type | FAPI HTTP client | BAPI HTTP client | Hotloading ClerkJS | `window.Clerk` UI components | Authorization header verification | `__session` cookie verification | Handshake support |
 | - | - | - | - | - | - | - | - |
 | Frontend-only | ✅ | | ✅ | ✅ | | | |
-| Backend-only | | ✅ | | | ✅ | ✅ | ✅ |
+| Backend-only | | ✅ | | | ✅ | ✅ | |
 | Fullstack | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
 
 ## Frontend-only


### PR DESCRIPTION
Updates the SDK types table to correctly note handshake support only for fullstack SDKs. Previously it was marked for backend-only and fullstack.