### PR TITLE
remove /backend-requests/handling/js-backend-sdks

### DIFF
--- a/docs/manifest.json
+++ b/docs/manifest.json
@@ -748,10 +748,6 @@
                     "items": [
                       [
                         {
-                          "title": "JS Backend SDKs",
-                          "href": "/docs/backend-requests/handling/js-backend-sdks"
-                        },
-                        {
                           "title": "Go",
                           "href": "/docs/backend-requests/handling/go",
                           "icon": "go"


### PR DESCRIPTION
A doc was recently removed, but left in the sidenav - this PR removes it from the sidenav.