### PR TITLE
add example sections to /sign-up/sign-up and /sign-in/sign-in

### DIFF
--- a/docs/references/javascript/sign-in/sign-in.mdx
+++ b/docs/references/javascript/sign-in/sign-in.mdx
@@ -257,3 +257,7 @@ In addition to the methods listed above, the `SignIn` class also has the followi
 - [`authenticateWithRedirect()`](/docs/references/javascript/sign-in/authenticate-with#authenticate-with-redirect)
 - [`authenticateWithMetamask()`](/docs/references/javascript/sign-in/authenticate-with#authenticate-with-metamask)
 - [`authenticateWithWeb3()`](/docs/references/javascript/sign-in/authenticate-with#authenticate-with-web3)
+
+## Example
+
+For examples of how to access the `SignUp` object and use the associated methods, see the [custom flow guides.](/docs/custom-flows/overview)

--- a/docs/references/javascript/sign-up/sign-up.mdx
+++ b/docs/references/javascript/sign-up/sign-up.mdx
@@ -353,3 +353,7 @@ In addition to the methods listed above, the `SignUp` class also has the followi
 - [`attemptWeb3WalletVerification()`](/docs/references/javascript/sign-up/web3-verification#attempt-web3-wallet-verification)
 
 [signup-ref]: /docs/references/javascript/sign-up/sign-up
+
+## Example
+
+For examples of how to access the `SignUp` object and use the associated methods, see the [custom flow guides.](/docs/custom-flows/overview)


### PR DESCRIPTION
<!--- Add the "deploy-preview" label and add your page previews here -->

> [!IMPORTANT]
> 🔎 Previews:
>
> -

<!--- Describe your changes in detail. Why does this change need to happen? Include any links to Slack discussions, Linear comments, etc. -->

### Explanation:

[User feedback ticket](https://linear.app/clerk/issue/DOCS-9279/add-example-section-to-referencesjavascriptsign-upsign-up) reads:

> Needs example use cases

<!--- How does this PR solve the problem? -->

### This PR:

- Adds example sections to the appropriate pages
