### PR TITLE
Add info about how to access SessionWithActivities object

### DIFF
--- a/docs/references/javascript/session-with-activities.mdx
+++ b/docs/references/javascript/session-with-activities.mdx
@@ -3,7 +3,7 @@ title: '`SessionWithActivities`'
 description: The SessionWithActivities object is a modified Session object. It contains most of the information that the Session object stores, adding extra information about the current session's latest activity.
 ---
 
-The `SessionWithActivities` object is a modified [`Session`](/docs/references/javascript/session) object. It contains most of the information that the `Session` object stores, adding extra information about the current session's latest activity. It is returned by the [`User.getSessions()`](/docs/references/javascript/user/user#get-sessions) method.
+The `SessionWithActivities` object is a modified [`Session`](/docs/references/javascript/session) object. It includes most of the information stored in the `Session` object, with additional details about the latest activity in the current session. `SessionWithActivities` is returned by the [`User.getSessions()`](/docs/references/javascript/user/user#get-sessions) method.
 
 The additional data included in the latest activity are useful for analytics purposes. A [`SessionActivity`](#session-activity) object will provide information about the user's location, device and browser.
 

--- a/docs/references/javascript/session-with-activities.mdx
+++ b/docs/references/javascript/session-with-activities.mdx
@@ -5,7 +5,7 @@ description: The SessionWithActivities object is a modified Session object. It c
 
 The `SessionWithActivities` object is a modified [`Session`](/docs/references/javascript/session) object. It includes most of the information stored in the `Session` object, with additional details about the latest activity in the current session. `SessionWithActivities` is returned by the [`User.getSessions()`](/docs/references/javascript/user/user#get-sessions) method.
 
-The additional data included in the latest activity are useful for analytics purposes. A [`SessionActivity`](#session-activity) object will provide information about the user's location, device and browser.
+The additional data included in the latest activity is useful for analytics purposes. A [`SessionActivity`](#session-activity) object provides information about the user's location, device and browser.
 
 While the `SessionWithActivities` object wraps the most important information around a `Session` object, the two objects have entirely different methods.
 

--- a/docs/references/javascript/session-with-activities.mdx
+++ b/docs/references/javascript/session-with-activities.mdx
@@ -3,11 +3,11 @@ title: '`SessionWithActivities`'
 description: The SessionWithActivities object is a modified Session object. It contains most of the information that the Session object stores, adding extra information about the current session's latest activity.
 ---
 
-The `SessionWithActivities` object is a modified [`Session`][session-ref] object. It contains most of the information that the [`Session`][session-ref] object stores, adding extra information about the current session's latest activity.
+The `SessionWithActivities` object is a modified [`Session`](/docs/references/javascript/session) object. It contains most of the information that the `Session` object stores, adding extra information about the current session's latest activity. It is returned by the [`User.getSessions()`](/docs/references/javascript/user/user#get-sessions) method.
 
 The additional data included in the latest activity are useful for analytics purposes. A [`SessionActivity`](#session-activity) object will provide information about the user's location, device and browser.
 
-While the `SessionWithActivities` object wraps the most important information around a [`Session`][session-ref] object, the two objects have entirely different methods.
+While the `SessionWithActivities` object wraps the most important information around a `Session` object, the two objects have entirely different methods.
 
 ## Properties
 
@@ -29,7 +29,7 @@ While the `SessionWithActivities` object wraps the most important information ar
   - `lastActiveAt`
   - `Date`
 
-  The time the session was last active on the [`Client`][client-ref].
+  The time the session was last active on the [`Client`](/docs/references/javascript/client).
 
   ---
 
@@ -124,7 +124,3 @@ function revoke(): Promise<SessionWithActivities>
 
   Will be set to `true` if the session activity came from a mobile device. Set to `false` otherwise.
 </Properties>
-
-[client-ref]: /docs/references/javascript/client
-
-[session-ref]: /docs/references/javascript/session


### PR DESCRIPTION
<!--- Add the "deploy-preview" label and add your page previews here -->

> [!IMPORTANT]
> 🔎 Previews:
>
> - https://clerk.com/docs/pr/1543/references/javascript/session-with-activities

<!--- Describe your changes in detail. Why does this change need to happen? Include any links to Slack discussions, Linear comments, etc. -->

### Explanation:

[User feedback ticket](https://linear.app/clerk/issue/DOCS-9161/add-info-about-how-to-get-this-object-referencesjavascriptsession-with) reads:

> I'd love to know how to get that object...

<!--- How does this PR solve the problem? -->

### This PR:

- Adds info about how to access the object
