### PR TITLE
Fix custom page file names for App Router

### DIFF
--- a/docs/custom-flows/email-password-mfa.mdx
+++ b/docs/custom-flows/email-password-mfa.mdx
@@ -49,7 +49,7 @@ This guide will walk you through how to build a custom email/password sign-in fl
 
   <Tabs type="framework" items={["Next.js", "JavaScript", "Expo", "iOS (Beta)"]}>
     <Tab>
-      ```tsx {{ filename: 'app/sign-in/[[...sign-in]].tsx', collapsible: true }}
+      ```tsx {{ filename: 'app/sign-in/[[...sign-in]]/page.tsx', collapsible: true }}
       'use client'
 
       import * as React from 'react'

--- a/docs/custom-flows/email-password.mdx
+++ b/docs/custom-flows/email-password.mdx
@@ -35,7 +35,7 @@ This guide will walk you through how to build a custom email/password sign-up an
     <Tab>
       This example is written for Next.js App Router but it can be adapted for any React meta framework, such as Remix.
 
-      ```tsx {{ filename: '/app/sign-up/[[...sign-up]].tsx', collapsible: true }}
+      ```tsx {{ filename: '/app/sign-up/[[...sign-up]]/page.tsx', collapsible: true }}
       'use client'
 
       import * as React from 'react'
@@ -493,7 +493,7 @@ This guide will walk you through how to build a custom email/password sign-up an
     <Tab>
       This example is written for Next.js App Router but it can be adapted for any React meta framework, such as Remix.
 
-      ```tsx {{ filename: '/app/sign-in/[[...sign-in]].tsx', collapsible: true }}
+      ```tsx {{ filename: '/app/sign-in/[[...sign-in]]/page.tsx', collapsible: true }}
       'use client'
 
       import * as React from 'react'


### PR DESCRIPTION
> [!IMPORTANT]
> 🔎 Previews:
>
> -

### Explanation:

- A couple of code blocks for custom sign in/sign up pages use an incorrect file path for the Next.js App Router.
- All pages in App Router must use the `page.tsx` file name, including [Optional Catch-all Segments](https://nextjs.org/#optional-catch-all-segments).

### This PR:

- Updates two instances of `[[sign-in]].tsx` to `[[sign-in]]/page.tsx`
- Updates one instance of `[[sign-up]].tsx` to `[[sign-up]]/page.tsx`

### Checklist

- [ ] I have clicked on "Files changed" and performed a thorough self-review
- [ ] I have added the "deploy-preview" label and added the preview link(s) to this PR description
- [ ] All existing checks pass
