### PR TITLE
chore(docs): Add information about customization limitations in Account Portal and Localization guides

### DIFF
--- a/docs/customization/account-portal/overview.mdx
+++ b/docs/customization/account-portal/overview.mdx
@@ -23,6 +23,9 @@ After a user has finished their flow in an Account Portal page, Clerk automatica
 
 For each application environment, Clerk provides pages for sign-up, sign-in, user profile, organization profile, and organization creation flow. **To integrate the Account Portal with your application, check out the [setup guide](/docs/customization/account-portal/getting-started).**
 
+> [!IMPORTANT]
+> These pages cannot be customized beyond the options provided in the [Clerk Dashboard](https://dashboard.clerk.com). If you need more customization such as [localization](/docs/customization/localization), consider using Clerk's [prebuilt components](/docs/components/overview) or [building your own custom user interface using Clerk's API](/docs/custom-flows/overview).
+
 ## Hosted pages
 
 ### Sign-in

--- a/docs/customization/localization.mdx
+++ b/docs/customization/localization.mdx
@@ -58,6 +58,9 @@ Clerk currently supports the following languages with English as the default:
 
 ### Usage
 
+> [!CAUTION]
+> The localizations will only update the text in the [Clerk components](/docs/components/overview) used in your application. The hosted [Clerk Account Portal](/docs/customization/account-portal/overview) will remain in English.
+
 To get started, install the `@clerk/localizations` package.
 
 <CodeBlockTabs type="installer" options={["npm", "yarn", "pnpm"]}>


### PR DESCRIPTION
<!--- Add the "deploy-preview" label and add your page previews here -->

> [!IMPORTANT]
> 🔎 Previews:
>
> - https://clerk.com/docs/pr/1609

<!--- Describe your changes in detail. Why does this change need to happen? Include any links to Slack discussions, Linear comments, etc. -->

### Explanation:

There's no mention on the localisations guide page that the usage guide will only affect components that are used in the application, versus when developers are still using the hosted sign in and sign up pages, etc.

### This PR:

- Adds information about customisation limitations in the Account Portal and Localisation guides
- Fixes [DOCS-9359](https://linear.app/clerk/issue/DOCS-9359/clarify-localization-guide-on-usage-affecting-only-ui-components)
