### PR TITLE
Fix `<GoogleOneTap />` examples

### DIFF
--- a/docs/components/authentication/google-one-tap.mdx
+++ b/docs/components/authentication/google-one-tap.mdx
@@ -62,15 +62,17 @@ The following example includes basic implementation of the `<GoogleOneTap />` co
 
     export default function RootLayout({ children }: { children: React.ReactNode }) {
       return (
-        <html lang="en">
-          <head>
-            <title>Google One Tap with Clerk and Next.js</title>
-          </head>
-          <ClerkProvider>
-            <GoogleOneTap />
-            <body>{children}</body>
-          </ClerkProvider>
-        </html>
+        <ClerkProvider>
+          <html lang="en">
+            <head>
+              <title>Google One Tap with Clerk and Next.js</title>
+            </head>
+            <body>
+              {children}
+              <GoogleOneTap />
+            </body>
+          </html>
+        </ClerkProvider>
       )
     }
     ```
@@ -87,7 +89,10 @@ The following example includes basic implementation of the `<GoogleOneTap />` co
         <title>Google One Tap with Clerk and Astro</title>
       </head>
 
-      <GoogleOneTap />
+      <body>
+        <slot />
+        <GoogleOneTap />
+      </body>
     </html>
     ```
   </Tab>

--- a/docs/components/authentication/google-one-tap.mdx
+++ b/docs/components/authentication/google-one-tap.mdx
@@ -54,51 +54,49 @@ The following example includes basic implementation of the `<GoogleOneTap />` co
 > [!NOTE]
 > `<GoogleOneTap>` does not render if the user is already signed into your Clerk application, so there's no need to manually check if a user is signed in yourself before rendering it.
 
-<Tabs items={["Next.js", "Astro", "Vue"]}>
+<Tabs items={["Next.js", "Astro", "React", "Remix", "Vue"]}>
   <Tab>
-    ```tsx {{ filename: 'app/layout.tsx', mark: [2, 13] }}
-    import React from 'react'
-    import { ClerkProvider, GoogleOneTap } from '@clerk/nextjs'
+    ```tsx {{ filename: 'app/sign-in/[[...sign-in]]/page.tsx' }}
+    import { GoogleOneTap } from '@clerk/nextjs'
 
-    export default function RootLayout({ children }: { children: React.ReactNode }) {
-      return (
-        <ClerkProvider>
-          <html lang="en">
-            <head>
-              <title>Google One Tap with Clerk and Next.js</title>
-            </head>
-            <body>
-              {children}
-              <GoogleOneTap />
-            </body>
-          </html>
-        </ClerkProvider>
-      )
+    export default function Page() {
+      return <GoogleOneTap />
     }
     ```
   </Tab>
 
   <Tab>
-    ```astro {{ filename: 'layouts/Layout.astro', mark: [2, 12] }}
+    ```astro {{ filename: 'pages/sign-in.astro' }}
     ---
     import { GoogleOneTap } from '@clerk/astro/components'
     ---
 
-    <html lang="en">
-      <head>
-        <title>Google One Tap with Clerk and Astro</title>
-      </head>
-
-      <body>
-        <slot />
-        <GoogleOneTap />
-      </body>
-    </html>
+    <GoogleOneTap />
     ```
   </Tab>
 
   <Tab>
-    ```vue {{ filename: 'App.vue', mark: [2, 6] }}
+    ```jsx {{ filename: '/src/sign-in/[[...index]].tsx' }}
+    import { GoogleOneTap } from '@clerk/clerk-react'
+
+    const SignInPage = () => <GoogleOneTap />
+
+    export default SignInPage
+    ```
+  </Tab>
+
+  <Tab>
+    ```jsx {{ filename: 'app/routes/sign-in/$.tsx' }}
+    import { GoogleOneTap } from '@clerk/remix'
+
+    export default function Page() {
+      return <GoogleOneTap />
+    }
+    ```
+  </Tab>
+
+  <Tab>
+    ```vue {{ filename: 'sign-in.vue' }}
     <script setup lang="ts">
     import { GoogleOneTap } from '@clerk/vue'
     </script>
@@ -115,7 +113,7 @@ The following example includes basic implementation of the `<GoogleOneTap />` co
 The methods in this section are available on instances of the [`Clerk`](/docs/references/javascript/clerk/clerk) class and are used to render and control the `<GoogleOneTap />` component.
 
 > [!NOTE]
-> The examples in this section assume you have completed the [JavaScript quickstart](/docs/quickstarts/javascript) to set up the Clerk JS SDK in your project.
+> The examples in this section assume you have completed the [JavaScript quickstart](/docs/quickstarts/javascript) to set up the ClerkJS SDK in your project.
 
 ### `openGoogleOneTap()`
 

--- a/docs/components/authentication/google-one-tap.mdx
+++ b/docs/components/authentication/google-one-tap.mdx
@@ -76,7 +76,7 @@ The following example includes basic implementation of the `<GoogleOneTap />` co
   </Tab>
 
   <Tab>
-    ```jsx {{ filename: '/src/sign-in/[[...index]].tsx' }}
+    ```jsx {{ filename: 'src/sign-in.tsx' }}
     import { GoogleOneTap } from '@clerk/clerk-react'
 
     const SignInPage = () => <GoogleOneTap />

--- a/docs/components/authentication/google-one-tap.mdx
+++ b/docs/components/authentication/google-one-tap.mdx
@@ -56,7 +56,7 @@ The following example includes basic implementation of the `<GoogleOneTap />` co
 
 <Tabs items={["Next.js", "Astro", "Vue"]}>
   <Tab>
-    ```tsx {{ filename: 'app/layout.tsx', mark: [2, 11] }}
+    ```tsx {{ filename: 'app/layout.tsx', mark: [2, 13] }}
     import React from 'react'
     import { ClerkProvider, GoogleOneTap } from '@clerk/nextjs'
 
@@ -79,7 +79,7 @@ The following example includes basic implementation of the `<GoogleOneTap />` co
   </Tab>
 
   <Tab>
-    ```astro {{ filename: 'layouts/Layout.astro' }}
+    ```astro {{ filename: 'layouts/Layout.astro', mark: [2, 12] }}
     ---
     import { GoogleOneTap } from '@clerk/astro/components'
     ---
@@ -98,7 +98,7 @@ The following example includes basic implementation of the `<GoogleOneTap />` co
   </Tab>
 
   <Tab>
-    ```vue {{ filename: 'App.vue' }}
+    ```vue {{ filename: 'App.vue', mark: [2, 6] }}
     <script setup lang="ts">
     import { GoogleOneTap } from '@clerk/vue'
     </script>

--- a/docs/components/authentication/sign-in.mdx
+++ b/docs/components/authentication/sign-in.mdx
@@ -145,11 +145,7 @@ The following example includes basic implementation of the `<SignIn />` componen
     import { SignIn } from '@clerk/remix'
 
     export default function SignInPage() {
-      return (
-        <div style={{ border: '2px solid blue', padding: '2rem' }}>
-          <SignIn />
-        </div>
-      )
+      return <SignIn />
     }
     ```
   </Tab>

--- a/docs/components/authentication/sign-in.mdx
+++ b/docs/components/authentication/sign-in.mdx
@@ -131,7 +131,7 @@ The following example includes basic implementation of the `<SignIn />` componen
   </Tab>
 
   <Tab>
-    ```jsx {{ filename: '/src/sign-in/[[...index]].tsx' }}
+    ```jsx {{ filename: 'src/sign-in.tsx' }}
     import { SignIn } from '@clerk/clerk-react'
 
     const SignInPage = () => <SignIn />

--- a/docs/components/authentication/sign-up.mdx
+++ b/docs/components/authentication/sign-up.mdx
@@ -117,7 +117,7 @@ The following example includes basic implementation of the `<SignUp />` componen
   </Tab>
 
   <Tab>
-    ```jsx {{ filename: '/src/sign-up/[[...index]].tsx' }}
+    ```jsx {{ filename: 'src/sign-up.tsx' }}
     import { SignUp } from '@clerk/clerk-react'
 
     const SignUpPage = () => <SignUp />

--- a/docs/components/waitlist.mdx
+++ b/docs/components/waitlist.mdx
@@ -70,7 +70,7 @@ The following example includes a basic implementation of the `<Waitlist />` comp
   </Tab>
 
   <Tab>
-    ```jsx {{ filename: '/waitlist.tsx' }}
+    ```jsx {{ filename: 'src/waitlist.tsx' }}
     import { Waitlist } from '@clerk/clerk-react'
 
     export default function WaitlistPage() {


### PR DESCRIPTION
### 🔎 Previews:

- https://clerk.com/docs/pr/1950/components/authentication/google-one-tap#usage-with-frameworks

### What does this solve?

- The `<GoogleOneTap />` component examples are placed incorrectly. The `<GoogleOneTap />` renders a `<div>` element and it can't be a direct child of `<html>`

### What changed?

- Moved component placements inside `<body>`

### Checklist

- [x] I have clicked on "Files changed" and performed a thorough self-review
- [x] I have added the "deploy-preview" label and added the preview link(s) to this PR description
- [x] All existing checks pass
