### PR TITLE
Add disable bot protection step to native sdk quickstarts

### DIFF
--- a/docs/quickstarts/chrome-extension.mdx
+++ b/docs/quickstarts/chrome-extension.mdx
@@ -33,6 +33,15 @@ description: Add authentication and user management to your Chrome Extension wit
 
   This guide will use a popup.
 
+  ## Disable bot protection
+
+  Bot protection is enabled by default for all Clerk apps. However, it is not supported in native apps.
+
+  To turn off bot protection:
+
+  1. In the Clerk Dashboard, navigate to the [**Attack protection**](https://dashboard.clerk.com/last-active?path=user-authentication/attack-protection) page.
+  1. Disable **Bot sign-up protection**.
+
   ## Create a new app using the Plasmo framework
 
   [Plasmo](https://docs.plasmo.com/framework) is a browser extension framework that includes hot reloading and creating development and production extension builds easily from the same code.

--- a/docs/quickstarts/expo.mdx
+++ b/docs/quickstarts/expo.mdx
@@ -91,6 +91,15 @@ description: Add authentication and user management to your Expo app with Clerk.
   EXPO_PUBLIC_CLERK_PUBLISHABLE_KEY={{pub_key}}
   ```
 
+  ## Disable bot protection
+
+  Bot protection is enabled by default for all Clerk apps. However, it is not supported in native apps.
+
+  To turn off bot protection:
+
+  1. In the Clerk Dashboard, navigate to the [**Attack protection**](https://dashboard.clerk.com/last-active?path=user-authentication/attack-protection) page.
+  1. Disable **Bot sign-up protection**.
+
   ## Add `<ClerkProvider>` to your root layout
 
   <Include src="_partials/clerk-provider" />

--- a/docs/quickstarts/ios.mdx
+++ b/docs/quickstarts/ios.mdx
@@ -23,6 +23,15 @@ description: Add authentication and user management to your iOS app with Clerk.
 </TutorialHero>
 
 <Steps>
+  ## Disable bot protection
+
+  Bot protection is enabled by default for all Clerk apps. However, it is not supported in native apps.
+
+  To turn off bot protection:
+
+  1. In the Clerk Dashboard, navigate to the [**Attack protection**](https://dashboard.clerk.com/last-active?path=user-authentication/attack-protection) page.
+  1. Disable **Bot sign-up protection**.
+
   ## Create an iOS Project
 
   To get started using Clerk with iOS, create a new project in Xcode. Select SwiftUI as your interface and Swift as your language.


### PR DESCRIPTION
> [!IMPORTANT]
> 🔎 Previews:
>
> - https://clerk.com/docs/pr/1826/quickstarts/expo
> - https://clerk.com/docs/pr/1826/quickstarts/chrome-extension
> - https://clerk.com/docs/pr/1826/quickstarts/ios

### Explanation:

- We've recently changed the product so that Bot Protection is enabled instances by default. Some customers using SDKs like Expo or Chrome Extension are running into issues with captcha/bot protection related issues. 

### Checklist

- [x] I have clicked on "Files changed" and performed a thorough self-review
- [x] I have added the "deploy-preview" label and added the preview link(s) to this PR description
- [x] All existing checks pass
