### PR TITLE
Add `bun` Support to Localization Doc

### DIFF
--- a/docs/customization/localization.mdx
+++ b/docs/customization/localization.mdx
@@ -63,7 +63,7 @@ Clerk currently supports the following languages with English as the default:
 
 To get started, install the `@clerk/localizations` package.
 
-<CodeBlockTabs options={["npm", "yarn", "pnpm"]}>
+<CodeBlockTabs options={["npm", "yarn", "pnpm", "bun"]}>
   ```bash {{ filename: 'terminal' }}
   npm install @clerk/localizations
   ```
@@ -74,6 +74,10 @@ To get started, install the `@clerk/localizations` package.
 
   ```bash {{ filename: 'terminal' }}
   pnpm add @clerk/localizations
+  ```
+
+  ```bash {{ filename: 'terminal' }}
+  bun add @clerk/localizations
   ```
 </CodeBlockTabs>
 


### PR DESCRIPTION
This PR adds `bun` as an option in the localization setup guide for installing `@clerk/localizations`.

**Changes:**
- Added `bun add @clerk/localizations` to installation commands.

> I believe `bun` should be added across all documentation.