### PR TITLE
fix(useAuth): Fix options formatting

### DIFF
--- a/docs/references/react/use-auth.mdx
+++ b/docs/references/react/use-auth.mdx
@@ -62,6 +62,8 @@ The `useAuth()` hook provides access to the current user's authentication state 
 
   A function that signs out the current user. Returns a promise that resolves when complete. See the [reference doc](/docs/references/javascript/clerk/clerk#sign-out).
 
+  ---
+
   - `getToken()`
   - `(options?: GetTokenOptions) => Promise<string | null>`
 


### PR DESCRIPTION
> [!IMPORTANT]
> 🔎 Previews:
>
> - https://clerk.com/docs/pr/1882/references/react/use-auth

### Explanation:

- Fix formatting of `useAuth()` options

### This PR:

- <!--- How does this PR solve the problem? -->

Before: 
![CleanShot 2025-01-10 at 15 48 58@2x](https://github.com/user-attachments/assets/7ce0cae8-308f-475f-bab3-c6ca25ee94a3)

After:
![CleanShot 2025-01-10 at 15 49 36@2x](https://github.com/user-attachments/assets/2bfc2202-219f-4735-9d52-403fce4a18b2)


### Checklist

- [ ] I have clicked on "Files changed" and performed a thorough self-review
- [ ] I have added the "deploy-preview" label and added the preview link(s) to this PR description
- [ ] All existing checks pass
