### PR TITLE
Remove Vue from community SDKs list

### DIFF
--- a/docs/manifest.json
+++ b/docs/manifest.json
@@ -3428,11 +3428,6 @@
                     "icon": "svelte"
                   },
                   {
-                    "title": "Vue",
-                    "href": "https://vue-clerk.vercel.app",
-                    "icon": "vue"
-                  },
-                  {
                     "title": "Elysia",
                     "href": "https://github.com/wobsoriano/elysia-clerk",
                     "icon": "elysia"


### PR DESCRIPTION
> [!IMPORTANT]
> 🔎 Previews:
>
> - https://clerk.com/docs/pr/1856

### Explanation:

- We now have an official Vue SDK!

### This PR:

- Removes Vue from community SDKs list

<img width="274" alt="Screenshot 2025-01-08 at 8 10 55 AM" src="https://github.com/user-attachments/assets/1d5c14ca-a615-4dbc-9189-894e72a15b7a" />

### Checklist

- [x] I have clicked on "Files changed" and performed a thorough self-review
- [x] I have added the "deploy-preview" label and added the preview link(s) to this PR description
- [x] All existing checks pass
