### PR TITLE
Fix "Clerk components" heading disappearing

### DIFF
--- a/docs/references/expo/overview.mdx
+++ b/docs/references/expo/overview.mdx
@@ -11,7 +11,7 @@ See [the quickstart](/docs/quickstarts/expo) to get started.
 
 The Expo SDK gives you access to the following resources:
 
-### Clerk hooks
+### Clerk hooks {{ id: 'hooks' }}
 
 The following hooks are available for both **native** and **web** apps:
 
@@ -19,7 +19,7 @@ The following hooks are available for both **native** and **web** apps:
 - [`useOAuth()`](/docs/references/expo/use-oauth)
 - [`useLocalCredentials()`](/docs/references/expo/use-local-credentials)
 
-### Clerk components
+### Clerk components {{ id: 'components' }}
 
 - **Native** apps:
   - [`<ClerkLoaded>`](/docs/components/control/clerk-loaded){{ target: '_blank' }}


### PR DESCRIPTION
> [!IMPORTANT]
> 🔎 Previews:
>
> - https://clerk.com/docs/pr/1923/references/expo/overview

### Explanation:

https://clerkinc.slack.com/archives/C05GH6N5LLS/p1737133942872259

### This PR:

Updates the `id` for a couple headings on the Expo overview page because "Clerk components" gets an auto-generated `id` of `clerk-components` and this is interacting with Clerk in some way causing the heading to disappear. I also updated the "Clerk hooks" `id` just for consistency on this page.

### Checklist

- [x] I have clicked on "Files changed" and performed a thorough self-review
- [x] I have added the "deploy-preview" label and added the preview link(s) to this PR description
- [x] All existing checks pass
