### PR TITLE
fix: Fixed Extension link, and changed clerkinc to clerk for other links

### DIFF
--- a/docs/troubleshooting/create-a-minimal-reproduction.mdx
+++ b/docs/troubleshooting/create-a-minimal-reproduction.mdx
@@ -17,7 +17,7 @@ The best way to create a minimal reproduction is to start fresh, with a minimal 
 - [Next.js Pages Router](https://github.com/clerk/clerk-nextjs-pages-quickstart)
 - [React](https://github.com/clerk/clerk-react-starter)
 - [Vanilla JS](https://github.com/clerk/clerk-js-starter)
-- [Expo](https://github.com/clerk/clerk-expo-starter)
+- [Expo](https://github.com/clerk/clerk-expo-quickstart)
 - [Remix](https://github.com/clerk/clerk-remix-v2)
 - [React Router](https://github.com/clerk/clerk-react-router-quickstart)
 - [Redwood](https://github.com/clerk/clerk-redwood-starter)

--- a/docs/troubleshooting/create-a-minimal-reproduction.mdx
+++ b/docs/troubleshooting/create-a-minimal-reproduction.mdx
@@ -15,14 +15,14 @@ The best way to create a minimal reproduction is to start fresh, with a minimal 
 
 - [Next.js App Router](https://github.com/clerk/clerk-nextjs-app-quickstart)
 - [Next.js Pages Router](https://github.com/clerk/clerk-nextjs-pages-quickstart)
-- [React](https://github.com/clerkinc/clerk-react-starter)
-- [Vanilla JS](https://github.com/clerkinc/clerk-js-starter)
-- [Expo](https://github.com/clerkinc/clerk-expo-starter)
+- [React](https://github.com/clerk/clerk-react-starter)
+- [Vanilla JS](https://github.com/clerk/clerk-js-starter)
+- [Expo](https://github.com/clerk/clerk-expo-starter)
 - [Remix](https://github.com/clerk/clerk-remix-v2)
 - [React Router](https://github.com/clerk/clerk-react-router-quickstart)
-- [Redwood](https://github.com/clerkinc/clerk-redwood-starter)
-- [Rails](https://github.com/clerkinc/clerk-rails-starter)
-- [Chrome Extension](https://github.com/clerkinc/clerk-chrome-extension-starter)
+- [Redwood](https://github.com/clerk/clerk-redwood-starter)
+- [Rails](https://github.com/clerk/clerk-rails-starter)
+- [Chrome Extension](https://github.com/clerk/clerk-chrome-extension-quickstart)
 - [Tanstack Start](https://github.com/clerk/clerk-tanstack-start-quickstart)
 
 ## Steps to create a minimal reproduction


### PR DESCRIPTION
> [!IMPORTANT]
> 🔎 Previews:
>
> - https://clerk.com/docs/pr/1898/troubleshooting/create-a-minimal-reproduction

### Explanation:

- The Chrome Extension link for the minimal reproduction page pointed to a now non-public repo. Some of the other links were to `github.com/clerkinc` which is no longer valid.

### This PR:

- Updated links.

### Checklist

- [x] I have clicked on "Files changed" and performed a thorough self-review
- [x] I have added the "deploy-preview" label and added the preview link(s) to this PR description
- [x] All existing checks pass
