### PR TITLE
chore: Testing tokens are now enabled in production instances as well

### DIFF
--- a/docs/references/backend/testing-tokens/create-testing-token.mdx
+++ b/docs/references/backend/testing-tokens/create-testing-token.mdx
@@ -3,7 +3,7 @@ title: '`createTestingToken()`'
 description: Use Clerk's Backend SDK to create a testing token for the instance.
 ---
 
-Creates a Testing Token for the instance. **It only works on development instances.**
+Creates a Testing Token for the instance.
 
 ```ts
 function createTestingToken(): Promise<TestingToken>

--- a/docs/testing/overview.mdx
+++ b/docs/testing/overview.mdx
@@ -16,7 +16,7 @@ Testing Tokens allow you to bypass bot detection mechanisms that protect Clerk a
 > [!NOTE]
 > While you can manually implement the following logic in your test suite, Clerk provides [Playwright](/docs/testing/playwright/overview) and [Cypress](/docs/testing/cypress) integrations that handle this automatically.
 
-Obtained via the [Backend API](/docs/reference/backend-api/tag/Testing-Tokens){{ target: '_blank' }}, Testing Tokens are short-lived and valid only for the specific instance for which they are issued. Testing Tokens are only available in development instances.
+Obtained via the [Backend API](/docs/reference/backend-api/tag/Testing-Tokens){{ target: '_blank' }}, Testing Tokens are short-lived and valid only for the specific instance for which they are issued.
 
 Once retrieved, include the token value in the `__clerk_testing_token` query parameter in your Frontend API requests. For example, a sign-up request using a Testing Token would look like this:
 


### PR DESCRIPTION
Previously, testing tokens were only available for dev instances.
This commit updates the necessary docs to reflect that, testing tokens are available for production instances as well.

<!--- Add the "deploy-preview" label and add your page previews here -->

> [!IMPORTANT]
> 🔎 Previews:
>
> - https://clerk.com/docs/pr/1678/testing/overview#testing-tokens
> - https://clerk.com/docs/pr/1678/references/backend/testing-tokens/create-testing-token#create-testing-token

<!--- Describe your changes in detail. Why does this change need to happen? Include any links to Slack discussions, Linear comments, etc. -->

### Explanation:

<!--- How does this PR solve the problem? -->

### This PR:

-
