### PR TITLE
Fix page title

### DIFF
--- a/docs/components/control/redirect-to-createorganization.mdx
+++ b/docs/components/control/redirect-to-createorganization.mdx
@@ -1,5 +1,5 @@
 ---
-title: <RedirectToCreateOrganization /> (Deprecated)
+title: '`<RedirectToCreateOrganization />` (Deprecated)'
 description: The <RedirectToCreateOrganization /> component will navigate to the user profile URL which has been configured in your application instance. The behavior will be just like a server-side (3xx) redirect, and will override the current location in the history stack.
 ---
 

--- a/docs/components/control/redirect-to-organizationprofile.mdx
+++ b/docs/components/control/redirect-to-organizationprofile.mdx
@@ -1,5 +1,5 @@
 ---
-title: <RedirectToOrganizationProfile /> (Deprecated)
+title: `'<RedirectToOrganizationProfile />'` (Deprecated)
 description: The <RedirectToOrganizationProfile /> component will navigate to the organization profile URL which has been configured in your application instance. The behavior will be just like a server-side (3xx) redirect, and will override the current location in the history stack.
 ---
 

--- a/docs/components/control/redirect-to-userprofile.mdx
+++ b/docs/components/control/redirect-to-userprofile.mdx
@@ -1,5 +1,5 @@
 ---
-title: <RedirectToUserProfile /> (Deprecated)
+title: `'<RedirectToUserProfile />'` (Deprecated)
 description: The <RedirectToUserProfile /> component will navigate to the user profile URL which has been configured in your application instance. The behavior will be just like a server-side (3xx) redirect, and will override the current location in the history stack.
 ---
 


### PR DESCRIPTION
Page titles are parsed as MDX so `<RedirectToCreateOrganization />` needs to be escaped or wrapped in `` ` ``

https://clerk.com/docs/pr/1891/components/control/redirect-to-createorganization