### PR TITLE
Documenting that `uploaderUserId` is optional when uploading organization logo

### DIFF
--- a/docs/references/backend/organization/update-organization-logo.mdx
+++ b/docs/references/backend/organization/update-organization-logo.mdx
@@ -24,7 +24,7 @@ function updateOrganizationLogo(
 
   ---
 
-  - `uploaderUserId`
+  - `uploaderUserId?`
   - `string`
 
   The ID of the user uploading the logo.


### PR DESCRIPTION
Companion to https://github.com/clerk/javascript/pull/4236


