### PR TITLE
docs(sdk): Add a warning about avoiding exposing secret key to the frontend

### DIFF
--- a/docs/references/sdk/conventions.mdx
+++ b/docs/references/sdk/conventions.mdx
@@ -33,6 +33,9 @@ You should always support these environment variables:
 
 Additionally, you need to make the environment variables for [API and SDK configuration](/docs/deployments/clerk-environment-variables#api-and-sdk-configuration) available to your users.
 
+> [!WARNING]
+> The `CLERK_SECRET_KEY` should never be exposed on the client-side (frontend). Always use a server-side environment variable.
+
 ### Optional
 
 Clerk recommends implementing the [sign-in and sign-up redirect](/docs/deployments/clerk-environment-variables#sign-in-and-sign-up-redirects) environment variables.


### PR DESCRIPTION
> [!IMPORTANT]
> 🔎 Previews:
>
> - https://clerk.com/docs/pr/1484/references/sdk/conventions#required

<!--- Describe your changes in detail. Why does this change need to happen? Include any links to Slack discussions, Linear comments, etc. -->

### Explanation:

<!--- How does this PR solve the problem? -->

### This PR:

- Adds a warning to mention that `CLERK_SECRET_KEY` should not be exposed to the client-side.
