### PR TITLE
Clarify how to integrate Account Portal into an app

### DIFF
--- a/docs/customization/account-portal/getting-started.mdx
+++ b/docs/customization/account-portal/getting-started.mdx
@@ -5,7 +5,7 @@ description: The Account Portal offers a comprehensive solution for managing use
 
 To integrate the Account Portal into your application, simply follow one of the [quickstart guides](/docs/quickstarts/overview). Once your application is set up, all you have to do is run it. Clerk will automatically redirect your users to the Account Portal sign-up/sign-in pages. After successful authentication, users will be redirected back to your application with an active session.
 
-You can also integrate the Account Portal into your application using Clerk's prebuilt components. For example, the [`<SignUpButton>`](/docs/components/unstyled/sign-up-button) and [`<SignInButton>`](/docs/components/unstyled/sign-in-button) components will redirect users to the Account Portal sign-up/sign-in pages if no props or [environment variables](/docs/deployments/clerk-environment-variables#sign-in-and-sign-up-redirects) are configured to do otherwise.
+You can also integrate the Account Portal into your application using Clerk's prebuilt components. For example, the [`<SignUpButton>`](/docs/components/unstyled/sign-up-button) and [`<SignInButton>`](/docs/components/unstyled/sign-in-button) components will redirect users to the Account Portal sign-up/sign-in pages if no props or [environment variables](/docs/deployments/clerk-environment-variables#sign-in-and-sign-up-redirects) are configured to override this behavior.
 
 > [!NOTE]
 > **Dynamic Development Host Detection**

--- a/docs/customization/account-portal/getting-started.mdx
+++ b/docs/customization/account-portal/getting-started.mdx
@@ -3,7 +3,7 @@ title: Getting started with the Account Portal
 description: The Account Portal offers a comprehensive solution for managing user authentication and profile management in your web application and is the fastest way to add Clerk's authentication to your application with minimal code required.
 ---
 
-To integrate the Account Portal into your application, simply follow one of the [quickstart guides](/docs/quickstarts/overview). Once your application is set up, all you have to do is run it. Clerk will automatically redirect your users to the Account Portal sign-up/sign-in pages. Once a user is successfully authenticated, they will be automatically redirected back to your application with an active session.
+To integrate the Account Portal into your application, simply follow one of the [quickstart guides](/docs/quickstarts/overview). Once your application is set up, all you have to do is run it. Clerk will automatically redirect your users to the Account Portal sign-up/sign-in pages. After successful authentication, users will be redirected back to your application with an active session.
 
 You can also integrate the Account Portal into your application using Clerk's prebuilt components. For example, the [`<SignUpButton>`](/docs/components/unstyled/sign-up-button) and [`<SignInButton>`](/docs/components/unstyled/sign-in-button) components will redirect users to the Account Portal sign-up/sign-in pages if no props or [environment variables](/docs/deployments/clerk-environment-variables#sign-in-and-sign-up-redirects) are configured to do otherwise.
 

--- a/docs/customization/account-portal/getting-started.mdx
+++ b/docs/customization/account-portal/getting-started.mdx
@@ -3,9 +3,9 @@ title: Getting started with the Account Portal
 description: The Account Portal offers a comprehensive solution for managing user authentication and profile management in your web application and is the fastest way to add Clerk's authentication to your application with minimal code required.
 ---
 
-To integrate the Account Portal into your application, simply follow one of our [quickstart guides](/docs/quickstarts/overview).
+To integrate the Account Portal into your application, simply follow one of the [quickstart guides](/docs/quickstarts/overview). Once your application is set up, all you have to do is run it. Clerk will automatically redirect your users to the Account Portal sign-up/sign-in pages. Once a user is successfully authenticated, they will be automatically redirected back to your application with an active session.
 
-Once your application is set up, all you have to do is fire it up. Clerk will automatically redirect your users to the Account Portal sign-in/sign-up pages. Once a user has successfully authenticated themself, they will be automatically redirected back to your application with an active session.
+You can also integrate the Account Portal into your application using Clerk's prebuilt components. For example, the [`<SignUpButton>`](/docs/components/unstyled/sign-up-button) and [`<SignInButton>`](/docs/components/unstyled/sign-in-button) components will redirect users to the Account Portal sign-up/sign-in pages if no props or [environment variables](/docs/deployments/clerk-environment-variables#sign-in-and-sign-up-redirects) are configured to do otherwise.
 
 > [!NOTE]
 > **Dynamic Development Host Detection**

--- a/docs/customization/account-portal/overview.mdx
+++ b/docs/customization/account-portal/overview.mdx
@@ -3,7 +3,7 @@ title: Account portal overview
 description: The Account Portal offers a comprehensive solution for managing user authentication and profile management in your web application and is the fastest way to add Clerk's authentication to your application with minimal code required.
 ---
 
-The Account Portal in Clerk is a powerful feature that allows you to streamline the sign-in, sign-up, and profile management experience for your users, without having to build your own components or host your own pages.
+The Account Portal in Clerk is a powerful feature that allows you to streamline the sign-in, sign-up, and profile management experience for your users, without having to build your own components or host your own pages. **To integrate the Account Portal with your application, check out the [setup guide](/docs/customization/account-portal/getting-started).**
 
 ![Account Portal](/docs/images/account-portal/account_portal_splash.png)
 
@@ -21,7 +21,7 @@ The Account Portal uses Clerk's [prebuilt components](/docs/components/overview)
 
 After a user has finished their flow in an Account Portal page, Clerk automatically redirects them back to your application along with the required authentication context. This way, users are automatically redirected to and from your application for a seamless experience.
 
-For each application environment, Clerk provides pages for sign-up, sign-in, user profile, organization profile, and organization creation flow. To integrate the Account Portal with your application, check out the [setup guide](/docs/customization/account-portal/getting-started).
+For each application environment, Clerk provides pages for sign-up, sign-in, user profile, organization profile, and organization creation flow. **To integrate the Account Portal with your application, check out the [setup guide](/docs/customization/account-portal/getting-started).**
 
 ## Hosted pages
 


### PR DESCRIPTION
<!--- Add the "deploy-preview" label and add your page previews here -->

> [!IMPORTANT]
> 🔎 Previews:
>
> -

<!--- Describe your changes in detail. Why does this change need to happen? Include any links to Slack discussions, Linear comments, etc. -->

### Explanation:

[User feedback ticket](https://linear.app/clerk/issue/DOCS-9073/update-intro-paragraph-for-customizationaccount-portalgetting-started) reads:

> It doesn't tell me how to add a custom domain name for the Account Portal pages. Also, how can I integrate Account Portal into my application? I want Clerk to manage sign in, sign up, account management, etc and just give my app the token when user is logs in.

<!--- How does this PR solve the problem? -->

### This PR:

- Adds emphasis on the sentence about integrating the AP into an app (pointing the user to the setup guide)
- Adds further explanation on how to integrate AP
