### PR TITLE
fix typo in fastify/overview.mdx ("Express" --> "Fastify")

### DIFF
--- a/docs/references/fastify/overview.mdx
+++ b/docs/references/fastify/overview.mdx
@@ -3,7 +3,7 @@ title: Clerk Fastify SDK
 description: Learn how to integrate Clerk into your Fastify application using the Clerk Fastify SDK.
 ---
 
-The Clerk Fastify SDK is the recommended method for integrating Clerk into your Express application. Refer to the [quickstart guide](/docs/quickstarts/fastify) to get started.
+The Clerk Fastify SDK is the recommended method for integrating Clerk into your Fastify application. Refer to the [quickstart guide](/docs/quickstarts/fastify) to get started.
 
 ## `clerkPlugin()`
 


### PR DESCRIPTION
> [!IMPORTANT]
> 🔎 Previews:
>
> -

### Explanation:

The Fastify guide incorrectly mentions Express in the intro- this corrects the typo.

### Checklist

- [X] I have clicked on "Files changed" and performed a thorough self-review
- [X] I have added the "deploy-preview" label and added the preview link(s) to this PR description
- [X] All existing checks pass
