### PR TITLE
fix: clarify email address sign up requirements

### DIFF
--- a/docs/authentication/configuration/sign-up-sign-in-options.mdx
+++ b/docs/authentication/configuration/sign-up-sign-in-options.mdx
@@ -17,7 +17,7 @@ Identifiers are how your application recognizes an individual user. There are th
 
 In the application configuration screen, you can select multiple identifiers, but at least one is required.
 
-**Email address** is the most common primary identifier. During the sign-up process, a user must supply and verify their email address. They must keep an email address on their account at all times. However, the email address that was used for registration can be later changed from the user's profile page.
+**Email address** is the most common primary identifier. When email address is the only enabled identifier, users must supply their email address during setup, and also keep an email address on their account at all times. However, the email address that was used for registration can be later changed from the user's profile page.
 
 When **phone number** is selected as the identifier, a user can sign up with their phone number and receive a code via SMS to verify it. SMS functionality is restricted to phone numbers from countries enabled on your [SMS allowlist](#sms-allowlist).
 

--- a/docs/authentication/configuration/sign-up-sign-in-options.mdx
+++ b/docs/authentication/configuration/sign-up-sign-in-options.mdx
@@ -17,7 +17,7 @@ Identifiers are how your application recognizes an individual user. There are th
 
 In the application configuration screen, you can select multiple identifiers, but at least one is required.
 
-**Email address** is the most common primary identifier. When email address is the only enabled identifier, users must supply their email address during setup, and also keep an email address on their account at all times. However, the email address that was used for registration can be later changed from the user's profile page.
+**Email address** is the most common primary identifier. When it is the only enabled identifier, users are required to supply an email address during sign-up and keep one on their account at all times. The email address that was supplied during sign-up can be later changed from the user's profile page.
 
 When **phone number** is selected as the identifier, a user can sign up with their phone number and receive a code via SMS to verify it. SMS functionality is restricted to phone numbers from countries enabled on your [SMS allowlist](#sms-allowlist).
 


### PR DESCRIPTION
> [!IMPORTANT]
> 🔎 Previews:
>
> - https://clerk.com/docs/pr/1793/authentication/configuration/sign-up-sign-in-options

### Explanation:

- The docs currently make it sound like an email address is required at all times, when in reality it's only required if email address is the only enabled identifier.

### This PR:

- Clarifies that users must keep an email address on their account at all times only when email address is the only enabled identifier.
- Removes the verification requirement since that's dependent on instance settings

### Checklist

- [ ] I have clicked on "Files changed" and performed a thorough self-review
- [ ] I have added the "deploy-preview" label and added the preview link(s) to this PR description
- [ ] All existing checks pass
