### PR TITLE
Correct broken link to Hasura docs

### DIFF
--- a/docs/integrations/databases/hasura.mdx
+++ b/docs/integrations/databases/hasura.mdx
@@ -27,7 +27,7 @@ You can find this URL in the Clerk Dashboard on the **[API keys](https://dashboa
 
 ![The API Keys page in the Clerk Dashboard. A red box outlines the 'Advanced' drop down button. A red arrow is pointing to the copy button next to 'JWKS URL' in the 'JWT public key' section.](/docs/images/integrations/jwks-url.webp)
 
-You can set up your project either with Hasura Cloud or you can [run the Hasura GraphQL engine locally using Docker Compose](https://hasura.io/docs/latest/graphql/core/getting-started/docker-simple.html#docker-simple).
+You can set up your project either with Hasura Cloud or you can [run the Hasura GraphQL engine locally using Docker Compose](https://hasura.io/docs/2.0/getting-started/docker-simple).
 
 ### Set up with Hasura Cloud
 


### PR DESCRIPTION
Hasura changed their docs around. I believe this new URL is the correct page, but could use a double-check!