### PR TITLE
(custom-session-token) add usage info for non-nextjs frameworks

### DIFF
--- a/docs/backend-requests/making/custom-session-token.mdx
+++ b/docs/backend-requests/making/custom-session-token.mdx
@@ -24,18 +24,16 @@ This guide will show you how to customize a session token to include additional 
 
   ## Use the custom claims in your application
 
-  The [`Auth`](/docs/references/nextjs/auth-object) object in the `@clerk/nextjs` package includes a `sessionClaims` property that contains the custom claims you added to your session token.
+  The [`Auth`](/docs/references/nextjs/auth-object) object includes a `sessionClaims` property that contains the custom claims you added to your session token. It's returned by the [`useAuth()`](/docs/references/react/use-auth) hook, the [`auth()`](/docs/references/nextjs/auth) and `getAuth()` helpers, and the `request` object in server contexts.
 
-  Access the custom claims in your application by calling `auth()` in App Router applications or `getAuth(req)` in Pages Router applications.
-
-  The following example demonstrates how to access the `fullName` and `primaryEmail` claims that were added to the session token in the last step.
+  The following example demonstrates how to access the `fullName` and `primaryEmail` claims that were added to the session token in the last step. This examples are written for Next.js, but they can be adapted to other frameworks by using the appropriate method for accessing the `Auth` object.
 
   <CodeBlockTabs options={["App Router", "Pages Router"]}>
-    ```tsx {{ filename: 'app/page.tsx' }}
+    ```tsx {{ filename: 'app/api/example/route.tsx' }}
     import { auth } from '@clerk/nextjs/server'
     import { NextResponse } from 'next/server'
 
-    export default async function Page() {
+    export async function GET() {
       const { sessionClaims } = await auth()
 
       const fullName = sessionClaims?.fullName


### PR DESCRIPTION
> [!IMPORTANT]
> 🔎 Previews:
>
> - https://clerk.com/docs/pr/1827/backend-requests/making/custom-session-token#use-the-custom-claims-in-your-application

### Explanation:

[User feedback reads:](https://linear.app/clerk/issue/DOCS-9693/add-more-examples-for-backend-requestsmakingcustom-session-token)
> WHy does this only apply to next js?

### Checklist

- [ ] I have clicked on "Files changed" and performed a thorough self-review
- [ ] I have added the "deploy-preview" label and added the preview link(s) to this PR description
- [ ] All existing checks pass
