### PR TITLE
Fix typo in biometricType value for Expo

### DIFF
--- a/docs/references/expo/use-local-credentials.mdx
+++ b/docs/references/expo/use-local-credentials.mdx
@@ -27,7 +27,7 @@ The `useLocalCredentials()` hook enables you to store a user's password credenti
   ---
 
   - `biometricType`
-  - `facial-recognition | fingerprint | null`
+  - `face-recognition | fingerprint | null`
 
   Indicates the supported enrolled biometric authenticator type.
 


### PR DESCRIPTION
<!--- Add the "deploy-preview" label and add your page previews here -->

> [!IMPORTANT]
> 🔎 Previews:
>
> - https://clerk.com/docs/pr/1476/references/expo/use-local-credentials

<!--- Describe your changes in detail. Why does this change need to happen? Include any links to Slack discussions, Linear comments, etc. -->

### Explanation:

<!--- How does this PR solve the problem? -->

### This PR:

-
