### PR TITLE
add run instructions to quickstarts

### DIFF
--- a/docs/quickstarts/astro.mdx
+++ b/docs/quickstarts/astro.mdx
@@ -163,6 +163,22 @@ Clerk's [Astro SDK](/docs/references/astro/overview) provides a set of component
 
   ### Create your first user
 
+  Run your project with the following command:
+
+  <CodeBlockTabs options={["npm", "yarn", "pnpm"]}>
+    ```bash {{ filename: 'terminal' }}
+    npm run dev
+    ```
+
+    ```bash {{ filename: 'terminal' }}
+    yarn dev
+    ```
+
+    ```bash {{ filename: 'terminal' }}
+    pnpm dev
+    ```
+  </CodeBlockTabs>
+
   Now visit your app's homepage at [`http://localhost:4321`](http://localhost:4321). Sign up to create your first user.
 </Steps>
 

--- a/docs/quickstarts/expo.mdx
+++ b/docs/quickstarts/expo.mdx
@@ -435,6 +435,22 @@ description: Add authentication and user management to your Expo app with Clerk.
 
   ### Create your first user
 
+  Run your project with the following command:
+
+  <CodeBlockTabs options={["npm", "yarn", "pnpm"]}>
+    ```bash {{ filename: 'terminal' }}
+    npm start
+    ```
+
+    ```bash {{ filename: 'terminal' }}
+    yarn start
+    ```
+
+    ```bash {{ filename: 'terminal' }}
+    pnpm start
+    ```
+  </CodeBlockTabs>
+
   Now visit your app's homepage at [`http://localhost:8081`](http://localhost:8081). Sign up to create your first user.
 </Steps>
 

--- a/docs/quickstarts/javascript.mdx
+++ b/docs/quickstarts/javascript.mdx
@@ -175,6 +175,22 @@ Select your preferred method below to get started.
 
       ### Create your first user
 
+      Run your project with the following command:
+
+      <CodeBlockTabs options={["npm", "yarn", "pnpm"]}>
+        ```bash {{ filename: 'terminal' }}
+        npm run dev
+        ```
+
+        ```bash {{ filename: 'terminal' }}
+        yarn dev
+        ```
+
+        ```bash {{ filename: 'terminal' }}
+        pnpm dev
+        ```
+      </CodeBlockTabs>
+
       Now visit your app's homepage at [`http://localhost:5173`](http://localhost:5173). Sign up to create your first user.
     </Steps>
   </Tab>

--- a/docs/quickstarts/react.mdx
+++ b/docs/quickstarts/react.mdx
@@ -172,6 +172,22 @@ description: Add authentication and user management to your React app with Clerk
 
   ### Create your first user
 
+  Run your project with the following command:
+
+  <CodeBlockTabs options={["npm", "yarn", "pnpm"]}>
+    ```bash {{ filename: 'terminal' }}
+    npm run dev
+    ```
+
+    ```bash {{ filename: 'terminal' }}
+    yarn dev
+    ```
+
+    ```bash {{ filename: 'terminal' }}
+    pnpm dev
+    ```
+  </CodeBlockTabs>
+
   Visit your app's homepage at [`http://localhost:5173`](http://localhost:5173). Sign up to create your first user.
 </Steps>
 


### PR DESCRIPTION
<!--- Add the "deploy-preview" label and add your page previews here -->

> [!IMPORTANT]
> 🔎 Previews:
>
> -

In the last step of many of our quickstarts, we ask users to create their first user locally, but we don't include instructions to run their local dev server.

### Explanation:

This adds local dev run instructions (e.g. `npm run dev`) to the final step. 

> ⚠️ I checked docs for these frameworks to ensure it has the right commands, but I'd really appreciate a second check here as I'm not deeply familiar with many of them. 

Companion PR for Dashboard quickstarts is: https://github.com/clerk/dashboard/pull/3656
