### PR TITLE
Update organization-profile.mdx

### DIFF
--- a/docs/customization/organization-profile.mdx
+++ b/docs/customization/organization-profile.mdx
@@ -358,7 +358,7 @@ The following example adds a link to the homepage in the navigation sidebar of t
 
 ## Reordering default routes
 
-If you want to reorder the default routes, `Members` and `Settings`, set the `label` prop to `'members'` or `'settings'`. This will target the existing default page and allow you to rearrange it.
+If you want to reorder the default routes, `Members` and `General`, set the `label` prop to `'members'` or `'general'`. This will target the existing default page and allow you to rearrange it.
 
 Note that when reordering default routes, the first item in the navigation sidebar cannot be a `<OrganizationSwitcher.OrganizationProfileLink />` or `<OrganizationProfile.Link />` component.
 
@@ -402,7 +402,7 @@ Note that when reordering default routes, the first item in the navigation sideb
             labelIcon={<DotIcon />}
           />
           <OrganizationSwitcher.OrganizationProfilePage label="members" />
-          <OrganizationSwitcher.OrganizationProfilePage label="settings" />
+          <OrganizationSwitcher.OrganizationProfilePage label="general" />
         </OrganizationSwitcher>
       </header>
     )
@@ -459,4 +459,4 @@ With the above example, the `<OrganizationProfile />` navigation sidebar will be
 1. Custom Page
 1. Homepage
 1. Members
-1. Settings
+1. General


### PR DESCRIPTION
Docs did not reflect proper props:
type OrganizationProfilePageProps = PageProps<'general' | 'members'>;

<!--- Add the "deploy-preview" label and add your page previews here -->

> [!IMPORTANT]
> 🔎 Previews:
>
> -

<!--- Describe your changes in detail. Why does this change need to happen? Include any links to Slack discussions, Linear comments, etc. -->

### Explanation: 
This is update the OrganizationProfilePageProps which renamed "settings" to "general" in the package:
type OrganizationProfilePageProps = PageProps<'general' | 'members'>;

<!--- How does this PR solve the problem? -->

### This PR:

-Updates the docs with the latest OrganizationProfilePageProps types
