### PR TITLE
Fixes ACS URL meaning on Azure and Okta guides

### DIFF
--- a/docs/authentication/saml/azure.mdx
+++ b/docs/authentication/saml/azure.mdx
@@ -68,8 +68,8 @@ description: Learn how to allow users to sign into your Clerk app with their Mic
 
   To configure your service provider (Clerk), you must add these two fields to your IdP's application:
 
-  - **Reply URL (Assertion Consumer Service URL)** - This is a unique identifier for your SAML connection that your IdP application needs.
-  - **Identifier (Entity ID)** - This is your application's URL that your IdP will redirect your users back to after they have authenticated in your IdP.
+  - **Reply URL (Assertion Consumer Service URL)** - This is your application's URL that your IdP will redirect your users back to after they have authenticated in your IdP.
+  - **Identifier (Entity ID)** - This is a unique identifier for your SAML connection that your IdP application needs.
 
   To fill out the appropriate values for these fields:
 

--- a/docs/authentication/saml/okta.mdx
+++ b/docs/authentication/saml/okta.mdx
@@ -52,8 +52,8 @@ description: Learn how to integrate Okta Workforce with Clerk using SAML SSO.
 
   To configure your service provider (Clerk), you must add these two fields to your IdP's application:
 
-  - **Single sign-on URL** - This is a unique identifier for your SAML connection that your IdP application needs.
-  - **Audience URI (SP Entity ID)** - This is your application's URL that your IdP will redirect your users back to after they have authenticated in your IdP.
+  - **Single sign-on URL** - This is your application's URL that your IdP will redirect your users back to after they have authenticated in your IdP.
+  - **Audience URI (SP Entity ID)** - This is a unique identifier for your SAML connection that your IdP application needs.
 
   To fill out the appropriate values for these fields:
 


### PR DESCRIPTION
<!--- Add the "deploy-preview" label and add your page previews here -->

> [!IMPORTANT]
> 🔎 Previews:
>
> -

<!--- Describe your changes in detail. Why does this change need to happen? Include any links to Slack discussions, Linear comments, etc. -->

### Explanation:

The ACS URL explanation was being switched with Entity ID, on both Google and Okta guides. 