### PR TITLE
Fix typo in assignment of jwk variable

### DIFF
--- a/docs/references/go/verifying-sessions.mdx
+++ b/docs/references/go/verifying-sessions.mdx
@@ -197,7 +197,7 @@ func protectedRoute(jwksClient *jwks.Client, store JWKStore) func(http.ResponseW
 			}
 
 			// Fetch the JSON Web Key
-			jwk, err = jwt.GetJSONWebKey(r.Context(), &jwt.GetJSONWebKeyParams{
+			jwk, err := jwt.GetJSONWebKey(r.Context(), &jwt.GetJSONWebKeyParams{
 				KeyID:      unsafeClaims.KeyID,
 				JWKSClient: jwksClient,
 			})


### PR DESCRIPTION
<!--- Add the "deploy-preview" label and add your page previews here -->

> [!IMPORTANT]
> 🔎 Previews:
>
> -

<!--- Describe your changes in detail. Why does this change need to happen? Include any links to Slack discussions, Linear comments, etc. -->


### Explanation:
Go Sdk Docs have a syntax typo, in https://clerk.com/docs/references/go/verifying-sessions#manually-verify-a-session-token 

`jwk, err = jwt.GetJSONWebKey(r.Co...`

<!--- How does this PR solve the problem? -->


### This PR:

Fixes by resolving the typo

`jwk, err := jwt.GetJSONWebKey(r.Co...`
