### PR TITLE
docs(express): Fix Express legacyRequireAuth example

### DIFF
--- a/docs/upgrade-guides/node-to-express.mdx
+++ b/docs/upgrade-guides/node-to-express.mdx
@@ -84,7 +84,7 @@ If you'd like to retain the previous behavior of `requireAuth()` (emitting an er
 
 ```ts
 const legacyRequireAuth = (req, res, next) => {
-  if (!req.auth) {
+  if (!req.auth.userId) {
     return next(new Error('Unauthenticated'))
   }
   next()
@@ -160,7 +160,7 @@ If you'd like to retain the previous behavior of `ClerkExpressRequireAuth` (emit
 
 ```ts
 const legacyRequireAuth = (req, res, next) => {
-  if (!req.auth) {
+  if (!req.auth.userId) {
     return next(new Error('Unauthenticated'))
   }
   next()


### PR DESCRIPTION
Old code using only req.auth would always evaluate to true, rendering the middleware useless, and potentially leading to users having insecure routes.

> [!IMPORTANT]
> 🔎 Previews:
>
> -

### Explanation:

- The docs currently have code that may misguide users. req.auth always evaluates to true making the legacyRequireAuth function incorrect.

### This PR:

- Modifies the current legacyRequireAuth function to use req.auth.userId instead of req.auth to check if a user is authenticated.

### Checklist

- [ ] I have clicked on "Files changed" and performed a thorough self-review
- [ ] I have added the "deploy-preview" label and added the preview link(s) to this PR description
- [ ] All existing checks pass
