### PR TITLE
[codeowners] remove Growth team from quickstarts

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,4 +1,1 @@
-* @clerk/docs
-
-# Help keep docs quickstart content in sync with Dashboard
-docs/quickstarts/* @clerk/growth
+- @clerk/docs


### PR DESCRIPTION
The intention behind setting the Growth team as codeowners on `/quickstarts/*` was to try to ensure we keep the Dashboard quickstart content in sync with the docs quickstarts, but this approach is just causing a lot of approval noise and delaying shipping in some cases, so this PR removes `@clerk/growth` as a codeowner. 