### PR TITLE
Quick Typo Fix

### DIFF
--- a/docs/references/chrome-extension/sync-host.mdx
+++ b/docs/references/chrome-extension/sync-host.mdx
@@ -116,7 +116,7 @@ Clerk allows you to sync the authentication state from your web app to your Chro
   > If you have not [configured a consistent key](/docs/references/chrome-extension/configure-consistent-crx-id), you will have to repeat this step every time your extension's ID changes.
 
   1. In the Clerk Dashboard, navigate to the [**API keys**](https://dashboard.clerk.com/last-active?path=api-keys) page.
-  1. Copy your Secret Key. It should start with `pk_test_` or `pk_live_` for your development and production instances, respectively.
+  1. Copy your Secret Key. It should start with `sk_test_` or `sk_live_` for your development and production instances, respectively.
   1. In your terminal, paste the following command. Replace `YOUR_SECRET_KEY` with your Clerk Secret Key and the `<CHROME_EXTENSION_KEY>` with your extension's ID.
 
   The final result should resemble the following:


### PR DESCRIPTION
The docs reference the Secret Key but then use the prefix for publishable key, fixed the prefix to sk


### Checklist

- [x] I have clicked on "Files changed" and performed a thorough self-review
- [x] I have added the "deploy-preview" label and added the preview link(s) to this PR description
- [x] All existing checks pass
