### PR TITLE
Updated NextJS proxy example to use nextUrl.pathname

### DIFF
--- a/docs/advanced-usage/using-proxies.mdx
+++ b/docs/advanced-usage/using-proxies.mdx
@@ -110,7 +110,7 @@ When using a proxy, all requests to the Frontend API will be made through your d
       import { clerkMiddleware } from '@clerk/nextjs/server'
 
       export default clerkMiddleware((auth, request) => {
-        if (request.url.match('__clerk')) {
+        if (request.nextUrl.pathname.match('__clerk')) {
           const proxyHeaders = new Headers(request.headers)
           proxyHeaders.set('Clerk-Proxy-Url', process.env.NEXT_PUBLIC_CLERK_PROXY_URL || '')
           proxyHeaders.set('Clerk-Secret-Key', process.env.CLERK_SECRET_KEY || '')


### PR DESCRIPTION
### 🔎 Previews:

- https://clerk.com/docs/pr/1945/advanced-usage/using-proxies
- (nextjs tab)

### What does this solve?

The current proxy example for NextJS matches `__clerk` anywhere in the URL which will match search params like `__clerk_ticket` or `__clerk_status` and proxy those requests. 

Developers who use the example scheme we have of `/__clerk` may run into issues. 

### What changed?

Updated the example to use `nextUrl.pathname` as this will exclude search params. 

### Checklist

- [x] I have clicked on "Files changed" and performed a thorough self-review
- [x] I have added the "deploy-preview" label and added the preview link(s) to this PR description
- [x] All existing checks pass
