### PR TITLE
Emphasize importance of `authorizedParties` argument use on the backend

### DIFF
--- a/docs/backend-requests/handling/manual-jwt.mdx
+++ b/docs/backend-requests/handling/manual-jwt.mdx
@@ -26,6 +26,7 @@ export async function GET(req: Request) {
 
   const { isSignedIn } = await clerkClient.authenticateRequest(req, {
     jwtKey: process.env.CLERK_JWT_KEY,
+    authorizedParties: ['https://example.com'],
   })
 
   if (!isSignedIn) {

--- a/docs/references/backend/authenticate-request.mdx
+++ b/docs/references/backend/authenticate-request.mdx
@@ -14,6 +14,9 @@ function authenticateRequest(
 ): Promise<RequestState>
 ```
 
+> [!NOTE]
+> We strongly recommend explicitly setting the `authorizedParties` option when authorizing requests. The value should be a list of domains that are allowed to make requests to your application. Not setting this value can open your application to [CSRF attacks](https://owasp.org/www-community/attacks/csrf).
+
 ## Parameters
 
 <Properties>


### PR DESCRIPTION
> [!IMPORTANT]
> 🔎 Previews:
>
> -

### Explanation:

In order to have a buttoned up security posture when using Clerk, it's important that developers ensure they are checking the `azp` claim against a list of allowed origins on the backend. There's more work to be done here emphasizing this but this PR is a start at the source at making sure the importance of using this argument is more clear.