### PR TITLE
Add `track` prop to dashboard link in Next.js Quickstart

### DIFF
--- a/docs/quickstarts/nextjs.mdx
+++ b/docs/quickstarts/nextjs.mdx
@@ -53,7 +53,7 @@ description: Add authentication and user management to your Next.js app with Cle
   </SignedIn>
 
   <SignedOut>
-    1. Navigate to the [Clerk Dashboard](https://dashboard.clerk.com/last-active?path=api-keys).
+    1. Navigate to the [Clerk Dashboard](https://dashboard.clerk.com/last-active?path=api-keys){{ track: 'exp_create_account_nextjs_quickstart' }}.
     1. In the top navigation, select **Configure**. Then in the sidebar, select **API Keys**.
     1. In the **Quick Copy** section, copy your Clerk publishable and secret key.
     1. Paste your keys into your `.env.local` file.


### PR DESCRIPTION
<!--- Add the "deploy-preview" label and add your page previews here -->

> [!IMPORTANT]
> 🔎 Previews:
>
> - https://clerk.com/docs/pr/1547/quickstarts/nextjs

Following https://github.com/clerk/clerk/pull/674 you can pass the `track` prop to any MDX link to fire a Segment event on click.

This PR adds an event to the "Clerk Dashboard" link in the Next.js Quickstart, to assist with the [upcoming experiment](https://github.com/clerk/clerk-docs/pull/1499)