### PR TITLE
updating Convex integration docs to mention acceptance of custom claims

### DIFF
--- a/docs/integrations/databases/convex.mdx
+++ b/docs/integrations/databases/convex.mdx
@@ -157,7 +157,7 @@ This tutorial assumes that you have already [set up a Clerk application](/docs/q
   })
   ```
 
-  You can customize the information in the JWT by navigating to the [JWT Templates](https://dashboard.clerk.com/last-active?path=jwt-templates)page in the Clerk Dashboard. Formerly, Convex explicityly listed fields derived from [OpenID standard claims](https://openid.net/specs/openid-connect-core-1_0.html#StandardClaims). However, Convex now allows keys to accept [custom claims](https://docs.convex.dev/api/interfaces/server.UserIdentity).
+  You can customize the information in the JWT by navigating to the [JWT Templates](https://dashboard.clerk.com/last-active?path=jwt-templates) page in the Clerk Dashboard. Previously, Convex explicitly listed fields derived from [OpenID standard claims](https://openid.net/specs/openid-connect-core-1_0.html#StandardClaims). Now, Convex allows keys to accept [custom claims](https://docs.convex.dev/api/interfaces/server.UserIdentity).
 
   ### Finished!
 

--- a/docs/integrations/databases/convex.mdx
+++ b/docs/integrations/databases/convex.mdx
@@ -157,7 +157,7 @@ This tutorial assumes that you have already [set up a Clerk application](/docs/q
   })
   ```
 
-  You can customize the information in the JWT by navigating to the [JWT Templates](https://dashboard.clerk.com/last-active?path=jwt-templates)page in the Clerk Dashboard. All the keys must be valid [OpenID standard claims](https://openid.net/specs/openid-connect-core-1_0.html#StandardClaims).
+  You can customize the information in the JWT by navigating to the [JWT Templates](https://dashboard.clerk.com/last-active?path=jwt-templates)page in the Clerk Dashboard. Formerly, Convex explicityly listed fields derived from [OpenID standard claims](https://openid.net/specs/openid-connect-core-1_0.html#StandardClaims). However, Convex now allows keys to accept [custom claims](https://docs.convex.dev/api/interfaces/server.UserIdentity).
 
   ### Finished!
 


### PR DESCRIPTION
<!--- Add the "deploy-preview" label and add your page previews here -->

> [!IMPORTANT]
> 🔎 Previews:
https://clerk.com/docs/pr/1673/integrations/databases/convex#integrate-convex-with-clerk
>
> -

<!--- Describe your changes in detail. Why does this change need to happen? Include any links to Slack discussions, Linear comments, etc. -->

### Explanation:
After speaking with the convex team, they pointed out an error in our docs regarding the callout of OpenId claims. Convex now accepts custom claims. 
<!--- How does this PR solve the problem? -->

### This PR:
I am updating the doc to have this callout mimic what's mentioned in the convex docs.

-
