### PR TITLE
easie: clarify deprovisioning

### DIFF
--- a/docs/authentication/enterprise-connections/overview.mdx
+++ b/docs/authentication/enterprise-connections/overview.mdx
@@ -41,7 +41,7 @@ The following IdPs are supported: Google Workspace and Microsoft Entra ID. For _
 
 Clerk prevents users linked to deprovisioned accounts in the OpenID provider from accessing the app.
 
-Within 10 minutes of a user being removed from the OpenID provider (e.g. [suspendeded](https://support.google.com/a/answer/33312?hl=en) or [deleted](https://support.google.com/a/answer/33314?hl=en) via Google Workspace, or [deleted](https://learn.microsoft.com/en-us/entra/fundamentals/how-to-create-delete-users#delete-a-user) via Microsoft Entra), Clerk will recognize that the user has been deprovisioned and will revoke that user's existing sessions.
+Before creating a new session token for an EASIE user, Clerk verifies that the user has not been removed from the OpenID provider (e.g. [suspendeded](https://support.google.com/a/answer/33312?hl=en) or [deleted](https://support.google.com/a/answer/33314?hl=en) via Google Workspace, or [deleted](https://learn.microsoft.com/en-us/entra/fundamentals/how-to-create-delete-users#delete-a-user) via Microsoft Entra), with a delay of up to 10 minutes. When deprovisioning is detected, Clerk revokes that user's existing sessions, and responds with 401 Unauthorized to any requests to retrieve a new session token.
 
 It is ultimately the app's responsibility to handle this unauthenticated state and display something appropriate to the user. For example, Next.js apps using [`auth.protect()`](/docs/references/nextjs/auth#auth-protect) will automatically redirect the user to the sign-in page.
 


### PR DESCRIPTION
## What problem does this solve?

The current EASIE deprovisioning docs don't describe exactly when Clerk performs the check, and what the result of the check is. A reader could assume that Clerk is using background polling to detect deprovisoining, and is updating the user object.

## What changed?

This clarifies that we only check for deprovisioning when creating a session token, and the primary effect of deprovisioning is preventing the generation of new session tokens.