### PR TITLE
docs: Add unsafeMetadata prop to SignUp component documentation

### DIFF
--- a/docs/components/authentication/sign-up.mdx
+++ b/docs/components/authentication/sign-up.mdx
@@ -75,6 +75,13 @@ All props are optional.
   - [`SignUpInitialValues`](/docs/references/javascript/types/sign-up-initial-values)
 
   The values used to prefill the sign-up fields with.
+
+  ---
+
+  - `unsafeMetadata`
+  - `{[string]: any} | null`
+
+  An object with the key and value for unsafeMetadata that will be saved after the user signs up. IE, `{{ "company": "companyID1234" }}`
 </Properties>
 
 ## Usage with frameworks

--- a/docs/components/authentication/sign-up.mdx
+++ b/docs/components/authentication/sign-up.mdx
@@ -81,7 +81,7 @@ All props are optional.
   - `unsafeMetadata`
   - `{[string]: any} | null`
 
-  An object with the key and value for unsafeMetadata that will be saved after the user signs up. IE, `{{ "company": "companyID1234" }}`
+  An object containing key-value pairs for `unsafeMetadata` that will be saved after the user signs up. For example: `{ "company": "companyID1234" }`.
 </Properties>
 
 ## Usage with frameworks


### PR DESCRIPTION
> [!IMPORTANT]
> 🔎 Previews:
>
> - https://clerk.com/docs/pr/1742

### Explanation:

- <!--- Describe your changes in detail. Why does this change need to happen? Include any links to Slack discussions, Linear comments, etc. -->
- `unsafeMetadata` prop is missing from `<SignUp />` component definition doc

### This PR:

- <!--- How does this PR solve the problem? -->
- Adds missing prop `unsafeMetadata` to `<SignUp />` component properties description

### Checklist

- [x] I have clicked on "Files changed" and performed a thorough self-review
- [x] I have added the "deploy-preview" label and added the preview link(s) to this PR description
- [x] All existing checks pass
