### PR TITLE
Minor code block formatting fixes

### DIFF
--- a/docs/advanced-usage/using-proxies.mdx
+++ b/docs/advanced-usage/using-proxies.mdx
@@ -102,43 +102,42 @@ When using a proxy, all requests to the Frontend API will be made through your d
     </Tab>
 
     <Tab>
-      ```ts {{ prettier: false, filename: 'middleware.ts' }}
-        import { NextResponse } from "next/server";
-        import { clerkMiddleware } from "@clerk/nextjs/server";
+      ```ts {{ filename: 'middleware.ts' }}
+      import { NextResponse } from 'next/server'
+      import { clerkMiddleware } from '@clerk/nextjs/server'
 
-        export default clerkMiddleware((auth, request) => {
-          if (request.url.match("__clerk")) {
-            const proxyHeaders = new Headers(request.headers);
-            proxyHeaders.set("Clerk-Proxy-Url", process.env.NEXT_PUBLIC_CLERK_PROXY_URL || "");
-            proxyHeaders.set("Clerk-Secret-Key", process.env.CLERK_SECRET_KEY || "");
-            if (request.ip) {
-              proxyHeaders.set("X-Forwarded-For", request.ip);
-            } else {
-              proxyHeaders.set("X-Forwarded-For", request.headers.get('X-Forwarded-For') || '');
-            }
-
-            const proxyUrl = new URL(request.url);
-            proxyUrl.host = "frontend-api.clerk.dev";
-            proxyUrl.protocol = "https";
-            proxyUrl.pathname = proxyUrl.pathname.replace("/__clerk", "");
-
-            return NextResponse.rewrite(proxyUrl, {
-              request: {
-                headers: proxyHeaders,
-              },
-            });
+      export default clerkMiddleware((auth, request) => {
+        if (request.url.match('__clerk')) {
+          const proxyHeaders = new Headers(request.headers)
+          proxyHeaders.set('Clerk-Proxy-Url', process.env.NEXT_PUBLIC_CLERK_PROXY_URL || '')
+          proxyHeaders.set('Clerk-Secret-Key', process.env.CLERK_SECRET_KEY || '')
+          if (request.ip) {
+            proxyHeaders.set('X-Forwarded-For', request.ip)
+          } else {
+            proxyHeaders.set('X-Forwarded-For', request.headers.get('X-Forwarded-For') || '')
           }
-        });
 
-        export const config = {
-          matcher: [
-            // Skip Next.js internals and all static files, unless found in search params
-            "/((?!_next|[^?]*\\.(?:html?|css|js(?!on)|jpe?g|webp|png|gif|svg|ttf|woff2?|ico|csv|docx?|xlsx?|zip|webmanifest)).*)",
-            // Always run for API routes AND anything passed through the proxy
-            "/(api|trpc|__clerk)(.*)",
-          ],
-        };
+          const proxyUrl = new URL(request.url)
+          proxyUrl.host = 'frontend-api.clerk.dev'
+          proxyUrl.protocol = 'https'
+          proxyUrl.pathname = proxyUrl.pathname.replace('/__clerk', '')
 
+          return NextResponse.rewrite(proxyUrl, {
+            request: {
+              headers: proxyHeaders,
+            },
+          })
+        }
+      })
+
+      export const config = {
+        matcher: [
+          // Skip Next.js internals and all static files, unless found in search params
+          '/((?!_next|[^?]*\\.(?:html?|css|js(?!on)|jpe?g|webp|png|gif|svg|ttf|woff2?|ico|csv|docx?|xlsx?|zip|webmanifest)).*)',
+          // Always run for API routes AND anything passed through the proxy
+          '/(api|trpc|__clerk)(.*)',
+        ],
+      }
       ```
     </Tab>
   </Tabs>

--- a/docs/customization/localization.mdx
+++ b/docs/customization/localization.mdx
@@ -216,51 +216,51 @@ For example, if you want to change the 'to continue to' string from the `<SignIn
 
 ```js {{ prettier: false }}
 signUp: {
-    start: {
-      title: 'Create your account',
-      subtitle: 'to continue to {{applicationName}}',
-      actionText: 'Have an account?',
-      actionLink: 'Sign in',
+  start: {
+    title: 'Create your account',
+    subtitle: 'to continue to {{applicationName}}',
+    actionText: 'Have an account?',
+    actionLink: 'Sign in',
+  },
+  emailLink: {
+    title: 'Verify your email',
+    subtitle: 'to continue to {{applicationName}}',
+    formTitle: 'Verification link',
+    formSubtitle: 'Use the verification link sent to your email address',
+    resendButton: "Didn't receive a link? Resend",
+    verified: {
+      title: 'Successfully signed up',
     },
-    emailLink: {
-      title: 'Verify your email',
-      subtitle: 'to continue to {{applicationName}}',
-      formTitle: 'Verification link',
-      formSubtitle: 'Use the verification link sent to your email address',
-      resendButton: "Didn't receive a link? Resend",
-      verified: {
-        title: 'Successfully signed up',
-      },
-      loading: {
-        title: 'Signing up...',
-      },
-      verifiedSwitchTab: {
-        title: 'Successfully verified email',
-        subtitle: 'Return to the newly opened tab to continue',
-        subtitleNewTab: 'Return to previous tab to continue',
-      },
+    loading: {
+      title: 'Signing up...',
     },
-    emailCode: {
-      title: 'Verify your email',
-      subtitle: 'to continue to {{applicationName}}',
-      formTitle: 'Verification code',
-      formSubtitle: 'Enter the verification code sent to your email address',
-      resendButton: "Didn't receive a code? Resend",
-    },
-    phoneCode: {
-      title: 'Verify your phone',
-      subtitle: 'to continue to {{applicationName}}',
-      formTitle: 'Verification code',
-      formSubtitle: 'Enter the verification code sent to your phone number',
-      resendButton: "Didn't receive a code? Resend",
-    },
-    continue: {
-      title: 'Fill in missing fields',
-      subtitle: 'to continue to {{applicationName}}',
-      actionText: 'Have an account?',
-      actionLink: 'Sign in',
+    verifiedSwitchTab: {
+      title: 'Successfully verified email',
+      subtitle: 'Return to the newly opened tab to continue',
+      subtitleNewTab: 'Return to previous tab to continue',
     },
   },
+  emailCode: {
+    title: 'Verify your email',
+    subtitle: 'to continue to {{applicationName}}',
+    formTitle: 'Verification code',
+    formSubtitle: 'Enter the verification code sent to your email address',
+    resendButton: "Didn't receive a code? Resend",
+  },
+  phoneCode: {
+    title: 'Verify your phone',
+    subtitle: 'to continue to {{applicationName}}',
+    formTitle: 'Verification code',
+    formSubtitle: 'Enter the verification code sent to your phone number',
+    resendButton: "Didn't receive a code? Resend",
+  },
+  continue: {
+    title: 'Fill in missing fields',
+    subtitle: 'to continue to {{applicationName}}',
+    actionText: 'Have an account?',
+    actionLink: 'Sign in',
+  },
+},
 ```
 
 If you want to customize multiple entries from the `<SignUp />` component, the procedure would resemble the following:

--- a/docs/guides/force-organizations.mdx
+++ b/docs/guides/force-organizations.mdx
@@ -38,30 +38,32 @@ This guide will be written for Next.js applications using App Router, but the sa
 
   <Tabs items={["<OrganizationList />", "<OrganizationSwitcher />"]}>
     <Tab>
-      ```tsx {{ prettier: false, filename: 'app/organization-list/[[...organization-list]]/page.tsx', mark: [6] }}
+      ```tsx {{ filename: 'app/organization-list/[[...organization-list]]/page.tsx', mark: [6] }}
       import { OrganizationList } from '@clerk/nextjs'
 
       export default function OrganizationListPage() {
         return (
           <OrganizationList
+            // prettier-ignore
             hidePersonal={true}
           />
-        );
-      };
+        )
+      }
       ```
     </Tab>
 
     <Tab>
-      ```tsx {{ prettier: false, filename: 'app/sidebar.tsx', mark: [5] }}
+      ```tsx {{ filename: 'app/sidebar.tsx', mark: [6] }}
       import { OrganizationSwitcher } from '@clerk/nextjs'
 
       export default function Sidebar() {
         return (
           <OrganizationSwitcher
+            // prettier-ignore
             hidePersonal={true}
           />
-        );
-      };
+        )
+      }
       ```
     </Tab>
   </Tabs>

--- a/docs/references/astro/migrating-from-astro-community-sdk.mdx
+++ b/docs/references/astro/migrating-from-astro-community-sdk.mdx
@@ -103,7 +103,7 @@ import { $sessionStore } from '@clerk/astro/client'
 Submodule `/v0` was dropped completely and the previously exported constants are no longer available.
 
 ```js {{ prettier: false, del: [1] }}
-import { apiKey, secretKey, DOMAIN, ... } from "astro-clerk-auth/v0"
+import { apiKey, secretKey, DOMAIN, ... } from 'astro-clerk-auth/v0'
 ```
 
 ### `clerkClient` changes
@@ -147,7 +147,7 @@ import {
   SignInButton,
   SignedIn,
   SignedOut,
-  UserButton
+  UserButton,
 } from '@clerk/astro/client/react'
 } from '@clerk/astro/react'
 

--- a/docs/references/backend/email-addresses/update-email-address.mdx
+++ b/docs/references/backend/email-addresses/update-email-address.mdx
@@ -44,14 +44,14 @@ _EmailAddress {
     externalVerificationRedirectURL: null,
     attempts: null,
     expireAt: null,
-    nonce: null
+    nonce: null,
   },
   linkedTo: [
     _IdentificationLink {
       id: 'idn_123',
-      type: 'oauth_google'
-    }
-  ]
+      type: 'oauth_google',
+    },
+  ],
 }
 ```
 

--- a/docs/references/backend/phone-numbers/update-phone-number.mdx
+++ b/docs/references/backend/phone-numbers/update-phone-number.mdx
@@ -53,9 +53,9 @@ _PhoneNumber {
     externalVerificationRedirectURL: null,
     attempts: null,
     expireAt: null,
-    nonce: null
+    nonce: null,
   },
-  linkedTo: []
+  linkedTo: [],
 }
 ```
 

--- a/docs/references/backend/saml-connections/update-saml-connection.mdx
+++ b/docs/references/backend/saml-connections/update-saml-connection.mdx
@@ -109,15 +109,14 @@ function updateSamlConnection(
 
 In this example, the name of the SAML connection is updated.
 
-```tsx {{ prettier: false, mark: [[3, 6], 13] }}
-const samlConnectionId = 'samlc_123';
+```tsx {{ mark: [[3, 5], 12] }}
+const samlConnectionId = 'samlc_123'
 
-const response = await clerkClient.samlConnections.updateSamlConnection(
-  samlConnectionId,
-  { name: 'Updated SAML Connection' }
-);
+const response = await clerkClient.samlConnections.updateSamlConnection(samlConnectionId, {
+  name: 'Updated SAML Connection',
+})
 
-console.log(response);
+console.log(response)
 /*
 {
   object: 'saml_connection',

--- a/docs/references/javascript/clerk/organization-methods.mdx
+++ b/docs/references/javascript/clerk/organization-methods.mdx
@@ -168,29 +168,29 @@ function createOrganization({ name, slug }: CreateOrganizationParams): Promise<O
 <Tabs type="npm-script" items={['NPM module', '<script>']}>
   <Tab>
     <CodeBlockTabs options={["main.js", "index.html"]}>
-      ```js {{ prettier: false, filename: 'main.js', mark: [[11, 13]] }}
-      import { Clerk } from '@clerk/clerk-js';
+      ```js {{ filename: 'main.js', mark: [[10, 13]] }}
+      import { Clerk } from '@clerk/clerk-js'
 
       // Initialize Clerk with your Clerk publishable key
-      const clerk = new Clerk('{{pub_key}}');
-      await clerk.load();
+      const clerk = new Clerk('{{pub_key}}')
+      await clerk.load()
 
       if (clerk.user) {
-        const createOrgButton = document.getElementById("create-org-button");
-        createOrgButton.addEventListener("click", () => {
-          clerk.createOrganization({ name: "test" })
+        const createOrgButton = document.getElementById('create-org-button')
+        createOrgButton.addEventListener('click', () => {
+          clerk
+            .createOrganization({ name: 'test' })
             .then((res) => console.log(res))
-            .catch((error) => console.log("An error occurred:", error.errors));
-        });
+            .catch((error) => console.log('An error occurred:', error.errors))
+        })
       } else {
-        document.getElementById("app").innerHTML = `
+        document.getElementById('app').innerHTML = `
           <div id="sign-in"></div>
-        `;
+        `
 
-        const signInDiv =
-          document.getElementById("sign-in");
+        const signInDiv = document.getElementById('sign-in')
 
-        clerk.mountSignIn(signInDiv);
+        clerk.mountSignIn(signInDiv)
       }
       ```
 

--- a/docs/references/javascript/types/clerk-api-error.mdx
+++ b/docs/references/javascript/types/clerk-api-error.mdx
@@ -36,17 +36,17 @@ An interface that represents an error returned by the Clerk API.
 The `meta` property consists of the following structure:
 
 ```ts {{ prettier: false }}
-  meta?: {
-    paramName?: string;
-    sessionId?: string;
-    emailAddresses?: string[];
-    identifiers?: string[];
-    zxcvbn?: {
-      suggestions: {
-        code: string;
-        message: string;
-      }[];
-    };
-    permissions?: string[];
-  };
+meta?: {
+  paramName?: string
+  sessionId?: string
+  emailAddresses?: string[]
+  identifiers?: string[]
+  zxcvbn?: {
+    suggestions: {
+      code: string
+      message: string
+    }[]
+  }
+  permissions?: string[]
+}
 ```

--- a/docs/references/nextjs/auth-object.mdx
+++ b/docs/references/nextjs/auth-object.mdx
@@ -290,8 +290,8 @@ The following is an example of the `Auth` object without an active organization:
     iss: 'https://clerk.quiet.muskox-85.lcl.dev',
     nbf: 1666622537,
     sid: 'sess_2GaMqUCB3Sc1WNAkWuNzsnYVVEy',
-    sub: 'user_2F2u1wtUyUlxKgFkKqtJNtpJJWj'
-  }
+    sub: 'user_2F2u1wtUyUlxKgFkKqtJNtpJJWj',
+  },
 }
 ```
 
@@ -316,7 +316,7 @@ The following is an example of the `Auth` object with an active organization:
     iss: 'https://clerk.quiet.muskox-85.lcl.dev',
     nbf: 1666622537,
     sid: 'sess_2GaMqUCB3Sc1WNAkWuNzsnYVVEy',
-    sub: 'user_2F2u1wtUyUlxKgFkKqtJNtpJJWj'
-  }
+    sub: 'user_2F2u1wtUyUlxKgFkKqtJNtpJJWj',
+  },
 }
 ```

--- a/docs/security/clerk-csp.mdx
+++ b/docs/security/clerk-csp.mdx
@@ -75,16 +75,16 @@ function applyCsp(request) {
 
   // format the CSP header
   const cspHeader = `
-      default-src 'self';
-      script-src 'self' 'strict-dynamic' 'nonce-${nonce}' https: http: ${
-        process.env.NODE_ENV === 'production' ? '' : `'unsafe-eval'`
-      };
-      connect-src 'self' https://{{fapi_url}};
-      img-src 'self' https://img.clerk.com;
-      worker-src 'self' blob:;
-      style-src 'self' 'unsafe-inline';
-      frame-src 'self' https://challenges.cloudflare.com;
-      form-action 'self';
+    default-src 'self';
+    script-src 'self' 'strict-dynamic' 'nonce-${nonce}' https: http: ${
+      process.env.NODE_ENV === 'production' ? '' : `'unsafe-eval'`
+    };
+    connect-src 'self' https://{{fapi_url}};
+    img-src 'self' https://img.clerk.com;
+    worker-src 'self' blob:;
+    style-src 'self' 'unsafe-inline';
+    frame-src 'self' https://challenges.cloudflare.com;
+    form-action 'self';
   `
   // Replace newline characters and spaces
   const contentSecurityPolicyHeaderValue = cspHeader.replace(/\s{2,}/g, ' ').trim()

--- a/docs/security/clerk-csp.mdx
+++ b/docs/security/clerk-csp.mdx
@@ -61,97 +61,89 @@ module.exports = nextConfig
 
 If you'd like to implement a [strict-dynamic CSP](https://content-security-policy.com/strict-dynamic/), Clerk supports this, but with a different type of configuration. As strict-dynamic CSPs require a "nonce" value that should be programmatically generated per-request, the best way to make this work is within middleware that runs on every request. The following example demonstrates how to implement a strict-dynamic CSP with Next.js middleware, but the same approach could be used with any other framework.
 
-```js {{ prettier: false, filename: 'middleware.ts' }}
-  import { NextResponse } from "next/server";
-  import { clerkMiddleware } from "@clerk/nextjs/server";
+```ts {{ filename: 'middleware.ts' }}
+import { NextResponse } from 'next/server'
+import { clerkMiddleware } from '@clerk/nextjs/server'
 
-  export default clerkMiddleware((auth, request) => {
-    return applyCsp(request);
-  });
+export default clerkMiddleware((auth, request) => {
+  return applyCsp(request)
+})
 
-  function applyCsp(request) {
-    // create a randomly generated nonce value
-    const nonce = Buffer.from(crypto.randomUUID()).toString("base64");
+function applyCsp(request) {
+  // create a randomly generated nonce value
+  const nonce = Buffer.from(crypto.randomUUID()).toString('base64')
 
-    // format the CSP header
-    const cspHeader = `
+  // format the CSP header
+  const cspHeader = `
       default-src 'self';
       script-src 'self' 'strict-dynamic' 'nonce-${nonce}' https: http: ${
-      process.env.NODE_ENV === "production" ? "" : `'unsafe-eval'`
-    };
+        process.env.NODE_ENV === 'production' ? '' : `'unsafe-eval'`
+      };
       connect-src 'self' https://{{fapi_url}};
       img-src 'self' https://img.clerk.com;
       worker-src 'self' blob:;
       style-src 'self' 'unsafe-inline';
       frame-src 'self' https://challenges.cloudflare.com;
       form-action 'self';
-  `;
-    // Replace newline characters and spaces
-    const contentSecurityPolicyHeaderValue = cspHeader
-      .replace(/\s{2,}/g, " ")
-      .trim();
+  `
+  // Replace newline characters and spaces
+  const contentSecurityPolicyHeaderValue = cspHeader.replace(/\s{2,}/g, ' ').trim()
 
-    // set the nonce and csp values in the request headers
-    const requestHeaders = new Headers(request.headers);
-    requestHeaders.set("x-nonce", nonce);
-    requestHeaders.set(
-      "Content-Security-Policy",
-      contentSecurityPolicyHeaderValue
-    );
+  // set the nonce and csp values in the request headers
+  const requestHeaders = new Headers(request.headers)
+  requestHeaders.set('x-nonce', nonce)
+  requestHeaders.set('Content-Security-Policy', contentSecurityPolicyHeaderValue)
 
-    const response = NextResponse.next({
-      request: {
-        headers: requestHeaders,
-      },
-    });
-    
-    response.headers.set(
-      "Content-Security-Policy",
-      contentSecurityPolicyHeaderValue
-    );
+  const response = NextResponse.next({
+    request: {
+      headers: requestHeaders,
+    },
+  })
 
-    return response;
-  }
+  response.headers.set('Content-Security-Policy', contentSecurityPolicyHeaderValue)
 
-  export const config = {
-    matcher: [
-      // Skip Next.js internals and all static files, unless found in search params
-      '/((?!_next|[^?]*\\.(?:html?|css|js(?!on)|jpe?g|webp|png|gif|svg|ttf|woff2?|ico|csv|docx?|xlsx?|zip|webmanifest)).*)',
-      // Always run for API routes
-      '/(api|trpc)(.*)',
-    ],
-  };
+  return response
+}
+
+export const config = {
+  matcher: [
+    // Skip Next.js internals and all static files, unless found in search params
+    '/((?!_next|[^?]*\\.(?:html?|css|js(?!on)|jpe?g|webp|png|gif|svg|ttf|woff2?|ico|csv|docx?|xlsx?|zip|webmanifest)).*)',
+    // Always run for API routes
+    '/(api|trpc)(.*)',
+  ],
+}
 ```
 
 With this `strict-dynamic` configuration in place, **all script tags must be passed with a `nonce` value** or they will be blocked. This can be done by passing the nonce value as a `nonce` parameter to the script tag. For example, `<script src="https://example.com/script.js" nonce="<nonce_value>"></script>`. If you are using Next.js, any scripts loaded through next will automatically have the nonce value injected.
 
 With the above middleware, the nonce value is made accessible via the `x-nonce` request header. An example is provided below on how to access this value within a Next.js page.
 
-```js {{ prettier: false, filename: 'pages/index.tsx' }}
-  import { headers } from "next/headers";
+```tsx {{ filename: 'pages/index.tsx' }}
+import { headers } from 'next/headers'
 
-  export default function Page() {
-    const nonce = headers().get("x-nonce");
+export default function Page() {
+  const nonce = headers().get('x-nonce')
 
-    return <p>{nonce}</p>;
-  }
+  return <p>{nonce}</p>
+}
 ```
 
 If you're using one of Clerk's React-based SDKs, in order for Clerk to load correctly, the nonce value must also be passed to Clerk's `<ClerkProvider>` component. This can be done by passing the nonce value as a `nonce` prop to the `<ClerkProvider>` component. For example:
 
-```js {{ prettier: false, filename: 'app/layout.tsx' }}
-import { ClerkProvider} from "@clerk/nextjs";
-import { headers } from "next/headers";
+```tsx {{ filename: 'app/layout.tsx' }}
+import { ClerkProvider } from '@clerk/nextjs'
+import { headers } from 'next/headers'
 
 export default function Layout({ children }) {
   return (
     // Note: since this is server-rendered, you don't _need_ to pass the nonce, see note below
-    <ClerkProvider nonce={headers().get("x-nonce")}>
+    <ClerkProvider nonce={headers().get('x-nonce')}>
       <html lang="en">
         <body>{children}</body>
       </html>
     </ClerkProvider>
-  );
+  )
 }
 ```
 

--- a/docs/upgrade-guides/core-2/chrome-extension.mdx
+++ b/docs/upgrade-guides/core-2/chrome-extension.mdx
@@ -114,7 +114,7 @@ Defining redirect URLs for after sign up, in, and/or out via the Clerk dashboard
 As part of this change, the default URL for each of these props has been set to `/`, so if you are passing `/` explicitly to any one of the above props, that line is no longer necessary and can be removed.
 
 ```jsx {{ prettier: false, del: [1], ins: [2] }}
-<UserButton afterSignOutUrl='/' />
+<UserButton afterSignOutUrl="/" />
 <UserButton />
 ```
 
@@ -500,13 +500,13 @@ As part of this major version, a number of previously deprecated props, argument
 
     ```js {{ prettier: false, del: [1, 4, 7], ins: [2, 5, 8] }}
     await setSession('sessionID', () => void)
-    await setActive({ session: 'sessionID',  beforeEmit: () => void })
+    await setActive({ session: 'sessionID', beforeEmit: () => void })
 
     await setSession(sessionObj)
     await setActive({ session: sessionObj })
 
     await setSession(sessionObj, () => void)
-    await setActive({ session: sessionObj,  beforeEmit: () => void })
+    await setActive({ session: sessionObj, beforeEmit: () => void })
     ```
 
     `setActive` also supports setting an active organization:
@@ -515,12 +515,12 @@ As part of this major version, a number of previously deprecated props, argument
     await setActive({
       session: 'sessionID',
       organization: 'orgID',
-      beforeEmit: () => void
+      beforeEmit: () => void,
     })
     await setActive({
       session: sessionObj,
       organization: orgObj,
-      beforeEmit: () => void
+      beforeEmit: () => void,
     })
     ```
   </AccordionPanel>

--- a/docs/upgrade-guides/core-2/expo.mdx
+++ b/docs/upgrade-guides/core-2/expo.mdx
@@ -94,7 +94,7 @@ Defining redirect URLs for after sign up, in, and/or out via the Clerk dashboard
 As part of this change, the default URL for each of these props has been set to `/`, so if you are passing `/` explicitly to any one of the above props, that line is no longer necessary and can be removed.
 
 ```jsx {{ prettier: false, del: [1], ins: [2] }}
-<UserButton afterSignOutUrl='/' />
+<UserButton afterSignOutUrl="/" />
 <UserButton />
 ```
 
@@ -492,13 +492,13 @@ As part of this major version, a number of previously deprecated props, argument
 
     ```js {{ prettier: false, del: [1, 4, 7], ins: [2, 5, 8] }}
     await setSession('sessionID', () => void)
-    await setActive({ session: 'sessionID',  beforeEmit: () => void })
+    await setActive({ session: 'sessionID', beforeEmit: () => void })
 
     await setSession(sessionObj)
     await setActive({ session: sessionObj })
 
     await setSession(sessionObj, () => void)
-    await setActive({ session: sessionObj,  beforeEmit: () => void })
+    await setActive({ session: sessionObj, beforeEmit: () => void })
     ```
 
     `setActive` also supports setting an active organization:
@@ -507,13 +507,13 @@ As part of this major version, a number of previously deprecated props, argument
     await setActive({
       session: 'sessionID',
       organization: 'orgID',
-      beforeEmit: () => void
+      beforeEmit: () => void,
     })
 
     await setActive({
       session: sessionObj,
       organization: orgObj,
-      beforeEmit: () => void
+      beforeEmit: () => void,
     })
     ```
   </AccordionPanel>

--- a/docs/upgrade-guides/core-2/javascript.mdx
+++ b/docs/upgrade-guides/core-2/javascript.mdx
@@ -70,7 +70,7 @@ Defining redirect URLs for after sign up, in, and/or out via the Clerk dashboard
 As part of this change, the default URL for each of these props has been set to `/`, so if you are passing `/` explicitly to any one of the above props, that line is no longer necessary and can be removed.
 
 ```jsx {{ prettier: false, del: [1], ins: [2] }}
-<UserButton afterSignOutUrl='/' />
+<UserButton afterSignOutUrl="/" />
 <UserButton />
 ```
 
@@ -92,8 +92,8 @@ In general, use the environment variables over the props.
 To retain the current behavior of your app without any changes, you can switch `afterSignXUrl` with `signXFallbackRedirectUrl` as such:
 
 ```jsx {{ prettier: false, del: [1], ins: [2] }}
-<SignIn afterSignInUrl='/foo' />
-<SignIn signInFallbackRedirectUrl='/foo' />
+<SignIn afterSignInUrl="/foo" />
+<SignIn signInFallbackRedirectUrl="/foo" />
 ```
 
 #### Why this is changing
@@ -555,13 +555,13 @@ As part of this major version, a number of previously deprecated props, argument
 
     ```js {{ prettier: false, del: [1, 4, 7], ins: [2, 5, 8] }}
     await setSession('sessionID', () => void)
-    await setActive({ session: 'sessionID',  beforeEmit: () => void })
+    await setActive({ session: 'sessionID', beforeEmit: () => void })
 
     await setSession(sessionObj)
     await setActive({ session: sessionObj })
 
     await setSession(sessionObj, () => void)
-    await setActive({ session: sessionObj,  beforeEmit: () => void })
+    await setActive({ session: sessionObj, beforeEmit: () => void })
     ```
 
     `setActive` also supports setting an active organization:
@@ -570,13 +570,13 @@ As part of this major version, a number of previously deprecated props, argument
     await setActive({
       session: 'sessionID',
       organization: 'orgID',
-      beforeEmit: () => void
+      beforeEmit: () => void,
     })
 
     await setActive({
       session: sessionObj,
       organization: orgObj,
-      beforeEmit: () => void
+      beforeEmit: () => void,
     })
     ```
   </AccordionPanel>

--- a/docs/upgrade-guides/core-2/nextjs.mdx
+++ b/docs/upgrade-guides/core-2/nextjs.mdx
@@ -141,20 +141,20 @@ Clerk strongly recommends migrating to the new `clerkMiddleware()` for an improv
 The most basic migration will be updating the import and changing out the default export, then mirroring the previous behavior of protecting all routes except `/sign-in` or `/sign-up` by doing the following:
 
 ```js {{ prettier: false, del: [1, 6], ins: [2, 4, [7, 11]] }}
-import { authMiddleware } from "@clerk/nextjs/server"
+import { authMiddleware } from '@clerk/nextjs/server'
 import { clerkMiddleware, createRouteMatcher } from '@clerk/nextjs/server'
 
-const isPublicRoute = createRouteMatcher(['/sign-in(.*)', '/sign-up(.*)']);
+const isPublicRoute = createRouteMatcher(['/sign-in(.*)', '/sign-up(.*)'])
 
 export default authMiddleware()
-export default clerkMiddleware((auth, request) =>{
-  if(!isPublicRoute(request)){
-    auth().protect();
+export default clerkMiddleware((auth, request) => {
+  if (!isPublicRoute(request)) {
+    auth().protect()
   }
-});
+})
 
 export const config = {
-  matcher: ["/((?!.*\\..*|_next).*)", "/", "/(api|trpc)(.*)"],
+  matcher: ['/((?!.*\\..*|_next).*)', '/', '/(api|trpc)(.*)'],
 }
 ```
 
@@ -384,8 +384,8 @@ As part of this release, some of the top-level exports of `@clerk/nextjs` have b
       redirect,
       createAuthenticateRequest,
       createIsomorphicRequest,
-    } from "@clerk/nextjs"
-    } from "@clerk/nextjs/server"
+    } from '@clerk/nextjs'
+    } from '@clerk/nextjs/server'
     ```
   </AccordionPanel>
 
@@ -399,8 +399,8 @@ As part of this release, some of the top-level exports of `@clerk/nextjs` have b
       isKnownError,
       isMetamaskError,
       EmailLinkErrorCode,
-    } from "@clerk/nextjs"
-    } from "@clerk/nextjs/errors"
+    } from '@clerk/nextjs'
+    } from '@clerk/nextjs/errors'
     ```
   </AccordionPanel>
 
@@ -408,8 +408,8 @@ As part of this release, some of the top-level exports of `@clerk/nextjs` have b
     The `@clerk/nextjs` import will work with both the App and Pages Router.
 
     ```js {{ prettier: false, del: [1], ins: [2] }}
-    import { } from "@clerk/nextjs/app-beta"
-    import { } from "@clerk/nextjs"
+    import { } from '@clerk/nextjs/app-beta'
+    import { } from '@clerk/nextjs'
     ```
 
     Some behavior may have changed between Clerk's beta and the stable release. Please check on your end if behavior stayed the same.
@@ -419,22 +419,22 @@ As part of this release, some of the top-level exports of `@clerk/nextjs` have b
     The top-level exports support SSR by default now.
 
     ```js {{ prettier: false, del: [1], ins: [2] }}
-    import { } from "@clerk/nextjs/ssr"
-    import { } from "@clerk/nextjs"
+    import { } from '@clerk/nextjs/ssr'
+    import { } from '@clerk/nextjs'
     ```
   </AccordionPanel>
 
   <AccordionPanel>
     ```js {{ prettier: false, del: [1], ins: [2] }}
-    import { } from "@clerk/nextjs/edge-middleware"
-    import { } from "@clerk/nextjs"
+    import { } from '@clerk/nextjs/edge-middleware'
+    import { } from '@clerk/nextjs'
     ```
   </AccordionPanel>
 
   <AccordionPanel>
     ```js {{ prettier: false, del: [1], ins: [2] }}
-    import { } from "@clerk/nextjs/edge-middlewarefiles"
-    import { } from "@clerk/nextjs"
+    import { } from '@clerk/nextjs/edge-middlewarefiles'
+    import { } from '@clerk/nextjs'
     ```
   </AccordionPanel>
 
@@ -448,12 +448,12 @@ As part of this release, some of the top-level exports of `@clerk/nextjs` have b
       LooseAuthProp,
       RequireAuthProp,
       StrictAuthProp,
-      WithAuthProp
-    } from "@clerk/nextjs/api"
-    } from "@clerk/clerk-sdk-node"
+      WithAuthProp,
+    } from '@clerk/nextjs/api'
+    } from '@clerk/clerk-sdk-node'
 
-    import { requireAuth, withAuth } from "@clerk/nextjs/api"
-    import { requireAuth, withAuth } from "@clerk/clerk-sdk-node"
+    import { requireAuth, withAuth } from '@clerk/nextjs/api'
+    import { requireAuth, withAuth } from '@clerk/clerk-sdk-node'
     ```
   </AccordionPanel>
 </Accordion>
@@ -465,7 +465,7 @@ Defining redirect URLs for after sign up, in, and/or out via the Clerk Dashboard
 As part of this change, the default redirect URL for each of these props has been set to `/`, so if you are passing `/` explicitly to any one of the above props, that line is no longer necessary and can be removed.
 
 ```jsx {{ prettier: false, del: [1], ins: [2] }}
-<UserButton afterSignOutUrl='/' />
+<UserButton afterSignOutUrl="/" />
 <UserButton />
 ```
 
@@ -487,8 +487,8 @@ In general, use the environment variables over the props.
 To retain the current behavior of your app without any changes, you can switch `afterSignXUrl` with `signXFallbackRedirectUrl` as such:
 
 ```jsx {{ prettier: false, del: [1], ins: [2] }}
-<SignIn afterSignInUrl='/foo' />
-<SignIn signInFallbackRedirectUrl='/foo' />
+<SignIn afterSignInUrl="/foo" />
+<SignIn signInFallbackRedirectUrl="/foo" />
 ```
 
 ### Removed: `orgs` claim on JWT
@@ -1029,13 +1029,13 @@ As part of this major version, a number of previously deprecated props, argument
 
     ```js {{ prettier: false, del: [1, 4, 7], ins: [2, 5, 8] }}
     await setSession('sessionID', () => void)
-    await setActive({ session: 'sessionID',  beforeEmit: () => void })
+    await setActive({ session: 'sessionID', beforeEmit: () => void })
 
     await setSession(sessionObj)
     await setActive({ session: sessionObj })
 
     await setSession(sessionObj, () => void)
-    await setActive({ session: sessionObj,  beforeEmit: () => void })
+    await setActive({ session: sessionObj, beforeEmit: () => void })
     ```
 
     `setActive` also supports setting an active organization:
@@ -1044,13 +1044,13 @@ As part of this major version, a number of previously deprecated props, argument
     await setActive({
       session: 'sessionID',
       organization: 'orgID',
-      beforeEmit: () => void
+      beforeEmit: () => void,
     })
 
     await setActive({
       session: sessionObj,
       organization: orgObj,
-      beforeEmit: () => void
+      beforeEmit: () => void,
     })
     ```
   </AccordionPanel>

--- a/docs/upgrade-guides/core-2/node.mdx
+++ b/docs/upgrade-guides/core-2/node.mdx
@@ -66,9 +66,9 @@ If you are having trouble with `npx`, it's also possible to install directly wit
 If you are using either of these import paths, they are no longer necessary and you can import directly from the top level `@clerk/express` path.
 
 ```js {{ prettier: false, del: [1, 2], ins: [3] }}
-import { ... } from "@clerk/clerk-sdk-node/esm/instance";
-import { ... } from "@clerk/clerk-sdk-node/cjs/instance";
-import { ... } from "@clerk/clerk-sdk-node";
+import { ... } from '@clerk/clerk-sdk-node/esm/instance'
+import { ... } from '@clerk/clerk-sdk-node/cjs/instance'
+import { ... } from '@clerk/clerk-sdk-node'
 ```
 
 ### Clerk client setters removed in favor of `createClerkClient` options
@@ -590,18 +590,18 @@ As part of this major version, a number of previously deprecated props, argument
     ```ts {{ prettier: false, del: [1, 8], ins: [2, [9, 14]] }}
     type LegacyAuthObject = {
     type AuthObject = {
-      sessionId: string | null;
-      actor: ActClaim | undefined | null;
-      userId: string | null;
-      getToken: ServerGetToken | null;
-      debug: AuthObjectDebug | null;
-      claims: JwtPayload | null;
-      sessionClaims: JwtPayload | null;
-      orgId: string | undefined | null;
-      orgRole: OrganizationCustomRoleKey | undefined | null;
-      orgSlug: string | undefined | null;
-      orgPermissions: OrganizationCustomPermissionKey[] | undefined | null;
-      has: CheckAuthorizationWithCustomPermissions | null;
+      sessionId: string | null
+      actor: ActClaim | undefined | null
+      userId: string | null
+      getToken: ServerGetToken | null
+      debug: AuthObjectDebug | null
+      claims: JwtPayload | null
+      sessionClaims: JwtPayload | null
+      orgId: string | undefined | null
+      orgRole: OrganizationCustomRoleKey | undefined | null
+      orgSlug: string | undefined | null
+      orgPermissions: OrganizationCustomPermissionKey[] | undefined | null
+      has: CheckAuthorizationWithCustomPermissions | null
     }
     ```
 

--- a/docs/upgrade-guides/core-2/react.mdx
+++ b/docs/upgrade-guides/core-2/react.mdx
@@ -94,7 +94,7 @@ Defining redirect URLs for after sign up, in, and/or out via the Clerk dashboard
 As part of this change, the default URL for each of these props has been set to `/`, so if you are passing `/` explicitly to any one of the above props, that line is no longer necessary and can be removed.
 
 ```jsx {{ prettier: false, del: [1], ins: [2] }}
-<UserButton afterSignOutUrl='/' />
+<UserButton afterSignOutUrl="/" />
 <UserButton />
 ```
 
@@ -116,8 +116,8 @@ In general, use the environment variables over the props.
 To retain the current behavior of your app without any changes, you can switch `afterSignXUrl` with `signXFallbackRedirectUrl` as such:
 
 ```jsx {{ prettier: false, del: [1], ins: [2] }}
-<SignIn afterSignInUrl='/foo' />
-<SignIn signInFallbackRedirectUrl='/foo' />
+<SignIn afterSignInUrl="/foo" />
+<SignIn signInFallbackRedirectUrl="/foo" />
 ```
 
 ### `navigate` prop to `ClerkProvider` replaced by `routerPush` and `routerReplace`
@@ -129,8 +129,8 @@ Two new props have been added to `ClerkProvider` that replace the single `naviga
 If you’d like to keep the same behavior as you had with the single `navigate` prop, pass the exact same function to both `routerPush` and `routerReplace` and the behavior will be identical. For example:
 
 ```jsx {{ prettier: false, del: [1], ins: [2] }}
-<ClerkProvider navigate={ x => x } />
-<ClerkProvider routerPush={ x => x } routerReplace={ x => x } />
+<ClerkProvider navigate={(x) => x} />
+<ClerkProvider routerPush={(x) => x} routerReplace={(x) => x} />
 ```
 
 However, you now have the option to differentiate behavior based on whether the navigation will be a push or replace.
@@ -271,8 +271,8 @@ As part of this major version, a number of previously deprecated props, argument
     The `afterSwitchOrganizationUrl` prop on the `<OrganizationSwitcher />` component has been renamed to `afterSelectOrganizationUrl`. This is a quick and simple rename.
 
     ```jsx {{ prettier: false, del: [1], ins: [2] }}
-    <OrganizationSwitcher afterSwitchOrganizationUrl='...' />
-    <OrganizationSwitcher afterSelectOrganizationUrl='...' />
+    <OrganizationSwitcher afterSwitchOrganizationUrl="..." />
+    <OrganizationSwitcher afterSelectOrganizationUrl="..." />
     ```
   </AccordionPanel>
 
@@ -607,20 +607,20 @@ As part of this major version, a number of previously deprecated props, argument
     ```js {{ prettier: false }}
     // before: useOrganizations return values
     {
-        isLoaded: boolean,
-        createOrganization: clerk.createOrganization,
-        getOrganizationMemberships: clerk.getOrganizationMemberships,
-        getOrganization: clerk.getOrganization,
+      isLoaded: boolean,
+      createOrganization: clerk.createOrganization,
+      getOrganizationMemberships: clerk.getOrganizationMemberships,
+      getOrganization: clerk.getOrganization,
     }
 
     // after: useOrganizationList return values
     {
-        isLoaded: boolean,
-        createOrganization: clerk.createOrganization,
-        userMemberships: PaginatedResourcesWithDefault<...> | PaginatedResources<...>,
-        userInvitations: PaginatedResourcesWithDefault<...> | PaginatedResources<...>,
-        userSuggestions: PaginatedResourcesWithDefault<...> | PaginatedResources<...>,
-        setActive: clerk.setActive,
+      isLoaded: boolean,
+      createOrganization: clerk.createOrganization,
+      userMemberships: PaginatedResourcesWithDefault<...> | PaginatedResources<...>,
+      userInvitations: PaginatedResourcesWithDefault<...> | PaginatedResources<...>,
+      userSuggestions: PaginatedResourcesWithDefault<...> | PaginatedResources<...>,
+      setActive: clerk.setActive,
     }
     ```
   </AccordionPanel>
@@ -771,13 +771,13 @@ As part of this major version, a number of previously deprecated props, argument
 
     ```js {{ prettier: false, del: [1, 4, 7], ins: [2, 5, 8] }}
     await setSession('sessionID', () => void)
-    await setActive({ session: 'sessionID',  beforeEmit: () => void })
+    await setActive({ session: 'sessionID', beforeEmit: () => void })
 
     await setSession(sessionObj)
     await setActive({ session: sessionObj })
 
     await setSession(sessionObj, () => void)
-    await setActive({ session: sessionObj,  beforeEmit: () => void })
+    await setActive({ session: sessionObj, beforeEmit: () => void })
     ```
 
     `setActive` also supports setting an active organization:
@@ -786,12 +786,12 @@ As part of this major version, a number of previously deprecated props, argument
     await setActive({
       session: 'sessionID',
       organization: 'orgID',
-      beforeEmit: () => void
+      beforeEmit: () => void,
     })
     await setActive({
       session: sessionObj,
       organization: orgObj,
-      beforeEmit: () => void
+      beforeEmit: () => void,
     })
     ```
   </AccordionPanel>

--- a/docs/upgrade-guides/core-2/remix.mdx
+++ b/docs/upgrade-guides/core-2/remix.mdx
@@ -85,20 +85,21 @@ If you are having trouble with `npx`, it's also possible to install directly wit
 
 `ClerkErrorBoundary` is no longer needed for correct error handling in remix, so we have removed this function from the remix SDK, and it can be removed from your code as well. Example below:
 
-```ts {{ prettier: false, del: [4, 13] }}
-import { rootAuthLoader } from '@clerk/remix/ssr.server';
+```ts {{ del: [4, 13] }}
+import { rootAuthLoader } from '@clerk/remix/ssr.server'
 import {
   ClerkApp,
-  ClerkErrorBoundary
-} from '@clerk/remix';
+  // prettier-ignore
+  ClerkErrorBoundary,
+} from '@clerk/remix'
 
 export const loader = (args: DataFunctionArgs) => {
-  return rootAuthLoader(args);
-};
+  return rootAuthLoader(args)
+}
 
-export default ClerkApp(App);
+export default ClerkApp(App)
 
-export const ErrorBoundary = ClerkErrorBoundary();
+export const ErrorBoundary = ClerkErrorBoundary()
 ```
 
 ### Component design adjustments
@@ -114,7 +115,7 @@ Defining redirect URLs for after sign up, in, and/or out via the Clerk dashboard
 As part of this change, the default URL for each of these props has been set to `/`, so if you are passing `/` explicitly to any one of the above props, that line is no longer necessary and can be removed.
 
 ```jsx {{ prettier: false, del: [1], ins: [2] }}
-<UserButton afterSignOutUrl='/' />
+<UserButton afterSignOutUrl="/" />
 <UserButton />
 ```
 
@@ -136,8 +137,8 @@ In general, use the environment variables over the props.
 To retain the current behavior of your app without any changes, you can switch `afterSignXUrl` with `signXFallbackRedirectUrl` as such:
 
 ```jsx {{ prettier: false, del: [1], ins: [2] }}
-<SignIn afterSignInUrl='/foo' />
-<SignIn signInFallbackRedirectUrl='/foo' />
+<SignIn afterSignInUrl="/foo" />
+<SignIn signInFallbackRedirectUrl="/foo" />
 ```
 
 ### Removed: `orgs` claim on JWT
@@ -328,13 +329,13 @@ As part of this major version, a number of previously deprecated props, argument
 
     ```js {{ prettier: false, del: [1, 4, 7], ins: [2, 5, 8] }}
     await setSession('sessionID', () => void)
-    await setActive({ session: 'sessionID',  beforeEmit: () => void })
+    await setActive({ session: 'sessionID', beforeEmit: () => void })
 
     await setSession(sessionObj)
     await setActive({ session: sessionObj })
 
     await setSession(sessionObj, () => void)
-    await setActive({ session: sessionObj,  beforeEmit: () => void })
+    await setActive({ session: sessionObj, beforeEmit: () => void })
     ```
 
     `setActive` also supports setting an active organization:
@@ -343,13 +344,13 @@ As part of this major version, a number of previously deprecated props, argument
     await setActive({
       session: 'sessionID',
       organization: 'orgID',
-      beforeEmit: () => void
+      beforeEmit: () => void,
     })
 
     await setActive({
       session: sessionObj,
       organization: orgObj,
-      beforeEmit: () => void
+      beforeEmit: () => void,
     })
     ```
   </AccordionPanel>


### PR DESCRIPTION
Apply minor formatting fixes:

- Remove `prettier: false` from code blocks that can be formatted
- Update code block language where appropriate
- For code blocks that cannot be formatted, tweak code to match code style, e.g.
  - Fix indentation and excess whitespace
  - Use single quotes (double quotes for JSX props)
  - Add trailing commas