### PR TITLE
Organization inviterUserId as nullable

### DIFF
--- a/docs/references/backend/organization/create-organization-invitation.mdx
+++ b/docs/references/backend/organization/create-organization-invitation.mdx
@@ -24,7 +24,7 @@ function createOrganizationInvitation(
   ---
 
   - `inviterUserId`
-  - `string`
+  - `string | null`
 
   The user ID of the user creating the invitation.
 


### PR DESCRIPTION
> [!IMPORTANT]
> 🔎 Previews:
>
> -

### Explanation:


This allows the inviterUserId to be nullable on the SDK, since it's nullable on the [BAPI](https://clerk.com/docs/reference/backend-api/tag/Organization-Invitations#operation/CreateOrganizationInvitation)

<img width="612" alt="image" src="https://github.com/user-attachments/assets/7508eac1-3a37-4194-bdc7-0bb65a9d90f9" />

### This PR:

Update the types allowed

### Checklist

- [x] I have clicked on "Files changed" and performed a thorough self-review
- [ ] I have added the "deploy-preview" label and added the preview link(s) to this PR description
- [ ] All existing checks pass
