### PR TITLE
fix: Add "Next steps" to React Router quickstart

### DIFF
--- a/docs/quickstarts/react-router.mdx
+++ b/docs/quickstarts/react-router.mdx
@@ -233,7 +233,7 @@ This guide assumes that you're using [React Router v7 or later](https://api.reac
   ---
 
   - [Read session and user data](/docs/references/react-router/read-session-data)
-  - Learn how to use Clerk's stores and helpers to access the active session and user data in your Astro app.
+  - Learn how to use Clerk's hooks and helpers to access the active session and user data in your React Router app.
 
   ---
 

--- a/docs/quickstarts/react-router.mdx
+++ b/docs/quickstarts/react-router.mdx
@@ -31,7 +31,9 @@ description: Learn how to use Clerk to quickly and easily add secure authenticat
   - Add `<ClerkProvider>` and Clerk components
 </TutorialHero>
 
-Clerk's [React Router SDK](/docs/references/react-router/overview) provides prebuilt components, hooks, and stores to make it easy to integrate authentication and user management in your React Router app. This guide assumes that you're using [React Router v7 or later](https://api.reactrouter.com/v7).
+Clerk's [React Router SDK](/docs/references/react-router/overview) provides prebuilt components, hooks, and stores to make it easy to integrate authentication and user management in your React Router app.
+
+This guide assumes that you're using [React Router v7 or later](https://api.reactrouter.com/v7) in framework mode. To use React Router as a library instead, see the [library mode guide](/docs/references/react-router/library-mode).
 
 > [!WARNING]
 > Due to an active [issue with React Router](https://github.com/remix-run/react-router/issues/12475), Clerk and React Router currently requires using Node.js 22.11 or lower.
@@ -221,3 +223,20 @@ Clerk's [React Router SDK](/docs/references/react-router/overview) provides preb
 
   Visit your app's homepage at [`http://localhost:5173`](http://localhost:5173). Sign up to create your first user.
 </Steps>
+
+## Next steps
+
+<Cards>
+  - [Add custom sign up and sign in pages](/docs/references/react-router/custom-signup-signin-pages)
+  - Learn how to add custom sign-up and sign-in pages to your React Router app with Clerk's prebuilt components.
+
+  ---
+
+  - [Read session and user data](/docs/references/react-router/read-session-data)
+  - Learn how to use Clerk's stores and helpers to access the active session and user data in your Astro app.
+
+  ---
+
+  - [Library mode](/docs/references/react-router/library-mode)
+  - Learn how to use Clerk with React Router in library mode to add authentication to your application.
+</Cards>

--- a/docs/quickstarts/react-router.mdx
+++ b/docs/quickstarts/react-router.mdx
@@ -227,7 +227,7 @@ This guide assumes that you're using [React Router v7 or later](https://api.reac
 ## Next steps
 
 <Cards>
-  - [Add custom sign up and sign in pages](/docs/references/react-router/custom-signup-signin-pages)
+  - [Add custom sign-up and sign-in pages](/docs/references/react-router/custom-signup-signin-pages)
   - Learn how to add custom sign-up and sign-in pages to your React Router app with Clerk's prebuilt components.
 
   ---


### PR DESCRIPTION
> [!IMPORTANT]
> 🔎 Previews:
>
> - https://clerk.com/docs/pr/1874/quickstarts/react-router

I don't know if we accidentally removed it or never added it in the first place, but compared to all other quickstarts the React Router one is missing the "Next steps" heading to link to the reference docs.

Since we have a callout for inside the library guide about the framework guide, I'm adding that backlink also to the quickstart so it's easier to discover.

### Checklist

- [ ] I have clicked on "Files changed" and performed a thorough self-review
- [ ] I have added the "deploy-preview" label and added the preview link(s) to this PR description
- [ ] All existing checks pass
