### PR TITLE
Change "Cypress" to "Playwright" in Playwright docs

### DIFF
--- a/docs/testing/playwright.mdx
+++ b/docs/testing/playwright.mdx
@@ -61,7 +61,7 @@ Playwright is a well-established JavaScript testing framework. This guide aims t
 
   ### Use `setupClerkTestingToken`
 
-  Now that Cypress is configured with Clerk, you can use the `setupClerkTestingToken()` function in your tests to augment them with the Testing Token. See the following example:
+  Now that Playwright is configured with Clerk, you can use the `setupClerkTestingToken()` function in your tests to augment them with the Testing Token. See the following example:
 
   ```tsx {{ filename: 'my-test.spec.ts' }}
   import { setupClerkTestingToken } from '@clerk/testing/playwright'


### PR DESCRIPTION
<!--- Add the "deploy-preview" label and add your page previews here -->

> [!IMPORTANT]
> 🔎 Previews:
>
> -

I was going through the docs to set up Playwright with Clerk and noticed the docs say "Cypress" instead of "Playwright" at the end.

### Explanation:

Changes "Cypress" to "Playwright"

### This PR:

- Changes "Cypress" to "Playwright" in `playwright.mdx`
