### PR TITLE
add instructions to sign up on localhost

### DIFF
--- a/docs/quickstarts/astro.mdx
+++ b/docs/quickstarts/astro.mdx
@@ -161,7 +161,7 @@ Clerk's [Astro SDK](/docs/references/astro/overview) provides a set of component
   </SiteLayout>
   ```
 
-  ### Sign up to create your first user
+  ### Create your first user
 
   Now visit your app's homepage at [`http://localhost:4321`](http://localhost:4321). Sign up to create your first user.
 </Steps>

--- a/docs/quickstarts/astro.mdx
+++ b/docs/quickstarts/astro.mdx
@@ -163,7 +163,7 @@ Clerk's [Astro SDK](/docs/references/astro/overview) provides a set of component
 
   ### Sign up to create your first user
 
-  Now visit your app's homepage at [`http://localhost:4321`](http://localhost:4321) while signed out to see the sign-in button. Sign up to create your first user. Once signed in, your app will render the user button.
+  Now visit your app's homepage at [`http://localhost:4321`](http://localhost:4321). Sign up to create your first user.
 </Steps>
 
 ## Next steps

--- a/docs/quickstarts/astro.mdx
+++ b/docs/quickstarts/astro.mdx
@@ -160,6 +160,10 @@ Clerk's [Astro SDK](/docs/references/astro/overview) provides a set of component
     <p>Sign in to try Clerk out!</p>
   </SiteLayout>
   ```
+
+  ### Sign up to create your first user
+
+  Now visit your app's homepage at [`http://localhost:4321`](http://localhost:4321) while signed out to see the sign-in button. Sign up to create your first user. Once signed in, your app will render the user button.
 </Steps>
 
 ## Next steps

--- a/docs/quickstarts/expo.mdx
+++ b/docs/quickstarts/expo.mdx
@@ -433,7 +433,7 @@ description: Add authentication and user management to your Expo app with Clerk.
 
   For more information about building these custom flows, including guided comments in the code examples, see the [Build a custom email/password authentication flow](/docs/custom-flows/email-password) guide.
 
-  ### Sign up to create your first user
+  ### Create your first user
 
   Now visit your app's homepage at [`http://localhost:8081`](http://localhost:8081). Sign up to create your first user.
 </Steps>

--- a/docs/quickstarts/expo.mdx
+++ b/docs/quickstarts/expo.mdx
@@ -435,7 +435,7 @@ description: Add authentication and user management to your Expo app with Clerk.
 
   ### Sign up to create your first user
 
-  Now visit your app's homepage at [`http://localhost:8081`](http://localhost:8081) while signed out to see the sign-in button. Sign up to create your first user. Once signed in, your app will render the user button.
+  Now visit your app's homepage at [`http://localhost:8081`](http://localhost:8081). Sign up to create your first user.
 </Steps>
 
 ## Enable OTA updates

--- a/docs/quickstarts/expo.mdx
+++ b/docs/quickstarts/expo.mdx
@@ -432,6 +432,10 @@ description: Add authentication and user management to your Expo app with Clerk.
   ```
 
   For more information about building these custom flows, including guided comments in the code examples, see the [Build a custom email/password authentication flow](/docs/custom-flows/email-password) guide.
+
+  ### Sign up to create your first user
+
+  Now visit your app's homepage at [`http://localhost:8081`](http://localhost:8081) while signed out to see the sign-in button. Sign up to create your first user. Once signed in, your app will render the user button.
 </Steps>
 
 ## Enable OTA updates

--- a/docs/quickstarts/javascript.mdx
+++ b/docs/quickstarts/javascript.mdx
@@ -172,6 +172,11 @@ Select your preferred method below to get started.
         </body>
       </html>
       ```
+
+      ### Sign up to create your first user
+
+      Now visit your app's homepage at [`http://localhost:5173`](http://localhost:5173) while signed out to see the sign-in button. Sign up to create your first user. Once signed in, your app will render the user button.
+      
     </Steps>
   </Tab>
 

--- a/docs/quickstarts/javascript.mdx
+++ b/docs/quickstarts/javascript.mdx
@@ -176,7 +176,6 @@ Select your preferred method below to get started.
       ### Create your first user
 
       Now visit your app's homepage at [`http://localhost:5173`](http://localhost:5173). Sign up to create your first user.
-      
     </Steps>
   </Tab>
 

--- a/docs/quickstarts/javascript.mdx
+++ b/docs/quickstarts/javascript.mdx
@@ -173,7 +173,7 @@ Select your preferred method below to get started.
       </html>
       ```
 
-      ### Sign up to create your first user
+      ### Create your first user
 
       Now visit your app's homepage at [`http://localhost:5173`](http://localhost:5173). Sign up to create your first user.
       

--- a/docs/quickstarts/javascript.mdx
+++ b/docs/quickstarts/javascript.mdx
@@ -175,7 +175,7 @@ Select your preferred method below to get started.
 
       ### Sign up to create your first user
 
-      Now visit your app's homepage at [`http://localhost:5173`](http://localhost:5173) while signed out to see the sign-in button. Sign up to create your first user. Once signed in, your app will render the user button.
+      Now visit your app's homepage at [`http://localhost:5173`](http://localhost:5173). Sign up to create your first user.
       
     </Steps>
   </Tab>

--- a/docs/quickstarts/nextjs.mdx
+++ b/docs/quickstarts/nextjs.mdx
@@ -155,7 +155,7 @@ description: Add authentication and user management to your Next.js app with Cle
     ```
   </CodeBlockTabs>
 
-  ### Sign up to create your first user
+  ### Create your first user
 
   Now visit your app's homepage at [`http://localhost:3000`](http://localhost:3000). Sign up to create your first user.
 </Steps>

--- a/docs/quickstarts/nextjs.mdx
+++ b/docs/quickstarts/nextjs.mdx
@@ -154,6 +154,10 @@ description: Add authentication and user management to your Next.js app with Cle
     export default MyApp
     ```
   </CodeBlockTabs>
+
+  ### Sign up to create your first user
+
+  Now visit your app's homepage at [`http://localhost:3000`](http://localhost:3000) while signed out to see the sign-in button. Sign up to create your first user. Once signed in, your app will render the user button.
 </Steps>
 
 ## Next steps

--- a/docs/quickstarts/nextjs.mdx
+++ b/docs/quickstarts/nextjs.mdx
@@ -157,7 +157,7 @@ description: Add authentication and user management to your Next.js app with Cle
 
   ### Sign up to create your first user
 
-  Now visit your app's homepage at [`http://localhost:3000`](http://localhost:3000) while signed out to see the sign-in button. Sign up to create your first user. Once signed in, your app will render the user button.
+  Now visit your app's homepage at [`http://localhost:3000`](http://localhost:3000). Sign up to create your first user.
 </Steps>
 
 ## Next steps

--- a/docs/quickstarts/react.mdx
+++ b/docs/quickstarts/react.mdx
@@ -170,7 +170,7 @@ description: Add authentication and user management to your React app with Clerk
   }
   ```
 
-  ### Sign up to create your first user 
+  ### Create your first user 
 
   Visit your app's homepage at [`http://localhost:5173`](http://localhost:5173). Sign up to create your first user.
 </Steps>

--- a/docs/quickstarts/react.mdx
+++ b/docs/quickstarts/react.mdx
@@ -170,7 +170,9 @@ description: Add authentication and user management to your React app with Clerk
   }
   ```
 
-  Then, visit your app's homepage at [`http://localhost:5173`](http://localhost:5173) while signed out to see the sign-in button. Once signed in, your app will render the user button.
+  ### Sign up to create your first user 
+
+  Visit your app's homepage at [`http://localhost:5173`](http://localhost:5173) while signed out to see the sign-in button. Sign up to create your first user. Once signed in, your app will render the user button.
 </Steps>
 
 ## Next step: Add routing with React Router

--- a/docs/quickstarts/react.mdx
+++ b/docs/quickstarts/react.mdx
@@ -172,7 +172,7 @@ description: Add authentication and user management to your React app with Clerk
 
   ### Sign up to create your first user 
 
-  Visit your app's homepage at [`http://localhost:5173`](http://localhost:5173) while signed out to see the sign-in button. Sign up to create your first user. Once signed in, your app will render the user button.
+  Visit your app's homepage at [`http://localhost:5173`](http://localhost:5173). Sign up to create your first user.
 </Steps>
 
 ## Next step: Add routing with React Router

--- a/docs/quickstarts/react.mdx
+++ b/docs/quickstarts/react.mdx
@@ -170,7 +170,7 @@ description: Add authentication and user management to your React app with Clerk
   }
   ```
 
-  ### Create your first user 
+  ### Create your first user
 
   Visit your app's homepage at [`http://localhost:5173`](http://localhost:5173). Sign up to create your first user.
 </Steps>

--- a/docs/quickstarts/remix.mdx
+++ b/docs/quickstarts/remix.mdx
@@ -267,7 +267,7 @@ Learn how to use Clerk to quickly and easily add secure authentication and user 
 
   ### Sign up to create your first user
 
-  Now visit your app's homepage at [`http://localhost:5173`](http://localhost:5173) while signed out to see the sign-in button. Sign up to create your first user. Once signed in, your app will render the user button.
+  Now visit your app's homepage at [`http://localhost:5173`](http://localhost:5173). Sign up to create your first user.
 </Steps>
 
 ## Next steps

--- a/docs/quickstarts/remix.mdx
+++ b/docs/quickstarts/remix.mdx
@@ -264,6 +264,10 @@ Learn how to use Clerk to quickly and easily add secure authentication and user 
     )
   }
   ```
+
+  ### Sign up to create your first user
+
+  Now visit your app's homepage at [`http://localhost:5173`](http://localhost:5173) while signed out to see the sign-in button. Sign up to create your first user. Once signed in, your app will render the user button.
 </Steps>
 
 ## Next steps

--- a/docs/quickstarts/remix.mdx
+++ b/docs/quickstarts/remix.mdx
@@ -265,7 +265,7 @@ Learn how to use Clerk to quickly and easily add secure authentication and user 
   }
   ```
 
-  ### Sign up to create your first user
+  ### Create your first user
 
   Now visit your app's homepage at [`http://localhost:5173`](http://localhost:5173). Sign up to create your first user.
 </Steps>


### PR DESCRIPTION
<!--- Add the "deploy-preview" label and add your page previews here -->

> [!IMPORTANT]
> 🔎 Previews:
>
> -

<!--- Describe your changes in detail. Why does this change need to happen? Include any links to Slack discussions, Linear comments, etc. -->

### Explanation:

We don't currently explicitly tell users to sign up on their localhost, which creates a gap in metrics between users who run locally, and create their first user (which is what we consider to be an `install` event)

### This PR:

- Adds explicit instructions as the last step of our quickstarts - the goal here is to make it clear that they should sign up to create their first user.

[Companion PR](https://github.com/clerk/dashboard/pull/3571) making the same updates for Dashboard
