### PR TITLE
docs(astro): Update unstyled components custom usage

### DIFF
--- a/docs/components/unstyled/sign-in-button.mdx
+++ b/docs/components/unstyled/sign-in-button.mdx
@@ -5,9 +5,16 @@ description: The <SignInButton> component is a button that links to the sign-in 
 
 The `<SignInButton>` component is a button that links to the sign-in page or displays the sign-in modal.
 
-## `<SignInButton>` properties
+## Properties
 
 <Properties>
+  - `asChild?`
+  - `boolean`
+
+  **For Astro only:** If `true`, the `<SignInButton>` component will render its children as a child of the component.
+
+  ---
+
   - `forceRedirectUrl?`
   - `string`
 
@@ -49,114 +56,110 @@ The `<SignInButton>` component is a button that links to the sign-in page or dis
   Children you want to wrap the `<SignInButton>` in.
 </Properties>
 
-## How to use the `<SignInButton>` component
+## Usage
 
 ### Basic usage
 
-<CodeBlockTabs type="framework" options={["Next.js", "React", "Remix", "Astro"]}>
-  ```jsx {{ filename: 'pages/index.js' }}
-  import { SignInButton } from '@clerk/nextjs'
+<Tabs items={["Next.js", "React", "Remix", "Astro"]}>
+  <Tab>
+    ```jsx {{ filename: 'pages/index.js' }}
+    import { SignInButton } from '@clerk/nextjs'
 
-  export default function Home() {
-    return (
-      <div>
-        <SignInButton />
-      </div>
-    )
-  }
-  ```
+    export default function Home() {
+      return <SignInButton />
+    }
+    ```
+  </Tab>
 
-  ```jsx {{ filename: 'example.js' }}
-  import { SignInButton } from '@clerk/clerk-react'
+  <Tab>
+    ```jsx {{ filename: 'example.js' }}
+    import { SignInButton } from '@clerk/clerk-react'
 
-  export default function Example() {
-    return (
-      <div>
-        <SignInButton />
-      </div>
-    )
-  }
-  ```
+    export default function Example() {
+      return <SignInButton />
+    }
+    ```
+  </Tab>
 
-  ```jsx {{ filename: 'pages/index.js' }}
-  import { SignInButton } from '@clerk/remix'
+  <Tab>
+    ```jsx {{ filename: 'pages/index.js' }}
+    import { SignInButton } from '@clerk/remix'
 
-  export default function Home() {
-    return (
-      <div>
-        <SignInButton />
-      </div>
-    )
-  }
-  ```
+    export default function Home() {
+      return <SignInButton />
+    }
+    ```
+  </Tab>
 
-  ```astro {{ filename: 'pages/index.astro' }}
-  ---
-  import { SignInButton } from '@clerk/astro/components'
-  ---
+  <Tab>
+    ```astro {{ filename: 'pages/index.astro' }}
+    ---
+    import { SignInButton } from '@clerk/astro/components'
+    ---
 
-  <div>
     <SignInButton />
-  </div>
-  ```
-</CodeBlockTabs>
+    ```
+  </Tab>
+</Tabs>
 
 ### Custom usage
 
-In some cases, you will want to use your own button, or button text. You can do that by wrapping your button in the `<SignInButton>` component.
+You can create a custom button by wrapping your own button, or button text, in the `<SignOutButton>` component.
 
-<CodeBlockTabs type="framework" options={["Next.js", "React", "Remix", "Astro"]}>
-  ```jsx {{ filename: 'pages/index.js' }}
-  import { SignInButton } from '@clerk/nextjs'
+<Tabs items={["Next.js", "React", "Remix", "Astro"]}>
+  <Tab>
+    ```jsx {{ filename: 'pages/index.js' }}
+    import { SignInButton } from '@clerk/nextjs'
 
-  export default function Home() {
-    return (
-      <div>
+    export default function Home() {
+      return (
         <SignInButton>
-          <button>Sign in with Clerk</button>
+          <button>My custom button</button>
         </SignInButton>
-      </div>
-    )
-  }
-  ```
+      )
+    }
+    ```
+  </Tab>
 
-  ```jsx {{ filename: 'example.js' }}
-  import { SignInButton } from '@clerk/clerk-react'
+  <Tab>
+    ```jsx {{ filename: 'example.js' }}
+    import { SignInButton } from '@clerk/clerk-react'
 
-  export default function Example() {
-    return (
-      <div>
+    export default function Example() {
+      return (
         <SignInButton>
-          <button>Sign in with Clerk</button>
+          <button>My custom button</button>
         </SignInButton>
-      </div>
-    )
-  }
-  ```
+      )
+    }
+    ```
+  </Tab>
 
-  ```jsx {{ filename: 'pages/index.js' }}
-  import { SignInButton } from '@clerk/remix'
+  <Tab>
+    ```jsx {{ filename: 'pages/index.js' }}
+    import { SignInButton } from '@clerk/remix'
 
-  export default function Home() {
-    return (
-      <div>
+    export default function Home() {
+      return (
         <SignInButton>
-          <button>Sign in with Clerk</button>
+          <button>My custom button</button>
         </SignInButton>
-      </div>
-    )
-  }
-  ```
+      )
+    }
+    ```
+  </Tab>
 
-  ```astro {{ filename: 'pages/index.astro' }}
-  ---
-  import { SignInButton } from '@clerk/astro/components'
-  ---
+  <Tab>
+    You must pass the `asChild` prop to the `<SignInButton>` component if you are passing children to it.
 
-  <div>
+    ```astro {{ filename: 'pages/index.astro' }}
+    ---
+    import { SignInButton } from '@clerk/astro/components'
+    ---
+
     <SignInButton asChild>
-      <button>Sign in with Clerk</button>
+      <button>My custom button</button>
     </SignInButton>
-  </div>
-  ```
-</CodeBlockTabs>
+    ```
+  </Tab>
+</Tabs>

--- a/docs/components/unstyled/sign-in-button.mdx
+++ b/docs/components/unstyled/sign-in-button.mdx
@@ -154,7 +154,9 @@ In some cases, you will want to use your own button, or button text. You can do 
   ---
 
   <div>
-    <SignInButton as="button"> Sign in with Clerk </SignInButton>
+    <SignInButton asChild>
+      <button>Sign in with Clerk</button>
+    </SignInButton>
   </div>
   ```
 </CodeBlockTabs>

--- a/docs/components/unstyled/sign-out-button.mdx
+++ b/docs/components/unstyled/sign-out-button.mdx
@@ -5,9 +5,16 @@ description: The `<SignOutButton>` component is a button that signs a user out.
 
 The `<SignOutButton>` component is a button that signs a user out. By default, it is a `<button>` tag that says **Sign Out**, but it is completely customizable by passing children.
 
-## `<SignOutButton>` properties
+## Properties
 
 <Properties>
+  - `asChild?`
+  - `boolean`
+
+  **For Astro only:** If `true`, the `<SignOutButton>` component will render its children as a child of the component.
+
+  ---
+
   - `redirectUrl?`
   - `string`
 
@@ -46,37 +53,19 @@ The type of the `signOutOptions` prop for the `<SignOutButton>` component is def
   The redirect URL to navigate to after sign out is complete.
 </Properties>
 
-## How to use the `<SignOutButton>` component
+## Usage
 
 ### Basic usage
 
-<Tabs type="framework" items={["Next.js", "React", "Remix", "Astro"]}>
+<Tabs items={["Next.js", "React", "Remix", "Astro"]}>
   <Tab>
-    <CodeBlockTabs type="router" options={["App Router", "Pages Router"]}>
-      ```jsx {{ filename: 'app/page.js' }}
-      import { SignOutButton } from '@clerk/nextjs'
+    ```jsx {{ filename: 'app/page.js' }}
+    import { SignOutButton } from '@clerk/nextjs'
 
-      export default function Home() {
-        return (
-          <div>
-            <SignOutButton />
-          </div>
-        )
-      }
-      ```
-
-      ```jsx {{ filename: 'pages/index.js' }}
-      import { SignOutButton } from '@clerk/nextjs'
-
-      export default function Home() {
-        return (
-          <div>
-            <SignOutButton />
-          </div>
-        )
-      }
-      ```
-    </CodeBlockTabs>
+    export default function Home() {
+      return <SignOutButton />
+    }
+    ```
   </Tab>
 
   <Tab>
@@ -84,11 +73,7 @@ The type of the `signOutOptions` prop for the `<SignOutButton>` component is def
     import { SignOutButton } from '@clerk/clerk-react'
 
     export default function Example() {
-      return (
-        <div>
-          <SignOutButton />
-        </div>
-      )
+      return <SignOutButton />
     }
     ```
   </Tab>
@@ -98,11 +83,7 @@ The type of the `signOutOptions` prop for the `<SignOutButton>` component is def
     import { SignOutButton } from '@clerk/remix'
 
     export default function Home() {
-      return (
-        <div>
-          <SignOutButton />
-        </div>
-      )
+      return <SignOutButton />
     }
     ```
   </Tab>
@@ -113,9 +94,7 @@ The type of the `signOutOptions` prop for the `<SignOutButton>` component is def
     import { SignOutButton } from '@clerk/astro/components'
     ---
 
-    <div>
-      <SignOutButton />
-    </div>
+    <SignOutButton />
     ```
   </Tab>
 </Tabs>
@@ -124,37 +103,19 @@ The type of the `signOutOptions` prop for the `<SignOutButton>` component is def
 
 You can create a custom button by wrapping your own button, or button text, in the `<SignOutButton>` component.
 
-<Tabs type="framework" items={["Next.js", "React", "Remix", "Astro"]}>
+<Tabs items={["Next.js", "React", "Remix", "Astro"]}>
   <Tab>
-    <CodeBlockTabs type="router" options={["App Router", "Pages Router"]}>
-      ```jsx {{ filename: 'app/page.js' }}
-      import { SignOutButton } from '@clerk/nextjs'
+    ```jsx {{ filename: 'app/page.js' }}
+    import { SignOutButton } from '@clerk/nextjs'
 
-      export default function Home() {
-        return (
-          <div>
-            <SignOutButton>
-              <button>Sign out</button>
-            </SignOutButton>
-          </div>
-        )
-      }
-      ```
-
-      ```jsx {{ filename: 'pages/index.js' }}
-      import { SignOutButton } from '@clerk/nextjs'
-
-      export default function Home() {
-        return (
-          <div>
-            <SignOutButton>
-              <button>Sign out</button>
-            </SignOutButton>
-          </div>
-        )
-      }
-      ```
-    </CodeBlockTabs>
+    export default function Home() {
+      return (
+        <SignOutButton>
+          <button>My custom button</button>
+        </SignOutButton>
+      )
+    }
+    ```
   </Tab>
 
   <Tab>
@@ -163,11 +124,9 @@ You can create a custom button by wrapping your own button, or button text, in t
 
     export default function Example() {
       return (
-        <div>
-          <SignOutButton>
-            <button>Sign out</button>
-          </SignOutButton>
-        </div>
+        <SignOutButton>
+          <button>My custom button</button>
+        </SignOutButton>
       )
     }
     ```
@@ -179,27 +138,25 @@ You can create a custom button by wrapping your own button, or button text, in t
 
     export default function Home() {
       return (
-        <div>
-          <SignOutButton>
-            <button>Sign out</button>
-          </SignOutButton>
-        </div>
+        <SignOutButton>
+          <button>My custom button</button>
+        </SignOutButton>
       )
     }
     ```
   </Tab>
 
   <Tab>
+    You must pass the `asChild` prop to the `<SignOutButton>` component if you are passing children to it.
+
     ```astro {{ filename: 'pages/index.astro' }}
     ---
     import { SignOutButton } from '@clerk/astro/components'
     ---
 
-    <div>
-      <SignOutButton asChild>
-        <button>Sign out</button>
-      </SignOutButton>
-    </div>
+    <SignOutButton asChild>
+      <button>My custom button</button>
+    </SignOutButton>
     ```
   </Tab>
 </Tabs>
@@ -214,57 +171,25 @@ Clicking the `<SignOutButton>` component signs the user out of all sessions. Thi
 
 You can sign out of a specific session by passing in a `sessionId` to the `signOutOptions` prop. This is useful for signing a single account out of a multi-session (multiple account) application.
 
-In the example below, the `sessionId` is retrieved from the [`useAuth()`](/docs/references/react/use-auth) hook. If the user is not signed in, the `sessionId` will be `null`, and the user is shown the [`<SignInButton>`](/docs/components/unstyled/sign-in-button) component. If the user is signed in, the user is shown the `<SignOutButton>` component, which when clicked, signs the user out of that specific session.
+In the following example, the `sessionId` is retrieved from the [`useAuth()`](/docs/references/react/use-auth) hook. If the user is not signed in, the `sessionId` will be `null`, and the user is shown the [`<SignInButton>`](/docs/components/unstyled/sign-in-button) component. If the user is signed in, the user is shown the `<SignOutButton>` component, which when clicked, signs the user out of that specific session.
 
-<Tabs type="framework" items={["Next.js", "React", "Remix"]}>
+<Tabs items={["Next.js", "React", "Remix"]}>
   <Tab>
-    <CodeBlockTabs type="router" options={["App Router", "Pages Router"]}>
-      ```tsx {{ filename: 'app/page.tsx' }}
-      'use client'
+    ```tsx {{ filename: 'app/page.tsx' }}
+    'use client'
 
-      import { SignInButton, SignOutButton, useAuth } from '@clerk/nextjs'
+    import { SignInButton, SignOutButton, useAuth } from '@clerk/nextjs'
 
-      export default function Home() {
-        const { sessionId } = useAuth()
+    export default function Home() {
+      const { sessionId } = useAuth()
 
-        if (!sessionId) {
-          return (
-            <div>
-              <SignInButton />
-            </div>
-          )
-        }
-
-        return (
-          <div>
-            <SignOutButton signOutOptions={{ sessionId }} />
-          </div>
-        )
+      if (!sessionId) {
+        return <SignInButton />
       }
-      ```
 
-      ```tsx {{ filename: 'pages/index.tsx' }}
-      import { SignInButton, SignOutButton, useAuth } from '@clerk/nextjs'
-
-      export default function Home() {
-        const { sessionId } = useAuth()
-
-        if (!sessionId) {
-          return (
-            <div>
-              <SignInButton />
-            </div>
-          )
-        }
-
-        return (
-          <div>
-            <SignOutButton signOutOptions={{ sessionId }} />
-          </div>
-        )
-      }
-      ```
-    </CodeBlockTabs>
+      return <SignOutButton signOutOptions={{ sessionId }} />
+    }
+    ```
   </Tab>
 
   <Tab>
@@ -275,18 +200,10 @@ In the example below, the `sessionId` is retrieved from the [`useAuth()`](/docs/
       const { sessionId } = useAuth()
 
       if (!sessionId) {
-        return (
-          <div>
-            <SignInButton />
-          </div>
-        )
+        return <SignInButton />
       }
 
-      return (
-        <div>
-          <SignOutButton signOutOptions={{ sessionId }} />
-        </div>
-      )
+      return <SignOutButton signOutOptions={{ sessionId }} />
     }
     ```
   </Tab>
@@ -299,18 +216,10 @@ In the example below, the `sessionId` is retrieved from the [`useAuth()`](/docs/
       const { sessionId } = useAuth()
 
       if (!sessionId) {
-        return (
-          <div>
-            <SignInButton />
-          </div>
-        )
+        return <SignInButton />
       }
 
-      return (
-        <div>
-          <SignOutButton signOutOptions={{ sessionId }} />
-        </div>
-      )
+      return <SignOutButton signOutOptions={{ sessionId }} />
     }
     ```
   </Tab>

--- a/docs/components/unstyled/sign-out-button.mdx
+++ b/docs/components/unstyled/sign-out-button.mdx
@@ -196,7 +196,9 @@ You can create a custom button by wrapping your own button, or button text, in t
     ---
 
     <div>
-      <SignOutButton as="button"> Sign out </SignOutButton>
+      <SignOutButton asChild>
+        <button>Sign out</button>
+      </SignOutButton>
     </div>
     ```
   </Tab>

--- a/docs/components/unstyled/sign-up-button.mdx
+++ b/docs/components/unstyled/sign-up-button.mdx
@@ -154,7 +154,9 @@ In some cases, you will want to use your own button, or button text. You can do 
   ---
 
   <div>
-    <SignUpButton as="button"> Sign up </SignUpButton>
+    <SignUpButton mode="modal" asChild>
+      <button>Sign up</button>
+    </SignUpButton>
   </div>
   ```
 </CodeBlockTabs>

--- a/docs/components/unstyled/sign-up-button.mdx
+++ b/docs/components/unstyled/sign-up-button.mdx
@@ -5,9 +5,16 @@ description: The <SignUpButton> component is a button that links to the sign-up 
 
 The `<SignUpButton>` component is a button that links to the sign-up page or displays the sign-up modal.
 
-## `<SignUpButton>` properties
+## Properties
 
 <Properties>
+  - `asChild?`
+  - `boolean`
+
+  **For Astro only:** If `true`, the `<SignUpButton>` component will render its children as a child of the component.
+
+  ---
+
   - `forceRedirectUrl?`
   - `string`
 
@@ -49,114 +56,110 @@ The `<SignUpButton>` component is a button that links to the sign-up page or dis
   Children you want to wrap the `<SignUpButton>` in.
 </Properties>
 
-## How to use the `<SignUp>` button
+## Usage
 
 ### Basic usage
 
-<CodeBlockTabs type="framework" options={["Next.js", "React", "Remix", "Astro"]}>
-  ```jsx {{ filename: 'pages/index.js' }}
-  import { SignUpButton } from '@clerk/nextjs'
+<Tabs items={["Next.js", "React", "Remix", "Astro"]}>
+  <Tab>
+    ```jsx {{ filename: 'pages/index.js' }}
+    import { SignUpButton } from '@clerk/nextjs'
 
-  export default function Home() {
-    return (
-      <div>
-        <SignUpButton />
-      </div>
-    )
-  }
-  ```
+    export default function Home() {
+      return <SignUpButton />
+    }
+    ```
+  </Tab>
 
-  ```jsx {{ filename: 'example.js' }}
-  import { SignUpButton } from '@clerk/clerk-react'
+  <Tab>
+    ```jsx {{ filename: 'example.js' }}
+    import { SignUpButton } from '@clerk/clerk-react'
 
-  export default function Example() {
-    return (
-      <div>
-        <SignUpButton />
-      </div>
-    )
-  }
-  ```
+    export default function Example() {
+      return <SignUpButton />
+    }
+    ```
+  </Tab>
 
-  ```jsx {{ filename: 'pages/index.js' }}
-  import { SignUpButton } from '@clerk/remix'
+  <Tab>
+    ```jsx {{ filename: 'pages/index.js' }}
+    import { SignUpButton } from '@clerk/remix'
 
-  export default function Home() {
-    return (
-      <div>
-        <SignUpButton />
-      </div>
-    )
-  }
-  ```
+    export default function Home() {
+      return <SignUpButton />
+    }
+    ```
+  </Tab>
 
-  ```astro {{ filename: 'pages/index.astro' }}
-  ---
-  import { SignUpButton } from '@clerk/astro/components'
-  ---
+  <Tab>
+    ```astro {{ filename: 'pages/index.astro' }}
+    ---
+    import { SignUpButton } from '@clerk/astro/components'
+    ---
 
-  <div>
     <SignUpButton />
-  </div>
-  ```
-</CodeBlockTabs>
+    ```
+  </Tab>
+</Tabs>
 
 ### Custom usage
 
-In some cases, you will want to use your own button, or button text. You can do that by wrapping your button in the `<SignUpButton>` component.
+You can create a custom button by wrapping your own button, or button text, in the `<SignUpButton>` component.
 
-<CodeBlockTabs type="framework" options={["Next.js", "React", "Remix", "Astro"]}>
-  ```jsx {{ filename: 'pages/index.js' }}
-  import { SignUpButton } from '@clerk/nextjs'
+<Tabs items={["Next.js", "React", "Remix", "Astro"]}>
+  <Tab>
+    ```jsx {{ filename: 'pages/index.js' }}
+    import { SignUpButton } from '@clerk/nextjs'
 
-  export default function Home() {
-    return (
-      <div>
-        <SignUpButton mode="modal">
-          <button>Sign up</button>
+    export default function Home() {
+      return (
+        <SignUpButton>
+          <button>My custom button</button>
         </SignUpButton>
-      </div>
-    )
-  }
-  ```
+      )
+    }
+    ```
+  </Tab>
 
-  ```jsx {{ filename: 'example.js' }}
-  import { SignUpButton } from '@clerk/clerk-react'
+  <Tab>
+    ```jsx {{ filename: 'example.js' }}
+    import { SignUpButton } from '@clerk/clerk-react'
 
-  export default function Example() {
-    return (
-      <div>
-        <SignUpButton mode="modal">
-          <button>Sign up</button>
+    export default function Example() {
+      return (
+        <SignUpButton>
+          <button>My custom button</button>
         </SignUpButton>
-      </div>
-    )
-  }
-  ```
+      )
+    }
+    ```
+  </Tab>
 
-  ```jsx {{ filename: 'pages/index.js' }}
-  import { SignUpButton } from '@clerk/remix'
+  <Tab>
+    ```jsx {{ filename: 'pages/index.js' }}
+    import { SignUpButton } from '@clerk/remix'
 
-  export default function Home() {
-    return (
-      <div>
-        <SignUpButton mode="modal">
-          <button>Sign up</button>
+    export default function Home() {
+      return (
+        <SignUpButton>
+          <button>My custom button</button>
         </SignUpButton>
-      </div>
-    )
-  }
-  ```
+      )
+    }
+    ```
+  </Tab>
 
-  ```astro {{ filename: 'pages/index.astro' }}
-  ---
-  import { SignUpButton } from '@clerk/astro/components'
-  ---
+  <Tab>
+    You must pass the `asChild` prop to the `<SignUpButton>` component if you are passing children to it.
 
-  <div>
-    <SignUpButton mode="modal" asChild>
-      <button>Sign up</button>
+    ```astro {{ filename: 'pages/index.astro' }}
+    ---
+    import { SignUpButton } from '@clerk/astro/components'
+    ---
+
+    <SignUpButton asChild>
+      <button>My custom button</button>
     </SignUpButton>
-  </div>
-  ```
-</CodeBlockTabs>
+    ```
+  </Tab>
+</Tabs>


### PR DESCRIPTION
<!--- Add the "deploy-preview" label and add your page previews here -->

> [!IMPORTANT]
> 🔎 Previews:
>
> - https://clerk.com/docs/pr/1556/components/unstyled/sign-in-button#custom-usage
> - https://clerk.com/docs/pr/1556/components/unstyled/sign-up-button#custom-usage
> - https://clerk.com/docs/pr/1556/components/unstyled/sign-out-button#custom-usage

<!--- Describe your changes in detail. Why does this change need to happen? Include any links to Slack discussions, Linear comments, etc. -->

### Explanation:

We added support for custom elements/components inside our unstyled components in Astro, similar to the [React counterpart](https://clerk.com/docs/components/unstyled/sign-in-button#custom-usage). Here's the [PR](https://github.com/clerk/javascript/pull/4122) for that change.
