### PR TITLE
Correct auth restrictions link

### DIFF
--- a/docs/authentication/configuration/restrictions.mdx
+++ b/docs/authentication/configuration/restrictions.mdx
@@ -47,7 +47,7 @@ Additional features available in **Waitlist** mode:
 
 - The [`<Waitlist />`](/docs/components/waitlist/overview) component provides a form where users can submit their details to join the waitlist. Once approved by admins, users will receive an email with access instructions.
 
-- If you're using the `<Waitlist />` component, you must provide the `waitlistUrl` prop either in the [`<ClerkProvider>`](/docs/components/clerk-provider#properties) or [`<SignIn />`](docs/components/authentication/sign-in#properties) component to ensure proper functionality.
+- If you're using the `<Waitlist />` component, you must provide the `waitlistUrl` prop either in the [`<ClerkProvider>`](/docs/components/clerk-provider#properties) or [`<SignIn />`](/docs/components/authentication/sign-in#properties) component to ensure proper functionality.
 
 ## Allowlist
 


### PR DESCRIPTION
Missing a leading slash!
