### PR TITLE
Update size limitation docs to reference only session tokens

### DIFF
--- a/docs/backend-requests/making/jwt-templates.mdx
+++ b/docs/backend-requests/making/jwt-templates.mdx
@@ -10,8 +10,6 @@ Clerk offers the ability to generate [JSON Web Tokens](https://en.wikipedia.org/
 
 You can control the claims that will go into these tokens by creating custom **JWT templates** that fit your needs. This enables you to integrate with any third-party services that support authentication with JWTs. An example use case is integrating with a third-party service that is able to consume JWTs, but requires them to be in a particular format.
 
-<Include src="_partials/token-size-callout" />
-
 ## What is a JWT template?
 
 **JWT templates** are essentially JSON objects that specify claims to be included in the generated tokens, along with their respective values.

--- a/docs/backend-requests/resources/session-tokens.mdx
+++ b/docs/backend-requests/resources/session-tokens.mdx
@@ -38,7 +38,7 @@ You can also create custom tokens using a [JWT template](/docs/backend-requests/
 
 The Clerk session token is stored in a cookie. All modern browsers [limit the maximum size of a cookie to 4kb](https://datatracker.ietf.org/doc/html/rfc2109#section-6.3). Exceeding this limit can have adverse effects, including a possible infinite redirect loop for users who exceed this size in Next.js applications.
 
-A session token with the [default session claims](#default-session-claims) won't run into this issue, as this configuration produces a cookie significantly smaller than 4kb. However, this limitation becomes relevant when implementing a [custom session token](/docs/backend-requests/making/custom-session-token) or creating a [custom JWT template](/docs/backend-requests/making/jwt-templates). In these cases, it's recommended to move particularly large claims out of the token and fetch these using a separate API call from your backend.
+A session token with the [default session claims](#default-session-claims) won't run into this issue, as this configuration produces a cookie significantly smaller than 4kb. However, this limitation becomes relevant when implementing a [custom session token](/docs/backend-requests/making/custom-session-token). In this case, it's recommended to move particularly large claims out of the token and fetch these using a separate API call from your backend.
 
 Claims to monitor for size limits:
 
@@ -51,7 +51,7 @@ Claims to monitor for size limits:
 If you include any of these claims in your token, use caution to ensure the stored data doesn't exceed the size limit.
 
 > [!NOTE]
-> If your application encounters this issue, the Clerk Dashboard will display a warning: **"Some users are exceeding cookie size limits"**. To resolve this, update your [custom session token](/docs/backend-requests/making/custom-session-token) or the [JWT template](/docs/backend-requests/making/jwt-templates) that is referenced in the warning.
+> If your application encounters this issue, the Clerk Dashboard will display a warning: **"Some users are exceeding cookie size limits"**. To resolve this, update your [custom session token](/docs/backend-requests/making/custom-session-token).
 
 ## Validate session tokens
 


### PR DESCRIPTION
The JWTs generated from JWT Templates actually never get stored in a cookie, and are not beholden to the 4kb limit.

> [!IMPORTANT]
> 🔎 Previews:
>
> - Primary Change: https://clerk.com/docs/pr/1790/backend-requests/resources/session-tokens#size-limitations
> - Removing callout: https://clerk.com/docs/pr/1790/backend-requests/making/jwt-templates

### Explanation:

The 4kb size limitations only apply to custom Session tokens, as they are stored in cookies.  JWTs that are generated from JWT Templates never are stored in cookies, and are not beholden to the same size limits.  We've updated our Dashboard warnings to reflect this as well.

### This PR:

- Updates the docs about our size limitations to no longer reference JWT Templates
- Removes the callout warning about the size limitations on the JWT Templates page

### Checklist

- [x] I have clicked on "Files changed" and performed a thorough self-review
- [x] I have added the "deploy-preview" label and added the preview link(s) to this PR description
- [x] All existing checks pass
