### PR TITLE
fix: Remove snipped about xms_edov being in preview

### DIFF
--- a/docs/authentication/enterprise-connections/easie/microsoft.mdx
+++ b/docs/authentication/enterprise-connections/easie/microsoft.mdx
@@ -74,7 +74,7 @@ To make the setup process easier, it's recommended to keep two browser tabs open
 
   [nOAuth](https://www.descope.com/blog/post/noauth) is an exploit in Microsoft Entra ID OAuth apps that can lead to account takeovers via email address spoofing. Clerk mitigates this risk by enforcing stricter checks on verified email addresses.
 
-  For further security, Microsoft offers an optional `xms_edov` claim, which provides additional context to determine whether the returned email is verified.
+  For further security, Microsoft offers an optional `xms_edov` [claim](https://learn.microsoft.com/en-us/entra/identity-platform/optional-claims-reference), which provides additional context to determine whether the returned email is verified.
 
   This claim is mandatory for applications backing EASIE connections. To enable it, you must:
 
@@ -83,8 +83,6 @@ To make the setup process easier, it's recommended to keep two browser tabs open
   1. Select **Add optional claim**.
   1. For the **Token type**, select **ID**. Then, in the table that opens, enable the `email` and `xms_pdl` claims.
   1. At the bottom of the modal, select **Add**. A new modal will prompt you to turn on the Microsoft Graph email permission. Enable it, then select **Add** to complete the form.
-     > [!NOTE]
-     > At the time of writing, the `xms_edov` claim is still in preview and may not be available for all apps. We'll choose another claim and rename it in the manifest later.
   1. Repeat the previous steps for **Token type**, but select **Access** instead of **ID**. The **Optional claims** list should now show two claims for `email` and two for `xms_pdl`: one each for **ID** and **Access**.
   1. In the sidebar, go to **Manifest**.
   1. In the text editor, search for `"acceptMappedClaims"` and set its value from `null` to `true`.


### PR DESCRIPTION
### Explanation:

Microsoft's optional `xms_edov` claim should not longer be in preview.

### This PR:

Update Microsoft OAuth docs to remove the updated note, as well as link to documentation about optional claims.

### Checklist

- [x] I have clicked on "Files changed" and performed a thorough self-review
- [x] I have added the "deploy-preview" label and added the preview link(s) to this PR description
- [x] All existing checks pass
