### PR TITLE
fix: CLERK_SIGN_IN_FALLBACK_URL usage

### DIFF
--- a/docs/deployments/clerk-environment-variables.mdx
+++ b/docs/deployments/clerk-environment-variables.mdx
@@ -145,7 +145,7 @@ The following environment variables are deprecated but still supported to avoid 
     | Variable | Description |
     | - | - |
     | `CLERK_AFTER_SIGN_UP_URL` | Full URL or path to navigate to after successful sign up. Defaults to `/`. `CLERK_SIGN_UP_FALLBACK_URL` and `CLERK_SIGN_UP_FORCE_REDIRECT_URL` have priority and should be used instead. |
-    | `CLERK_AFTER_SIGN_IN_URL` | Full URL or path to navigate to after successful sign in. Defaults to `/`. `CLERK_SIGN_IN_FALLBACK_URL` and `CLERK_SIGN_IN_FORCE_REDIRECT_URL` have priority and should be used instead. |
+    | `CLERK_AFTER_SIGN_IN_URL` | Full URL or path to navigate to after successful sign in. Defaults to `/`. `CLERK_SIGN_IN_FALLBACK_REDIRECT_URL` and `CLERK_SIGN_IN_FORCE_REDIRECT_URL` have priority and should be used instead. |
   </Tab>
 
   <Tab>

--- a/docs/references/react-router/custom-signup-signin-pages.mdx
+++ b/docs/references/react-router/custom-signup-signin-pages.mdx
@@ -61,10 +61,10 @@ If the prebuilt components don't meet your specific needs or if you require more
   Update your environment variables to point to your custom sign-up and sign-in pages. Learn more about the available [environment variables](/docs/deployments/clerk-environment-variables).
 
   ```env {{ filename: '.env' }}
-  CLERK_SIGN_IN_FALLBACK_URL=/
-  CLERK_SIGN_UP_FALLBACK_URL=/
   CLERK_SIGN_IN_URL=/sign-in
   CLERK_SIGN_UP_URL=/sign-up
+  CLERK_SIGN_IN_FALLBACK_REDIRECT_URL=/
+  CLERK_SIGN_UP_FALLBACK_REDIRECT_URL=/
   ```
 
   These values control the behavior of the `<SignUp />` and `<SignIn />` components and when you visit the respective links at the bottom of each component.

--- a/docs/references/remix/custom-signup-signin-pages.mdx
+++ b/docs/references/remix/custom-signup-signin-pages.mdx
@@ -56,8 +56,8 @@ The functionality of the components are controlled by the instance settings you 
       ```env {{ filename: '.env' }}
       CLERK_SIGN_IN_URL=/sign-in
       CLERK_SIGN_UP_URL=/sign-up
-      CLERK_SIGN_IN_FALLBACK_URL=/
-      CLERK_SIGN_UP_FALLBACK_URL=/
+      CLERK_SIGN_IN_FALLBACK_REDIRECT_URL=/
+      CLERK_SIGN_UP_FALLBACK_REDIRECT_URL=/
       ```
     </Tab>
 

--- a/docs/upgrade-guides/core-2/javascript.mdx
+++ b/docs/upgrade-guides/core-2/javascript.mdx
@@ -648,8 +648,8 @@ As part of this major version, a number of previously deprecated props, argument
 
     - If not using a react-based SDK, pass the values into `Clerk.load` as such: `Clerk.load({ afterSignUpUrl: 'x', afterSignInUrl: 'y' })`
     - If using a React-based SDK, pass the desired values into [`<ClerkProvider>`](/docs/components/clerk-provider#properties).
-    - If using the Next.js SDK, set with `NEXT_PUBLIC_CLERK_SIGN_IN_FALLBACK_URL` or `NEXT_PUBLIC_CLERK_SIGN_UP_FALLBACK_URL`
-    - If using remix SDK, set with `CLERK_SIGN_IN_FALLBACK_URL` or `CLERK_SIGN_UP_FALLBACK_URL`
+    - If using the Next.js SDK, set with `NEXT_PUBLIC_CLERK_SIGN_IN_FALLBACK_REDIRECT_URL` or `NEXT_PUBLIC_CLERK_SIGN_UP_FALLBACK_REDIRECT_URL`
+    - If using remix SDK, set with `CLERK_SIGN_IN_FALLBACK_REDIRECT_URL` or `CLERK_SIGN_UP_FALLBACK_REDIRECT_URL`
   </AccordionPanel>
 
   <AccordionPanel>


### PR DESCRIPTION
> [!IMPORTANT]
> 🔎 Previews:
>
> - https://clerk.com/docs/pr/1888/deployments/clerk-environment-variables
> - https://clerk.com/docs/pr/1888/references/react-router/custom-signup-signin-pages
> - https://clerk.com/docs/pr/1888/references/remix/custom-signup-signin-pages
> - https://clerk.com/docs/pr/1888/upgrade-guides/core-2/javascript

### Explanation:

- Update references of `CLERK_SIGN_IN_FALLBACK_URL` to `CLERK_SIGN_IN_FALLBACK_REDIRECT_URL`

### This PR:

- <!--- How does this PR solve the problem? -->

### Checklist

- [ ] I have clicked on "Files changed" and performed a thorough self-review
- [ ] I have added the "deploy-preview" label and added the preview link(s) to this PR description
- [ ] All existing checks pass
