### PR TITLE
Add `bun` Support to Next.js Quickstart  

### DIFF
--- a/docs/quickstarts/nextjs.mdx
+++ b/docs/quickstarts/nextjs.mdx
@@ -31,7 +31,7 @@ description: Add authentication and user management to your Next.js app with Cle
 
   Run the following command to install the SDK:
 
-  <CodeBlockTabs options={["npm", "yarn", "pnpm"]}>
+  <CodeBlockTabs options={["npm", "yarn", "pnpm", "bun"]}>
     ```bash {{ filename: 'terminal' }}
     npm install @clerk/nextjs
     ```
@@ -42,6 +42,10 @@ description: Add authentication and user management to your Next.js app with Cle
 
     ```bash {{ filename: 'terminal' }}
     pnpm add @clerk/nextjs
+    ```
+
+    ```bash {{ filename: 'terminal' }}
+    bun add @clerk/nextjs
     ```
   </CodeBlockTabs>
 
@@ -161,7 +165,7 @@ description: Add authentication and user management to your Next.js app with Cle
 
   Run your project with the following command:
 
-  <CodeBlockTabs options={["npm", "yarn", "pnpm"]}>
+  <CodeBlockTabs options={["npm", "yarn", "pnpm", "bun"]}>
     ```bash {{ filename: 'terminal' }}
     npm run dev
     ```
@@ -172,6 +176,10 @@ description: Add authentication and user management to your Next.js app with Cle
 
     ```bash {{ filename: 'terminal' }}
     pnpm dev
+    ```
+
+    ```bash {{ filename: 'terminal' }}
+    bun dev
     ```
   </CodeBlockTabs>
 


### PR DESCRIPTION
This PR adds `bun` as an option in the **Next.js** quickstart guide for installing and running Clerk.

**Changes:**
- Added `bun add @clerk/nextjs` to installation commands.
- Added `bun dev` to development commands.

> I believe `bun` should be added across all documentation, but this PR specifically updates the Next.js quickstart guide as a first step.