### PR TITLE
Remove unsafe-inline from style-src for strict dynamic

### DIFF
--- a/docs/security/clerk-csp.mdx
+++ b/docs/security/clerk-csp.mdx
@@ -82,7 +82,7 @@ function applyCsp(request) {
     connect-src 'self' https://{{fapi_url}};
     img-src 'self' https://img.clerk.com;
     worker-src 'self' blob:;
-    style-src 'self' 'unsafe-inline';
+    style-src 'self';
     frame-src 'self' https://challenges.cloudflare.com;
     form-action 'self';
   `


### PR DESCRIPTION
### 🔎 Previews:

-

### What does this solve?

Put in a change that will thread through the nonce to clerk-injected styles with strict dynamic CSPs a few months ago but forgot to update the docs with it, shame on me. 

### Checklist

- [ ] I have clicked on "Files changed" and performed a thorough self-review
- [ ] I have added the "deploy-preview" label and added the preview link(s) to this PR description
- [ ] All existing checks pass
