### PR TITLE
fix(docs): Update satellite domains documentation

### DIFF
--- a/docs/advanced-usage/satellite-domains.mdx
+++ b/docs/advanced-usage/satellite-domains.mdx
@@ -12,9 +12,9 @@ Clerk supports sharing sessions across different domains by adding one or many s
 
 Your "primary" domain is where the authentication state lives, and satellite domains are able to securely read that state from the primary domain, enabling a seamless authentication flow across domains.
 
-Users must complete the sign-in flow on the primary domain, either using Clerk’s [`<SignIn />`](/docs/components/authentication/sign-in) component or [`useSignIn()`](/docs/references/react/use-sign-in) hook.
+Users must complete both the sign-in and sign-up flows on the primary domain, by using Clerk’s [`<SignIn />`](/docs/components/authentication/sign-in) component or [`useSignIn()`](/docs/references/react/use-sign-in) hook for sign-in and [`<SignUp />`](/docs/components/authentication/sign-up) component or [`useSignUp()`](/docs/references/react/use-sign-up) hook for sign-up.
 
-To access authentication state from a satellite domain, users will be transparently redirected to the primary domain. If users need to sign in, they must be redirected to a sign in flow hosted on the primary domain, then redirected back to the originating satellite domain.
+To access authentication state from a satellite domain, users will be transparently redirected to the primary domain. If users need to sign in, they must be redirected to a sign in flow hosted on the primary domain, then redirected back to the originating satellite domain. The same redirection process applies to sign-up flows.
 
 ## How to add satellite domains
 

--- a/docs/advanced-usage/satellite-domains.mdx
+++ b/docs/advanced-usage/satellite-domains.mdx
@@ -12,7 +12,7 @@ Clerk supports sharing sessions across different domains by adding one or many s
 
 Your "primary" domain is where the authentication state lives, and satellite domains are able to securely read that state from the primary domain, enabling a seamless authentication flow across domains.
 
-Users must complete both the sign-in and sign-up flows on the primary domain, by using Clerk’s [`<SignIn />`](/docs/components/authentication/sign-in) component or [`useSignIn()`](/docs/references/react/use-sign-in) hook for sign-in and [`<SignUp />`](/docs/components/authentication/sign-up) component or [`useSignUp()`](/docs/references/react/use-sign-up) hook for sign-up.
+Users must complete both the sign-in and sign-up flows on the primary domain by using Clerk's [`<SignIn />`](/docs/components/authentication/sign-in) component or [`useSignIn()`](/docs/references/react/use-sign-in) hook for sign-in and [`<SignUp />`](/docs/components/authentication/sign-up) component or [`useSignUp()`](/docs/references/react/use-sign-up) hook for sign-up.
 
 To access authentication state from a satellite domain, users will be transparently redirected to the primary domain. If users need to sign in, they must be redirected to a sign in flow hosted on the primary domain, then redirected back to the originating satellite domain. The same redirection process applies to sign-up flows.
 

--- a/docs/authentication/social-connections/linear.mdx
+++ b/docs/authentication/social-connections/linear.mdx
@@ -49,7 +49,6 @@ To make the setup process easier, it's recommended to keep two browser tabs open
   1. Ensure that both **Enable for sign-up and sign-in** and **Use custom credentials** are toggled on.
   1. Save the **Redirect URI** somewhere secure. Keep the modal and page open.
 
-
   ### Create a Linear app
 
   1. In the top-left of [Linear](https://linear.app/), select your workspace, then select **Preferences**.


### PR DESCRIPTION
<!--- Add the "deploy-preview" label and add your page previews here -->

> [!IMPORTANT]
> 🔎 Previews:
>
> - https://clerk.com/docs/pr/1643

<!--- Describe your changes in detail. Why does this change need to happen? Include any links to Slack discussions, Linear comments, etc. -->

### Explanation:

Users are only made aware of the requirement for sign-in flow to be completed on the primary domain, but not until later on in the implementation step is the sign-up flow requirement mentioned.
<!--- How does this PR solve the problem? -->

### This PR:

- Clarifies that users must complete both the sign-in and sign-up flows on the primary domain using Clerk's <SignIn /> component or useSignIn() hook for sign-in and <SignUp /> component or useSignUp() hook for sign-up. It also explains the redirection process for accessing authentication state from a satellite domain, including sign-in and sign-up flows.
- Fixes [DOCS-9422](https://linear.app/clerk/issue/DOCS-9422/feedback-for-satellite-domains-docs)
