### PR TITLE
`.dev` → `.com`

### DIFF
--- a/docs/deployments/overview.mdx
+++ b/docs/deployments/overview.mdx
@@ -17,7 +17,7 @@ Before you begin:
 1. The homepage of the dashboard will show you what is still required to deploy your production instance.
 
 > [!WARNING]
-> For security reasons, **[SSO Connections](https://dashboard.clerk.dev/last-active?path=user-authentication/sso-connections)**, **[Integrations](https://dashboard.clerk.dev/last-active?path=integrations)**, and **[Paths](https://dashboard.clerk.dev/last-active?path=paths)** settings do not copy over. You will need to set these values again.
+> For security reasons, **[SSO Connections](https://dashboard.clerk.com/last-active?path=user-authentication/sso-connections)**, **[Integrations](https://dashboard.clerk.com/last-active?path=integrations)**, and **[Paths](https://dashboard.clerk.com/last-active?path=paths)** settings do not copy over. You will need to set these values again.
 
 ## API keys and environment variables
 


### PR DESCRIPTION
Corrects `dashboard.clerk.dev/*` links to `dashboard.clerk.com/*` on https://clerk.com/docs/deployments/overview