### PR TITLE
Change redirect variables description in clerk-environment-variables.mdx

### DIFF
--- a/docs/deployments/clerk-environment-variables.mdx
+++ b/docs/deployments/clerk-environment-variables.mdx
@@ -23,8 +23,8 @@ However, it's recommended to use environment variables instead of these props wh
   <Tab>
     | Variable | Description |
     | - | - |
-    | `CLERK_SIGN_IN_URL` | Full URL or path to the sign in page. Use this variable to provide the target of the 'Sign In' link that's rendered in the `<SignUp />` component. |
-    | `CLERK_SIGN_UP_URL` | Full URL or path to the sign up page. Use this variable to provide the target of the 'Sign Up' link that's rendered in the `<SignIn />` component. |
+    | `CLERK_SIGN_IN_URL` | Full URL or path to the sign in page. Use this variable to provide the target of the 'Sign In' link that's rendered in the `<SignIn />` component. |
+    | `CLERK_SIGN_UP_URL` | Full URL or path to the sign up page. Use this variable to provide the target of the 'Sign Up' link that's rendered in the `<SignUp />` component. |
     | `CLERK_SIGN_IN_FORCE_REDIRECT_URL` | If provided, this URL will always be redirected to after the user signs in. |
     | `CLERK_SIGN_UP_FORCE_REDIRECT_URL` | If provided, this URL will always be redirected to after the user signs up. |
     | `CLERK_SIGN_IN_FALLBACK_REDIRECT_URL` | The fallback URL to redirect to after the user signs in, if there's no `redirect_url` in the path already. Defaults to `/`. |
@@ -34,8 +34,8 @@ However, it's recommended to use environment variables instead of these props wh
   <Tab>
     | Variable | Description |
     | - | - |
-    | `NEXT_PUBLIC_CLERK_SIGN_IN_URL` | Full URL or path to the sign in page. Use this variable to provide the target of the 'Sign In' link that's rendered in the `<SignUp />` component. |
-    | `NEXT_PUBLIC_CLERK_SIGN_UP_URL` | Full URL or path to the sign up page. Use this variable to provide the target of the 'Sign Up' link that's rendered in the `<SignIn />` component. |
+    | `NEXT_PUBLIC_CLERK_SIGN_IN_URL` | Full URL or path to the sign in page. Use this variable to provide the target of the 'Sign In' link that's rendered in the `<SignIn />` component. |
+    | `NEXT_PUBLIC_CLERK_SIGN_UP_URL` | Full URL or path to the sign up page. Use this variable to provide the target of the 'Sign Up' link that's rendered in the `<SignUp />` component. |
     | `NEXT_PUBLIC_CLERK_SIGN_IN_FORCE_REDIRECT_URL` | If provided, this URL will always be redirected to after the user signs in. |
     | `NEXT_PUBLIC_CLERK_SIGN_UP_FORCE_REDIRECT_URL` | If provided, this URL will always be redirected to after the user signs up. |
     | `NEXT_PUBLIC_CLERK_SIGN_IN_FALLBACK_REDIRECT_URL` | The fallback URL to redirect to after the user signs in, if there's no `redirect_url` in the path already. Defaults to `/`. |


### PR DESCRIPTION
<!--- Add the "deploy-preview" label and add your page previews here -->

> [!IMPORTANT]
> 🔎 Previews:
>
> -

<!--- Describe your changes in detail. Why does this change need to happen? Include any links to Slack discussions, Linear comments, etc. -->

### Explanation:
I think the description is wrong. The Signin page should render the `<SignIn /> component and the Signup page should render the `<SignUp />` component, not reverse (as the doc say currently)

<!--- How does this PR solve the problem? -->

### This PR:

- Corrects the components to be used with the signing and signup pages