### PR TITLE
Fix reference in user metadata page

### DIFF
--- a/docs/users/metadata.mdx
+++ b/docs/users/metadata.mdx
@@ -198,7 +198,7 @@ Public metadata is accessible by both the frontend and the backend, but can only
       const client = await clerkClient()
 
       await client.users.updateUserMetadata(userId, {
-        privateMetadata: {
+        publicMetadata: {
           stripeId: stripeId,
         },
       })


### PR DESCRIPTION
> [!IMPORTANT]
> 🔎 Previews:
>
> - https://clerk.com/docs/pr/1775/users/metadata#public-metadata

### Explanation:

- The example for setting public metadata for Next was referencing private metadata.

### This PR:

- Updates the parameter to `publicMetdata`

### Checklist

- [x] I have clicked on "Files changed" and performed a thorough self-review
- [x] I have added the "deploy-preview" label and added the preview link(s) to this PR description
- [ ] All existing checks pass
