### PR TITLE
Added GH Workflow Cron

### DIFF
--- a/.github/workflows/plain-ingest.yml
+++ b/.github/workflows/plain-ingest.yml
@@ -1,0 +1,23 @@
+name: Index docs
+
+on:
+  schedule:
+    - cron: '0 */3 * * *'
+
+jobs:
+  lint:
+    name: Index Documents
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v3
+        with:
+          node-version: '18'
+
+      - name: Install CLI
+        run: npm install -g @team-plain/cli@latest
+
+      - name: Index Documents
+        run: plain index-sitemap https://www.plain.com/docs/sitemap.xml
+        env:
+          PLAIN_API_KEY: ${{ secrets.PLAIN_API_KEY }}`


### PR DESCRIPTION
The GitHub Worflow cron is for ingesting docs into the Plain AI to help it with context in the new reply AI feature.
