### PR TITLE
fix: Sign In and Sign Up swapped wrongly

### DIFF
--- a/docs/deployments/clerk-environment-variables.mdx
+++ b/docs/deployments/clerk-environment-variables.mdx
@@ -23,8 +23,8 @@ However, it's recommended to use environment variables instead of these props wh
   <Tab>
     | Variable | Description |
     | - | - |
-    | `CLERK_SIGN_IN_URL` | Full URL or path to the sign in page. Use this variable to provide the target of the 'Sign In' link that's rendered in the `<SignUp />` component. |
-    | `CLERK_SIGN_UP_URL` | Full URL or path to the sign up page. Use this variable to provide the target of the 'Sign Up' link that's rendered in the `<SignIn />` component. |
+    | `CLERK_SIGN_IN_URL` | Full URL or path to the sign in page. Use this variable to provide the target of the 'Sign In' link that's rendered in the `<SignIn />` component. |
+    | `CLERK_SIGN_UP_URL` | Full URL or path to the sign up page. Use this variable to provide the target of the 'Sign Up' link that's rendered in the `<SignUp />` component. |
     | `CLERK_SIGN_IN_FORCE_REDIRECT_URL` | If provided, this URL will always be redirected to after the user signs in. |
     | `CLERK_SIGN_UP_FORCE_REDIRECT_URL` | If provided, this URL will always be redirected to after the user signs up. |
     | `CLERK_SIGN_IN_FALLBACK_REDIRECT_URL` | The fallback URL to redirect to after the user signs in, if there's no `redirect_url` in the path already. Defaults to `/`. |


### PR DESCRIPTION
<!--- deploy-preview-->

> [!IMPORTANT]
> 🔎 Previews:
>
> - https://github.com/clerk/clerk-docs/pull/1522

### Explanation:
- The Sign In and Sign Up terms were swapped when describing their respective URL as environmental variables 

### This PR:

- This PR simply swaps the Sign In and Sign Up terms and ensures a pleasant reading experience for other users
