### PR TITLE
Add missing `async` keyword in user metadata examples

### DIFF
--- a/docs/users/metadata.mdx
+++ b/docs/users/metadata.mdx
@@ -61,7 +61,7 @@ Private metadata is only accessible by the backend, which makes this useful for 
     ```ts {{ filename: 'private.ts' }}
     import { clerkClient } from '@clerk/clerk-sdk-node'
 
-    app.post('/updateStripe', (req, res) => {
+    app.post('/updateStripe', async (req, res) => {
       const { stripeId, userId } = await body.json()
       await clerkClient.users.updateUserMetadata(userId, {
         privateMetadata: {
@@ -157,7 +157,7 @@ You can retrieve the private metadata for a user by using the [`getUser`](/docs/
     ```ts {{ filename: 'private.ts' }}
     import { clerkClient } from '@clerk/clerk-sdk-node'
 
-    app.post('/updateStripe', (req, res) => {
+    app.post('/updateStripe', async (req, res) => {
       const { userId } = await req.body.json()
 
       const user = await clerkClient.users.getUser(userId)
@@ -366,7 +366,7 @@ Updating this value overrides the previous value; it does not merge. To perform 
     ```ts {{ filename: 'private.ts' }}
     import { clerkClient } from '@clerk/clerk-sdk-node'
 
-    app.post('/updateStripe', (req, res) => {
+    app.post('/updateStripe', async (req, res) => {
       const { stripeId, userId } = await body.json()
       await clerkClient.users.updateUserMetadata(userId, {
         unsafeMetadata: {


### PR DESCRIPTION
The function bodies use `await` but the `async` keyword is missing from the functions