### PR TITLE
Add callout about Clerk auto-deleting empty organizations

### DIFF
--- a/docs/organizations/overview.mdx
+++ b/docs/organizations/overview.mdx
@@ -82,9 +82,14 @@ If you would like to hide personal workspaces and require users to always have a
 
 ## Create an organization
 
-### Application owner
+[You can create organizations in the Clerk Dashboard](#application-owner), or [your end users can create organizations in your application.](#application-user)
 
-You can create organizations in the Clerk Dashboard or in your application. To create an organization in the Clerk Dashboard:
+> [!WARNING]
+> Clerk automatically deletes organizations that have no members after one hour.
+
+### Create an organization in the Clerk Dashboard
+
+To create an organization in the Clerk Dashboard:
 
 1. Navigate to the [Clerk Dashboard](https://dashboard.clerk.com/last-active?path=organizations).
 1. In the navigation sidebar, select **Organizations**.
@@ -109,21 +114,20 @@ For more details on pricing, see [our pricing page](/pricing){{ target: '_blank'
 
 If you need more organizations or custom pricing, please contact [our sales team](/contact/sales){{ target: '_blank' }} to upgrade to the Enterprise plan.
 
-### Application user
+### Create an organization in your application
 
-By default, users can create organizations within your application. To disable this permission for all users:
+By default, users have the permission to create organizations within your application. To configure this permission for all users:
 
 1. Navigate to the [Clerk Dashboard](https://dashboard.clerk.com/last-active?path=organizations-settings).
-1. In the navigation sidebar, select **Organization Settings**.
-1. At the bottom of the page, in the **Limit creation** section, toggle **Allow new users to create organizations** off.
-1. You can also configure the number of organizations that can be created by each user. By default, unlimited organizations can be created by each user.
+1. In the top navigation, select **Configure**. Then, in the sidebar, under **Organization management**, select **Settings**.
+1. At the bottom of the page, in the **Limit creation** section, enable/disable **Allow new users to create organizations**. You can also configure the number of organizations that can be created by each user. By default, each user can create an unlimited number of organizations.
 
-If you want to only disable this permission for certain users, you can override it on a per-user basis on the user's profile page in the Clerk Dashboard:
+If you want to only configure this permission for a specific user, you can override it on a per-user basis on the user's profile page in the Clerk Dashboard:
 
 1. Navigate to the [Clerk Dashboard](https://dashboard.clerk.com/last-active?path=users).
-1. In the navigation sidebar, select **Users**.
+1. In the top navigation, select **Users**.
 1. Select the user you want to update.
-1. In the **User permissions** section, toggle **Allow user to create organizations** off.
+1. In the **User permissions** section, enable/disable **Allow user to create organizations**.
 
 When a user creates an organization, they become the organization's admin. As the organization's admin, they have full control over the organization, including the ability to update the organization's settings, invite users to join the organization, and manage the organization's members.
 


### PR DESCRIPTION
<!--- Add the "deploy-preview" label and add your page previews here -->

> [!IMPORTANT]
> 🔎 Previews:
>
> - https://clerk.com/docs/pr/1550/organizations/overview#create-an-organization

<!--- Describe your changes in detail. Why does this change need to happen? Include any links to Slack discussions, Linear comments, etc. -->

### Explanation:

[Linear ticket](https://linear.app/clerk/issue/DOCS-9108/add-a-callout-that-orgs-that-have-no-members-will-be-automatically) reads:

> When assisting a user, I learned that Clerk automatically deletes orgs that have no members in them. This can be alarming to a user who may be creating orgs without members for a certain use-case. To minimize confusion, we would like to add a callout / warning in the docs so users can be aware of this, and also so support has somewhere in the docs to point to if users do write in about this behavior. I'm not entirely sure where this should live so I wanted to make a linear tix for this

In the Slack thread linked in the Linear ticket, Mary mentioned:

> we have a regular running job that deletes "orphan" orgs (orgs with no members) every hour

#### THIS PR:

- Adds this information to the docs