### PR TITLE
`inngest.com` domain requires `www.`

### DIFF
--- a/docs/integrations/webhooks/inngest.mdx
+++ b/docs/integrations/webhooks/inngest.mdx
@@ -3,7 +3,7 @@ title: Handling webhooks with Inngest
 description: Learn how to integrate Clerk with Inngest.
 ---
 
-Webhooks allow you to [synchronize data](/docs/integrations/webhooks/sync-data) from Clerk to your application backend. You can either handle them directly in your backend with an endpoint or use a tool like [Inngest](https://inngest.com/) which receives the webhook events for you and reliably executes functions in your codebase. When handling webhooks, Inngest receives the [webhook events](/docs/integrations/webhooks/overview#supported-webhook-events) for you and uses a built-in queue to reliably execute longer running functions with additional functionality including:
+Webhooks allow you to [synchronize data](/docs/integrations/webhooks/sync-data) from Clerk to your application backend. You can either handle them directly in your backend with an endpoint or use a tool like [Inngest](https://www.inngest.com) which receives the webhook events for you and reliably executes functions in your codebase. When handling webhooks, Inngest receives the [webhook events](/docs/integrations/webhooks/overview#supported-webhook-events) for you and uses a built-in queue to reliably execute longer running functions with additional functionality including:
 
 - [Limiting concurrency](https://www.inngest.com/docs/guides/concurrency) to handle spikes in events without overwhelming your API or database.
 - Triggering multiple functions from a single event ([fan-out jobs](https://www.inngest.com/docs/guides/fan-out-jobs)).


### PR DESCRIPTION
Linking directly to the apex domain for `inngest.com` errors out 🙈  Needs `www.` subdomain to resolve correctly (like the rest of the links in the doc).

<img width="1582" alt="Screenshot 2024-10-21 at 11 13 57 AM" src="https://github.com/user-attachments/assets/90c64ca0-268d-4e0a-a8c1-d4e608493d9d">
