### PR TITLE
Correct typo in use-sign-up.mdx

### DIFF
--- a/docs/references/react/use-sign-up.mdx
+++ b/docs/references/react/use-sign-up.mdx
@@ -74,7 +74,7 @@ export default function SignUpStep() {
 
 The `status` property of the `SignUp` object can be one of the following values:
 
-| Values | Descriptiom |
+| Values | Description |
 | - | - |
 | `complete` | The user has been created and custom flow can proceed to `setActive()` to create session. |
 | `abandoned` | The sign-up attempt will be abandoned if it was started more than 24 hours previously. |


### PR DESCRIPTION
Fixed a typo in the `useSignUp` hook page
