### PR TITLE
Add script that warns about changes in quickstarts

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
     "lint": "concurrently \"npm:lint:*\"",
     "format": "prettier . --write",
     "lint:check-links": "node ./scripts/check-links.mjs",
-    "lint:formatting": "prettier . --check"
+    "lint:formatting": "prettier . --check",
+    "lint:check-quickstarts": "node ./scripts/check-quickstarts.mjs"
   },
   "devDependencies": {
     "@clerk/testing": "^1.2.18",

--- a/scripts/check-quickstarts.mjs
+++ b/scripts/check-quickstarts.mjs
@@ -1,0 +1,31 @@
+import { execSync } from 'child_process'
+import path from 'path'
+
+const quickstartsDir = './docs/quickstarts'
+
+try {
+  // Check for changes in the quickstarts directory using git status
+  const gitStatus = execSync(`git status --porcelain ${quickstartsDir}`).toString()
+
+  if (gitStatus.length > 0) {
+    console.log('⚠️  Changes found in the following quickstarts:')
+
+    // Split the status output into lines and format them
+    gitStatus
+      .split('\n')
+      .filter((line) => line.trim())
+      .forEach((line) => {
+        const [, filePath] = line.trim().split(/\s+/)
+        console.log(`- ${path.relative(quickstartsDir, filePath)}`)
+      })
+
+    console.log('⚠️  Please update the corresponding quickstart in the Dashboard')
+    process.exit(0)
+  }
+
+  console.log('✅ No changes detected in quickstarts directory')
+  process.exit(0)
+} catch (error) {
+  console.error(`Error checking directory: ${error.message}`)
+  process.exit(1)
+}


### PR DESCRIPTION
If there are changes to a `/quickstarts/**.mdx` file, we need the linter to check and warn the Docs Team that they need to reflect those changes in the corresponding quickstart in the Dashboard