### PR TITLE
refactor: Added callout that phone number must be in E.164 format

### DIFF
--- a/docs/_partials/custom-flows/phone-number.mdx
+++ b/docs/_partials/custom-flows/phone-number.mdx
@@ -1,0 +1,2 @@
+> [!WARNING]
+> Phone numbers must be in [E.164 format](https://en.wikipedia.org/wiki/E.164).

--- a/docs/custom-flows/add-phone.mdx
+++ b/docs/custom-flows/add-phone.mdx
@@ -16,6 +16,9 @@ The following example demonstrates how to build a custom user interface that all
 1. Uses the `prepareVerification()` method on the newly created `PhoneNumber` object to send a verification code to the user.
 1. Uses the `attemptVerification()` method on the same `PhoneNumber` object with the verification code provided by the user to verify the phone number.
 
+> [!WARNING]
+> The phone number submitted to Clerk in this custom flow must be in the [E.164 format](https://en.wikipedia.org/wiki/E.164)
+
 <Tabs items={["Next.js", "iOS (beta)"]}>
   <Tab>
     ```tsx {{ filename: 'app/account/add-phone/page.tsx', collapsible: true }}

--- a/docs/custom-flows/add-phone.mdx
+++ b/docs/custom-flows/add-phone.mdx
@@ -16,8 +16,7 @@ The following example demonstrates how to build a custom user interface that all
 1. Uses the `prepareVerification()` method on the newly created `PhoneNumber` object to send a verification code to the user.
 1. Uses the `attemptVerification()` method on the same `PhoneNumber` object with the verification code provided by the user to verify the phone number.
 
-> [!WARNING]
-> The phone number submitted to Clerk in this custom flow must be in the [E.164 format](https://en.wikipedia.org/wiki/E.164)
+<Include src="_partials/custom-flows/phone-number" />
 
 <Tabs items={["Next.js", "iOS (beta)"]}>
   <Tab>

--- a/docs/custom-flows/email-sms-otp.mdx
+++ b/docs/custom-flows/email-sms-otp.mdx
@@ -27,6 +27,9 @@ This guide will walk you through how to build a custom SMS OTP sign-up and sign-
   1. Attempt to complete the verification with the code the user provides.
   1. If the verification is successful, set the newly created session as the active session.
 
+  > [!WARNING]
+  > The phone number submitted to Clerk in this custom flow must be in the [E.164 format](https://en.wikipedia.org/wiki/E.164)
+
   <Tabs items={["Next.js", "JavaScript", "iOS (beta)"]}>
     <Tab>
       This example is written for Next.js App Router but can be adapted to any React meta framework, such as Remix.

--- a/docs/custom-flows/email-sms-otp.mdx
+++ b/docs/custom-flows/email-sms-otp.mdx
@@ -9,6 +9,8 @@ Clerk supports passwordless authentication, which lets users sign in and sign up
 
 This guide will walk you through how to build a custom SMS OTP sign-up and sign-in flow. The process for using email OTP is similar, and the differences will be highlighted throughout.
 
+<Include src="_partials/custom-flows/phone-number" />
+
 <Steps>
   ## Enable SMS OTP
 
@@ -26,9 +28,6 @@ This guide will walk you through how to build a custom SMS OTP sign-up and sign-
   1. Prepare the verification, which sends a one-time code to the given identifier.
   1. Attempt to complete the verification with the code the user provides.
   1. If the verification is successful, set the newly created session as the active session.
-
-  > [!WARNING]
-  > The phone number submitted to Clerk in this custom flow must be in the [E.164 format](https://en.wikipedia.org/wiki/E.164)
 
   <Tabs items={["Next.js", "JavaScript", "iOS (beta)"]}>
     <Tab>

--- a/docs/custom-flows/manage-sms-based-mfa.mdx
+++ b/docs/custom-flows/manage-sms-based-mfa.mdx
@@ -12,9 +12,6 @@ One of the options that Clerk supports for MFA is **SMS verification codes**. Th
 > [!TIP]
 > To learn how to build a custom flow for managing authenticator app (TOTP) MFA, see the [dedicated guide](/docs/custom-flows/manage-totp-based-mfa).
 
-> [!WARNING]
-> The phone number submitted to Clerk in this custom flow must be in the [E.164 format](https://en.wikipedia.org/wiki/E.164)
-
 <Steps>
   ## Enable multi-factor authentication
 
@@ -33,6 +30,8 @@ One of the options that Clerk supports for MFA is **SMS verification codes**. Th
   - The page where users can add a phone number to their account.
 
   Use the following tabs to view the code necessary for each page.
+
+  <Include src="_partials/custom-flows/phone-number" />
 
   <Tabs items={["Manage MFA page", "Add phone number page"]}>
     <Tab>

--- a/docs/custom-flows/manage-sms-based-mfa.mdx
+++ b/docs/custom-flows/manage-sms-based-mfa.mdx
@@ -12,6 +12,9 @@ One of the options that Clerk supports for MFA is **SMS verification codes**. Th
 > [!TIP]
 > To learn how to build a custom flow for managing authenticator app (TOTP) MFA, see the [dedicated guide](/docs/custom-flows/manage-totp-based-mfa).
 
+> [!WARNING]
+> The phone number submitted to Clerk in this custom flow must be in the [E.164 format](https://en.wikipedia.org/wiki/E.164)
+
 <Steps>
   ## Enable multi-factor authentication
 


### PR DESCRIPTION
> [!IMPORTANT]
> 🔎 Previews:
>
> - https://clerk.com/docs/pr/1913/custom-flows/manage-sms-based-mfa
> - https://clerk.com/docs/pr/1913/custom-flows/add-phone
> - https://clerk.com/docs/pr/1913/custom-flows/email-sms-otp

### Explanation:

- Custom flow docs for phone/sms do not mention the format. 

### This PR:

- Added callout with link to Wikipedia indicating that they must be in E.164 format.

### Checklist

- [x] I have clicked on "Files changed" and performed a thorough self-review
- [x] I have added the "deploy-preview" label and added the preview link(s) to this PR description
- [x] All existing checks pass
