### PR TITLE
Remove localhost from a link in v6.mdx

### DIFF
--- a/docs/upgrade-guides/nextjs/v6.mdx
+++ b/docs/upgrade-guides/nextjs/v6.mdx
@@ -116,7 +116,7 @@ Note that this isn't recommended, and in most cases you should use `auth()` to a
 
 The following deprecated APIs have been removed.
 
-- `authMiddleware()` - [Migrate to `clerkMiddleware()`](http://localhost:3000/docs/upgrade-guides/core-2/nextjs#migrating-to-clerk-middleware)
+- `authMiddleware()` - [Migrate to `clerkMiddleware()`](/docs/upgrade-guides/core-2/nextjs#migrating-to-clerk-middleware)
 - `redirectToSignIn()` - Migrate to `const { redirectToSignIn } = await auth()`
 - `redirectToSignUp()` - Migrate to `const { redirectToSignUp } = await auth()`
 - `clerkClient` - Migrate to `await clerkClient()`


### PR DESCRIPTION
<!--- Add the "deploy-preview" label and add your page previews here -->

> [!IMPORTANT]
> 🔎 Previews:
> * https://clerk.com/docs/upgrade-guides/nextjs/v6

<!--- How does this PR solve the problem? -->

### This PR:

- Fixes a relative url at the bottom of "Upgrade to @clerk/nextjs v6" page
