### PR TITLE
Fix `biometricType` type typo

### DIFF
--- a/docs/references/expo/use-local-credentials.mdx
+++ b/docs/references/expo/use-local-credentials.mdx
@@ -27,7 +27,7 @@ The `useLocalCredentials()` hook enables you to store a user's password credenti
   ---
 
   - `biometricType`
-  - `face-recognition | fingerprint | null`
+  - `'face-recognition' | 'fingerprint' | null`
 
   Indicates the supported enrolled biometric authenticator type.
 


### PR DESCRIPTION
<!--- Add the "deploy-preview" label and add your page previews here -->

> [!IMPORTANT]
> 🔎 Previews:
>
> - https://clerk.com/docs/pr/1478/references/expo/use-local-credentials

I believe that `face-recognition` and `fingerprint` are meant to be string values.