### PR TITLE
(/quickstarts/nextjs) Mention use of Account Portal

### DIFF
--- a/docs/quickstarts/nextjs.mdx
+++ b/docs/quickstarts/nextjs.mdx
@@ -102,7 +102,7 @@ description: Add authentication and user management to your Next.js app with Cle
   - [`<SignedIn>`](/docs/components/control/signed-in): Children of this component can only be seen while **signed in**.
   - [`<SignedOut>`](/docs/components/control/signed-out): Children of this component can only be seen while **signed out**.
   - [`<UserButton />`](/docs/components/user/user-button): A prebuilt component that comes styled out of the box to show the avatar from the account the user is signed in with.
-  - [`<SignInButton />`](/docs/components/unstyled/sign-in-button): An unstyled component that links to the sign-in page. For this example, it links to the [Account Portal sign-in page.](/docs/customization/account-portal/overview)
+  - [`<SignInButton />`](/docs/components/unstyled/sign-in-button): An unstyled component that links to the sign-in page. For this example, because you have not specified any props or [environment variables](/docs/deployments/clerk-environment-variables) for the sign-in URL, the component will link to the [Account Portal sign-in page.](/docs/customization/account-portal/overview)
 
   Select your preferred router to learn how to make this data available across your entire app:
 

--- a/docs/quickstarts/nextjs.mdx
+++ b/docs/quickstarts/nextjs.mdx
@@ -53,8 +53,8 @@ description: Add authentication and user management to your Next.js app with Cle
   </SignedIn>
 
   <SignedOut>
-    1. Navigate to the Clerk Dashboard.
-    1. In the navigation sidebar, select [API Keys](https://dashboard.clerk.com/last-active?path=api-keys).
+    1. Navigate to the [Clerk Dashboard](https://dashboard.clerk.com/last-active?path=api-keys).
+    1. In the top navigation, select **Configure**. Then in the sidebar, select **API Keys**.
     1. In the **Quick Copy** section, copy your Clerk publishable and secret key.
     1. Paste your keys into your `.env.local` file.
 
@@ -102,7 +102,7 @@ description: Add authentication and user management to your Next.js app with Cle
   - [`<SignedIn>`](/docs/components/control/signed-in): Children of this component can only be seen while **signed in**.
   - [`<SignedOut>`](/docs/components/control/signed-out): Children of this component can only be seen while **signed out**.
   - [`<UserButton />`](/docs/components/user/user-button): A prebuilt component that comes styled out of the box to show the avatar from the account the user is signed in with.
-  - [`<SignInButton />`](/docs/components/unstyled/sign-in-button): An unstyled component that links to the sign-in page or displays the sign-in modal.
+  - [`<SignInButton />`](/docs/components/unstyled/sign-in-button): An unstyled component that links to the sign-in page. For this example, it links to the [Account Portal sign-in page.](/docs/customization/account-portal/overview)
 
   Select your preferred router to learn how to make this data available across your entire app:
 
@@ -157,7 +157,23 @@ description: Add authentication and user management to your Next.js app with Cle
 
   ### Create your first user
 
-  Now visit your app's homepage at [`http://localhost:3000`](http://localhost:3000). Sign up to create your first user.
+  Run your project with the following command:
+
+  <CodeBlockTabs options={["npm", "yarn", "pnpm"]}>
+    ```bash {{ filename: 'terminal' }}
+    npm run dev
+    ```
+
+    ```bash {{ filename: 'terminal' }}
+    yarn dev
+    ```
+
+    ```bash {{ filename: 'terminal' }}
+    pnpm dev
+    ```
+  </CodeBlockTabs>
+
+  Visit your app's homepage at [http://localhost:3000](http://localhost:3000). Sign up to create your first user.
 </Steps>
 
 ## Next steps


### PR DESCRIPTION
<!--- Add the "deploy-preview" label and add your page previews here -->

> [!IMPORTANT]
> 🔎 Previews:
>
> -

<!--- Describe your changes in detail. Why does this change need to happen? Include any links to Slack discussions, Linear comments, etc. -->

### Explanation:

[User feedback ticket](https://linear.app/clerk/issue/DOCS-9078/mention-use-of-account-portal-in-quickstartsnextjs) reads:

> Wondering about the hosted experiences (sign up, sign in etc?) and how that may be used - or even where to find that info within these docs.

<!--- How does this PR solve the problem? -->

### This PR:

- Adds information about the SignInButton component linking to the Account Portal, and adds a reference link to the AP
- Updates Dashboard navigation instructions
- Updates "Create your first user" instructions to include instructions on running the project
