### PR TITLE
docs: update Spotify social connection guide

### DIFF
--- a/docs/authentication/social-connections/spotify.mdx
+++ b/docs/authentication/social-connections/spotify.mdx
@@ -5,7 +5,10 @@ description: Learn how to set up a social connection with Spotify in your Clerk 
 
 Learn how to set up a social connection with Spotify in your Clerk application.
 
-Clerk does not currently support preconfigured shared OAuth credentials for Spotify on development instances. You will have to provide custom credentials for both development _and_ production instances, which includes generating your own Client ID and Client Secret using your Spotify Developer account. Don't worry, this guide will walk you through that process in just a few simple steps.
+**Clerk does not currently support preconfigured shared OAuth credentials for Spotify on development instances.** You will have to provide custom credentials for both development _and_ production instances, which includes generating your own Client ID and Client Secret using your Spotify Developer account. Don't worry, this guide will walk you through that process in just a few simple steps.
+
+> [!CAUTION]
+> [Spotify](https://developer.spotify.com/documentation/web-api/concepts/quota-modes) requires users to be added to the Spotify application's allowlist in order to allow them to connect to your Clerk application with Spotify OAuth. Each user who attempts to use your Clerk app in **development** with Spotify as their authentication method will need to be added to your app's allowlist before they can use it. _Your users may be able to log into your development Clerk app without having been allowlisted in Spotify. However, API requests with an access token associated to that user and Spotify app will receive a 403 status code error._
 
 ## Before you start
 


### PR DESCRIPTION
<!--- Add the "deploy-preview" label and add your page previews here -->

> [!IMPORTANT]
> 🔎 Previews:
>
> -

<!--- Describe your changes in detail. Why does this change need to happen? Include any links to Slack discussions, Linear comments, etc. -->

### Explanation: Users in development instance with Spotify OAuth configured also need to add the dev users to their Spotify app's allow list in the Spotify developer dashboard.

<!--- How does this PR solve the problem? -->

### This PR: Fixes [DOCS-9724](https://linear.app/clerk/issue/DOCS-9274/add-spotify-oauth-information-regarding-dev-users)

-
