### PR TITLE
(social-connections/hubspot) add missing scope

### DIFF
--- a/docs/authentication/social-connections/hubspot.mdx
+++ b/docs/authentication/social-connections/hubspot.mdx
@@ -53,6 +53,8 @@ To make the setup process easier, it's recommended to keep two browser tabs open
   1. In the **App Info** tab, complete the form. The **Public app name** is required.
   1. Select the **Auth** tab.
   1. In the **Redirect URLs** section, paste the **Redirect URI** value you saved from the Clerk Dashboard.
+  1. In the **Scopes** section, select **Add new scope**.
+  1. Enable the **crm.objects.owners.read** scope and select **Update**.
   1. Select **Create app**. You'll be redirected back to the **App Info** tab.
   1. Select the **Auth** tab.
   1. Save the **Client ID** and **Client Secret** values somewhere secure.


### PR DESCRIPTION
> [!IMPORTANT]
> 🔎 Previews:
>
> - https://clerk.com/docs/pr/1896/authentication/social-connections/hubspot

### Explanation:

Trying to use HubSpot as an OAuth provider was giving this error:
<img width="1512" alt="Screenshot 2025-01-14 at 10 50 20" src="https://github.com/user-attachments/assets/1d14a45a-2cc3-40ef-838a-43f6b4665287" />

We never had a step in the docs where the user is supposed to add a required `crm.objects.owners.read` scope. This PR adds this crucial step.

### Checklist

- [ ] I have clicked on "Files changed" and performed a thorough self-review
- [ ] I have added the "deploy-preview" label and added the preview link(s) to this PR description
- [ ] All existing checks pass
