### PR TITLE
Add new default role setting docs

### DIFF
--- a/docs/manifest.json
+++ b/docs/manifest.json
@@ -605,6 +605,10 @@
                           "href": "/docs/organizations/verify-user-permissions"
                         },
                         {
+                          "title": "Reassign the default role",
+                          "href": "/docs/organizations/default-role"
+                        },
+                        {
                           "title": "Reassign the creator role",
                           "href": "/docs/organizations/creator-role"
                         },

--- a/docs/organizations/creator-role.mdx
+++ b/docs/organizations/creator-role.mdx
@@ -17,9 +17,9 @@ The **Creator** role must _at least_ have the following [System Permissions](/do
 To reassign the **Creator** role:
 
 1. Navigate to the [Clerk Dashboard](https://dashboard.clerk.com/last-active?path=organizations-settings/roles).
-1. In the navigation sidebar, select **Organization Settings**.
-1. Select the **Roles** tab. [Create a new role](/docs/organizations/create-roles-permissions#create-a-new-role-for-your-organization) or select an existing role from the list.
-1. Select the **Show System Permissions** checkbox.
-1. In the list of system permissions, ensure that **Manage members,** **Read members,** and **Delete organization** are selected.
-1. At the top right of the screen, open the "..." menu.
+1. In the top navigation bar, select **Configure**.
+1. In the sidebar, select **Organization Management** -> **Roles and Permissions**.
+1. Select the **Roles** tab. [Create a new role](/docs/organizations/create-roles-permissions#create-a-new-role-for-your-organization) or use an existing role from the list.
+1. Ensure that **Manage members,** **Read members,** and **Delete organization** system permissions are selected for the role.
+1. Open the "..." menu for the role.
 1. From the dropdown, select the **Set as Creator role** option.

--- a/docs/organizations/default-role.mdx
+++ b/docs/organizations/default-role.mdx
@@ -11,7 +11,8 @@ You cannot delete an organization role if it is used as the organization **Defau
 To reassign the **Default** role:
 
 1. Navigate to the [Clerk Dashboard](https://dashboard.clerk.com/last-active?path=organizations-settings/roles).
-1. In the navigation sidebar, select **Organization Settings**.
-1. Select the **Roles** tab. [Create a new role](/docs/organizations/create-roles-permissions#create-a-new-role-for-your-organization) or select an existing role from the list.
-1. At the top right of the screen, open the "..." menu.
+1. In the top navigation bar, select **Configure**.
+1. In the sidebar, select **Organization Management** -> **Roles and Permissions**.
+1. Select the **Roles** tab. [Create a new role](/docs/organizations/create-roles-permissions#create-a-new-role-for-your-organization) or use an existing role from the list.
+1. Open the "..." menu for the role.
 1. From the dropdown, select the **Set as Default role** option.

--- a/docs/organizations/default-role.mdx
+++ b/docs/organizations/default-role.mdx
@@ -1,0 +1,17 @@
+---
+title: Reassign the Default role for members
+description: Learn how to assign Clerk's Default role to any other role in an organization.
+content-type: guide
+---
+
+New organization members are intially assigned the [**Default** role](/docs/organizations/roles-permissions#the-default-role-for-members). By default, that role is `org:member`. This role is used as a default in `<OrganizationProfile />` invitations and for organization enrollment with [verified domains](/docs/organizations/verified-domains).
+
+You cannot delete an organization role if it is used as the organization **Default** role. But, you _can_ reassign the **Default** role to any other role.
+
+To reassign the **Default** role:
+
+1. Navigate to the [Clerk Dashboard](https://dashboard.clerk.com/last-active?path=organizations-settings/roles).
+1. In the navigation sidebar, select **Organization Settings**.
+1. Select the **Roles** tab. [Create a new role](/docs/organizations/create-roles-permissions#create-a-new-role-for-your-organization) or select an existing role from the list.
+1. At the top right of the screen, open the "..." menu.
+1. From the dropdown, select the **Set as Default role** option.

--- a/docs/organizations/roles-permissions.mdx
+++ b/docs/organizations/roles-permissions.mdx
@@ -27,6 +27,13 @@ Custom roles can be granted permissions and access. For example, you can create 
 
 To learn more about creating custom roles, see the [Create roles and permissions](/docs/organizations/create-roles-permissions) guide.
 
+### The Default role for members
+
+The **Default** role for members is the role that users are initially assigned as a new organization member. Initially, this role is the **Member** (`org:member`) role. This is the role that is used as a pre-filled default for invitations in `<OrganizationProfile />` and for organization enrollment with [verified domains](/docs/organizations/verified-domains).
+
+> [!WARNING]
+> You can't delete a role if it's used as the organization's **Default** role. However, you can [reassign the **Default** role to another role](/docs/organizations/default-role).
+
 ### The **Creator** role
 
 When a user creates a new organization, that user is automatically added as the organization's first member and is assigned the **Creator** role. By default, **Admin** (`org:admin`) is the **Creator** role.

--- a/docs/organizations/verified-domains.mdx
+++ b/docs/organizations/verified-domains.mdx
@@ -3,7 +3,7 @@ title: Verified domains
 description: Learn about how to use verified domains for organizations.
 ---
 
-Verified domains can be used to streamline enrollment into an organization. For example, if the domain `@clerk.com` is verified, any user with an email address ending in `@clerk.com` can be automatically invited or be suggested to join an organization with that domain. This feature is useful for organizations that want to restrict membership to users with specific email domains.
+Verified domains can be used to streamline enrollment into an organization. For example, if the domain `@clerk.com` is verified, any user with an email address ending in `@clerk.com` can be automatically invited or be suggested to join an organization with that domain. The role assigned to this user will be the role set as the [**Default** role](/docs/organizations/roles-permissions#the-default-role-for-members) in the organization settings page. This feature is useful for organizations that want to restrict membership to users with specific email domains.
 
 A verified domain cannot be a disposable domain or common email provider. For example, you cannot create a verified domain for `@gmail.com`.
 
@@ -16,10 +16,9 @@ In order to enable this feature:
 1. Navigate to the [Clerk Dashboard](https://dashboard.clerk.com/last-active?path=organizations-settings)
 1. In the navigation sidebar, select **Organizations Settings**.
 1. In the **Verified domains** section, check the **Enable verified domains** checkbox.
-1. The following settings will appear:
+1. The following setting will appear:
 
 - [**Enrollment mode**](#enrollment-mode) - Choose between **Automatic invitation** and **Automatic suggestion**.
-- [**Default role**](#default-role) - Choose the default role for users who join the organization through a verified domain.
 
 ### Enrollment mode
 
@@ -29,15 +28,6 @@ You can enable the following enrollment modes to be available for your applicati
 - **Automatic suggestion** - During sign-up, a user will receive a suggestion for the organization if their email's domain matches the verified domain. The user can request to join, and an administrator must accept this request before the user can join the organization.
 
 Once a domain is added and verified in your organization, the user will have the option to select an enrollment mode from those you made available.
-
-### Default role
-
-Once verified domains are enabled, you are required to define which role will be assigned to the user that will receive the organization invitation or organization suggestion in order to join your organization.
-
-By default, the options are "Member" and "Admin". However, you can also [create custom roles for your organization](/docs/organizations/create-roles-permissions).
-
-> [!WARNING]
-> You can't delete an organization role if it's used as the verified domain's default role.
 
 ## Adding and verifying domains
 


### PR DESCRIPTION
<!--- Add the "deploy-preview" label and add your page previews here -->

> [!IMPORTANT]
> 🔎 Previews:
>
> - https://clerk.com/docs/pr/1584/organizations/roles-permissions#the-default-role-for-members
> - https://clerk.com/docs/pr/1584/organizations/verified-domains
> - https://clerk.com/docs/pr/1584/organizations/default-role

We introduced a new "default role for members" setting to the organization settings page.

### Explanation:

<!--- How does this PR solve the problem? -->

This PR updates the appropriate docs to do the following:
- introduce the new top-level default role setting
- remove references to the old verified domains specific default role setting
