### PR TITLE
fix: Move "SDKs" card on index page to correct place

### DIFF
--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -110,12 +110,6 @@ Find all the guides and resources you need to develop with Clerk.
   - [Ruby on Rails](/docs/references/ruby/overview)
   - Integrate user management and authentication into your Ruby application.
   - {<svg viewBox="0 0 32 32" fill="none"><path fill="#CC342D" d="M25.164 2.611c3.407.59 4.374 2.92 4.302 5.36l.017-.035-1.534 20.098L8.012 29.4h.018c-1.655-.07-5.344-.221-5.512-5.378l1.848-3.371 3.167 7.4.565 1.317 3.152-10.274-.034.008.018-.034 10.399 3.321-1.569-6.102-1.112-4.382 9.91-.639-.692-.573-7.114-5.8L25.167 2.6l-.003.011ZM8.28 8.218c4.001-3.97 9.165-6.316 11.148-4.315 1.98 1.997-.118 6.86-4.127 10.827-4.003 3.968-9.104 6.442-11.082 4.446-1.984-1.997.05-6.985 4.058-10.955l.003-.003Z"/></svg>}
-
-  ---
-
-  - [SDKs](/docs/references/overview)
-  - Clerk's SDKs allow you to call the Clerk server API without having to implement the calls yourself.
-  - {<svg viewBox="0 0 32 32" fill="none"><path fill="currentColor" fillOpacity=".15" stroke="currentColor" strokeLinecap="round" strokeLinejoin="round" strokeWidth="1.5" d="M16 31.25 29.25 25l-9.54-4.5L16 22.25l-3.71-1.75L2.75 25 16 31.25Z"/><path stroke="currentColor" strokeLinecap="round" strokeLinejoin="round" strokeWidth="1.5" d="M16 22.25 29.25 16l-9.54-4.5L16 13.25l-3.71-1.75L2.75 16 16 22.25Z"/><path fill="currentColor" fillOpacity=".15" stroke="currentColor" strokeLinecap="round" strokeLinejoin="round" strokeWidth="1.5" d="M2.75 7 16 .75 29.25 7 16 13.25 2.75 7Z"/></svg>}
 </Cards>
 
 ## Explore by feature
@@ -148,6 +142,12 @@ Find all the guides and resources you need to develop with Clerk.
   - [Organizations](/docs/organizations/overview)
   - Organizations are shared accounts, useful for project and team leaders. Members with elevated privileges can manage member access to the organization's data and resources.
   - {<svg viewBox="0 0 32 32" fill="none"><g stroke="currentColor" strokeLinecap="round" strokeLinejoin="round" strokeWidth="1.5"><circle cx="16" cy="16" r="15.25" fill="currentColor" fillOpacity=".15"/><path d="M1 16h30M16 1v30M14 1S7.75 5.978 7.75 16 14 31 14 31M18 1s6.25 4.978 6.25 15S18 31 18 31"/></g></svg>}
+
+  ---
+
+  - [SDKs](/docs/references/overview)
+  - Clerk's SDKs allow you to call the Clerk server API without having to implement the calls yourself.
+  - {<svg viewBox="0 0 32 32" fill="none"><path fill="currentColor" fillOpacity=".15" stroke="currentColor" strokeLinecap="round" strokeLinejoin="round" strokeWidth="1.5" d="M16 31.25 29.25 25l-9.54-4.5L16 22.25l-3.71-1.75L2.75 25 16 31.25Z"/><path stroke="currentColor" strokeLinecap="round" strokeLinejoin="round" strokeWidth="1.5" d="M16 22.25 29.25 16l-9.54-4.5L16 13.25l-3.71-1.75L2.75 16 16 22.25Z"/><path fill="currentColor" fillOpacity=".15" stroke="currentColor" strokeLinecap="round" strokeLinejoin="round" strokeWidth="1.5" d="M2.75 7 16 .75 29.25 7 16 13.25 2.75 7Z"/></svg>}
 </Cards>
 
 ## Learn the concepts


### PR DESCRIPTION
> [!IMPORTANT]
> 🔎 Previews:
>
> - https://clerk.com/docs/pr/1868

### Explanation:

The "SDKs" card was in the wrong place.

Current:

![CleanShot 2025-01-09 at 14 04 24](https://github.com/user-attachments/assets/0598c9c6-5073-4cf9-95e0-077a8f8c866e)

Fixed:

![CleanShot 2025-01-09 at 14 04 38](https://github.com/user-attachments/assets/52b7760d-ea75-4f1b-a1f3-d1d69d8e0351)


### This PR:

- <!--- How does this PR solve the problem? -->

### Checklist

- [ ] I have clicked on "Files changed" and performed a thorough self-review
- [ ] I have added the "deploy-preview" label and added the preview link(s) to this PR description
- [ ] All existing checks pass
