### PR TITLE
feat: Add new organizationId option to getToken()

### DIFF
--- a/docs/references/javascript/session.mdx
+++ b/docs/references/javascript/session.mdx
@@ -174,7 +174,7 @@ function getToken(options?: GetTokenOptions): Promise<string | null>
   - `organizationId?`
   - `string`
 
-  The organization which the generated session token should be associated with. _Does not modify the session's currently active organization._
+  The organization associated with the generated session token. _Does not modify the session's currently active organization._
 </Properties>
 
 #### Example

--- a/docs/references/javascript/session.mdx
+++ b/docs/references/javascript/session.mdx
@@ -168,6 +168,13 @@ function getToken(options?: GetTokenOptions): Promise<string | null>
   - `boolean`
 
   Whether to skip the cache lookup and force a call to the server instead, even within the TTL. Useful if the token claims are time-sensitive or depend on data that can be updated (e.g. user fields).<br />Defaults to `false`.
+
+  ---
+
+  - `organizationId?`
+  - `string`
+
+  The organization which the generated session token should be associated with. _Does not modify the session's currently active organization._
 </Properties>
 
 #### Example


### PR DESCRIPTION
<!--- Add the "deploy-preview" label and add your page previews here -->

> [!IMPORTANT]
> 🔎 Previews:
>
> - https://clerk.com/docs/pr/1497/references/javascript/session#get-token-options

<!--- Describe your changes in detail. Why does this change need to happen? Include any links to Slack discussions, Linear comments, etc. -->

### Explanation:

<!--- How does this PR solve the problem? -->

Adds docs for the new `organizationId` option that `Clerk.session.getToken()` now accepts. This allows session tokens to be created that are associated with a specific organization ID, which can be separate from the session's active organization.

### This PR:

-
