### PR TITLE
Remove OAuth references from custom SAML connection docs

### DIFF
--- a/docs/custom-flows/saml-connections.mdx
+++ b/docs/custom-flows/saml-connections.mdx
@@ -71,7 +71,6 @@ The following example shows two files:
       import { AuthenticateWithRedirectCallback } from '@clerk/nextjs'
 
       export default function SSOCallback() {
-        console.log('testing')
         // Handle the redirect flow by rendering the
         // prebuilt AuthenticateWithRedirectCallback component.
         // This is the final step in the custom SAML flow.

--- a/docs/custom-flows/saml-connections.mdx
+++ b/docs/custom-flows/saml-connections.mdx
@@ -14,7 +14,7 @@ You must configure your application instance through the Clerk Dashboard for the
 
 When using SAML, the sign-in and sign-up flows are equivalent. A successful SAML flow consists of the following steps:
 
-1. Start the SAML flow by calling [`SignIn.authenticateWithRedirect(params)`](/docs/references/javascript/sign-in/authenticate-with#authenticate-with-redirect) or [`SignUp.authenticateWithRedirect(params)`](/docs/references/javascript/sign-up/authenticate-with#authenticate-with-redirect). Note that both of these methods require a `redirectUrl` param, which is the URL that the browser will be redirected to once the user authenticates with the OAuth provider.
+1. Start the SAML flow by calling [`SignIn.authenticateWithRedirect(params)`](/docs/references/javascript/sign-in/authenticate-with#authenticate-with-redirect) or [`SignUp.authenticateWithRedirect(params)`](/docs/references/javascript/sign-up/authenticate-with#authenticate-with-redirect). Note that both of these methods require a `redirectUrl` param, which is the URL that the browser will be redirected to once the user authenticates with the identity provider.
 1. Create a route at the URL that the `redirectUrl` param points to. The following example names this route `/sso-callback`. This route should either call the [`Clerk.handleRedirectCallback()`](/docs/references/javascript/clerk/handle-navigation#handle-redirect-callback) method or render the prebuilt [`<AuthenticateWithRedirectCallback/>`](/docs/components/control/authenticate-with-callback) component.
 
 The following example shows two files:
@@ -31,13 +31,13 @@ The following example shows two files:
       import * as React from 'react'
       import { useSignIn, useSignUp } from '@clerk/nextjs'
 
-      export default function OauthSignIn() {
+      export default function SAMLSignIn() {
         const { signIn } = useSignIn()
         const { signUp } = useSignUp()
 
         if (!signIn || !signUp) return null
 
-        const signInWith = (e: React.FormEvent) => {
+        const signInWithSAML = (e: React.FormEvent) => {
           e.preventDefault()
 
           const email = (e.target as HTMLFormElement).email.value
@@ -58,10 +58,8 @@ The following example shows two files:
             })
         }
 
-        // Render a button for each supported SAML provider
-        // you want to add to your app
         return (
-          <form onSubmit={(e) => signInWith(e)}>
+          <form onSubmit={(e) => signInWithSAML(e)}>
             <input type="email" name="email" placeholder="Enter email address" />
             <button>Sign in with SAML</button>
           </form>
@@ -86,7 +84,7 @@ The following example shows two files:
 
 ## SAML account transfer flows
 
-It is common for users who are authenticating with OAuth to use a sign-in button when they mean to sign-up, and vice versa. For those cases, the `SignIn` and `SignUp` objects have a `transferable` status that indicates whether the user can be transferred to the other flow.
+It is common for users who are authenticating with SAML to use a sign-in button when they mean to sign-up, and vice versa. For those cases, the `SignIn` and `SignUp` objects have a `transferable` status that indicates whether the user can be transferred to the other flow.
 
 If you would like to keep your sign-in and sign-up flows completely separate, then you can skip this section.
 
@@ -100,13 +98,13 @@ The following example shows how to handle these cases in your sign-in flow. The 
     import * as React from 'react'
     import { useSignIn, useSignUp } from '@clerk/nextjs'
 
-    export default function OauthSignIn() {
+    export default function SAMLSignIn() {
       const { signIn } = useSignIn()
       const { signUp, setActive } = useSignUp()
 
       if (!signIn || !signUp) return null
 
-      const signInWith = (e: React.FormEvent) => {
+      const signInWithSAML = (e: React.FormEvent) => {
         e.preventDefault()
 
         const email = (e.target as HTMLFormElement).email.value
@@ -165,12 +163,10 @@ The following example shows how to handle these cases in your sign-in flow. The 
         } else {
           // If the user has an account in your application
           // and has an SAML account connected to it, you can sign them in.
-          signInWith(e)
+          signInWithSAML(e)
         }
       }
 
-      // Render a button for each supported OAuth provider
-      // you want to add to your app
       return (
         <form onSubmit={(e) => handleSignIn(e)}>
           <input type="email" name="email" placeholder="Enter email address" />


### PR DESCRIPTION
<!--- Add the "deploy-preview" label and add your page previews here -->

> [!IMPORTANT]
> 🔎 Previews:
>
> - https://clerk.com/docs/pr/1514

<!--- Describe your changes in detail. Why does this change need to happen? Include any links to Slack discussions, Linear comments, etc. -->

### Explanation:

We are mentioning "OAuth" in a couple of places and code snippets from the custom SAML connections docs. I believe it was previously copied from the custom OAuth connections docs.

I've removed those references to use SAML nomenclature. 
