### PR TITLE
Add example on defining Clerk keys per tenant from `clerkMiddleware`

### DIFF
--- a/docs/references/nextjs/clerk-middleware.mdx
+++ b/docs/references/nextjs/clerk-middleware.mdx
@@ -387,5 +387,44 @@ When providing `CLERK_ENCRYPTION_KEY`, it is recommended to use a 32-byte (256-b
 openssl rand --hex 32
 ```
 
+For multi-tenant applications where you need to provide different Clerk keys depending on the incoming request, you can use a function to dynamically set these keys. Here's an example:
+
+```tsx {{ filename: 'middleware.ts' }}
+import { clerkMiddleware, createRouteMatcher } from '@clerk/nextjs/server'
+
+// Get the tenant from the request
+function getTenant(req: Request) {
+  const host = req.headers.get('host')
+  const subdomain = host?.split('.')[0]
+  return subdomain
+}
+
+// Get Clerk keys for the tenant
+// You would typically fetch these from a external store or environment variables.
+function getClerkKeys(tenant: string) {
+  const tenantKeys = {
+    tenant1: {
+      publishableKey: 'pk_tenant1...',
+      secretKey: 'sk_tenant1...',
+    },
+    tenant2: {
+      publishableKey: 'pk_tenant2...',
+      secretKey: 'sk_tenant2...',
+    },
+  }
+  return tenantKeys[tenant] || tenantKeys.default
+}
+
+export default clerkMiddleware((auth, req) => {
+  const tenant = getTenant(req)
+  const { publishableKey, secretKey } = getClerkKeys(tenant)
+
+  return {
+    publishableKey,
+    secretKey,
+  }
+})
+```
+
 > [!NOTE]
 > Dynamic keys are not accessible on the client-side.

--- a/docs/references/nextjs/clerk-middleware.mdx
+++ b/docs/references/nextjs/clerk-middleware.mdx
@@ -416,6 +416,8 @@ function getClerkKeys(tenant: string) {
 }
 
 export default clerkMiddleware((auth, req) => {
+   // Add your middleware checks
+}, (req) => {
   const tenant = getTenant(req)
   const { publishableKey, secretKey } = getClerkKeys(tenant)
 

--- a/docs/references/nextjs/clerk-middleware.mdx
+++ b/docs/references/nextjs/clerk-middleware.mdx
@@ -408,6 +408,7 @@ For multi-tenant applications, you can dynamically define Clerk keys depending o
 ```ts {{ filename: 'middleware.ts' }}
 import { clerkMiddleware } from '@clerk/nextjs/server'
 
+// You would typically fetch these keys from a external store or environment variables.
 const tenantKeys = {
   tenant1: { publishableKey: 'pk_tenant1...', secretKey: 'sk_tenant1...' },
   tenant2: { publishableKey: 'pk_tenant2...', secretKey: 'sk_tenant2...' },
@@ -420,8 +421,6 @@ export default clerkMiddleware(
   (req) => {
     // Resolve tenant based on the request
     const tenant = getTenant(req)
-
-    // You would typically fetch these keys from a external store or environment variables.
     return tenantKeys[tenant]
   },
 )

--- a/docs/references/nextjs/clerk-middleware.mdx
+++ b/docs/references/nextjs/clerk-middleware.mdx
@@ -370,6 +370,22 @@ The `clerkMiddleware()` function accepts an optional object. The following optio
   The Clerk secret key for your instance. This can be found in your Clerk Dashboard on the **[API Keys](https://dashboard.clerk.com/last-active?path=api-keys)** page. The `CLERK_ENCRYPTION_KEY` environment variable must be set when providing `secretKey` as an option, refer to [Dynamic keys](#dynamic-keys).
 </Properties>
 
+It's also possible to dynamically set options based on the incoming request:
+
+```ts {{ filename: 'middleware.ts' }}
+import { clerkMiddleware } from '@clerk/nextjs/server'
+
+export default clerkMiddleware(
+  (auth, req) => {
+    // Add your middleware checks
+  },
+  (req) => ({
+    // Provide `domain` based on the request host
+    domain: req.nextUrl.host,
+  }),
+)
+```
+
 ### Dynamic keys
 
 The following options, known as "Dynamic Keys," are shared to the Next.js application server through `clerkMiddleware`, enabling access by server-side helpers like [`auth()`](/docs/references/nextjs/auth):
@@ -387,45 +403,28 @@ When providing `CLERK_ENCRYPTION_KEY`, it is recommended to use a 32-byte (256-b
 openssl rand --hex 32
 ```
 
-For multi-tenant applications where you need to provide different Clerk keys depending on the incoming request, you can use a function to dynamically set these keys. Here's an example:
+For multi-tenant applications, you can dynamically define Clerk keys depending on the incoming request. Here's an example:
 
-```tsx {{ filename: 'middleware.ts' }}
-import { clerkMiddleware, createRouteMatcher } from '@clerk/nextjs/server'
+```ts {{ filename: 'middleware.ts' }}
+import { clerkMiddleware } from '@clerk/nextjs/server'
 
-// Get the tenant from the request
-function getTenant(req: Request) {
-  const host = req.headers.get('host')
-  const subdomain = host?.split('.')[0]
-  return subdomain
+const tenantKeys = {
+  tenant1: { publishableKey: 'pk_tenant1...', secretKey: 'sk_tenant1...' },
+  tenant2: { publishableKey: 'pk_tenant2...', secretKey: 'sk_tenant2...' },
 }
 
-// Get Clerk keys for the tenant
-// You would typically fetch these from a external store or environment variables.
-function getClerkKeys(tenant: string) {
-  const tenantKeys = {
-    tenant1: {
-      publishableKey: 'pk_tenant1...',
-      secretKey: 'sk_tenant1...',
-    },
-    tenant2: {
-      publishableKey: 'pk_tenant2...',
-      secretKey: 'sk_tenant2...',
-    },
-  }
-  return tenantKeys[tenant] || tenantKeys.default
-}
+export default clerkMiddleware(
+  (auth, req) => {
+    // Add your middleware checks
+  },
+  (req) => {
+    // Resolve tenant based on the request
+    const tenant = getTenant(req)
 
-export default clerkMiddleware((auth, req) => {
-   // Add your middleware checks
-}, (req) => {
-  const tenant = getTenant(req)
-  const { publishableKey, secretKey } = getClerkKeys(tenant)
-
-  return {
-    publishableKey,
-    secretKey,
-  }
-})
+    // You would typically fetch these keys from a external store or environment variables.
+    return tenantKeys[tenant]
+  },
+)
 ```
 
 > [!NOTE]


### PR DESCRIPTION
<!--- Add the "deploy-preview" label and add your page previews here -->

> [!IMPORTANT]
> 🔎 Previews:
>
> - https://clerk.com/docs/pr/1508

<!--- Describe your changes in detail. Why does this change need to happen? Include any links to Slack discussions, Linear comments, etc. -->

### Explanation:

Resolves DOCS-9092

> User's feedback: I don't understand the dynamic keys section. The changelog post says: "Users building a multi-tenant application might need to provide different Clerk keys depending on the incoming request.".

Adds example on the Next.js dynamic keys section regarding how to make keys conditional per tenant on request time. 

<!--- How does this PR solve the problem? -->

