### PR TITLE
Expo native requires custom flows over UI components

### DIFF
--- a/docs/quickstarts/expo.mdx
+++ b/docs/quickstarts/expo.mdx
@@ -206,7 +206,7 @@ description: Add authentication and user management to your Expo app with Clerk.
 
   ### Conditionally render content
 
-  You can control which content signed-in and signed-out users can see with Clerk's [prebuilt components](/docs/components/overview). For this quickstart, you'll use:
+  You can control which content signed-in and signed-out users can see with Clerk's [control components](/docs/components/overview#what-are-control-components). For this quickstart, you'll use:
 
   - [`<SignedIn>`](/docs/components/control/signed-in): Children of this component can only be seen while **signed in**.
   - [`<SignedOut>`](/docs/components/control/signed-out): Children of this component can only be seen while **signed out**.
@@ -251,7 +251,8 @@ description: Add authentication and user management to your Expo app with Clerk.
 
   ### Add `sign-up` and `sign-in` pages
 
-  Finally, add pages for signing in and signing up.
+  Clerk currently only supports control components for Expo native. UI components are only available for Expo web.
+  Instead, you must build [custom flows](/docs/custom-flows/overview) using Clerk's API. The following sections demonstrate how to build custom email/password sign-up and sign-in flows. If you want to use different authentication methods, such as passwordless or OAuth, see the dedicated custom flow guides.
 
   First, protect your `auth` routes in the `layout`. Create a new route group `(auth)` with a `_layout.tsx` file. This layout will redirect users to the home page if they're already signed in:
 
@@ -430,7 +431,7 @@ description: Add authentication and user management to your Expo app with Clerk.
   }
   ```
 
-  For more information about building these _custom flows_, including guided comments in the code examples, see the [Build a custom email/password authentication flow](/docs/custom-flows/email-password) guide.
+  For more information about building these custom flows, including guided comments in the code examples, see the [Build a custom email/password authentication flow](/docs/custom-flows/email-password) guide.
 </Steps>
 
 ## Enable OTA updates


### PR DESCRIPTION
<!--- Add the "deploy-preview" label and add your page previews here -->

> [!IMPORTANT]
> 🔎 Previews:
>
> - https://clerk.com/docs/pr/1502/quickstarts/expo

<!--- Describe your changes in detail. Why does this change need to happen? Include any links to Slack discussions, Linear comments, etc. -->

### Explanation:

[User feedback ticket](https://linear.app/clerk/issue/DOCS-9126/user-feedback-about-expo-quickstartcustom-flows) had a user confused about how to implement a passwordless custom flow for their Expo app. Our quickstart didn't mention how Expo native doesn't support UI components - and also doesn't link to our custom flows or really explain why custom flows are needed.

<!--- How does this PR solve the problem? -->

### This PR:

- Adds explanation as to why custom flows are needed for Expo (native doesn't support UI components)
- Adds sentence about seeing the dedicated custom flow guides for other auth methods
