### PR TITLE
chore: update captcha not enabled error message

### DIFF
--- a/docs/errors/sign-up.mdx
+++ b/docs/errors/sign-up.mdx
@@ -41,7 +41,7 @@ An index of Clerk errors related to sign-up.
 ```json
 {
   "shortMessage": "CAPTCHA not enabled",
-  "longMessage": "Bot detection can be applied only for production instances which have enabled CAPTCHA.",
+  "longMessage": "Bot detection can be applied only for instances which have enabled CAPTCHA.",
   "code": "captcha_not_enabled"
 }
 ```


### PR DESCRIPTION
### Explanation:

Captcha is now enabled for all instance types (development and production). The error message has been updated to reflect that.

### This PR:

- Updates the `captcha_not_enabled` error message 

### Checklist

- [x] I have clicked on "Files changed" and performed a thorough self-review
- [x] I have added the "deploy-preview" label and added the preview link(s) to this PR description
- [x] All existing checks pass
