### PR TITLE
Add deprecation notice to Node SDK

### DIFF
--- a/docs/backend-requests/handling/nodejs.mdx
+++ b/docs/backend-requests/handling/nodejs.mdx
@@ -1,9 +1,12 @@
 ---
-title: Handling requests with Node.js and Express
-description: Learn how to handle authenticated requests with Node.js and Express middleware using Clerk.
+title: Handling requests with the Node SDK
+description: Learn how to handle authenticated requests with Clerk's Node SDK.
 ---
 
-## Node.js and Connect/Express Middleware
+> [!CAUTION]
+> On January 8, 2025, the Node SDK will no longer be available. [Upgrade to the Express SDK.](/docs/upgrade-guides/node-to-express)
+
+## Node SDK Middleware
 
 The Clerk Node SDK offers two authentication middlewares specifically for [Express](https://expressjs.com/) and Connect/Express compatible frameworks such as [Fastify](https://www.fastify.io/docs/latest/Reference/Middleware/).
 

--- a/docs/references/express/overview.mdx
+++ b/docs/references/express/overview.mdx
@@ -7,6 +7,9 @@ Clerk makes it simple to add authentication to your Express application. This do
 
 See the [quickstart](/docs/quickstarts/express) to get started.
 
+> [!IMPORTANT]
+> If you are upgrading from the Node SDK, see the [upgrade guide](/docs/upgrade-guides/node-to-express) for more information.
+
 ## Available methods
 
 ### `clerkMiddleware()`

--- a/docs/references/express/overview.mdx
+++ b/docs/references/express/overview.mdx
@@ -7,6 +7,8 @@ Clerk makes it simple to add authentication to your Express application. This do
 
 See the [quickstart](/docs/quickstarts/express) to get started.
 
+{/* TODO: Remove callout when Node SDK is removed from docs */}
+
 > [!IMPORTANT]
 > If you are upgrading from the Node SDK, see the [upgrade guide](/docs/upgrade-guides/node-to-express) for more information.
 

--- a/docs/references/nodejs/available-methods.mdx
+++ b/docs/references/nodejs/available-methods.mdx
@@ -3,6 +3,9 @@ title: Node.js Available Methods
 description: Learn how to use the Clerk Node.js SDK to interact with the Clerk API.
 ---
 
+> [!CAUTION]
+> On January 8, 2025, the Node SDK will no longer be available. [Upgrade to the Express SDK.](/docs/upgrade-guides/node-to-express)
+
 All resource operations are mounted as sub-APIs on the `clerkClient` object. You can find the full list of available operations in the [JavaScript Backend SDK](/docs/references/backend/overview) documentation. To access a resource, you must first instantiate a `clerkClient` instance.
 
 ## Instantiate a default `clerkClient` instance

--- a/docs/references/nodejs/overview.mdx
+++ b/docs/references/nodejs/overview.mdx
@@ -3,8 +3,8 @@ title: Clerk Node.js SDK
 description: Learn how to integrate Node.js into your Clerk application.
 ---
 
-> [!IMPORTANT]
-> Starting October 8, 2024, the Node SDK is entering a three-month notice period. We encourage everyone to migrate to `@clerk/express`. For full details, please see our [changelog](https://clerk.com/changelog/2024-10-08-express-sdk).
+> [!CAUTION]
+> On January 8, 2025, the Node SDK will no longer be available. [Upgrade to the Express SDK.](/docs/upgrade-guides/node-to-express)
 
 ## Set up Clerk Node.js
 

--- a/docs/references/nodejs/overview.mdx
+++ b/docs/references/nodejs/overview.mdx
@@ -3,6 +3,9 @@ title: Clerk Node.js SDK
 description: Learn how to integrate Node.js into your Clerk application.
 ---
 
+> [!IMPORTANT]
+> Starting October 8, 2024, the Node SDK is entering a three-month notice period. We encourage everyone to migrate to `@clerk/express`. For full details, please see our [changelog](https://clerk.com/changelog/2024-10-08-express-sdk).
+
 ## Set up Clerk Node.js
 
 <Steps>


### PR DESCRIPTION
<!--- Add the "deploy-preview" label and add your page previews here -->

> [!IMPORTANT]
> 🔎 Previews:
>
> - https://clerk.com/docs/pr/1652/references/nodejs/overview

<!--- Describe your changes in detail. Why does this change need to happen? Include any links to Slack discussions, Linear comments, etc. -->

### Explanation:

We started the transition period to deprecate `@clerk/clerk-sdk-node`. We need to display some callout when visiting the overview page.

### This PR:

- Adds a callout to Node SDK pages that guides users to the Node-->Express upgrade guide
<img width="550" alt="Screenshot 2024-10-24 at 16 45 53" src="https://github.com/user-attachments/assets/469422a6-8ea5-410c-89a6-93ca54e8cb45">

- Adds a callout to Express SDK overview that mentions the Node-->Express upgrade guide
<img width="550" alt="Screenshot 2024-10-24 at 16 45 59" src="https://github.com/user-attachments/assets/817481eb-d2d5-451b-a2c0-4fdb04c49280">

