### PR TITLE
Fix link in clerk-middleware.mdx

### DIFF
--- a/docs/references/nextjs/clerk-middleware.mdx
+++ b/docs/references/nextjs/clerk-middleware.mdx
@@ -341,7 +341,7 @@ The `clerkMiddleware()` function accepts an optional object. The following optio
   - `organizationSyncOptions?`
   - <code>[OrganizationSyncOptions](#organization-sync-options) | undefined</code>
 
-  Used to activate a specific [organization](docs/organizations/overview) or [personal account](/docs/organizations/organization-workspaces#organization-workspaces-in-the-clerk-dashboard:~:text=Personal%20account) based on URL path parameters. If there's a mismatch between the active organization in the session (e.g., as reported by [`auth()`](/docs/references/nextjs/auth)) and the organization indicated by the URL, the middleware will attempt to activate the organization specified in the URL.
+  Used to activate a specific [organization](/docs/organizations/overview) or [personal account](/docs/organizations/organization-workspaces#organization-workspaces-in-the-clerk-dashboard:~:text=Personal%20account) based on URL path parameters. If there's a mismatch between the active organization in the session (e.g., as reported by [`auth()`](/docs/references/nextjs/auth)) and the organization indicated by the URL, the middleware will attempt to activate the organization specified in the URL.
 
   ---
 


### PR DESCRIPTION
> [!IMPORTANT]
> 🔎 Previews:
>
> - https://clerk.com/docs/pr/0000/docs/references/nextjs/clerk-middleware

This PR fixes a broken link on `/docs/references/nextjs/clerk-middleware`:

```diff
- docs/organizations/overview
+ /docs/organizations/overview
```

### Checklist

- [x] I have clicked on "Files changed" and performed a thorough self-review
- [x] I have added the "deploy-preview" label and added the preview link(s) to this PR description
- [x] All existing checks pass
