### PR TITLE
Added note about logout

### DIFF
--- a/docs/advanced-usage/clerk-idp.mdx
+++ b/docs/advanced-usage/clerk-idp.mdx
@@ -105,3 +105,7 @@ Access tokens expire after 2 hours, and refresh tokens expire after 3 days.
 ### Is OpenID Connect supported?
 
 At this time, OIDC is not supported.
+
+### How can I log a user out of the OAuth session?
+
+Clerk does not support logging a user out when using this OAuth endpoint. The only option is to wait until the tokens expire.


### PR DESCRIPTION
Logout is not supported when using clerk OAuth. I added a note indicating this.

https://discord.com/channels/856971667393609759/1283094343779090443/1283094343779090443

<!--- Add the "deploy-preview" label and add your page previews here -->

> [!IMPORTANT]
> 🔎 Previews:
>
> -

<!--- Describe your changes in detail. Why does this change need to happen? Include any links to Slack discussions, Linear comments, etc. -->

### Explanation:

It notes that OAuth logout is not supported to save other people time.

### This PR:

Adds a FAQ question and answer that states logout is not support with Clerk's OAuth endpoint.
