### PR TITLE
Update Reset a user's MFA instructions to use Dashboard over BAPI

### DIFF
--- a/docs/authentication/configuration/sign-up-sign-in-options.mdx
+++ b/docs/authentication/configuration/sign-up-sign-in-options.mdx
@@ -196,10 +196,14 @@ If you're building a custom user interface instead of using Clerk's [Account Por
 
 ### Reset a user's MFA
 
-To reset a user's MFA, you can either make a call to [Clerk's Backend API](https://clerk.com/docs/reference/backend-api/tag/Users#operation/DisableMFA) or use the [`disableUserMFA()`](/docs/references/backend/user/disable-user-mfa) method from the Javascript Backend SDK to remove the need to call the API directly.
+You can reset a user's MFA by deleting their MFA enrollments. This will remove all of their MFA methods and they will have to enroll in MFA again.
 
-> [!NOTE]
-> Disabling MFA for a user will disable **all** of their MFA methods for the user at once.
+To reset a user's MFA:
+
+1. Navigate to the [Clerk Dashboard](https://dashboard.clerk.com/last-active?path=user-authentication/multi-factor).
+1. In the top navigation, select **Users**.
+1. Select the user from the list.
+1. Select the **Delete MFA enrollments** button.
 
 ## Sign-up restrictions
 


### PR DESCRIPTION
<!--- Add the "deploy-preview" label and add your page previews here -->

> [!IMPORTANT]
> 🔎 Previews:
>
> -

<!--- Describe your changes in detail. Why does this change need to happen? Include any links to Slack discussions, Linear comments, etc. -->

### Explanation:

[Slack discussion.](https://clerkinc.slack.com/archives/C053FSYKAH1/p1724940050286029)
> This week in our weekly triage we saw a ticket where one of our customer's users was locked out of their account as they had MFA enabled and lost access to their authenticator/device. These sort of tickets have come up in the past and we've been telling customers to use BAPI to delete the user's MFA enrollments which isn't the best experience.
> To improve our customer's experience and to reduce ticket volume, we've introduced a new DAPI endpoint and a new action in the Dashboard for organization members with permissions to manage users or Personal Accounts to delete a user's MFA enrollments.

<!--- How does this PR solve the problem? -->

### This PR:

- Updates the instructions for disabling a user's MFA, prioritizing using the Dashboard over BAPI
