### PR TITLE
[fix] change spelling from ap to app

### DIFF
--- a/docs/references/javascript/user/user.mdx
+++ b/docs/references/javascript/user/user.mdx
@@ -192,7 +192,7 @@ The ClerkJS SDK provides some helper [methods](#methods) on the `User` object to
   - `totpEnabled`
   - `boolean`
 
-  A boolean indicating whether the user has enabled TOTP by generating a TOTP secret and verifying it via an authenticator ap
+  A boolean indicating whether the user has enabled TOTP by generating a TOTP secret and verifying it via an authenticator app
 
   ---
 


### PR DESCRIPTION
<!--- Add the "deploy-preview" label and add your page previews here -->

> [!IMPORTANT]
> 🔎 Previews:
>
> - https://clerk.com/docs/pr/1526

<!--- Describe your changes in detail. Why does this change need to happen? Include any links to Slack discussions, Linear comments, etc. -->

### Explanation:

<!--- How does this PR solve the problem? -->

### This PR: 
- Fixes spelling from `ap` to `app`

-
