### PR TITLE
fix: phonetic article agreement "an much" => "a much"

### DIFF
--- a/docs/how-clerk-works/overview.mdx
+++ b/docs/how-clerk-works/overview.mdx
@@ -61,7 +61,7 @@ To maintain security, these administrative tasks should only be executed on the 
 
 Although the administrative features of BAPI are useful for many applications, it's most commonly used to verify a user's authentication state when processing requests from your app's frontend. For instance, if a user submits a request to update some data associated with their account, **your server must ensure the user is authenticated and authorized to make this change.** Without proper validation, malicious actors could potentially take over user accounts.
 
-Like FAPI, while you can interact directly with BAPI, most developers opt to use Clerk's SDKs for smoother integration with their preferred language or framework. Documentation for Clerk's SDKs is available in [the left sidebar of the docs](https://clerk.com/docs). That being said, FAPI is an much more complex and nuanced API that relies on more custom logic outside of its endpoints to create a functional SDK on top of it. As such, **interacting directly with FAPI is not recommended**, whereas interacting directly with BAPI is generally reasonable.
+Like FAPI, while you can interact directly with BAPI, most developers opt to use Clerk's SDKs for smoother integration with their preferred language or framework. Documentation for Clerk's SDKs is available in [the left sidebar of the docs](https://clerk.com/docs). That being said, FAPI is a much more complex and nuanced API that relies on more custom logic outside of its endpoints to create a functional SDK on top of it. As such, **interacting directly with FAPI is not recommended**, whereas interacting directly with BAPI is generally reasonable.
 
 ## Stateful authentication
 


### PR DESCRIPTION
### Explanation:

Minor fix. "An" is generally used before words that start with vowel sounds.