### PR TITLE
create /types/set-active-params

### DIFF
--- a/docs/manifest.json
+++ b/docs/manifest.json
@@ -2235,6 +2235,10 @@
                           "href": "/docs/references/javascript/types/session-verification"
                         },
                         {
+                          "title": "`SetActiveParams`",
+                          "href": "/docs/references/javascript/types/set-active-params"
+                        },
+                        {
                           "title": "`SignInFirstFactor`",
                           "href": "/docs/references/javascript/types/sign-in-first-factor"
                         },

--- a/docs/references/javascript/clerk/session-methods.mdx
+++ b/docs/references/javascript/clerk/session-methods.mdx
@@ -7,34 +7,11 @@ These methods on the [`Clerk`](/docs/references/javascript/clerk/clerk) class he
 
 ## `setActive()`
 
-A method used to set the active session and/or organization.
+A method used to set the active session and/or organization. Accepts a [`SetActiveParams`](/docs/references/javascript/types/set-active-params) object.
 
 ```typescript
-function setActive({ session, organization, beforeEmit }: SetActiveParams): Promise<void>
+function setActive(params: SetActiveParams): Promise<void>
 ```
-
-### `SetActiveParams`
-
-<Properties>
-  - `session?`
-  - <code>[Session](/docs/references/javascript/session) | string | null</code>
-
-  The session resource or session ID (string version) to be set as active. If `null`, the current session is deleted.
-
-  ---
-
-  - `organization?`
-  - <code>[Organization](/docs/references/javascript/organization/organization) | string | null</code>
-
-  The organization resource or organization ID/slug (string version) to be set as active in the current session. If `null`, the currently active organization is removed as active.
-
-  ---
-
-  - `beforeEmit?`
-  - `(session?: Session | null) => void | Promise<any>`
-
-  Callback run just before the active session and/or organization is set to the passed object. Can be used to set up for pre-navigation actions.
-</Properties>
 
 ### Example
 

--- a/docs/references/javascript/types/set-active-params.mdx
+++ b/docs/references/javascript/types/set-active-params.mdx
@@ -1,0 +1,27 @@
+---
+title: `SetActiveParams`
+description: The parameters for the `setActive()` method.
+---
+
+The parameters for the `setActive()` method.
+
+<Properties>
+  - `session`
+  - <code>[Session](/docs/references/javascript/session) | string | null</code>
+
+  The session resource or session ID (string version) to be set as active. If `null`, the current session is deleted.
+
+  ---
+
+  - `organization`
+  - <code>[Organization](/docs/references/javascript/organization/organization) | string | null</code>
+
+  The organization resource or organization ID/slug (string version) to be set as active in the current session. If `null`, the currently active organization is removed as active.
+
+  ---
+
+  - `beforeEmit?`
+  - `(session?: Session | null) => void | Promise<any>`
+
+  Callback run just before the active session and/or organization is set to the passed object. Can be used to set up for pre-navigation actions.
+</Properties>

--- a/docs/references/javascript/types/set-active-params.mdx
+++ b/docs/references/javascript/types/set-active-params.mdx
@@ -20,8 +20,15 @@ The parameters for the `setActive()` method.
 
   ---
 
-  - `beforeEmit?`
+  - `beforeEmit?` (deprecated)
   - `(session?: Session | null) => void | Promise<any>`
 
-  Callback run just before the active session and/or organization is set to the passed object. Can be used to set up for pre-navigation actions.
+  Deprecated in favor of `redirectUrl`. Callback run just before the active session and/or organization is set to the passed object. Can be used to set up for pre-navigation actions.
+
+  ---
+
+  - `redirectUrl?`
+  - `string`
+
+  The URL to redirect to just before the active session and/or organization is set.
 </Properties>

--- a/docs/references/react/use-organization-list.mdx
+++ b/docs/references/react/use-organization-list.mdx
@@ -96,7 +96,7 @@ type OrganizationSuggestionStatus = 'pending' | 'accepted'
   ---
 
   - `setActive()`
-  - <code>(params: [SetActiveParams](#set-active-params)) => Promise\<void></code>
+  - <code>(params: [SetActiveParams](/docs/references/javascript/types/set-active-params)) => Promise\<void></code>
 
   A function that sets the active session and/or organization.
 
@@ -136,29 +136,6 @@ type OrganizationSuggestionStatus = 'pending' | 'accepted'
   - `string`
 
   The slug of the organization.
-</Properties>
-
-### `SetActiveParams`
-
-<Properties>
-  - `session`
-  - <code>[Session](/docs/references/javascript/session) | string | null</code>
-
-  The session resource or session ID (string version) to be set as active. If `null`, the current session is deleted.
-
-  ---
-
-  - `organization`
-  - <code>[Organization](/docs/references/javascript/organization/organization) | string | null</code>
-
-  The organization resource or organization ID/slug (string version) to be set as active in the current session. If `null`, the currently active organization is removed as active.
-
-  ---
-
-  - `beforeEmit?`
-  - `(session?: Session | null) => void | Promise<any>`
-
-  Callback run just before the active session and/or organization is set to the passed object. Can be used to set up for pre-navigation actions.
 </Properties>
 
 ### `PaginatedResources`

--- a/docs/references/react/use-session-list.mdx
+++ b/docs/references/react/use-session-list.mdx
@@ -16,7 +16,7 @@ The `useSessionList()` hook returns an array of [`Session`](/docs/references/jav
   ---
 
   - `setActive()`
-  - <code>(params: [SetActiveParams](#set-active-params)) => Promise\<void></code>
+  - <code>(params: [SetActiveParams](/docs/references/javascript/types/set-active-params)) => Promise\<void></code>
 
   A function that sets the active session and/or organization.
 
@@ -26,29 +26,6 @@ The `useSessionList()` hook returns an array of [`Session`](/docs/references/jav
   - <code>[Session](/docs/references/javascript/session)\[]</code>
 
   A list of sessions that have been registered on the client device.
-</Properties>
-
-### `SetActiveParams`
-
-<Properties>
-  - `session`
-  - <code>[Session](/docs/references/javascript/session) | string | null</code>
-
-  The session resource or session ID (string version) to be set as active. If `null`, the current session is deleted.
-
-  ---
-
-  - `organization`
-  - <code>[Organization](/docs/references/javascript/organization/organization) | string | null</code>
-
-  The organization resource or organization ID/slug (string version) to be set as active in the current session. If `null`, the currently active organization is removed as active.
-
-  ---
-
-  - `beforeEmit?`
-  - `(session?: Session | null) => void | Promise<any>`
-
-  Callback run just before the active session and/or organization is set to the passed object. Can be used to set up for pre-navigation actions.
 </Properties>
 
 ## How to use the `useSessionList()` hook

--- a/docs/references/react/use-sign-in.mdx
+++ b/docs/references/react/use-sign-in.mdx
@@ -16,7 +16,7 @@ The `useSignIn()` hook provides access to the [`SignIn`](/docs/references/javasc
   ---
 
   - `setActive()`
-  - <code>(params: [SetActiveParams](#set-active-params)) => Promise\<void></code>
+  - <code>(params: [SetActiveParams](/docs/references/javascript/types/set-active-params)) => Promise\<void></code>
 
   A function that sets the active session.
 
@@ -26,29 +26,6 @@ The `useSignIn()` hook provides access to the [`SignIn`](/docs/references/javasc
   - [`SignIn`](/docs/references/javascript/sign-in/sign-in)
 
   An object that contains the current sign-in attempt status and methods to create a new sign-in attempt.
-</Properties>
-
-### `SetActiveParams`
-
-<Properties>
-  - `session`
-  - <code>[Session](/docs/references/javascript/session) | string | null</code>
-
-  The session resource or session ID (string version) to be set as active. If `null`, the current session is deleted.
-
-  ---
-
-  - `organization`
-  - <code>[Organization](/docs/references/javascript/organization/organization) | string | null</code>
-
-  The organization resource or organization ID/slug (string version) to be set as active in the current session. If `null`, the currently active organization is removed as active.
-
-  ---
-
-  - `beforeEmit?`
-  - `(session?: Session | null) => void | Promise<any>`
-
-  Callback run just before the active session and/or organization is set to the passed object. Can be used to set up for pre-navigation actions.
 </Properties>
 
 ## How to use the `useSignIn()` hook

--- a/docs/references/react/use-sign-up.mdx
+++ b/docs/references/react/use-sign-up.mdx
@@ -16,7 +16,7 @@ The `useSignUp()` hook provides access to the [`SignUp`](/docs/references/javasc
   ---
 
   - `setActive()`
-  - <code>(params: [SetActiveParams](#set-active-params)) => Promise\<void></code>
+  - <code>(params: [SetActiveParams](/docs/references/javascript/types/set-active-params)) => Promise\<void></code>
 
   A function that sets the active session.
 
@@ -26,29 +26,6 @@ The `useSignUp()` hook provides access to the [`SignUp`](/docs/references/javasc
   - [`SignUp`](/docs/references/javascript/sign-up/sign-up)
 
   An object that contains the current sign-up attempt status and methods to create a new sign-up attempt.
-</Properties>
-
-### `SetActiveParams`
-
-<Properties>
-  - `session`
-  - <code>[Session](/docs/references/javascript/session) | string | null</code>
-
-  The session resource or session ID (string version) to be set as active. If `null`, the current session is deleted.
-
-  ---
-
-  - `organization`
-  - <code>[Organization](/docs/references/javascript/organization/organization) | string | null</code>
-
-  The organization resource or organization ID/slug (string version) to be set as active in the current session. If `null`, the currently active organization is removed as active.
-
-  ---
-
-  - `beforeEmit?`
-  - `(session?: Session | null) => void | Promise<any>`
-
-  Callback run just before the active session and/or organization is set to the passed object. Can be used to set up for pre-navigation actions.
 </Properties>
 
 ## How to use the `useSignUp()` hook

--- a/docs/references/vue/use-session-list.mdx
+++ b/docs/references/vue/use-session-list.mdx
@@ -16,7 +16,7 @@ The `useSessionList()` composable returns an array of [`Session`](/docs/referenc
   ---
 
   - `setActive()`
-  - <code>Ref\<(params: [SetActiveParams](#set-active-params)) => Promise\<void>></code>
+  - <code>Ref\<(params: [SetActiveParams](/docs/references/javascript/types/set-active-params)) => Promise\<void>></code>
 
   A function that sets the active session and/or organization.
 
@@ -26,29 +26,6 @@ The `useSessionList()` composable returns an array of [`Session`](/docs/referenc
   - <code>Ref\<[Session](/docs/references/javascript/session)></code>
 
   A list of sessions that have been registered on the client device.
-</Properties>
-
-### `SetActiveParams`
-
-<Properties>
-  - `session`
-  - <code>[Session](/docs/references/javascript/session) | string | null</code>
-
-  The session resource or session ID (string version) to be set as active. If `null`, the current session is deleted.
-
-  ---
-
-  - `organization`
-  - <code>[Organization](/docs/references/javascript/organization/organization) | string | null</code>
-
-  The organization resource or organization ID/slug (string version) to be set as active in the current session. If `null`, the currently active organization is removed as active.
-
-  ---
-
-  - `beforeEmit?`
-  - `(session?: Session | null) => void | Promise<any>`
-
-  Callback run just before the active session and/or organization is set to the passed object. Can be used to set up for pre-navigation actions.
 </Properties>
 
 ## How to use the `useSessionList()` composable

--- a/docs/references/vue/use-sign-in.mdx
+++ b/docs/references/vue/use-sign-in.mdx
@@ -16,7 +16,7 @@ The `useSignIn()` composable provides access to the [`SignIn`](/docs/references/
   ---
 
   - `setActive()`
-  - <code>Ref\<(params: [SetActiveParams](#set-active-params)) => Promise\<void>></code>
+  - <code>Ref\<(params: [SetActiveParams](/docs/references/javascript/types/set-active-params)) => Promise\<void>></code>
 
   A function that sets the active session.
 
@@ -26,29 +26,6 @@ The `useSignIn()` composable provides access to the [`SignIn`](/docs/references/
   - <code>Ref\<[SignIn](/docs/references/javascript/sign-in/sign-in)></code>
 
   An object that contains the current sign-in attempt status and methods to create a new sign-in attempt.
-</Properties>
-
-### `SetActiveParams`
-
-<Properties>
-  - `session`
-  - <code>[Session](/docs/references/javascript/session) | string | null</code>
-
-  The session resource or session ID (string version) to be set as active. If `null`, the current session is deleted.
-
-  ---
-
-  - `organization`
-  - <code>[Organization](/docs/references/javascript/organization/organization) | string | null</code>
-
-  The organization resource or organization ID/slug (string version) to be set as active in the current session. If `null`, the currently active organization is removed as active.
-
-  ---
-
-  - `beforeEmit?`
-  - `(session?: Session | null) => void | Promise<any>`
-
-  Callback run just before the active session and/or organization is set to the passed object. Can be used to set up for pre-navigation actions.
 </Properties>
 
 ## How to use the `useSignIn()` composable

--- a/docs/references/vue/use-sign-up.mdx
+++ b/docs/references/vue/use-sign-up.mdx
@@ -16,7 +16,7 @@ The `useSignUp()` composable provides access to the [`SignUp`](/docs/references/
   ---
 
   - `setActive()`
-  - <code>Ref\<(params: [SetActiveParams](#set-active-params)) => Promise\<void>></code>
+  - <code>Ref\<(params: [SetActiveParams](/docs/references/javascript/types/set-active-params)) => Promise\<void>></code>
 
   A function that sets the active session.
 
@@ -26,29 +26,6 @@ The `useSignUp()` composable provides access to the [`SignUp`](/docs/references/
   - <code>Ref\<[SignUp](/docs/references/javascript/sign-up/sign-up)></code>
 
   An object that contains the current sign-up attempt status and methods to create a new sign-up attempt.
-</Properties>
-
-### `SetActiveParams`
-
-<Properties>
-  - `session`
-  - <code>[Session](/docs/references/javascript/session) | string | null</code>
-
-  The session resource or session ID (string version) to be set as active. If `null`, the current session is deleted.
-
-  ---
-
-  - `organization`
-  - <code>[Organization](/docs/references/javascript/organization/organization) | string | null</code>
-
-  The organization resource or organization ID/slug (string version) to be set as active in the current session. If `null`, the currently active organization is removed as active.
-
-  ---
-
-  - `beforeEmit?`
-  - `(session?: Session | null) => void | Promise<any>`
-
-  Callback run just before the active session and/or organization is set to the passed object. Can be used to set up for pre-navigation actions.
 </Properties>
 
 ## How to use the `useSignUp()` composable


### PR DESCRIPTION
> [!IMPORTANT]
> 🔎 Previews:
>
> - https://clerk.com/docs/PR/1918

https://linear.app/clerk/issue/DOCS-9619/deprecate-beforeemit-from-setactive-in-favor-of-redirecturl