### PR TITLE
docs(vue): Add missing `setup` directive

### DIFF
--- a/docs/quickstarts/vue.mdx
+++ b/docs/quickstarts/vue.mdx
@@ -144,7 +144,7 @@ Clerk's [Vue SDK](/docs/references/vue/overview) provides prebuilt components an
   - [`<SignInButton />`](/docs/components/unstyled/sign-in-button): An unstyled component that links to the sign-in page or displays the sign-in modal.
 
   ```vue {{ filename: 'src/App.vue', mark: [2, [6, 13]] }}
-  <script setup>
+  <script setup lang="ts">
   import { SignedIn, SignedOut, SignInButton, UserButton } from '@clerk/vue'
   </script>
 

--- a/docs/quickstarts/vue.mdx
+++ b/docs/quickstarts/vue.mdx
@@ -144,7 +144,7 @@ Clerk's [Vue SDK](/docs/references/vue/overview) provides prebuilt components an
   - [`<SignInButton />`](/docs/components/unstyled/sign-in-button): An unstyled component that links to the sign-in page or displays the sign-in modal.
 
   ```vue {{ filename: 'src/App.vue', mark: [2, [6, 13]] }}
-  <script>
+  <script setup>
   import { SignedIn, SignedOut, SignInButton, UserButton } from '@clerk/vue'
   </script>
 


### PR DESCRIPTION
> [!IMPORTANT]
> 🔎 Previews:
>
> - https://clerk.com/docs/pr/1901/quickstarts/vue#create-a-header-with-clerk-components

### Explanation:

- Missing `setup` directive in the script tag which is important to make the quickstart work

### This PR:

- Adds the `setup` directive and also `lang` for consistency

### Checklist

- [x] I have clicked on "Files changed" and performed a thorough self-review
- [x] I have added the "deploy-preview" label and added the preview link(s) to this PR description
- [x] All existing checks pass
