### PR TITLE
docs(express): Start de-emphasizing usage of `getAuth`

### DIFF
--- a/docs/quickstarts/express.mdx
+++ b/docs/quickstarts/express.mdx
@@ -111,17 +111,17 @@ Learn how to integrate Clerk into your Express backend for secure user authentic
 
   To protect your routes, use the [`requireAuth()`](/docs/references/express/overview#require-auth) middleware. This middleware functions similarly to `clerkMiddleware()`, but also protects your routes by redirecting unauthenticated users to the sign-in page.
 
-  In the following example, `requireAuth()` is used to protect the `/protected` route. If the user is not authenticated, they are redirected to the '/sign-in' route. If the user is authenticated, the [`getAuth()`](/docs/references/express/overview#get-auth) helper is used to get the `userId`, which is passed to [`clerkClient.users.getUser()`](/docs/references/backend/user/get-user){{ target: '_blank' }} to fetch the current user's `User` object.
+  In the following example, `requireAuth()` is used to protect the `/protected` route. If the user is not authenticated, they are redirected to the '/sign-in' route. If the user is authenticated, the `req.auth` object is used to get the `userId`, which is passed to [`clerkClient.users.getUser()`](/docs/references/backend/user/get-user){{ target: '_blank' }} to fetch the current user's `User` object.
 
   ```ts {{ filename: 'index.ts', mark: [3, [7, 11], [13, 16]] }}
   import 'dotenv/config'
   import express from 'express'
-  import { clerkClient, getAuth, requireAuth } from '@clerk/express'
+  import { clerkClient, requireAuth } from '@clerk/express'
 
   const app = express()
 
   app.get('/protected', requireAuth({ signInUrl: '/sign-in' }), (req, res) => {
-    const { userId } = getAuth(req)
+    const { userId } = req.auth
     const user = await clerkClient.users.getUser(userId)
     return res.json({ user })
   })

--- a/docs/upgrade-guides/node-to-express.mdx
+++ b/docs/upgrade-guides/node-to-express.mdx
@@ -40,13 +40,13 @@ Then, install the Express SDK by running the following command:
 
 ## Migrate from `withAuth()`
 
-If you previously used `withAuth()` to wrap your route handlers, you can now use [`getAuth()`](/docs/references/express/overview#get-auth) with the Express SDK. Pass the request object to `getAuth()` to retrieve the authentication state within the route handler.
+If you previously used `withAuth()` to wrap your route handlers, you can now retrieve the authentication state within your Express route handlers using the `req.auth` object.
 
 `clerkMiddleware()` is required to be set in the middleware chain before this util is used, as shown in the following example.
 
 ```ts {{ del: [1, [10, 13]], ins: [2, 8, [14, 17]] }}
 import { withAuth } from '@clerk/clerk-sdk-node'
-import { clerkMiddleware, getAuth } from '@clerk/express'
+import { clerkMiddleware } from '@clerk/express'
 import express from 'express'
 
 const app = express()
@@ -59,7 +59,7 @@ app.get(
   withAuth((req, res) => res.json(req.auth)),
 )
 app.get('/auth-state', (req, res) => {
-  const authState = getAuth(req)
+  const authState = req.auth
   return res.json(authState)
 })
 
@@ -96,21 +96,21 @@ You also want to make sure to catch and handle the error using an [error middlew
 
 ## Migrate from `ClerkExpressWithAuth`
 
-To replace your existing Node SDK middleware [`ClerkExpressWithAuth()`](/docs/backend-requests/handling/nodejs), which allows requests to proceed even when users are not authenticated, you need to write your own middleware that uses [`getAuth()`](/docs/references/express/overview#get-auth) to retrieve the auth state and then return an empty object if the user is not authenticated.
+To replace your existing Node SDK middleware [`ClerkExpressWithAuth()`](/docs/backend-requests/handling/nodejs), which allows requests to proceed even when users are not authenticated, you need to write your own middleware that uses `req.auth` object to retrieve the auth state and then return an empty object if the user is not authenticated.
 
 ```ts {{ del: [1, [19, 21]], ins: [2, 8, 9, [11, 16], [22, 24]] }}
 import { ClerkExpressWithAuth } from '@clerk/clerk-sdk-node'
-import { clerkMiddleware, getAuth } from '@clerk/express'
+import { clerkMiddleware } from '@clerk/express'
 import express from 'express'
 
 const app = express()
 const port = 3000
 
-// clerkMiddleware is required to be set in the middleware chain before getAuth is used
+// clerkMiddleware is required to be set in the middleware chain before req.auth is used
 app.use(clerkMiddleware())
 
 const withAuth = (req, res, next) => {
-  const { userId } = getAuth(req)
+  const { userId } = req.auth
   // If the user is not authenticated, return an empty object
   req.auth = userId ? auth : {}
   next()


### PR DESCRIPTION
<!--- Add the "deploy-preview" label and add your page previews here -->

> [!IMPORTANT]
> 🔎 Previews:
>
> - https://clerk.com/docs/pr/1595/quickstarts/express#protect-your-routes-using-require-auth
> - https://clerk.com/docs/pr/1595/upgrade-guides/node-to-express

<!--- Describe your changes in detail. Why does this change need to happen? Include any links to Slack discussions, Linear comments, etc. -->

### Explanation:

The `getAuth()` helper is basically an unnecessary abstraction, which just calls `req.auth` under the hood and throws an error if the middleware is not installed.

### This PR:

This PR de-emphasizes the use of `getAuth()` and promote direct access to `req.auth` to access authenticate state. We're still keeping it to support the [Backend SDK](https://clerk.com/docs/references/sdk/backend-only#create-a-require-auth-helper) spec.