### PR TITLE
docs(astro): Remove typescript declaration step

### DIFF
--- a/docs/quickstarts/astro.mdx
+++ b/docs/quickstarts/astro.mdx
@@ -105,19 +105,6 @@ description: Add authentication and user management to your Astro app with Clerk
      ```
   1. By default, `clerkMiddleware()` will not protect any routes. All routes are public and you must opt-in to protection for routes. See the [`clerkMiddleware()` reference](/docs/references/astro/clerk-middleware) to learn how to require authentication for specific routes.
 
-  ## Add TypeScript declarations
-
-  Update the `env.d.ts` file in your `src/` directory to add type definitions for the `locals` added by the middleware.
-
-  ```ts {{ prettier: false, filename: 'src/env.d.ts', mark: [3] }}
-  // The line directly below will only be present if you've ran your app
-  // Don't worry about adding it manually
-  /// <reference path="../.astro/types.d.ts" />
-
-  /// <reference types="astro/client" />
-  /// <reference types="@clerk/astro/env" />
-  ```
-
   ## Add Clerk components to your app
 
   You can control which content signed-in and signed-out users can see with Clerk's [prebuilt control components](/docs/components/overview#what-are-control-components). Create a header using the following components:


### PR DESCRIPTION
> [!IMPORTANT]
> 🔎 Previews:
>
> - https://clerk.com/docs/pr/1808/quickstarts/astro

### Explanation:

- We released [`@clerk/astro` v2](https://github.com/clerk/javascript/pull/4721), which comes with automatic generation of context local types

### This PR:

- Removes the [Add TypeScript declarations](https://clerk.com/docs/quickstarts/astro#add-type-script-declarations) step since our Astro integration now handles this automatically

### Checklist

- [x] I have clicked on "Files changed" and performed a thorough self-review
- [x] I have added the "deploy-preview" label and added the preview link(s) to this PR description
- [x] All existing checks pass
