### PR TITLE
Update local-credentials.mdx

### DIFF
--- a/docs/references/expo/local-credentials.mdx
+++ b/docs/references/expo/local-credentials.mdx
@@ -100,10 +100,10 @@ This guide shows you how to use the `useLocalCredentials()` hook to enhance your
         />
         <TextInput value={password} onChangeText={(password) => setPassword(password)} />
         <Button title="Sign In" onPress={() => onSignInPress()} />
-        {hasCredentials && biometryType && (
+        {hasCredentials && biometricType && (
           <TouchableOpacity onPress={() => onSignInPress(true)}>
             <SymbolView
-              name={biometryType === 'face-recognition' ? 'faceid' : 'touchid'}
+              name={biometricType === 'face-recognition' ? 'faceid' : 'touchid'}
               type="monochrome"
             />
           </TouchableOpacity>


### PR DESCRIPTION
In the example, biometricType is imported from the useLocalCredentials() hook, but biometryType is used on the sign-in button. I think this was a typo.