### PR TITLE
Add React Router 7 compatilibty issue callout

### DIFF
--- a/docs/quickstarts/react-router.mdx
+++ b/docs/quickstarts/react-router.mdx
@@ -33,6 +33,9 @@ description: Learn how to use Clerk to quickly and easily add secure authenticat
 
 Clerk's [React Router SDK](/docs/references/react-router/overview) provides prebuilt components, hooks, and stores to make it easy to integrate authentication and user management in your React Router app. This guide assumes that you're using [React Router v7 or later](https://api.reactrouter.com/v7).
 
+> [!WARNING]
+> Due to an upstream compatibility issue with [React Router](https://github.com/remix-run/react-router/issues/12475), you'll need to use Node.js 22.11 or lower until the issue is resolved.
+
 <Steps>
   ## Install `@clerk/react-router`
 

--- a/docs/quickstarts/react-router.mdx
+++ b/docs/quickstarts/react-router.mdx
@@ -34,7 +34,7 @@ description: Learn how to use Clerk to quickly and easily add secure authenticat
 Clerk's [React Router SDK](/docs/references/react-router/overview) provides prebuilt components, hooks, and stores to make it easy to integrate authentication and user management in your React Router app. This guide assumes that you're using [React Router v7 or later](https://api.reactrouter.com/v7).
 
 > [!WARNING]
-> Due to an upstream compatibility issue with [React Router](https://github.com/remix-run/react-router/issues/12475), you'll need to use Node.js 22.11 or lower until the issue is resolved.
+> Due to an upstream issue with [React Router](https://github.com/remix-run/react-router/issues/12475), you'll need to use Node.js 22.11 or lower until the issue is resolved.
 
 <Steps>
   ## Install `@clerk/react-router`

--- a/docs/quickstarts/react-router.mdx
+++ b/docs/quickstarts/react-router.mdx
@@ -34,7 +34,7 @@ description: Learn how to use Clerk to quickly and easily add secure authenticat
 Clerk's [React Router SDK](/docs/references/react-router/overview) provides prebuilt components, hooks, and stores to make it easy to integrate authentication and user management in your React Router app. This guide assumes that you're using [React Router v7 or later](https://api.reactrouter.com/v7).
 
 > [!WARNING]
-> Due to an upstream issue with [React Router](https://github.com/remix-run/react-router/issues/12475), you'll need to use Node.js 22.11 or lower until the issue is resolved.
+> Due to an active [issue with React Router](https://github.com/remix-run/react-router/issues/12475), Clerk and React Router currently requires using Node.js 22.11 or lower.
 
 <Steps>
   ## Install `@clerk/react-router`

--- a/docs/references/react-router/overview.mdx
+++ b/docs/references/react-router/overview.mdx
@@ -4,7 +4,7 @@ description: Learn how to integrate Clerk into your React Router application usi
 ---
 
 > [!WARNING]
-> Due to an upstream compatibility issue with [React Router](https://github.com/remix-run/react-router/issues/12475), you'll need to use Node.js 22.11 or lower until the issue is resolved.
+> Due to an upstream issue with [React Router](https://github.com/remix-run/react-router/issues/12475), you'll need to use Node.js 22.11 or lower until the issue is resolved.
 
 The Clerk React Router SDK is built on top of the [React SDK](/docs/references/react/overview) and is the recommended method for integrating Clerk into your React Router application.
 

--- a/docs/references/react-router/overview.mdx
+++ b/docs/references/react-router/overview.mdx
@@ -4,7 +4,7 @@ description: Learn how to integrate Clerk into your React Router application usi
 ---
 
 > [!WARNING]
-> The React Router SDK is currently in beta.
+> Due to an upstream compatibility issue with [React Router](https://github.com/remix-run/react-router/issues/12475), you'll need to use Node.js 22.11 or lower until the issue is resolved.
 
 The Clerk React Router SDK is built on top of the [React SDK](/docs/references/react/overview) and is the recommended method for integrating Clerk into your React Router application.
 

--- a/docs/references/react-router/overview.mdx
+++ b/docs/references/react-router/overview.mdx
@@ -4,7 +4,7 @@ description: Learn how to integrate Clerk into your React Router application usi
 ---
 
 > [!WARNING]
-> Due to an upstream issue with [React Router](https://github.com/remix-run/react-router/issues/12475), you'll need to use Node.js 22.11 or lower until the issue is resolved.
+> Due to an active [issue with React Router](https://github.com/remix-run/react-router/issues/12475), Clerk and React Router currently requires using Node.js 22.11 or lower.
 
 The Clerk React Router SDK is built on top of the [React SDK](/docs/references/react/overview) and is the recommended method for integrating Clerk into your React Router application.
 


### PR DESCRIPTION
> [!IMPORTANT]
> 🔎 Previews:
>
> - https://clerk.com/docs/pr/1866/quickstarts/react-router
> - https://clerk.com/docs/pr/1866/references/react-router/overview

<img width="738" alt="Screenshot 2025-01-08 at 3 07 36 PM" src="https://github.com/user-attachments/assets/c478e0d3-d9d3-4345-bc69-dfc9bb3530ba" />

### Explanation:

- Adding node version requirement warning to React Router docs due to current upstream issue. See https://github.com/clerk/javascript/issues/4826#issuecomment-2573054703

### This PR:
- Adds warning callout to React Router quickstart and overview pages informing users to use Node.js 22.11 or lower

### Checklist

- [x] I have clicked on "Files changed" and performed a thorough self-review
- [x] I have added the "deploy-preview" label and added the preview link(s) to this PR description
- [x] All existing checks pass
