### PR TITLE
Update cognito migration guide

### DIFF
--- a/docs/deployments/migrate-from-cognito.mdx
+++ b/docs/deployments/migrate-from-cognito.mdx
@@ -161,7 +161,7 @@ async function main() {
         passwordHasher: 'awscognito',
       })
       console.log('Created clerk user for:', identifier)
-      await new Promise((resolve) => setTimeout(resolve, 200))
+      await new Promise((resolve) => setTimeout(resolve, 500))
     } catch (err) {
       console.error(err)
       break usersLoop

--- a/docs/integrations/databases/fauna.mdx
+++ b/docs/integrations/databases/fauna.mdx
@@ -72,26 +72,26 @@ Don't forget to click the **Apply changes** button at the bottom right to save y
 The way to authenticate requests to Fauna with Clerk is to use a JWT. After adding the necessary claims in a JWT template, you can generate the token by calling the `getToken` method from the [`useAuth()`](/docs/references/react/use-auth) hook provided by Clerk.
 
 ```jsx
-import React from 'react';
-import { useAuth } from '@clerk/nextjs';
-import { Client, fql } from "fauna";
+import React from 'react'
+import { useAuth } from '@clerk/nextjs'
+import { Client, fql } from 'fauna'
 
 const Example = () => {
-  const { getToken } = useAuth();
-  const [message, setMessage] = React.useState('');
+  const { getToken } = useAuth()
+  const [message, setMessage] = React.useState('')
 
   const makeQuery = async () => {
-    let client;
+    let client
     try {
-      const secret = await getToken({ template: '<your-template-name>' });
-      client = new Client({ secret: secret });
-      const response = await client.query(fql`'Hello World!'`);
-      setMessage(response);
+      const secret = await getToken({ template: '<your-template-name>' })
+      client = new Client({ secret: secret })
+      const response = await client.query(fql`'Hello World!'`)
+      setMessage(response)
     } catch (error) {
-      console.error(error);
-      setMessage('Error occurred');
+      console.error(error)
+      setMessage('Error occurred')
     } finally {
-      if (client) client.close();
+      if (client) client.close()
     }
   }
 
@@ -100,10 +100,10 @@ const Example = () => {
       <button onClick={makeQuery}>Make authenticated query</button>
       <p>Message: {message}</p>
     </>
-  );
-};
+  )
+}
 
-export default Example;
+export default Example
 ```
 
 > [!NOTE]


### PR DESCRIPTION
The rate limit for `createUser` is 20 requests per 10 seconds. The Cognito migration guide had a setTimeout of 200 milliseconds, allowing 50 requests per 10 seconds. I’ve adjusted the setTimeout to align with our rate limit.