### PR TITLE
feat(vue): Add client helpers (part 2)

### DIFF
--- a/docs/references/vue/use-organization.mdx
+++ b/docs/references/vue/use-organization.mdx
@@ -9,21 +9,21 @@ The `useOrganization()` composable is used to retrieve attributes of the current
 
 <Properties>
   - `isLoaded`
-  - `boolean`
+  - `Ref<boolean>`
 
   A boolean that is set to `false` until Clerk loads and initializes.
 
   ---
 
   - `organization`
-  - [`Organization`](/docs/references/javascript/organization/organization)
+  - <code>Ref\<[Organization](/docs/references/javascript/organization/organization)></code>
 
   The currently active organization.
 
   ---
 
   - `membership`
-  - [`OrganizationMembership`](/docs/references/javascript/organization-membership)
+  - <code>Ref\<[OrganizationMembership](/docs/references/javascript/organization-membership)></code>
 
   The current organization membership.
 </Properties>

--- a/docs/references/vue/use-organization.mdx
+++ b/docs/references/vue/use-organization.mdx
@@ -1,0 +1,113 @@
+---
+title: '`useOrganization()`'
+description: Clerk's useOrganization() composable retrieves attributes of the currently active organization.
+---
+
+The `useOrganization()` composable is used to retrieve attributes of the currently active organization.
+
+## `useOrganization()` returns
+
+<Properties>
+  - `isLoaded`
+  - `boolean`
+
+  A boolean that is set to `false` until Clerk loads and initializes.
+
+  ---
+
+  - `organization`
+  - [`Organization`](/docs/references/javascript/organization/organization)
+
+  The currently active organization.
+
+  ---
+
+  - `membership`
+  - [`OrganizationMembership`](/docs/references/javascript/organization-membership)
+
+  The current organization membership.
+</Properties>
+
+## How to use the `useOrganization()` composable
+
+The following example shows how to use the `useOrganization()` composable to access the current active [`Organization`](/docs/references/javascript/organization/organization) object.
+
+```vue {{ filename: 'home.vue' }}
+<script setup>
+import { useOrganization } from '@clerk/vue'
+
+const { organization, isLoaded } = useOrganization()
+</script>
+
+<template>
+  <div v-if="isLoaded">
+    <p>This current organization is {{ organization.name }}</p>
+  </div>
+
+  <div v-else>
+    <p>Loading...</p>
+  </div>
+</template>
+```
+
+## Paginating data
+
+The following example demonstrates how to implement pagination for organization memberships. The `memberships` attribute will be populated with the first page of the organization's memberships. When the "Previous page" or "Next page" button is clicked, the `fetchMemberships` function will be called to fetch the previous or next page of memberships.
+
+You can implement this pattern to any Clerk function that returns a [`ClerkPaginatedResponse`](/docs/references/javascript/types/clerk-paginated-response#clerk-paginated-response) object.
+
+```vue {{ filename: 'member-list.vue' }}
+<script setup>
+import { ref, watchEffect } from 'vue'
+import { useOrganization } from '@clerk/vue'
+
+const memberships = ref([])
+const currentPage = ref(1)
+const { organization, isLoading } = useOrganization()
+
+const pageSize = 10
+
+async function fetchMemberships() {
+  if (!organization.value) {
+    return
+  }
+
+  const { data } = await organization.value.getMemberships({
+    initialPage: currentPage.value,
+    pageSize: 5,
+  })
+  memberships.value = data
+}
+
+watchEffect(() => {
+  if (!organization.value) {
+    return
+  }
+
+  fetchMemberships()
+})
+
+const fetchPrevious = () => currentPage.value--
+const fetchNext = () => currentPage.value++
+</script>
+
+<template>
+  <div v-if="isLoading">
+    <h2>Organization members</h2>
+    <ul>
+      <li v-for="membership in memberships" :key="membership.id">
+        {{ membership.publicUserData.firstName }} {{ membership.publicUserData.lastName }} &lt;{{
+          membership.publicUserData.identifier
+        }}&gt; :: {{ membership.role }}
+      </li>
+    </ul>
+    <div>
+      <button :disabled="currentPage === 1" @click="fetchPrevious">Previous</button>
+      <button @click="fetchNext">Next</button>
+    </div>
+  </div>
+  <div v-else>
+    <p>Loading...</p>
+  </div>
+</template>
+```

--- a/docs/references/vue/use-organization.mdx
+++ b/docs/references/vue/use-organization.mdx
@@ -1,11 +1,11 @@
 ---
-title: '`useOrganization()`'
+title: useOrganization()
 description: Clerk's useOrganization() composable retrieves attributes of the currently active organization.
 ---
 
 The `useOrganization()` composable is used to retrieve attributes of the currently active organization.
 
-## `useOrganization()` returns
+## Returns
 
 <Properties>
   - `isLoaded`
@@ -34,12 +34,15 @@ The following example shows how to use the `useOrganization()` composable to acc
 
 ```vue {{ filename: 'home.vue' }}
 <script setup>
-import { useOrganization } from '@clerk/vue'
+import { OrganizationSwitcher, useOrganization } from '@clerk/vue'
 
 const { organization, isLoaded } = useOrganization()
 </script>
 
 <template>
+  <div v-if="!organization">
+    <OrganizationSwitcher />
+  </div>
   <div v-if="isLoaded">
     <p>This current organization is {{ organization.name }}</p>
   </div>
@@ -59,13 +62,13 @@ You can implement this pattern to any Clerk function that returns a [`ClerkPagin
 ```vue {{ filename: 'member-list.vue' }}
 <script setup>
 import { ref, watchEffect } from 'vue'
-import { useOrganization } from '@clerk/vue'
+import { OrganizationSwitcher, useOrganization } from '@clerk/vue'
 
 const memberships = ref([])
 const currentPage = ref(1)
-const { organization, isLoading } = useOrganization()
+const { organization, isLoaded } = useOrganization()
 
-const pageSize = 10
+const pageSize = 5
 
 async function fetchMemberships() {
   if (!organization.value) {
@@ -74,7 +77,7 @@ async function fetchMemberships() {
 
   const { data } = await organization.value.getMemberships({
     initialPage: currentPage.value,
-    pageSize: 5,
+    pageSize: pageSize,
   })
   memberships.value = data
 }
@@ -92,7 +95,10 @@ const fetchNext = () => currentPage.value++
 </script>
 
 <template>
-  <div v-if="isLoading">
+  <div v-if="!organization">
+    <OrganizationSwitcher />
+  </div>
+  <div v-else-if="isLoaded">
     <h2>Organization members</h2>
     <ul>
       <li v-for="membership in memberships" :key="membership.id">
@@ -103,7 +109,7 @@ const fetchNext = () => currentPage.value++
     </ul>
     <div>
       <button :disabled="currentPage === 1" @click="fetchPrevious">Previous</button>
-      <button @click="fetchNext">Next</button>
+      <button :disabled="memberships.length < pageSize" @click="fetchNext">Next</button>
     </div>
   </div>
   <div v-else>

--- a/docs/references/vue/use-organization.mdx
+++ b/docs/references/vue/use-organization.mdx
@@ -1,9 +1,9 @@
 ---
-title: useOrganization()
-description: Clerk's useOrganization() composable retrieves attributes of the currently active organization.
+title: '`useOrganization()`'
+description: Access and manage the currently active organization in your Vue application with Clerk's useOrganization() composable.
 ---
 
-The `useOrganization()` composable is used to retrieve attributes of the currently active organization.
+The `useOrganization()` composable retrieves attributes of the currently active organization.
 
 ## Returns
 
@@ -30,9 +30,11 @@ The `useOrganization()` composable is used to retrieve attributes of the current
 
 ## How to use the `useOrganization()` composable
 
-The following example shows how to use the `useOrganization()` composable to access the current active [`Organization`](/docs/references/javascript/organization/organization) object.
+### Retrieve the current active organization
 
-```vue {{ filename: 'home.vue' }}
+Use `useOrganization()` to access the current active [`Organization`](/docs/references/javascript/organization/organization) object.
+
+```vue {{ filename: 'OrganizationStatus.vue' }}
 <script setup>
 import { OrganizationSwitcher, useOrganization } from '@clerk/vue'
 
@@ -44,7 +46,7 @@ const { organization, isLoaded } = useOrganization()
     <OrganizationSwitcher />
   </div>
   <div v-if="isLoaded">
-    <p>This current organization is {{ organization.name }}</p>
+    <p>This current organization is {{ organization?.name }}</p>
   </div>
 
   <div v-else>
@@ -53,13 +55,13 @@ const { organization, isLoaded } = useOrganization()
 </template>
 ```
 
-## Paginating data
+### Paginate organization memberships
 
-The following example demonstrates how to implement pagination for organization memberships. The `memberships` attribute will be populated with the first page of the organization's memberships. When the "Previous page" or "Next page" button is clicked, the `fetchMemberships` function will be called to fetch the previous or next page of memberships.
+Use `useOrganization()` to access the organization's memberships through the `getMemberships()` method. Pagination is implemented by fetching pages of memberships when the "Previous page" or "Next page" buttons are clicked.
 
-You can implement this pattern to any Clerk function that returns a [`ClerkPaginatedResponse`](/docs/references/javascript/types/clerk-paginated-response#clerk-paginated-response) object.
+This pagination pattern can be applied to any Clerk method that returns a [`ClerkPaginatedResponse`](/docs/references/javascript/types/clerk-paginated-response#clerk-paginated-response) object.
 
-```vue {{ filename: 'member-list.vue' }}
+```vue {{ filename: 'MembershipList.vue' }}
 <script setup>
 import { ref, watchEffect } from 'vue'
 import { OrganizationSwitcher, useOrganization } from '@clerk/vue'
@@ -98,8 +100,10 @@ const fetchNext = () => currentPage.value++
   <div v-if="!organization">
     <OrganizationSwitcher />
   </div>
+
   <div v-else-if="isLoaded">
     <h2>Organization members</h2>
+
     <ul>
       <li v-for="membership in memberships" :key="membership.id">
         {{ membership.publicUserData.firstName }} {{ membership.publicUserData.lastName }} &lt;{{
@@ -107,11 +111,13 @@ const fetchNext = () => currentPage.value++
         }}&gt; :: {{ membership.role }}
       </li>
     </ul>
+
     <div>
       <button :disabled="currentPage === 1" @click="fetchPrevious">Previous</button>
       <button :disabled="memberships.length < pageSize" @click="fetchNext">Next</button>
     </div>
   </div>
+
   <div v-else>
     <p>Loading...</p>
   </div>

--- a/docs/references/vue/use-organization.mdx
+++ b/docs/references/vue/use-organization.mdx
@@ -1,5 +1,5 @@
 ---
-title: '`useOrganization()`'
+title: useOrganization()
 description: Access and manage the currently active organization in your Vue application with Clerk's useOrganization() composable.
 ---
 

--- a/docs/references/vue/use-session-list.mdx
+++ b/docs/references/vue/use-session-list.mdx
@@ -9,21 +9,21 @@ The `useSessionList()` composable returns an array of [`Session`](/docs/referenc
 
 <Properties>
   - `isLoaded`
-  - `boolean`
+  - `Ref<boolean>`
 
   A boolean that is set to `false` until Clerk loads and initializes.
 
   ---
 
   - `setActive()`
-  - <code>(params: [SetActiveParams](#set-active-params)) => Promise\<void></code>
+  - <code>Ref\<(params: [SetActiveParams](#set-active-params)) => Promise\<void>></code>
 
   A function that sets the active session and/or organization.
 
   ---
 
   - `sessions`
-  - <code>[Session](/docs/references/javascript/session)\[]</code>
+  - <code>Ref\<[Session](/docs/references/javascript/session)></code>
 
   A list of sessions that have been registered on the client device.
 </Properties>

--- a/docs/references/vue/use-session-list.mdx
+++ b/docs/references/vue/use-session-list.mdx
@@ -1,0 +1,77 @@
+---
+title: '`useSessionList()`'
+description: Clerk's useSessionList() composable retrieves a list of sessions that have been registered on the client device.
+---
+
+The `useSessionList()` composable returns an array of [`Session`](/docs/references/javascript/session) objects that have been registered on the client device.
+
+## `useSessionList()` returns
+
+<Properties>
+  - `isLoaded`
+  - `boolean`
+
+  A boolean that is set to `false` until Clerk loads and initializes.
+
+  ---
+
+  - `setActive()`
+  - <code>(params: [SetActiveParams](#set-active-params)) => Promise\<void></code>
+
+  A function that sets the active session and/or organization.
+
+  ---
+
+  - `sessions`
+  - <code>[Session](/docs/references/javascript/session)\[]</code>
+
+  A list of sessions that have been registered on the client device.
+</Properties>
+
+### `SetActiveParams`
+
+<Properties>
+  - `session`
+  - <code>[Session](/docs/references/javascript/session) | string | null</code>
+
+  The session resource or session ID (string version) to be set as active. If `null`, the current session is deleted.
+
+  ---
+
+  - `organization`
+  - <code>[Organization](/docs/references/javascript/organization/organization) | string | null</code>
+
+  The organization resource or organization ID/slug (string version) to be set as active in the current session. If `null`, the currently active organization is removed as active.
+
+  ---
+
+  - `beforeEmit?`
+  - `(session?: Session | null) => void | Promise<any>`
+
+  Callback run just before the active session and/or organization is set to the passed object. Can be used to composable up for pre-navigation actions.
+</Properties>
+
+## How to use the `useSessionList()` composable
+
+The following example demonstrates how to use the `useSessionList()` composable to retrieve a list of sessions that have been registered on the client device. The `isLoaded` property is used to handle the loading state, and the `sessions` property is used to display the number of times the user has visited the page.
+
+```vue {{ filename: 'home.vue' }}
+<script setup>
+import { useSessionList } from '@clerk/vue'
+
+const { isLoaded, sessions } = useSessionList()
+</script>
+
+<template>
+  <div v-if="!isLoaded">
+    <!-- handle loading state -->
+  </div>
+
+  <div v-else>
+    <p>
+      Welcome back. You have been here
+      {{ sessions.length }} times before.
+    </p>
+  </div>
+</template>
+```

--- a/docs/references/vue/use-session-list.mdx
+++ b/docs/references/vue/use-session-list.mdx
@@ -1,5 +1,5 @@
 ---
-title: '`useSessionList()`'
+title: useSessionList()
 description: Access and manage a list of sessions registered on the client device in your Vue application with Clerk's useSessionList() composable.
 ---
 

--- a/docs/references/vue/use-session-list.mdx
+++ b/docs/references/vue/use-session-list.mdx
@@ -1,11 +1,11 @@
 ---
-title: '`useSessionList()`'
+title: useSessionList()
 description: Clerk's useSessionList() composable retrieves a list of sessions that have been registered on the client device.
 ---
 
 The `useSessionList()` composable returns an array of [`Session`](/docs/references/javascript/session) objects that have been registered on the client device.
 
-## `useSessionList()` returns
+## Returns
 
 <Properties>
   - `isLoaded`

--- a/docs/references/vue/use-session-list.mdx
+++ b/docs/references/vue/use-session-list.mdx
@@ -1,6 +1,6 @@
 ---
-title: useSessionList()
-description: Clerk's useSessionList() composable retrieves a list of sessions that have been registered on the client device.
+title: '`useSessionList()`'
+description: Access and manage a list of sessions registered on the client device in your Vue application with Clerk's useSessionList() composable.
 ---
 
 The `useSessionList()` composable returns an array of [`Session`](/docs/references/javascript/session) objects that have been registered on the client device.
@@ -11,7 +11,7 @@ The `useSessionList()` composable returns an array of [`Session`](/docs/referenc
   - `isLoaded`
   - `Ref<boolean>`
 
-  A boolean that is set to `false` until Clerk loads and initializes.
+  A boolean that indicates whether Clerk has completed initialization. Initially `false`, becomes `true` once Clerk loads.
 
   ---
 
@@ -53,9 +53,11 @@ The `useSessionList()` composable returns an array of [`Session`](/docs/referenc
 
 ## How to use the `useSessionList()` composable
 
-The following example demonstrates how to use the `useSessionList()` composable to retrieve a list of sessions that have been registered on the client device. The `isLoaded` property is used to handle the loading state, and the `sessions` property is used to display the number of times the user has visited the page.
+### Retrieve a list of sessions
 
-```vue {{ filename: 'home.vue' }}
+Use `useSessionList()` to retrieve a list of sessions that have been registered on the client device. The `sessions` property is used to show the number of times the user has visited the page.
+
+```vue {{ filename: 'SessionList.vue' }}
 <script setup>
 import { useSessionList } from '@clerk/vue'
 
@@ -64,14 +66,11 @@ const { isLoaded, sessions } = useSessionList()
 
 <template>
   <div v-if="!isLoaded">
-    <!-- handle loading state -->
+    <!-- Handle loading state -->
   </div>
 
   <div v-else>
-    <p>
-      Welcome back. You have been here
-      {{ sessions.length }} times before.
-    </p>
+    <p>Welcome back. You've been here {{ sessions.length }} times before.</p>
   </div>
 </template>
 ```

--- a/docs/references/vue/use-session.mdx
+++ b/docs/references/vue/use-session.mdx
@@ -9,21 +9,21 @@ The `useSession()` composable provides access to the current user's [`Session`](
 
 <Properties>
   - `isLoaded`
-  - `boolean`
+  - `Ref<boolean>`
 
   A boolean that is set to `false` until Clerk loads and initializes.
 
   ---
 
   - `isSignedIn`
-  - `boolean`
+  - `Ref<boolean>`
 
   A boolean that is set to `true` if the user is signed in.
 
   ---
 
   - `session`
-  - [`Session`](/docs/references/javascript/session)
+  - <code>Ref\<[Session](/docs/references/javascript/session)></code>
 
   Holds the current active session for the user.
 </Properties>

--- a/docs/references/vue/use-session.mdx
+++ b/docs/references/vue/use-session.mdx
@@ -1,0 +1,55 @@
+---
+title: '`useSession()`'
+description: Clerk's useSession() composable provides access to the the current user Session object, as well as helpers to set the active session.
+---
+
+The `useSession()` composable provides access to the current user's [`Session`](/docs/references/javascript/session) object, as well as helpers for setting the active session.
+
+## `useSession()` returns
+
+<Properties>
+  - `isLoaded`
+  - `boolean`
+
+  A boolean that is set to `false` until Clerk loads and initializes.
+
+  ---
+
+  - `isSignedIn`
+  - `boolean`
+
+  A boolean that is set to `true` if the user is signed in.
+
+  ---
+
+  - `session`
+  - [`Session`](/docs/references/javascript/session)
+
+  Holds the current active session for the user.
+</Properties>
+
+## How to use the `useSession()` composable
+
+The following example demonstrates how to use the `useSession()` composable to access the `SignIn` object, which has the `lastActiveAt` property on it. The `lastActiveAt` property is used to display the last active time of the current session to the user.
+
+```vue {{ filename: 'home.vue' }}
+<script setup>
+import { useSession } from '@clerk/vue'
+
+const { isLoaded, session, isSignedIn } = useSession()
+</script>
+
+<template>
+  <div v-if="!isLoaded">
+    <!-- Add logic to handle loading state -->
+  </div>
+
+  <div v-else-if="!isSignedIn">
+    <!-- Add logic to handle not signed in state -->
+  </div>
+
+  <div v-else>
+    <p>This session has been active since {{ session.lastActiveAt.toLocaleString() }}</p>
+  </div>
+</template>
+```

--- a/docs/references/vue/use-session.mdx
+++ b/docs/references/vue/use-session.mdx
@@ -1,5 +1,5 @@
 ---
-title: '`useSession()`'
+title: useSession()
 description: Access and manage the current user's session in your Vue application with Clerk's useSession() composable.
 ---
 

--- a/docs/references/vue/use-session.mdx
+++ b/docs/references/vue/use-session.mdx
@@ -1,6 +1,6 @@
 ---
-title: useSession()
-description: Clerk's useSession() composable provides access to the the current user Session object, as well as helpers to set the active session.
+title: '`useSession()`'
+description: Access and manage the current user's session in your Vue application with Clerk's useSession() composable.
 ---
 
 The `useSession()` composable provides access to the current user's [`Session`](/docs/references/javascript/session) object, as well as helpers for setting the active session.
@@ -11,7 +11,7 @@ The `useSession()` composable provides access to the current user's [`Session`](
   - `isLoaded`
   - `Ref<boolean>`
 
-  A boolean that is set to `false` until Clerk loads and initializes.
+  A boolean that indicates whether Clerk has completed initialization. Initially `false`, becomes `true` once Clerk loads.
 
   ---
 
@@ -30,9 +30,11 @@ The `useSession()` composable provides access to the current user's [`Session`](
 
 ## How to use the `useSession()` composable
 
-The following example demonstrates how to use the `useSession()` composable to access the `SignIn` object, which has the `lastActiveAt` property on it. The `lastActiveAt` property is used to display the last active time of the current session to the user.
+### Check the current state of a session
 
-```vue {{ filename: 'home.vue' }}
+Use `useSession()` to access the `Session` object, which has the `lastActiveAt` property. The `lastActiveAt` property is a `Date` object used to show the time the session was last active.
+
+```vue {{ filename: 'SessionStatus.vue' }}
 <script setup>
 import { useSession } from '@clerk/vue'
 
@@ -41,11 +43,11 @@ const { isLoaded, session, isSignedIn } = useSession()
 
 <template>
   <div v-if="!isLoaded">
-    <!-- Add logic to handle loading state -->
+    <!-- Handle loading state -->
   </div>
 
   <div v-else-if="!isSignedIn">
-    <!-- Add logic to handle not signed in state -->
+    <!-- Handle signed out state -->
   </div>
 
   <div v-else>

--- a/docs/references/vue/use-session.mdx
+++ b/docs/references/vue/use-session.mdx
@@ -1,11 +1,11 @@
 ---
-title: '`useSession()`'
+title: useSession()
 description: Clerk's useSession() composable provides access to the the current user Session object, as well as helpers to set the active session.
 ---
 
 The `useSession()` composable provides access to the current user's [`Session`](/docs/references/javascript/session) object, as well as helpers for setting the active session.
 
-## `useSession()` returns
+## Returns
 
 <Properties>
   - `isLoaded`

--- a/docs/references/vue/use-sign-up.mdx
+++ b/docs/references/vue/use-sign-up.mdx
@@ -1,0 +1,86 @@
+---
+title: '`useSignUp()`'
+description: Clerk's useSignUp() composable gives you access to the SignUp object, which allows you to check the current state of a sign-up.
+---
+
+The `useSignUp()` composable gives you access to the [`SignUp`](/docs/references/javascript/sign-up/sign-up) object, which allows you to check the current state of a sign-up. This is also useful for creating a [custom sign-up flow.](#create-a-custom-sign-up-flow-with-use-sign-up)
+
+## `useSignUp()` returns
+
+<Properties>
+  - `isLoaded`
+  - `boolean`
+
+  A boolean that is set to `false` until Clerk loads and initializes.
+
+  ---
+
+  - `setActive()`
+  - <code>(params: [SetActiveParams](#set-active-params)) => Promise\<void></code>
+
+  A function that sets the active session.
+
+  ---
+
+  - `signUp`
+  - [`SignUp`](/docs/references/javascript/sign-up/sign-up)
+
+  An object that contains the current sign-up attempt status and methods to create a new sign-up attempt.
+</Properties>
+
+### `SetActiveParams`
+
+<Properties>
+  - `session`
+  - <code>[Session](/docs/references/javascript/session) | string | null</code>
+
+  The session resource or session ID (string version) to be set as active. If `null`, the current session is deleted.
+
+  ---
+
+  - `organization`
+  - <code>[Organization](/docs/references/javascript/organization/organization) | string | null</code>
+
+  The organization resource or organization ID/slug (string version) to be set as active in the current session. If `null`, the currently active organization is removed as active.
+
+  ---
+
+  - `beforeEmit?`
+  - `(session?: Session | null) => void | Promise<any>`
+
+  Callback run just before the active session and/or organization is set to the passed object. Can be used to composable up for pre-navigation actions.
+</Properties>
+
+## How to use the `useSignUp()` composable
+
+### Check the current state of a sign-up with `useSignUp()`
+
+Use the `useSignUp()` composable to access the `SignUp` object and check the current state of a sign-up.
+
+```vue {{ filename: 'sign-up-step.vue' }}
+<script setup>
+import { useSignUp } from '@clerk/vue'
+
+const { isLoaded, signUp } = useSignUp()
+</script>
+
+<template>
+  <div v-if="!isLoaded">
+    <!-- Add logic to handle loading state -->
+  </div>
+
+  <div v-else>The current sign-up attempt status is {{ signUp.status }}.</div>
+</template>
+```
+
+The `status` property of the `SignUp` object can be one of the following values:
+
+| Values | Description |
+| - | - |
+| `complete` | The user has been created and custom flow can proceed to `setActive()` to create session. |
+| `abandoned` | The sign-up attempt will be abandoned if it was started more than 24 hours previously. |
+| `missing_requirements` | A requirement from the [Email, Phone, Username](https://dashboard.clerk.com/last-active?path=user-authentication/email-phone-username) settings is missing. For example, in the Clerk Dashboard, the Password setting is required but a password was not provided in the custom flow. |
+
+### Create a custom sign-up flow with `useSignUp()`
+
+The `useSignUp()` composable can also be used to build fully custom sign-up flows, if Clerk's prebuilt components don't meet your specific needs or if you require more control over the authentication flow. Different sign-up flows include email and password, email and phone codes, email links, and multifactor (MFA). To learn more about using the `useSignUp()` composable to create custom flows, check out the [custom flow guides](/docs/custom-flows/overview).

--- a/docs/references/vue/use-sign-up.mdx
+++ b/docs/references/vue/use-sign-up.mdx
@@ -9,21 +9,21 @@ The `useSignUp()` composable gives you access to the [`SignUp`](/docs/references
 
 <Properties>
   - `isLoaded`
-  - `boolean`
+  - `Ref<boolean>`
 
   A boolean that is set to `false` until Clerk loads and initializes.
 
   ---
 
   - `setActive()`
-  - <code>(params: [SetActiveParams](#set-active-params)) => Promise\<void></code>
+  - <code>Ref\<(params: [SetActiveParams](#set-active-params)) => Promise\<void>></code>
 
   A function that sets the active session.
 
   ---
 
   - `signUp`
-  - [`SignUp`](/docs/references/javascript/sign-up/sign-up)
+  - <code>Ref\<[SignUp](/docs/references/javascript/sign-up/sign-up)></code>
 
   An object that contains the current sign-up attempt status and methods to create a new sign-up attempt.
 </Properties>

--- a/docs/references/vue/use-sign-up.mdx
+++ b/docs/references/vue/use-sign-up.mdx
@@ -1,9 +1,9 @@
 ---
-title: useSignUp()
-description: Clerk's useSignUp() composable gives you access to the SignUp object, which allows you to check the current state of a sign-up.
+title: '`useSignUp()`'
+description: Access and manage sign-up state in your Vue application with Clerk's useSignUp() composable.
 ---
 
-The `useSignUp()` composable gives you access to the [`SignUp`](/docs/references/javascript/sign-up/sign-up) object, which allows you to check the current state of a sign-up. This is also useful for creating a [custom sign-up flow.](#create-a-custom-sign-up-flow-with-use-sign-up)
+The `useSignUp()` composable provides access to the [`SignUp`](/docs/references/javascript/sign-up/sign-up) object, which allows you to check the current state of a sign-up attempt and manage the sign-up flow. You can use this to create a [custom sign-up flow](/docs/custom-flows/overview#sign-up-flow).
 
 ## Returns
 
@@ -11,7 +11,7 @@ The `useSignUp()` composable gives you access to the [`SignUp`](/docs/references
   - `isLoaded`
   - `Ref<boolean>`
 
-  A boolean that is set to `false` until Clerk loads and initializes.
+  A boolean that indicates whether Clerk has completed initialization. Initially `false`, becomes `true` once Clerk loads.
 
   ---
 
@@ -55,9 +55,9 @@ The `useSignUp()` composable gives you access to the [`SignUp`](/docs/references
 
 ### Check the current state of a sign-up
 
-Use the `useSignUp()` composable to access the `SignUp` object and check the current state of a sign-up.
+Use `useSignUp()` to access the `SignUp` object and check the current state of a sign-up.
 
-```vue {{ filename: 'sign-up-step.vue' }}
+```vue {{ filename: 'SignUpStep.vue' }}
 <script setup>
 import { useSignUp } from '@clerk/vue'
 
@@ -66,7 +66,7 @@ const { isLoaded, signUp } = useSignUp()
 
 <template>
   <div v-if="!isLoaded">
-    <!-- Add logic to handle loading state -->
+    <!-- Handle loading state -->
   </div>
 
   <div v-else>The current sign-up attempt status is {{ signUp.status }}.</div>
@@ -75,12 +75,23 @@ const { isLoaded, signUp } = useSignUp()
 
 The `status` property of the `SignUp` object can be one of the following values:
 
-| Values | Description |
-| - | - |
-| `complete` | The user has been created and custom flow can proceed to `setActive()` to create session. |
-| `abandoned` | The sign-up attempt will be abandoned if it was started more than 24 hours previously. |
-| `missing_requirements` | A requirement from the [Email, Phone, Username](https://dashboard.clerk.com/last-active?path=user-authentication/email-phone-username) settings is missing. For example, in the Clerk Dashboard, the Password setting is required but a password was not provided in the custom flow. |
+<Properties>
+  - `complete`
+  - `string`
 
-### Create a custom sign-up flow
+  The user has been created and the custom flow can proceed to `setActive()` to create session.
 
-The `useSignUp()` composable can also be used to build fully custom sign-up flows, if Clerk's prebuilt components don't meet your specific needs or if you require more control over the authentication flow. Different sign-up flows include email and password, email and phone codes, email links, and multifactor (MFA). To learn more about using the `useSignUp()` composable to create custom flows, check out the [custom flow guides](/docs/custom-flows/overview).
+  ---
+
+  - `abandoned`
+  - `string`
+
+  The sign-up attempt will be abandoned if it was started more than 24 hours previously.
+
+  ---
+
+  - `missing_requirements`
+  - `string`
+
+  A requirement is missing from the [Email, Phone, Username](https://dashboard.clerk.com/last-active?path=user-authentication/email-phone-username) settings. For example, in the Clerk Dashboard, the **Password** setting is required but a password wasn't provided in the custom flow.
+</Properties>

--- a/docs/references/vue/use-sign-up.mdx
+++ b/docs/references/vue/use-sign-up.mdx
@@ -1,11 +1,11 @@
 ---
-title: '`useSignUp()`'
+title: useSignUp()
 description: Clerk's useSignUp() composable gives you access to the SignUp object, which allows you to check the current state of a sign-up.
 ---
 
 The `useSignUp()` composable gives you access to the [`SignUp`](/docs/references/javascript/sign-up/sign-up) object, which allows you to check the current state of a sign-up. This is also useful for creating a [custom sign-up flow.](#create-a-custom-sign-up-flow-with-use-sign-up)
 
-## `useSignUp()` returns
+## Returns
 
 <Properties>
   - `isLoaded`
@@ -53,7 +53,7 @@ The `useSignUp()` composable gives you access to the [`SignUp`](/docs/references
 
 ## How to use the `useSignUp()` composable
 
-### Check the current state of a sign-up with `useSignUp()`
+### Check the current state of a sign-up
 
 Use the `useSignUp()` composable to access the `SignUp` object and check the current state of a sign-up.
 
@@ -81,6 +81,6 @@ The `status` property of the `SignUp` object can be one of the following values:
 | `abandoned` | The sign-up attempt will be abandoned if it was started more than 24 hours previously. |
 | `missing_requirements` | A requirement from the [Email, Phone, Username](https://dashboard.clerk.com/last-active?path=user-authentication/email-phone-username) settings is missing. For example, in the Clerk Dashboard, the Password setting is required but a password was not provided in the custom flow. |
 
-### Create a custom sign-up flow with `useSignUp()`
+### Create a custom sign-up flow
 
 The `useSignUp()` composable can also be used to build fully custom sign-up flows, if Clerk's prebuilt components don't meet your specific needs or if you require more control over the authentication flow. Different sign-up flows include email and password, email and phone codes, email links, and multifactor (MFA). To learn more about using the `useSignUp()` composable to create custom flows, check out the [custom flow guides](/docs/custom-flows/overview).

--- a/docs/references/vue/use-sign-up.mdx
+++ b/docs/references/vue/use-sign-up.mdx
@@ -69,7 +69,7 @@ const { isLoaded, signUp } = useSignUp()
     <!-- Handle loading state -->
   </div>
 
-  <div v-else>The current sign-up attempt status is {{ signUp.status }}.</div>
+  <div v-else>The current sign-up attempt status is {{ signUp?.status }}.</div>
 </template>
 ```
 

--- a/docs/references/vue/use-sign-up.mdx
+++ b/docs/references/vue/use-sign-up.mdx
@@ -1,5 +1,5 @@
 ---
-title: '`useSignUp()`'
+title: useSignUp()
 description: Access and manage sign-up state in your Vue application with Clerk's useSignUp() composable.
 ---
 


### PR DESCRIPTION
> [!IMPORTANT]
> 🔎 Previews:
>
> - https://clerk.com/docs/pr/1712/references/vue/use-sign-up
> - https://clerk.com/docs/pr/1712/references/vue/use-session
> - https://clerk.com/docs/pr/1712/references/vue/use-session-list
> - https://clerk.com/docs/pr/1712/references/vue/use-organization

### Explanation:

- We are launching an official Vue SDK for Clerk! 🎉
- We need to showcase how to use built-in composables (or what they call hooks in React)
- You will notice that all of the pages mirror the React client-side helpers. I thought of just adding a message somewhere saying that the Vue SDK provides equivalent functionality through composables, but created dedicated Vue pages since not all Vue developers use React.

### This PR:

- Adds client helpers (`useSignUp()`, `useSession()`, `useSessionList()`, `useOrganization()`) specific for Vue (basically a copy pasta of the React SDK client-side helpers but using Vue instead)
- You'll notice the return types look like this (`Ref<boolean>`), that just means the variable is a [Vue ref](https://vuejs.org/api/reactivity-core.html#ref)

### Checklist

- [x] I have clicked on "Files changed" and performed a thorough self-review
- [x] I have added the "deploy-preview" label and added the preview link(s) to this PR description
- [x] All existing checks pass
