### PR TITLE
Clarifying which string is a placeholder in our file upload examples

### DIFF
--- a/docs/references/backend/organization/update-organization-logo.mdx
+++ b/docs/references/backend/organization/update-organization-logo.mdx
@@ -38,7 +38,10 @@ function updateOrganizationLogo(
 ```tsx
 const organizationId = 'org_123'
 const uploaderUserId = 'user_123'
-const file = new File(['logo-file-contents'], 'logo.png', { type: 'image/png' })
+
+const fileBits = ["logo-pic-content"]
+const fileName = "logo.png"
+const file = new File(fileBits, fileName, { type: 'image/png' })
 
 const params = {
   file,

--- a/docs/references/backend/organization/update-organization-logo.mdx
+++ b/docs/references/backend/organization/update-organization-logo.mdx
@@ -38,7 +38,7 @@ function updateOrganizationLogo(
 ```tsx
 const organizationId = 'org_123'
 const uploaderUserId = 'user_123'
-const file = new File(['logo'], 'logo.png', { type: 'image/png' })
+const file = new File(['logo-file-contents'], 'logo.png', { type: 'image/png' })
 
 const params = {
   file,

--- a/docs/references/backend/organization/update-organization-logo.mdx
+++ b/docs/references/backend/organization/update-organization-logo.mdx
@@ -39,8 +39,8 @@ function updateOrganizationLogo(
 const organizationId = 'org_123'
 const uploaderUserId = 'user_123'
 
-const fileBits = ["logo-pic-content"]
-const fileName = "logo.png"
+const fileBits = ['logo-pic-content']
+const fileName = 'logo.png'
 const file = new File(fileBits, fileName, { type: 'image/png' })
 
 const params = {

--- a/docs/references/backend/user/update-user-profile-image.mdx
+++ b/docs/references/backend/user/update-user-profile-image.mdx
@@ -18,7 +18,7 @@ function updateUserProfileImage(userId: string, params: { file: Blob | File }): 
 
 ```tsx
 const userId = 'user_123'
-const file = new File(['profile-pic'], 'profile-pic.png', { type: 'image/png' })
+const file = new File(['profile-pic-file-contents'], 'profile-pic.png', { type: 'image/png' })
 
 const params = {
   file,

--- a/docs/references/backend/user/update-user-profile-image.mdx
+++ b/docs/references/backend/user/update-user-profile-image.mdx
@@ -18,7 +18,9 @@ function updateUserProfileImage(userId: string, params: { file: Blob | File }): 
 
 ```tsx
 const userId = 'user_123'
-const file = new File(['profile-pic-file-contents'], 'profile-pic.png', { type: 'image/png' })
+const fileBits = ["profile-pic-content"]
+const fileName = "profile-pic.png"
+const file = new File(fileBits, fileName, { type: 'image/png' })
 
 const params = {
   file,

--- a/docs/references/backend/user/update-user-profile-image.mdx
+++ b/docs/references/backend/user/update-user-profile-image.mdx
@@ -18,8 +18,8 @@ function updateUserProfileImage(userId: string, params: { file: Blob | File }): 
 
 ```tsx
 const userId = 'user_123'
-const fileBits = ["profile-pic-content"]
-const fileName = "profile-pic.png"
+const fileBits = ['profile-pic-content']
+const fileName = 'profile-pic.png'
 const file = new File(fileBits, fileName, { type: 'image/png' })
 
 const params = {


### PR DESCRIPTION
## What changed?

This PR updates the examples for our APIs that deal with file uploads - uploading user profile pictures and organization logos - clarifying which string is placeholder text and must be replaced with actual file contents.

## Why now?

In testing my [recent change to these APIs](https://github.com/clerk/javascript/pull/4236), I tried running the example verbatim, and was surprised to get this error:
```
_ClerkAPIResponseError: Bad Request
    at OrganizationAPI.request (/Users/izaak/dev/clerk_docker/javascript/packages/backend/dist/index.js:1543:21)
    at process.processTicksAndRejections (node:internal/process/task_queues:95:5)
    at async /Users/izaak/dev/nodejs-playground/main.js:31:20 {
  toString: [Function (anonymous)],
  status: 400,
  clerkTraceId: 'c49860b6376ec75ad288ba9893540a17',
  clerkError: true,
  errors: [
    {
      code: 'request_body_invalid',
      message: 'unsupported image type',
      longMessage: "'text/plain; charset=utf-8' images are not currently supported. Please consult the API documentation for more information.",
      meta: {
        paramName: undefined,
        sessionId: undefined,
        emailAddresses: undefined,
        identifiers: undefined,
        zxcvbn: undefined
      }
    }
  ]
}
```

That API error wasn't particularly helpful, and it took me a fair amount of debugging time to realize that the root of the problem was that the example is uploading literal string 'logo'. I'm not familiar with the `File` API, and I was naievely assuming that because it was referencing `logo.png`, it was attempting to upload a file named `logo.png` from the root of the project directory. 

## Why not convert it to a fully-working example?

I'm not against that! This is what a full working example would look like:

```js
const { createClerkClient } = require('@clerk/backend');
const { openAsBlob } = require('node:fs'); // Node.JS ^19.8

(async () => {
  const clerkClient = createClerkClient({ secretKey: process.env.CLERK_SECRET_KEY});

  // Prod:
  const organizationId = 'org_123';

  let filePath = "./logo.png"
  const blob = await openAsBlob(filePath) // <-- Critical
  const file = new File([blob], "logo.png", { type: "image/png" });

  const params = {
    "file": file,
  };

  const response = await clerkClient.organizations.updateOrganizationLogo(
    organizationId,
    params
  );
  console.log(response);
})();
```

The main issue is that I don't see a way to read a file (from the filesystem) without taking both an import and converting to an async function, and I don't see any other example snippets that do this. Furthermore, I think it's unlikely that most customers will try this API in isolation reading from the filesystem as I did - they'll probably have file contents from some other source that they can easily substitute in.