### PR TITLE
Add a note that `dynamic` is required for the `nonce` prop

### DIFF
--- a/docs/components/clerk-provider.mdx
+++ b/docs/components/clerk-provider.mdx
@@ -226,7 +226,7 @@ The `<ClerkProvider>` component must be added to your React entrypoint.
   - `nonce?`
   - `string`
 
-  This nonce value will be passed through to the `@clerk/clerk-js` script tag. You can use this to implement [strict-dynamic CSP](/docs/security/clerk-csp#implementing-a-strict-dynamic-csp).
+  This nonce value will be passed through to the `@clerk/clerk-js` script tag. You can use this to implement [strict-dynamic CSP](/docs/security/clerk-csp#implementing-a-strict-dynamic-csp). Note that the `dynamic` prop is also required on `ClerkProvider` in order for `nonce` to work.
 
   ---
 

--- a/docs/components/clerk-provider.mdx
+++ b/docs/components/clerk-provider.mdx
@@ -226,7 +226,7 @@ The `<ClerkProvider>` component must be added to your React entrypoint.
   - `nonce?`
   - `string`
 
-  This nonce value will be passed through to the `@clerk/clerk-js` script tag. You can use this to implement [strict-dynamic CSP](/docs/security/clerk-csp#implementing-a-strict-dynamic-csp). Note that the `dynamic` prop is also required on `ClerkProvider` in order for `nonce` to work.
+  This nonce value will be passed to the `@clerk/clerk-js` script tag. Use it to implement a [strict-dynamic CSP](/docs/security/clerk-csp#implementing-a-strict-dynamic-csp). Requires the `dynamic` prop to also be set.
 
   ---
 

--- a/docs/security/clerk-csp.mdx
+++ b/docs/security/clerk-csp.mdx
@@ -117,6 +117,9 @@ export const config = {
 
 With this `strict-dynamic` configuration in place, **all script tags must be passed with a `nonce` value** or they will be blocked. This can be done by passing the nonce value as a `nonce` parameter to the script tag. For example, `<script src="https://example.com/script.js" nonce="<nonce_value>"></script>`. If you are using Next.js, any scripts loaded through next will automatically have the nonce value injected.
 
+> [!NOTE]
+> You must pass the [`dynamic` prop](/docs/components/clerk-provider#properties) to `<ClerkProvider>` in order for `strict-dynamic` CSPs to work correctly. This is because the nonce value is generated on the server and passed to the client, which requires dynamic rendering.
+
 With the above middleware, the nonce value is made accessible via the `x-nonce` request header. An example is provided below on how to access this value within a Next.js page.
 
 ```tsx {{ filename: 'pages/index.tsx' }}

--- a/docs/security/clerk-csp.mdx
+++ b/docs/security/clerk-csp.mdx
@@ -118,7 +118,7 @@ export const config = {
 With this `strict-dynamic` configuration in place, **all script tags must be passed with a `nonce` value** or they will be blocked. This can be done by passing the nonce value as a `nonce` parameter to the script tag. For example, `<script src="https://example.com/script.js" nonce="<nonce_value>"></script>`. If you are using Next.js, any scripts loaded through next will automatically have the nonce value injected.
 
 > [!NOTE]
-> You must pass the [`dynamic` prop](/docs/components/clerk-provider#properties) to `<ClerkProvider>` in order for `strict-dynamic` CSPs to work correctly. This is because the nonce value is generated on the server and passed to the client, which requires dynamic rendering.
+> You must pass the [`dynamic` prop](/docs/components/clerk-provider#properties) to `<ClerkProvider>` for `strict-dynamic` CSPs to work correctly. This is because the nonce value is generated on the server and passed to the client, which requires dynamic rendering.
 
 With the above middleware, the nonce value is made accessible via the `x-nonce` request header. An example is provided below on how to access this value within a Next.js page.
 


### PR DESCRIPTION
<!--- Add the "deploy-preview" label and add your page previews here -->

> [!IMPORTANT]
> 🔎 Previews:
>
> - https://clerk.com/docs/pr/1685/security/clerk-csp#implementing-a-strict-dynamic-csp
> - https://clerk.com/docs/pr/1685/components/clerk-provider#properties

<!--- Describe your changes in detail. Why does this change need to happen? Include any links to Slack discussions, Linear comments, etc. -->

### Explanation:

With the recent changes to ClerkProvider that cause it to static render by default, in order to pass `nonce` as a prop, which is pulled from headers, it requires server rendering, which means that `dynamic` must also be present. This is now documented in ClerkProvider's props as well as the CSP guide in the strict-dynamic section.
