### PR TITLE
Fix typo in invitation redirect documentation

### DIFF
--- a/docs/users/invitations.mdx
+++ b/docs/users/invitations.mdx
@@ -64,7 +64,7 @@ curl https://api.clerk.com/v1/invitations -X POST -d '{"email_address": "email@e
 Once the user visits the invitation link, they will be redirected to the page you specified, which means you must handle the sign-up flow in your code for that page. You can either embed the [`<SignUp />`](/docs/components/authentication/sign-up) component on that page, or if the prebuilt component doesn't meet your specific needs or if you require more control over the logic, you can build a [custom flow](/docs/custom-flows/invitations).
 
 > [!TIP]
-> To test redirect URLs in your development environment, you can pass your port (`http://localhost:3000`). If you want to use the Account Portal, you can pass your Clerk Frontend API URL as the base URL. For example, `https://prepared-phoenix-98.clerk.accounts.dev/sign-up` redirecrs the user to the Account Portal sign-up page. You can find your Frontend API URL on the [**API keys**](https://dashboard.clerk.com/last-active?path=api-keys) page in the Clerk Dashboard. On the left side, select **Show API URLs**.
+> To test redirect URLs in your development environment, you can pass your port (`http://localhost:3000`). If you want to use the Account Portal, you can pass your Clerk Frontend API URL as the base URL. For example, `https://prepared-phoenix-98.clerk.accounts.dev/sign-up` redirects the user to the Account Portal sign-up page. You can find your Frontend API URL on the [**API keys**](https://dashboard.clerk.com/last-active?path=api-keys) page in the Clerk Dashboard. On the left side, select **Show API URLs**.
 
 ### Invitation metadata
 


### PR DESCRIPTION
Fixes a typo `redirecrs` => `redirect`

### Explanation:
should be redirect 

### This PR:
fixes the typo

### Checklist

- [ x] I have clicked on "Files changed" and performed a thorough self-review
- [ ] I have added the "deploy-preview" label and added the preview link(s) to this PR description
- [ ] All existing checks pass
