### PR TITLE
chore: Remove Astro from Community SDKs list

### DIFF
--- a/docs/manifest.json
+++ b/docs/manifest.json
@@ -3325,11 +3325,6 @@
                     "icon": "c-sharp"
                   },
                   {
-                    "title": "Astro",
-                    "href": "https://github.com/panteliselef/astro-with-clerk-auth/blob/main/packages/astro-clerk-auth/README.md",
-                    "icon": "astro"
-                  },
-                  {
                     "title": "Koa",
                     "href": "https://github.com/dimkl/clerk-koa/blob/main/README.md",
                     "icon": "koa"


### PR DESCRIPTION
> [!IMPORTANT]
> 🔎 Previews:
>
> -

<img width="268" alt="Screenshot 2024-12-18 at 10 34 56 AM" src="https://github.com/user-attachments/assets/3598ac59-9d95-4fbe-9878-0a6f5a431cd9" />

### Explanation:

- The [Astro community SDK](https://github.com/panteliselef/astro-with-clerk-auth) has graduated into an official SDK and is deprecated.

### This PR:

- Removes the Astro from the Community SDKs list.

### Checklist

- [x] I have clicked on "Files changed" and performed a thorough self-review
- [x] I have added the "deploy-preview" label and added the preview link(s) to this PR description
- [x] All existing checks pass
