### PR TITLE
Refactor `requireAuth()` middleware naming in node-to-express.mdx

### DIFF
--- a/docs/upgrade-guides/node-to-express.mdx
+++ b/docs/upgrade-guides/node-to-express.mdx
@@ -70,7 +70,7 @@ app.listen(port, () => {
 
 ## `requireAuth()` usage changes
 
-In the Node SDK, `requireAuth()` wrapped route handlers. With the Express SDK, you must instead pass `requireAuth)` as a middleware function before your handler instead of wrapping your handler. Additionally, `requireAuth()` will now redirect un-authenticated users to the sign in page, where previously it would emit an error.
+In the Node SDK, `requireAuth()` wrapped route handlers. With the Express SDK, you must instead pass `requireAuth()` as a middleware function before your handler instead of wrapping your handler. Additionally, `requireAuth()` will now redirect un-authenticated users to the sign in page, where previously it would emit an error.
 
 ```ts {{ del: [1, 4], ins: [2, 5] }}
 import { requireAuth } from '@clerk/clerk-sdk-node'


### PR DESCRIPTION
Correction in the naming of `requireAuth()` which was written as `requireAuth)` under the section of "requireAuth usage changes" in .


> 🔎 Previews:
> The Page where I noticed the typo: [Upgrade from Clerk's Node SDK to the Express SDK](https://clerk.com/docs/upgrade-guides/node-to-express)
>  I have attached image of the section where I made changes.
![image](https://github.com/user-attachments/assets/94028118-634b-4c65-8fec-def21b894e19)



### Explanation:

- It's Just a typo error correction, from `requireAuth)` `requireAuth()`.
- It maintains fluency while reading the docs. Not solving much problem but rather any user reading that portion will not stumble across that noticeable error in parentheses.

### This PR:

- Corrects the format of the name `requireAuth)` to `requireAuth()`

### Checklist

- [ ✅] I have clicked on "Files changed" and performed a thorough self-review
- [✅ ] I have added the "deploy-preview" label and added the preview link(s) to this PR description
- [ ✅] All existing checks pass
