### PR TITLE
fix: Step 7 & 8 of Neon integration guide

### DIFF
--- a/docs/integrations/databases/neon.mdx
+++ b/docs/integrations/databases/neon.mdx
@@ -157,7 +157,7 @@ This tutorial demonstrates how to integrate Neon Postgres with Clerk in a Next.j
 
     const message = formData.get('message') as string
     await db.insert(UserMessages).values({
-      user_id: user.id,
+      user_id: userId,
       message,
     })
   }
@@ -166,7 +166,7 @@ This tutorial demonstrates how to integrate Neon Postgres with Clerk in a Next.j
     const { userId } = auth()
     if (!userId) throw new Error('User not found')
 
-    await db.delete(UserMessages).where(eq(UserMessages.user_id, user.id))
+    await db.delete(UserMessages).where(eq(UserMessages.user_id, userId))
   }
   ```
 
@@ -186,7 +186,7 @@ This tutorial demonstrates how to integrate Neon Postgres with Clerk in a Next.j
   export default async function Home() {
     const { userId } = auth()
     if (!userId) throw new Error('User not found')
-    const existingMessage = db.query.UserMessages.findFirst({
+    const existingMessage = await db.query.UserMessages.findFirst({
       where: (messages, { eq }) => eq(messages.user_id, userId),
     })
 


### PR DESCRIPTION
> [!IMPORTANT]
> 🔎 Previews:
>
> - 

### Explanation:
Fixes misspelled user ID from `user.id` to `userId` on step 7, and adds `await` to the messages fetch on step 8

### This PR:

- Fixes the misspelled and missing code to make the guide work out of the box
