### PR TITLE
Property 'biometryType' does not exist on type 'LocalCredentialsReturn'

### DIFF
--- a/docs/references/expo/local-credentials.mdx
+++ b/docs/references/expo/local-credentials.mdx
@@ -55,7 +55,7 @@ This guide shows you how to use the `useLocalCredentials()` hook to enhance your
 
     const [emailAddress, setEmailAddress] = React.useState('')
     const [password, setPassword] = React.useState('')
-    const { hasCredentials, setCredentials, authenticate, biometryType } = useLocalCredentials()
+    const { hasCredentials, setCredentials, authenticate, biometricType } = useLocalCredentials()
 
     const onSignInPress = React.useCallback(
       async (useLocal = false) => {


### PR DESCRIPTION
Chance `biometryType` to `biometricType`

<!--- Add the "deploy-preview" label and add your page previews here -->

> [!IMPORTANT]
> 🔎 Previews:
>
> -

<!--- Describe your changes in detail. Why does this change need to happen? Include any links to Slack discussions, Linear comments, etc. -->

### Explanation:

Typo in the doc

### This PR:

Fixes the typo
