### PR TITLE
(authentication/configuration/restrictions): update block email subaddress behavior

### DIFF
--- a/docs/authentication/configuration/restrictions.mdx
+++ b/docs/authentication/configuration/restrictions.mdx
@@ -76,7 +76,7 @@ For example, if you add `john.doe@clerk.dev` as a blocked email address, it mean
 > [!NOTE]
 > Existing accounts with email subaddresses will not be affected by this restriction, and will still be allowed to sign in.
 >
-> This feature aims to prevent malicious sign-in attempts. The first canonical email containing a subaddress will be allowed, but subsequent sign-ins using additional subaddresses will be blocked.
+> This feature is designed to prevent malicious sign-in attempts. The first email containing a subaddress will be allowed, but any subsequent sign-ins using additional subaddresses will be blocked.
 
 To enable this feature:
 

--- a/docs/authentication/configuration/restrictions.mdx
+++ b/docs/authentication/configuration/restrictions.mdx
@@ -75,6 +75,8 @@ For example, if you add `john.doe@clerk.dev` as a blocked email address, it mean
 
 > [!NOTE]
 > Existing accounts with email subaddresses will not be affected by this restriction, and will still be allowed to sign in.
+>
+> This feature aims to prevent malicious sign-in attempts. The first canonical email containing a subaddress will be allowed, but subsequent sign-ins using additional subaddresses will be blocked.
 
 To enable this feature:
 


### PR DESCRIPTION
<!--- Add the "deploy-preview" label and add your page previews here -->

> [!IMPORTANT]
> 🔎 Previews:
>
> - https://clerk.com/docs/pr/1645

<!--- Describe your changes in detail. Why does this change need to happen? Include any links to Slack discussions, Linear comments, etc. -->

### Explanation:
We're changing how the block email subaddress restriction works. 

#### Before:
`nicolas+finance@gmail.com` would be blocked, as the e-mail contains a `+`

#### Now:
🧑‍🦱 A legit user trying to be organized with their mailbox:

- I want to sign up for a new bank that uses Clerk.
- I sign up with an email containing a subaddress: `nicolas+finance@clerk.dev`.
- ✅ Sign-up should be successful.

🎩 An attacker trying to abuse subaddressing:

- They sign up with the first account: `imahacker+1@gmail.com`.
- ✅ Sign-up is successful.
- Now they try to sign up again with `imahacker+2@gmail.com`.
- ❌ The attempt fails because the same canonical identifier already exists.

