### PR TITLE
docs(astro): Add custom menu items examples for Astro

### DIFF
--- a/docs/customization/user-button.mdx
+++ b/docs/customization/user-button.mdx
@@ -57,60 +57,143 @@ The `<UserButton />` component must be wrapped in a `<UserButton.MenuItems />` c
 
 The following example demonstrates how to add an action to the `<UserButton />` component.
 
-```tsx filename="/app/page.tsx"
-'use client'
+<Tabs items={["Next.js", "Astro"]}>
+  <Tab>
+    ```tsx filename="/app/page.tsx"
+    'use client'
 
-import { UserButton } from '@clerk/nextjs'
+    import { UserButton } from '@clerk/nextjs'
 
-const DotIcon = () => {
-  return (
-    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512" fill="currentColor">
-      <path d="M256 512A256 256 0 1 0 256 0a256 256 0 1 0 0 512z" />
-    </svg>
-  )
-}
+    const DotIcon = () => {
+      return (
+        <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512" fill="currentColor">
+          <path d="M256 512A256 256 0 1 0 256 0a256 256 0 1 0 0 512z" />
+        </svg>
+      )
+    }
 
-export default function Home() {
-  return (
+    export default function Home() {
+      return (
+        <header>
+          <UserButton>
+            <UserButton.MenuItems>
+              <UserButton.Action
+                label="Open chat"
+                labelIcon={<DotIcon />}
+                onClick={() => alert('init chat')}
+              />
+            </UserButton.MenuItems>
+          </UserButton>
+        </header>
+      )
+    }
+    ```
+  </Tab>
+
+  <Tab>
+    To handle click events in Astro, we use a `clickIdentifier` prop and a custom event listener instead of an `onClick` handler. The `e.detail` value is then used to determine which item was clicked.
+
+    ```astro filename="pages/index.astro"
+    ---
+    import { UserButton } from '@clerk/astro/components'
+    ---
+
     <header>
       <UserButton>
         <UserButton.MenuItems>
-          <UserButton.Action
-            label="Open chat"
-            labelIcon={<DotIcon />}
-            onClick={() => alert('init chat')}
-          />
+          <UserButton.Action label="Open chat" clickIdentifier="open_chat">
+            <svg
+              slot="label-icon"
+              xmlns="http://www.w3.org/2000/svg"
+              viewBox="0 0 512 512"
+              fill="currentColor"
+            >
+              <path d="M256 512A256 256 0 1 0 256 0a256 256 0 1 0 0 512z"></path>
+            </svg>
+          </UserButton.Action>
         </UserButton.MenuItems>
       </UserButton>
     </header>
-  )
-}
-```
+
+    <script>
+      document.addEventListener('clerk:menu-item-click', (e) => {
+        if (e.detail === 'open_chat') {
+          console.log('init chat')
+        }
+      })
+    </script>
+    ```
+  </Tab>
+</Tabs>
 
 The following example demonstrates how to add an action, as well as a [custom page](/docs/customization/user-profile), to the `<UserButton />` component.
 
-```tsx filename="/app/page.tsx"
-'use client'
+<Tabs items={["Next.js", "Astro"]}>
+  <Tab>
+    ```tsx filename="/app/page.tsx"
+    'use client'
 
-import { UserButton } from '@clerk/nextjs'
+    import { UserButton } from '@clerk/nextjs'
 
-const DotIcon = () => {
-  return (
-    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512" fill="currentColor">
-      <path d="M256 512A256 256 0 1 0 256 0a256 256 0 1 0 0 512z" />
-    </svg>
-  )
-}
+    const DotIcon = () => {
+      return (
+        <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512" fill="currentColor">
+          <path d="M256 512A256 256 0 1 0 256 0a256 256 0 1 0 0 512z" />
+        </svg>
+      )
+    }
 
-export default function Home() {
-  return (
+    export default function Home() {
+      return (
+        <header>
+          <UserButton>
+            <UserButton.MenuItems>
+              <UserButton.Action label="Help" labelIcon={<DotIcon />} open="help" />
+            </UserButton.MenuItems>
+
+            <UserButton.UserProfilePage label="Help" labelIcon={<DotIcon />} url="help">
+              <div>
+                <h1>Help Page</h1>
+                <p>This is the custom help page</p>
+              </div>
+            </UserButton.UserProfilePage>
+          </UserButton>
+        </header>
+      )
+    }
+    ```
+  </Tab>
+
+  <Tab>
+    ```astro filename="pages/index.astro"
+    ---
+    import { UserButton } from '@clerk/astro/components'
+    ---
+
     <header>
       <UserButton>
         <UserButton.MenuItems>
-          <UserButton.Action label="Help" labelIcon={<DotIcon />} open="help" />
+          <UserButton.Action label="Help" open="help">
+            <svg
+              slot="label-icon"
+              xmlns="http://www.w3.org/2000/svg"
+              viewBox="0 0 512 512"
+              fill="currentColor"
+            >
+              <path d="M256 512A256 256 0 1 0 256 0a256 256 0 1 0 0 512z"></path>
+            </svg>
+          </UserButton.Action>
         </UserButton.MenuItems>
 
-        <UserButton.UserProfilePage label="Help" labelIcon={<DotIcon />} url="help">
+        <UserButton.UserProfilePage label="Help" url="help">
+          <svg
+            slot="label-icon"
+            xmlns="http://www.w3.org/2000/svg"
+            viewBox="0 0 512 512"
+            fill="currentColor"
+          >
+            <path d="M256 512A256 256 0 1 0 256 0a256 256 0 1 0 0 512z"></path>
+          </svg>
           <div>
             <h1>Help Page</h1>
             <p>This is the custom help page</p>
@@ -118,9 +201,9 @@ export default function Home() {
         </UserButton.UserProfilePage>
       </UserButton>
     </header>
-  )
-}
-```
+    ```
+  </Tab>
+</Tabs>
 
 ## `<UserButton.Link>`
 
@@ -157,71 +240,131 @@ The `<UserButton />` component must be wrapped in a `<UserButton.MenuItems />` c
 
 The following example demonstrates how to add a link to the `<UserButton />` component.
 
-```tsx filename="/app/page.tsx"
-'use client'
+<Tabs items={["Next.js", "Astro"]}>
+  <Tab>
+    ```tsx filename="/app/page.tsx"
+    'use client'
 
-import { UserButton } from '@clerk/nextjs'
+    import { UserButton } from '@clerk/nextjs'
 
-const DotIcon = () => {
-  return (
-    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512" fill="currentColor">
-      <path d="M256 512A256 256 0 1 0 256 0a256 256 0 1 0 0 512z" />
-    </svg>
-  )
-}
+    const DotIcon = () => {
+      return (
+        <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512" fill="currentColor">
+          <path d="M256 512A256 256 0 1 0 256 0a256 256 0 1 0 0 512z" />
+        </svg>
+      )
+    }
 
-export default function Home() {
-  return (
+    export default function Home() {
+      return (
+        <header>
+          <UserButton>
+            <UserButton.MenuItems>
+              <UserButton.Link
+                label="Create organization"
+                labelIcon={<DotIcon />}
+                href="/create-organization"
+              />
+            </UserButton.MenuItems>
+          </UserButton>
+        </header>
+      )
+    }
+    ```
+  </Tab>
+
+  <Tab>
+    ```astro filename="pages/index.astro"
+    ---
+    import { UserButton } from '@clerk/astro/components'
+    ---
+
     <header>
       <UserButton>
         <UserButton.MenuItems>
-          <UserButton.Link
-            label="Create organization"
-            labelIcon={<DotIcon />}
-            href="/create-organization"
-          />
+          <UserButton.Link label="Create organization" open="/create-organization">
+            <svg
+              slot="label-icon"
+              xmlns="http://www.w3.org/2000/svg"
+              viewBox="0 0 512 512"
+              fill="currentColor"
+            >
+              <path d="M256 512A256 256 0 1 0 256 0a256 256 0 1 0 0 512z"></path>
+            </svg>
+          </UserButton.Link>
         </UserButton.MenuItems>
       </UserButton>
     </header>
-  )
-}
-```
+    ```
+  </Tab>
+</Tabs>
 
 ## Reorder default items
 
 The `<UserButton />` component includes two default menu items: `Manage account` and `Sign out`. You can reorder these default items by setting the `label` prop to `'manageAccount'` or `'signOut'`. This will target the existing default item and allow you to rearrange it, as shown in the following example:
 
-```tsx filename="/app/page.tsx"
-'use client'
+<Tabs items={["Next.js", "Astro"]}>
+  <Tab>
+    ```tsx filename="/app/page.tsx"
+    'use client'
 
-import { UserButton } from '@clerk/nextjs'
+    import { UserButton } from '@clerk/nextjs'
 
-const DotIcon = () => {
-  return (
-    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512" fill="currentColor">
-      <path d="M256 512A256 256 0 1 0 256 0a256 256 0 1 0 0 512z" />
-    </svg>
-  )
-}
+    const DotIcon = () => {
+      return (
+        <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512" fill="currentColor">
+          <path d="M256 512A256 256 0 1 0 256 0a256 256 0 1 0 0 512z" />
+        </svg>
+      )
+    }
 
-export default function Home() {
-  return (
+    export default function Home() {
+      return (
+        <header>
+          <UserButton>
+            <UserButton.MenuItems>
+              <UserButton.Action label="signOut" />
+              <UserButton.Link
+                label="Create organization"
+                labelIcon={<DotIcon />}
+                href="/create-organization"
+              />
+              <UserButton.Action label="manageAccount" />
+            </UserButton.MenuItems>
+          </UserButton>
+        </header>
+      )
+    }
+    ```
+  </Tab>
+
+  <Tab>
+    ```astro filename="pages/index.astro"
+    ---
+    import { UserButton } from '@clerk/astro/components'
+    ---
+
     <header>
       <UserButton>
         <UserButton.MenuItems>
           <UserButton.Action label="signOut" />
-          <UserButton.Link
-            label="Create organization"
-            labelIcon={<DotIcon />}
-            href="/create-organization"
-          />
+          <UserButton.Link label="Create organization" open="/create-organization">
+            <svg
+              slot="label-icon"
+              xmlns="http://www.w3.org/2000/svg"
+              viewBox="0 0 512 512"
+              fill="currentColor"
+            >
+              <path d="M256 512A256 256 0 1 0 256 0a256 256 0 1 0 0 512z"></path>
+            </svg>
+          </UserButton.Link>
           <UserButton.Action label="manageAccount" />
         </UserButton.MenuItems>
       </UserButton>
     </header>
-  )
-}
-```
+    ```
+  </Tab>
+</Tabs>
 
 With the above example, the `<UserButton />` menu items will be in the following order:
 
@@ -233,44 +376,81 @@ With the above example, the `<UserButton />` menu items will be in the following
 
 To conditionally render menu items based on a user's role or permissions, you can use the [`has()`](/docs/references/nextjs/auth-object#has) helper function:
 
-```tsx filename="/app/page.tsx"
-'use client'
+<Tabs items={["Next.js", "Astro"]}>
+  <Tab>
+    ```tsx filename="/app/page.tsx"
+    'use client'
 
-import { UserButton, useAuth } from '@clerk/nextjs'
+    import { UserButton, useAuth } from '@clerk/nextjs'
 
-const DotIcon = () => {
-  return (
-    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512" fill="currentColor">
-      <path d="M256 512A256 256 0 1 0 256 0a256 256 0 1 0 0 512z" />
-    </svg>
-  )
-}
+    const DotIcon = () => {
+      return (
+        <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512" fill="currentColor">
+          <path d="M256 512A256 256 0 1 0 256 0a256 256 0 1 0 0 512z" />
+        </svg>
+      )
+    }
 
-export default function Home() {
-  const { has, isLoaded } = useAuth()
+    export default function Home() {
+      const { has, isLoaded } = useAuth()
 
-  if (!isLoaded) {
-    return <span>Loading...</span>
-  }
+      if (!isLoaded) {
+        return <span>Loading...</span>
+      }
 
-  const isAdmin = has({ permission: 'org:app:admin' })
+      const isAdmin = has({ permission: 'org:app:admin' })
 
-  return (
+      return (
+        <header>
+          <UserButton>
+            {isAdmin && (
+              <UserButton.MenuItems>
+                <UserButton.Link
+                  label="Create organization"
+                  labelIcon={<DotIcon />}
+                  href="/create-organization"
+                />
+              </UserButton.MenuItems>
+            )}
+          </UserButton>
+        </header>
+      )
+    }
+    ```
+  </Tab>
+
+  <Tab>
+    ```astro filename="pages/index.astro"
+    ---
+    import { UserButton } from '@clerk/astro/components'
+
+    const { has } = Astro.locals.auth()
+
+    const isAdmin = has({ permission: 'org:app:admin' })
+    ---
+
     <header>
       <UserButton>
-        {isAdmin && (
-          <UserButton.MenuItems>
-            <UserButton.Link
-              label="Create organization"
-              labelIcon={<DotIcon />}
-              href="/create-organization"
-            />
-          </UserButton.MenuItems>
-        )}
+        {
+          isAdmin && (
+            <UserButton.MenuItems>
+              <UserButton.Link label="Create organization" open="/create-organization">
+                <svg
+                  slot="label-icon"
+                  xmlns="http://www.w3.org/2000/svg"
+                  viewBox="0 0 512 512"
+                  fill="currentColor"
+                >
+                  <path d="M256 512A256 256 0 1 0 256 0a256 256 0 1 0 0 512z" />
+                </svg>
+              </UserButton.Link>
+            </UserButton.MenuItems>
+          )
+        }
       </UserButton>
     </header>
-  )
-}
-```
+    ```
+  </Tab>
+</Tabs>
 
 With the above example, the "Create organization" menu item will only render if the current user has the `org:app:admin` permission.

--- a/docs/customization/user-button.mdx
+++ b/docs/customization/user-button.mdx
@@ -91,7 +91,7 @@ The following example demonstrates how to add an action to the `<UserButton />` 
   </Tab>
 
   <Tab>
-    To handle click events in Astro, we use a `clickIdentifier` prop and a custom event listener instead of an `onClick` handler. The `e.detail` value is then used to determine which item was clicked.
+    In Astro components, props are converted to strings, so we can't use an `onClick` handler. Instead, we use a `clickIdentifier` prop and a custom event listener to handle click events. To determine which item was clicked, `e.detail` will contain the value you passed to the `clickIdentifier`.
 
     ```astro filename="pages/index.astro"
     ---

--- a/docs/customization/user-button.mdx
+++ b/docs/customization/user-button.mdx
@@ -180,6 +180,10 @@ The following example demonstrates how to add an action, as well as a [custom pa
   </Tab>
 
   <Tab>
+    In the following example, the `<UserButton.Action />` component is used to add a "Help" menu item to the `<UserButton />` component. The `open` prop is set to `"help"` to open the `/help` page when the menu item is selected.
+
+    The `<UserButton.UserProfilePage />` component is used to render the `/help` page, and because its configured as a user profile page, the `<UserProfile />` modal will be opened with the custom "Help" menu item. [Read more about custom pages.](/docs/customization/user-profile)
+
     ```astro filename="pages/index.astro"
     ---
     import { UserButton } from '@clerk/astro/components'

--- a/docs/customization/user-button.mdx
+++ b/docs/customization/user-button.mdx
@@ -43,7 +43,7 @@ The `<UserButton />` component must be wrapped in a `<UserButton.MenuItems />` c
   - `open?`
   - `string`
 
-  The path segment that will be used to open user profile modal to a specific page.
+  The path segment that will be used to open the user profile modal to a specific page.
 
   ---
 
@@ -91,7 +91,9 @@ The following example demonstrates how to add an action to the `<UserButton />` 
   </Tab>
 
   <Tab>
-    In Astro components, props are converted to strings, so we can't use an `onClick` handler. Instead, we use a `clickIdentifier` prop and a custom event listener to handle click events. To determine which item was clicked, `e.detail` will contain the value you passed to the `clickIdentifier`.
+    In Astro components, props are converted to strings, so you can't use an `onClick` handler to handle click events. Instead, you can set an arbitrary prop, set up a custom event listener that will check for the value passed to that prop, and then execute a desired action based on that value.
+
+    For example, `clickIdentifier` is the arbitrary prop being used to identify the click event. Two `<UserButton.Action />` components are added to the menu, each with a different `clickIdentifier` prop. When the menu item is clicked, the custom event listener will check for the value passed to the `clickIdentifier` prop, either `"open_chat"` or `"open_cart"`, and then execute an action based on that value.
 
     ```astro filename="pages/index.astro"
     ---
@@ -111,6 +113,16 @@ The following example demonstrates how to add an action to the `<UserButton />` 
               <path d="M256 512A256 256 0 1 0 256 0a256 256 0 1 0 0 512z"></path>
             </svg>
           </UserButton.Action>
+          <UserButton.Action label="Open cart" clickIdentifier="open_cart">
+            <svg
+              slot="label-icon"
+              xmlns="http://www.w3.org/2000/svg"
+              viewBox="0 0 512 512"
+              fill="currentColor"
+            >
+              <path d="M256 512A256 256 0 1 0 256 0a256 256 0 1 0 0 512z"></path>
+            </svg>
+          </UserButton.Action>
         </UserButton.MenuItems>
       </UserButton>
     </header>
@@ -119,6 +131,9 @@ The following example demonstrates how to add an action to the `<UserButton />` 
       document.addEventListener('clerk:menu-item-click', (e) => {
         if (e.detail === 'open_chat') {
           console.log('init chat')
+        }
+        if (e.detail === 'open_cart') {
+          console.log('init cart')
         }
       })
     </script>
@@ -282,7 +297,7 @@ The following example demonstrates how to add a link to the `<UserButton />` com
     <header>
       <UserButton>
         <UserButton.MenuItems>
-          <UserButton.Link label="Create organization" open="/create-organization">
+          <UserButton.Link label="Create organization" href="/create-organization">
             <svg
               slot="label-icon"
               xmlns="http://www.w3.org/2000/svg"


### PR DESCRIPTION
<!--- Add the "deploy-preview" label and add your page previews here -->

> [!IMPORTANT]
> 🔎 Previews:
>
> - https://clerk.com/docs/pr/1519/customization/user-button

<!--- Describe your changes in detail. Why does this change need to happen? Include any links to Slack discussions, Linear comments, etc. -->

### Explanation:

This PR provides examples of custom menu items for the `<UserButton />` component in Astro and highlights how [slots](https://docs.astro.build/en/basics/astro-components/#slots) are used to render child elements (label icons).

Related PR: https://github.com/clerk/javascript/pull/3969
