### PR TITLE
docs(react): Replace CRA with Vite

### DIFF
--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -40,7 +40,7 @@ Find all the guides and resources you need to develop with Clerk.
   ---
 
   - [React](/docs/quickstarts/react)
-  - Get started installing and initializing Clerk in a new Create React App.
+  - Get started installing and initializing Clerk in a new React Vite App.
   - {<svg viewBox="0 0 22 20" fill="none"><path style={{ fill: 'var(--light, #087EA4) var(--dark, #58C4DC)' }} d="M11 11.91a2 2 0 1 0 0-4 2 2 0 0 0 0 4Z"/><g style={{ stroke: 'var(--light, #087EA4) var(--dark, #58C4DC)' }}><path d="M11 14.41c5.523 0 10-2.014 10-4.5 0-2.485-4.477-4.5-10-4.5S1 7.425 1 9.91c0 2.486 4.477 4.5 10 4.5Z"/><path d="M7.102 12.16c2.762 4.783 6.745 7.653 8.897 6.41 2.153-1.242 1.659-6.127-1.103-10.91C12.136 2.877 8.152.007 6 1.25 3.847 2.493 4.341 7.377 7.102 12.16Z"/><path d="M7.102 7.66C4.341 12.443 3.847 17.328 6 18.57c2.153 1.243 6.136-1.627 8.898-6.41 2.76-4.783 3.255-9.667 1.102-10.91C13.847.007 9.864 2.877 7.102 7.66Z"/></g></svg>}
 
   ---

--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -40,7 +40,7 @@ Find all the guides and resources you need to develop with Clerk.
   ---
 
   - [React](/docs/quickstarts/react)
-  - Get started installing and initializing Clerk in a new React Vite App.
+  - Get started installing and initializing Clerk in a new React + Vite app.
   - {<svg viewBox="0 0 22 20" fill="none"><path style={{ fill: 'var(--light, #087EA4) var(--dark, #58C4DC)' }} d="M11 11.91a2 2 0 1 0 0-4 2 2 0 0 0 0 4Z"/><g style={{ stroke: 'var(--light, #087EA4) var(--dark, #58C4DC)' }}><path d="M11 14.41c5.523 0 10-2.014 10-4.5 0-2.485-4.477-4.5-10-4.5S1 7.425 1 9.91c0 2.486 4.477 4.5 10 4.5Z"/><path d="M7.102 12.16c2.762 4.783 6.745 7.653 8.897 6.41 2.153-1.242 1.659-6.127-1.103-10.91C12.136 2.877 8.152.007 6 1.25 3.847 2.493 4.341 7.377 7.102 12.16Z"/><path d="M7.102 7.66C4.341 12.443 3.847 17.328 6 18.57c2.153 1.243 6.136-1.627 8.898-6.41 2.76-4.783 3.255-9.667 1.102-10.91C13.847.007 9.864 2.877 7.102 7.66Z"/></g></svg>}
 
   ---


### PR DESCRIPTION
> [!IMPORTANT]
> 🔎 Previews:
>
> - https://clerk.com/docs/pr/1732#explore-by-frontend-framework

### Explanation:

- Our docs currently reference Create React App (CRA), which is no longer the recommended way to start React projects
- We use Vite throughout our documentation for React examples

### This PR:

- Updates the "Create React App" with Vite

### Checklist

- [x] I have clicked on "Files changed" and performed a thorough self-review
- [x] I have added the "deploy-preview" label and added the preview link(s) to this PR description
- [x] All existing checks pass
