### PR TITLE
add info on adding domains to allowed js origins for google one tap

### DIFF
--- a/docs/authentication/social-connections/google.mdx
+++ b/docs/authentication/social-connections/google.mdx
@@ -47,7 +47,6 @@ To make the setup process easier, it's recommended to keep two browser tabs open
   1. Select **Add connection** and select **For all users**.
   1. In the **Choose provider** dropdown, select **Google**.
   1. Ensure that both **Enable for sign-up and sign-in** and **Use custom credentials** are toggled on.
-  1. Under **Authorized JavaScript origins**, select **Add URI** and add your domain (e.g., `https://your-domain.com`). For local development, add `http://localhost:PORT` (replace `PORT` with the port number of your local development server).
   1. Save the **Authorized Redirect URI** somewhere secure. Keep this modal and page open.
 
   ### Create a Google Developer project
@@ -57,6 +56,7 @@ To make the setup process easier, it's recommended to keep two browser tabs open
   1. In the top-left, select the menu icon (**≡**) and select **APIs & Services**. Then, select **Credentials**.
   1. Next to **Credentials**, select **Create Credentials**. Then, select **OAuth client ID.** You might need to [configure your OAuth consent screen](https://support.google.com/cloud/answer/6158849#userconsent). Otherwise, you'll be redirected to the **Create OAuth client ID** page.
   1. Select the appropriate application type for your project. In most cases, it's **Web application**.
+  1. In the **Authorized JavaScript origins** setting, select **Add URI** and add your domain (e.g., `https://your-domain.com` and `https://www.your-domain.com` if you have a `www` version). For local development, add `http://localhost:PORT` (replace `PORT` with the port number of your local development server).
   1. In the **Authorized Redirect URIs** setting, paste the **Authorized Redirect URI** value you saved from the Clerk Dashboard.
   1. Select **Create**. A modal will open with your **Client ID** and **Client Secret**. Save these values somewhere secure.
 

--- a/docs/authentication/social-connections/google.mdx
+++ b/docs/authentication/social-connections/google.mdx
@@ -47,6 +47,7 @@ To make the setup process easier, it's recommended to keep two browser tabs open
   1. Select **Add connection** and select **For all users**.
   1. In the **Choose provider** dropdown, select **Google**.
   1. Ensure that both **Enable for sign-up and sign-in** and **Use custom credentials** are toggled on.
+  1. Under **Authorized JavaScript origins**, select **Add URI** and add your domain (e.g., `https://your-domain.com`). For local development, add `http://localhost:PORT` (replace `PORT` with the port number of your local development server).
   1. Save the **Authorized Redirect URI** somewhere secure. Keep this modal and page open.
 
   ### Create a Google Developer project

--- a/docs/components/authentication/google-one-tap.mdx
+++ b/docs/components/authentication/google-one-tap.mdx
@@ -4,7 +4,10 @@ description: Clerk's <GoogleOneTap /> component renders a UI for authenticating 
 ---
 
 > [!IMPORTANT]
-> To use Google One Tap with Clerk, you must [enable Google as a social connection in the Clerk Dashboard](/docs/authentication/social-connections/google#configuring-google-social-connection) and make sure to use custom credentials.
+> To use Google One Tap with Clerk, you must:
+>
+> 1. [Enable Google as a social connection in the Clerk Dashboard](/docs/authentication/social-connections/google#configuring-google-social-connection) and make sure to use custom credentials.
+> 1. Configure your **Authorized JavaScript origins** in the [Google Cloud Console](https://console.cloud.google.com/apis/credentials) by adding your domain (e.g., `https://your-domain.com`). For local development, add `http://localhost:PORT` (replace `PORT` with the port number of your local development server).
 
 The `<GoogleOneTap />` component renders the [Google One Tap](https://developers.google.com/identity/gsi/web/guides/features) UI so that users can use a single button to sign-up or sign-in to your Clerk application with their Google accounts.
 

--- a/docs/components/authentication/google-one-tap.mdx
+++ b/docs/components/authentication/google-one-tap.mdx
@@ -4,10 +4,7 @@ description: Clerk's <GoogleOneTap /> component renders a UI for authenticating 
 ---
 
 > [!IMPORTANT]
-> To use Google One Tap with Clerk, you must:
->
-> 1. [Enable Google as a social connection in the Clerk Dashboard](/docs/authentication/social-connections/google#configuring-google-social-connection) and make sure to use custom credentials.
-> 1. Configure your **Authorized JavaScript origins** in the [Google Cloud Console](https://console.cloud.google.com/apis/credentials) by adding your domain (e.g., `https://your-domain.com` and `https://www.your-domain.com` if you have a www version). For local development, add both `http://localhost` and `http://localhost:PORT` (replace `PORT` with the port number of your local development server).
+> To use Google One Tap with Clerk, you must [enable Google as a social connection in the Clerk Dashboard](/docs/authentication/social-connections/google#configure-for-your-production-instance) and make sure to use custom credentials.
 
 The `<GoogleOneTap />` component renders the [Google One Tap](https://developers.google.com/identity/gsi/web/guides/features) UI so that users can use a single button to sign-up or sign-in to your Clerk application with their Google accounts.
 

--- a/docs/components/authentication/google-one-tap.mdx
+++ b/docs/components/authentication/google-one-tap.mdx
@@ -7,7 +7,7 @@ description: Clerk's <GoogleOneTap /> component renders a UI for authenticating 
 > To use Google One Tap with Clerk, you must:
 >
 > 1. [Enable Google as a social connection in the Clerk Dashboard](/docs/authentication/social-connections/google#configuring-google-social-connection) and make sure to use custom credentials.
-> 1. Configure your **Authorized JavaScript origins** in the [Google Cloud Console](https://console.cloud.google.com/apis/credentials) by adding your domain (e.g., `https://your-domain.com`). For local development, add `http://localhost:PORT` (replace `PORT` with the port number of your local development server).
+> 1. Configure your **Authorized JavaScript origins** in the [Google Cloud Console](https://console.cloud.google.com/apis/credentials) by adding your domain (e.g., `https://your-domain.com` and `https://www.your-domain.com` if you have a www version). For local development, add both `http://localhost` and `http://localhost:PORT` (replace `PORT` with the port number of your local development server).
 
 The `<GoogleOneTap />` component renders the [Google One Tap](https://developers.google.com/identity/gsi/web/guides/features) UI so that users can use a single button to sign-up or sign-in to your Clerk application with their Google accounts.
 

--- a/docs/custom-flows/google-one-tap.mdx
+++ b/docs/custom-flows/google-one-tap.mdx
@@ -12,7 +12,7 @@ This guide will walk you through how to build a custom Google One Tap authentica
 <Steps>
   ## Enable Google as a social connection
 
-  To use Google One Tap with Clerk, follow the steps in the [dedicated guide](/docs/authentication/social-connections/google#configuring-google-social-connection) to configure Google as a social connection in the Clerk Dashboard using custom credentials.
+  To use Google One Tap with Clerk, follow the steps in the [dedicated guide](/docs/authentication/social-connections/google#configure-for-your-production-instance) to configure Google as a social connection in the Clerk Dashboard using custom credentials.
 
   ## Create the Google One Tap authentication flow
 


### PR DESCRIPTION
**preview**
- docs/components/authentication/google-one-tap
- docs/authentication/social-connections/google

**ticket**: https://linear.app/clerk/issue/DOCS-9766/add-note-to-google-one-tap-about-allowed-js-origins