### PR TITLE
Update sync-data.mdx

### DIFF
--- a/docs/integrations/webhooks/sync-data.mdx
+++ b/docs/integrations/webhooks/sync-data.mdx
@@ -75,7 +75,7 @@ This guide can be adapted to listen for any Clerk event.
     ```tsx {{ filename: 'middleware.tsx' }}
     import { clerkMiddleware } from '@clerk/nextjs/server'
 
-    // Make sure that the `/api/webhooks/(.*)` route is not protected here
+    // Make sure that the `/api/webhooks(.*)` route is not protected here
     export default clerkMiddleware()
 
     export const config = {


### PR DESCRIPTION
<!--- Add the "deploy-preview" label and add your page previews here -->

> [!IMPORTANT]
> 🔎 Previews:
>
> -

<!--- Describe your changes in detail. Why does this change need to happen? Include any links to Slack discussions, Linear comments, etc. -->

### Explanation:

In the[ guide to sync data](https://clerk.com/docs/integrations/webhooks/sync-data#set-webhook-route-as-public-in-your-middleware) step 4.
There is an additional `/` in the comment of the `clerkMiddleware ` that creates a 404 error.
The `/` shouldn't be there since the `route.tsx` is created in `/api/webhooks` as we can see in the `authMiddleware` documentation.

![image](https://github.com/user-attachments/assets/7c0e204c-8d29-4d0d-bb0a-71ea4986ea28)
![image](https://github.com/user-attachments/assets/15559766-37dc-432d-acfc-22b4f6124247)

<!--- How does this PR solve the problem? -->

### This PR:

- Removes the additional `/`
