### PR TITLE
fix: typo in custom-session-token docs

### DIFF
--- a/docs/backend-requests/making/custom-session-token.mdx
+++ b/docs/backend-requests/making/custom-session-token.mdx
@@ -40,11 +40,11 @@ This guide will show you how to customize a session token to include additional 
     export default async function Page() {
       const { sessionClaims } = await auth()
 
-      const firstName = sessionClaims?.fullName
+      const fullName = sessionClaims?.fullName
 
       const primaryEmail = sessionClaims?.primaryEmail
 
-      return NextResponse.json({ firstName, primaryEmail })
+      return NextResponse.json({ fullName, primaryEmail })
     }
     ```
 
@@ -55,11 +55,11 @@ This guide will show you how to customize a session token to include additional 
     export default async function handler(req: NextApiRequest, res: NextApiResponse) {
       const { sessionClaims } = getAuth(req)
 
-      const firstName = sessionClaims.fullName
+      const fullName = sessionClaims.fullName
 
       const primaryEmail = sessionClaims.primaryEmail
 
-      return res.status(200).json({ firstName, primaryEmail })
+      return res.status(200).json({ fullName, primaryEmail })
     }
     ```
   </CodeBlockTabs>
@@ -73,14 +73,14 @@ This guide will show you how to customize a session token to include additional 
   1. Create the `CustomJwtSessionClaims` interface and declare it globally.
   1. Add the custom claims to the `CustomJwtSessionClaims` interface.
 
-  The following example demonstrates how to add the `firstName` and `primaryEmail` claims to the `CustomJwtSessionClaims` interface.
+  The following example demonstrates how to add the `fullName` and `primaryEmail` claims to the `CustomJwtSessionClaims` interface.
 
   ```tsx {{ filename: 'types/globals.d.ts' }}
   export {}
 
   declare global {
     interface CustomJwtSessionClaims {
-      firstName?: string
+      fullName?: string
       primaryEmail?: string
     }
   }


### PR DESCRIPTION
> [!IMPORTANT]
> 🔎 Previews:
>
> - https://clerk.com/docs/pr/1787/backend-requests/making/custom-session-token

### Explanation:

Upstream at https://clerk.com/docs/backend-requests/making/custom-session-token, there's a mismatched use of `fullName` and `firstName` in the docs on how to set up custom claims on a session token:

![2024-12-10-custom-session-token-typo-highlight](https://github.com/user-attachments/assets/cc07bcd3-2ee2-4d9f-86e2-e552530aff42)

This issue might be confusing to users, and makes it more difficult to confirm that types are working as expected.

### This PR:

This PR resolves the issue by updating text to match existing screenshots, using `fullName` consistently rather than `firstName`.

### Checklist

- [x] I have clicked on "Files changed" and performed a thorough self-review
- [x] I have added the "deploy-preview" label and added the preview link(s) to this PR description
- [x] All existing checks pass
