### PR TITLE
document `sessionClaims` property for `useAuth`

### DIFF
--- a/docs/references/astro/auth-store.mdx
+++ b/docs/references/astro/auth-store.mdx
@@ -22,6 +22,13 @@ The `$authStore` store provides a convenient way to access the current auth stat
 
   ---
 
+  - `sessionClaims`
+  - `JwtPayload`
+
+  The current user's [session claims](/docs/backend-requests/resources/session-tokens#default-session-claims).
+
+  ---
+
   - `orgId`
   - `string`
 

--- a/docs/references/react/use-auth.mdx
+++ b/docs/references/react/use-auth.mdx
@@ -36,6 +36,13 @@ The `useAuth()` hook provides access to the current user's authentication state 
 
   ---
 
+  - `sessionClaims`
+  - `JwtPayload`
+
+  The current user's [session claims](/docs/backend-requests/resources/session-tokens#default-session-claims).
+
+  ---
+
   - `orgId`
   - `string`
 


### PR DESCRIPTION
⚠️ Requires https://github.com/clerk/javascript/pull/4823 to be merged

### Explanation:

- <!--- Describe your changes in detail. Why does this change need to happen? Include any links to Slack discussions, Linear comments, etc. -->

### This PR:

This documents the `sessionClaims` property for the various implementations of `useAuth` as added in https://github.com/clerk/javascript/pull/4823 and which https://clerk.com/docs/backend-requests/making/custom-session-token#use-the-custom-claims-in-your-application actually claims is already available

### Checklist

- [x] I have clicked on "Files changed" and performed a thorough self-review
- [ ] I have added the "deploy-preview" label and added the preview link(s) to this PR description
- [ ] All existing checks pass
