### PR TITLE
Update redeploy workflow

### DIFF
--- a/.github/workflows/redeploy.yml
+++ b/.github/workflows/redeploy.yml
@@ -12,10 +12,9 @@ on:
 jobs:
   redeploy:
     runs-on: ubuntu-latest
+    env:
+      DEPLOY_HOOK: ${{ github.ref == 'refs/heads/main' && secrets.WEBSITE_DEPLOY_HOOK || secrets.WEBSITE_DEPLOY_HOOK_CORE_1 }}
     steps:
       - name: Trigger redeploy
         run: |
-          curl -X POST ${{ secrets.WEBSITE_DEPLOY_HOOK }}
-      - name: Trigger search reindex
-        run: |
-          curl -X POST ${{ secrets.SEARCH_INDEX_DEPLOY_HOOK }}
+          curl -X POST ${{ env.DEPLOY_HOOK }}


### PR DESCRIPTION
This PR updates the `redeploy` workflow now that the Algolia search index has been updated (see https://github.com/clerk/clerk/pull/662)

- The `Trigger search reindex` step is no longer needed as reindexing is handled by webhooks instead
- The website deploy hook used is now different depending on whether the push was to `main` or `core-1`. This ensures that the correct pages are crawled by Algolia

> [!IMPORTANT]
> - The `WEBSITE_DEPLOY_HOOK_CORE_1` secret must be added in the repository settings before merging this PR
> - The `SEARCH_INDEX_DEPLOY_HOOK` secret can be deleted once this PR has been merged