### PR TITLE
Update Staging guides: support subdomains over buying separate domains

### DIFF
--- a/docs/deployments/set-up-staging.mdx
+++ b/docs/deployments/set-up-staging.mdx
@@ -3,9 +3,9 @@ title: Set up a staging environment with Clerk
 description: Learn how to set up a staging environment with Clerk authentication.
 ---
 
-Staging environments enable you to internally test and demo changes to your application or website before deploying them to production. Currently, Clerk only offers **Development** and **Production** instances. Official support for **Staging** instances is still on [Clerk's roadmap](https://feedback.clerk.com/roadmap/de417dd1-fa2e-4997-868f-4c9248027e7d). However, you can set up a "staging environment" by creating a separate Clerk application with a separate domain.
+Staging environments enable you to internally test and demo changes to your application or website before deploying them to production. Currently, Clerk only offers **Development** and **Production** instances. Official support for **Staging** instances is still on [Clerk's roadmap](https://feedback.clerk.com/roadmap/de417dd1-fa2e-4997-868f-4c9248027e7d). However, you can set up a "staging environment" by creating a subdomain for a separate Clerk application.
 
-Creating a separate Clerk application will prevent you from using live production environment data in your staging environment. And if you are on a Pro, Enterprise, or Startup plan, **Clerk will fully upgrade your staging application for free.**
+Creating a separate Clerk application will prevent you from using live production environment data in your staging environment. If you are on a Pro, Enterprise, or Startup plan, **Clerk will fully upgrade your staging application for free.**
 
 It is important to note that when you use a separate Clerk application for your staging environment, changes to this application will not be automatically mirrored in your main application for your production environment. You must manually make these changes yourself if you want them to be reflected in both applications.
 
@@ -13,12 +13,12 @@ It is important to note that when you use a separate Clerk application for your 
 
 The following steps will help you set up a new Clerk application with a staging-specific domain:
 
-1. **Acquire a separate domain** - This domain will be used for your staging environment. _This cannot be a subdomain_ of the domain used in your production environment. For example, if your production domain is `my-site.com`, you could use `my-site-staging.com`. If you do not want to use a new domain, see [the instructions for using a subdomain](/docs/deployments/staging-alternatives).
-1. **Create a new Clerk app** - Your staging environment will connect to this app instead of your main Clerk application. See [the Clerk quickstart guide](/docs/quickstarts/setup-clerk) to learn how to create a Clerk app.
+1. **Set up a subdomain** - This will be your staging domain. For example, if your domain is `my-site.com`, you could use `staging.my-site.com`.
+1. **Create a new Clerk app** - Your staging environment will connect to this app instead of your main one. See [the Clerk quickstart guide](/docs/quickstarts/setup-clerk) to learn how to create a Clerk app.
 1. **Deploy and configure your staging app's production instance** - Using production API keys will make your staging app more secure. Follow the [Deploy to production](/docs/deployments/overview) guide to do so.
 1. **Contact Clerk support to upgrade your staging app for free** - If you are on a Pro, Enterprise, or Startup plan, Clerk will fully upgrade your staging app for free.
 
-## Alternatives to using a separate domain
+## Alternatives
 
 ### Preview environments
 
@@ -26,4 +26,4 @@ While staging environments are typically long-lived, preview environments are ty
 
 ### Shared production credentials
 
-If you do not want to purchase a separate domain, or if you would like to share settings and data between your production and staging environments, see the [Staging alternatives](/docs/deployments/staging-alternatives) guide. This is not recommended because you will be sharing a user table between your production and staging environments.
+If you would like to share settings and data between your production and staging environments, see [the dedicated guide](/docs/deployments/staging-alternatives). This is not recommended because you will be sharing a user table between your production and staging environments.

--- a/docs/deployments/staging-alternatives.mdx
+++ b/docs/deployments/staging-alternatives.mdx
@@ -6,25 +6,25 @@ description:
 ## Shared production credentials
 
 > [!CAUTION]
-> This is not recommended. Instead, you should either [set up a staging environment with a separate domain](/docs/deployments/set-up-staging) or [use a preview deployment](/docs/deployments/set-up-preview-environment).
+> This is not recommended. Instead, you should either [set up a staging environment with a subdomain and separate Clerk app](/docs/deployments/set-up-staging) or [use a preview deployment](/docs/deployments/set-up-preview-environment).
 
-If you do not want to purchase a separate domain, or if you would like to share settings and data between your production and staging environments, you can use a subdomain of your production domain to set up a staging environment.
+If you would like to share settings and data between your production and staging environments, you can use a subdomain of your production domain to set up a staging environment.
 
-### Limitations of using a subdomain
+### Limitations of shared production credentials
 
-The limitations of using a subdomain to set up a staging environment with Clerk include:
+The limitations of using shared production credentials to set up a staging environment with Clerk include:
 
 - You will be combining staging data with live production data.
 - When you enable Clerk features to test in staging, they will be enabled in your Production environment as well.
 
-### Set up staging with a subdomain
+### Set up staging with shared production credentials
 
 1. **Add your subdomain to your hosting provider** - Ensure that your subdomain is associated with your staging branch so that it will point to new staging deployments. This process will vary based on your provider. The following are some guides from popular hosting providers:
    - [Vercel](https://vercel.com/guides/set-up-a-staging-environment-on-vercel)
    - [Netlify](https://docs.netlify.com/domains-https/netlify-dns/delegate-a-subdomain-to-netlify-dns/)
    - [Cloudflare](https://developers.cloudflare.com/dns/manage-dns-records/how-to/create-subdomain/)
-1. **Add your CNAME record to your domain provider** - Depending on the provider, the verification process for this can take hours or days.
-1. **Add your production instance API keys to your staging deployment** - In your staging deployment's environment variables, add your Clerk app's production instance API keys. Visit the [**API Keys**](https://dashboard.clerk.com/last-active?path=api-keys) section in the Clerk Dashboard to find them, and ensure that the instance at the top of the Dashboard is set to **Production**. The following are environment variable guides from some popular providers:
+1. **Add your CNAME record to your domain provider** - Depending on the provider, the verification process can take hours or days.
+1. **Add your production instance's API keys to your staging deployment** - In your staging deployment's environment variables, add your production instance's API keys. To find them, visit the [**API Keys**](https://dashboard.clerk.com/last-active?path=api-keys) page in the Clerk Dashboard and ensure that the instance at the top of the Dashboard is set to **Production**. The following are environment variable guides from some popular providers:
    - [Vercel](https://vercel.com/docs/projects/environment-variables#declare-an-environment-variable)
    - [Netlify](https://docs.netlify.com/environment-variables/get-started/#create-environment-variables)
-   - [Cloudflare](https://developers.cloudflare.com/workers/configuration/environment-variables/#add-environment-variables-via-the-dashboar)
+   - [Cloudflare](https://developers.cloudflare.com/workers/configuration/environment-variables/#add-environment-variables-via-the-dashboard)


### PR DESCRIPTION
<!--- Add the "deploy-preview" label and add your page previews here -->

> [!IMPORTANT]
> 🔎 Previews:
>
> -

<!--- Describe your changes in detail. Why does this change need to happen? Include any links to Slack discussions, Linear comments, etc. -->

### Explanation:

Clerk now supports multiple applications being hosted on the same domain. Users no longer need to purchase a separate domain to set up a "staging" application - they can use subdomains.
Relevant ticket: https://linear.app/clerk/issue/DOCS-9206/update-staging-environment-docs

<!--- How does this PR solve the problem? -->

### This PR:

-
