### PR TITLE
bug(orgs): remove outdated instruction to set an organization owner

### DIFF
--- a/docs/organizations/overview.mdx
+++ b/docs/organizations/overview.mdx
@@ -91,7 +91,7 @@ To create an organization in the Clerk Dashboard:
 
 1. In the top in the Clerk Dashboard, select [**Organizations**](https://dashboard.clerk.com/last-active?path=organizations).
 1. Select the **Create Organization** button.
-1. Enter the organization's name and slug. The slug is a unique identifier for the organization and is used in URLs. Select the organization's owner from the list of users in your application. The owner is the user who will be the organization's admin.
+1. Enter the organization's name and slug. The slug is a unique identifier for the organization and is used in URLs.
 
 #### Monthly active organization (MAO)
 


### PR DESCRIPTION
## What problem does this solve?

Currently, the docs reference an outdated flow for creating organizations, wherein you need to select an organization owner.

Currently, we don't ask for the organization owner at all. After creating an org, the dashboard user can invite application users with the admin role if they so choose.

## What changed?

This removes that instruction.

## What's next?

We still display an "Owner" field on the organization inspect view, which is always empty if the org was created via the dashboard. See the linear ticket for next steps - the current intention is to change that field to "created by" (as it actually is in the API layer), and set it to something like "An Admin" if it's empty.

## Preview
https://clerk.com/docs/pr/1924/organizations/overview