### PR TITLE
Create GH action for warning about quickstart changes

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -7,7 +7,30 @@ on:
 jobs:
   trigger_lint:
     runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
     steps:
-      - uses: actions/checkout@v3
-      - run: npm i
-      - run: npm run lint
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Run lint
+        id: lint
+        run: |
+          npm i
+          npm run lint
+          # Capture the output of the quickstart check script
+          # and store it in a Github Actions output file
+          # to be used in the next step's conditional
+          echo "quickstart_changes=$(node scripts/check-quickstarts.mjs | grep -c '⚠️  Please update the corresponding quickstarts in the Dashboard' || true)" >> $GITHUB_OUTPUT
+
+      - name: Share lint results
+        if: steps.lint.outputs.quickstart_changes > 0
+        uses: actions/github-script@v7
+        with:
+          script: |
+            github.rest.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: '⚠️  Please update the corresponding quickstarts in the Dashboard',
+            })

--- a/scripts/check-quickstarts.mjs
+++ b/scripts/check-quickstarts.mjs
@@ -4,22 +4,37 @@ import path from 'path'
 const quickstartsDir = './docs/quickstarts'
 
 try {
-  // Check for changes in the quickstarts directory using git status
-  const gitStatus = execSync(`git status --porcelain ${quickstartsDir}`).toString()
+  let changedFiles = ''
 
-  if (gitStatus.length > 0) {
+  // Check if we're in a PR
+  if (process.env.GITHUB_BASE_REF) {
+    // Get names of files that have changed
+    changedFiles = execSync(
+      `git diff --name-only origin/${process.env.GITHUB_BASE_REF}...HEAD ${quickstartsDir}`,
+    ).toString()
+  } else {
+    // If we aren't in a PR (dev env), check working directory changes
+    changedFiles = execSync(`git status --porcelain ${quickstartsDir}`).toString()
+  }
+
+  if (changedFiles.length > 0) {
     console.log('⚠️  Changes found in the following quickstarts:')
 
-    // Split the status output into lines and format them
-    gitStatus
+    // Split the output into lines and format them
+    changedFiles
       .split('\n')
       .filter((line) => line.trim())
       .forEach((line) => {
-        const [, filePath] = line.trim().split(/\s+/)
-        console.log(`- ${path.relative(quickstartsDir, filePath)}`)
+        // For PR diff, the line is just the filepath
+        // For local status, we need to extract the filepath from the status line
+        const filePath = process.env.GITHUB_BASE_REF ? line : line.trim().split(/\s+/)[1]
+
+        if (filePath) {
+          console.log(`- ${path.relative(quickstartsDir, filePath)}`)
+        }
       })
 
-    console.log('⚠️  Please update the corresponding quickstart in the Dashboard')
+    console.log('⚠️  Please update the corresponding quickstarts in the Dashboard')
     process.exit(0)
   }
 


### PR DESCRIPTION
Related to https://github.com/clerk/clerk-docs/pull/1952
We have a script that warns us in development if changes have been made to a quickstart.
This PR updates the script to also check for those changes in the GH PR, not just in local dev.
This PR also updates our lint GH action to post a comment if changes have been made to a quickstart, to remind contributors to also update the Dashboard for the corresponding quickstarts.