### PR TITLE
Update repo icon in Expo quickstart

### DIFF
--- a/docs/quickstarts/expo.mdx
+++ b/docs/quickstarts/expo.mdx
@@ -9,7 +9,6 @@ description: Add authentication and user management to your Expo app with Clerk.
     {
       title: "Expo quickstart repo",
       link: "https://github.com/clerk/clerk-expo-quickstart",
-      icon: "expo"
     },
   ]}
   beforeYouStart={[


### PR DESCRIPTION
> [!IMPORTANT]
> 🔎 Previews:
>
> - https://clerk.com/docs/pr/1884/quickstarts/expo

This PR updates the Expo quickstart so that the repo link uses the GitHub icon instead of the Clerk icon, for consistency with other quickstarts.

| Before | After |
| - | - |
| ![CleanShot 2025-01-13 at 12 38 45@2x](https://github.com/user-attachments/assets/275d55fd-d0cd-403f-a8b8-6887046d547d) | ![CleanShot 2025-01-13 at 12 38 40@2x](https://github.com/user-attachments/assets/70cfb107-b71c-4030-88e0-4e0051040fcb) |

### Checklist

- [x] I have clicked on "Files changed" and performed a thorough self-review
- [x] I have added the "deploy-preview" label and added the preview link(s) to this PR description
- [x] All existing checks pass
