### PR TITLE
Remove typo in guides overview

### DIFF
--- a/docs/guides/overview.mdx
+++ b/docs/guides/overview.mdx
@@ -3,4 +3,4 @@ title: Clerk guides
 description: Guides covering how to build or work with parts of Clerk
 ---
 
-Clerk offers a variety of guides to help you build and work with Clerk. These guides cover a broad range of topics, from understanding key concepts like [routing](/docs/guides/routing) to practical code examples, such as, such as [adding a custom onboarding flow to your sign-up process](/docs/guides/add-onboarding-flow).
+Clerk offers a variety of guides to help you build and work with Clerk. These guides cover a broad range of topics, from understanding key concepts like [routing](/docs/guides/routing) to practical code examples, such as [adding a custom onboarding flow to your sign-up process](/docs/guides/add-onboarding-flow).


### PR DESCRIPTION
<!--- Add the "deploy-preview" label and add your page previews here -->

> [!IMPORTANT]
> 🔎 Previews:
>
> -

<!--- Describe your changes in detail. Why does this change need to happen? Include any links to Slack discussions, Linear comments, etc. -->

### Explanation:

<!--- How does this PR solve the problem? -->

### This PR:

-
