### PR TITLE
Create GH action for warning about quickstart changes

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -16,8 +16,7 @@ jobs:
   check_quickstarts:
     runs-on: ubuntu-latest
     outputs:
-      needs_update: ${{ steps.check.outputs.needs_update }}
-      changed_files: ${{ steps.check.outputs.changed_files }}
+      output: ${{ steps.check.outputs.output }}
     steps:
       - uses: actions/checkout@v3
         with:
@@ -30,28 +29,22 @@ jobs:
       - id: check
         run: |
           OUTPUT=$(npm run lint:check-quickstarts)
-          echo "Output from check-quickstarts: $OUTPUT"
-          echo "changed_files<<EOF" >> $GITHUB_OUTPUT
+          # We need this specific syntax because the output has multiple lines
+          echo "output<<EOF" >> $GITHUB_OUTPUT
           echo "$OUTPUT" >> $GITHUB_OUTPUT
           echo "EOF" >> $GITHUB_OUTPUT
-          if [[ "$OUTPUT" == *"Please update the corresponding quickstarts in the Dashboard"* ]]; then
-            echo "needs_update=true" >> $GITHUB_OUTPUT
-          else
-            echo "needs_update=false" >> $GITHUB_OUTPUT
-          fi
 
   share_quickstart_changes:
     needs: check_quickstarts
-    if: needs.check_quickstarts.outputs.needs_update == 'true'
+    if: contains(needs.check_quickstarts.outputs.output, 'Please update the corresponding quickstarts in the Dashboard')
     runs-on: ubuntu-latest
     steps:
       - uses: actions/github-script@v7
         with:
           script: |
-            const changedFiles = `${{ needs.check_quickstarts.outputs.changed_files }}`;
             github.rest.issues.createComment({
               issue_number: context.issue.number,
               owner: context.repo.owner,
               repo: context.repo.repo,
-              body: '⚠️  Please update the corresponding quickstarts in the Dashboard\n\nChanged files:\n```\n' + changedFiles + '\n```'
+              body: `${{ needs.check_quickstarts.outputs.output }}`
             })

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -17,6 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       needs_update: ${{ steps.check.outputs.needs_update }}
+      changed_files: ${{ steps.check.outputs.changed_files }}
     steps:
       - uses: actions/checkout@v3
         with:
@@ -30,6 +31,9 @@ jobs:
         run: |
           OUTPUT=$(npm run lint:check-quickstarts)
           echo "Output from check-quickstarts: $OUTPUT"
+          echo "changed_files<<EOF" >> $GITHUB_OUTPUT
+          echo "$OUTPUT" >> $GITHUB_OUTPUT
+          echo "EOF" >> $GITHUB_OUTPUT
           if [[ "$OUTPUT" == *"Please update the corresponding quickstarts in the Dashboard"* ]]; then
             echo "needs_update=true" >> $GITHUB_OUTPUT
           else
@@ -44,9 +48,10 @@ jobs:
       - uses: actions/github-script@v7
         with:
           script: |
+            const changedFiles = `${{ needs.check_quickstarts.outputs.changed_files }}`;
             github.rest.issues.createComment({
               issue_number: context.issue.number,
               owner: context.repo.owner,
               repo: context.repo.repo,
-              body: '⚠️  Please update the corresponding quickstarts in the Dashboard',
+              body: '⚠️  Please update the corresponding quickstarts in the Dashboard\n\nChanged files:\n```\n' + changedFiles + '\n```'
             })

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -10,7 +10,8 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - run: npm i
-      - run: npm run lint -- --ignore-pattern "**/check-quickstarts.mjs"
+      - run: npm run lint:formatting
+      - run: npm run lint:check-links
 
   check_quickstarts:
     runs-on: ubuntu-latest

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -22,8 +22,8 @@ jobs:
           fetch-depth: 0
       - run: |
           git fetch origin ${{ github.base_ref }}
-          git checkout -b pr
-          git reset --soft origin/${{ github.base_ref }}
+          git checkout ${{ github.base_ref }}
+          git checkout ${{ github.sha }}
       - run: npm i
       - id: check
         run: |

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -27,7 +27,7 @@ jobs:
       - run: npm i
       - id: check
         run: |
-          OUTPUT=$(npm run check-quickstarts)
+          OUTPUT=$(npm run lint:check-quickstarts)
           if [ "$OUTPUT" = "⚠️  Please update the corresponding quickstarts in the Dashboard" ]; then
             echo "needs_update=true" >> $GITHUB_OUTPUT
           else

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -29,7 +29,8 @@ jobs:
       - id: check
         run: |
           OUTPUT=$(npm run lint:check-quickstarts)
-          if [ "$OUTPUT" = "⚠️  Please update the corresponding quickstarts in the Dashboard" ]; then
+          echo "Output from check-quickstarts: $OUTPUT"
+          if [[ "$OUTPUT" == *"Please update the corresponding quickstarts in the Dashboard"* ]]; then
             echo "needs_update=true" >> $GITHUB_OUTPUT
           else
             echo "needs_update=false" >> $GITHUB_OUTPUT

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -5,9 +5,22 @@ on:
     branches: [main]
 
 jobs:
-  trigger_lint:
+  lint:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
       - run: npm i
-      - run: npm run lint
+      - run: npm run lint -- --ignore-pattern "**/check-quickstarts.mjs"
+
+  check_quickstarts:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - run: |
+          git fetch origin ${{ github.base_ref }}
+          git checkout -b pr
+          git reset --soft origin/${{ github.base_ref }}
+      - run: npm i
+      - run: npm run check-quickstarts

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -28,7 +28,7 @@ jobs:
       - run: npm i
       - id: check
         run: |
-          OUTPUT=$(npm run lint:check-quickstarts)
+          OUTPUT=$(npm run lint:check-quickstarts | tail -n +4)
           # We need this specific syntax because the output has multiple lines
           echo "output<<EOF" >> $GITHUB_OUTPUT
           echo "$OUTPUT" >> $GITHUB_OUTPUT

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -14,6 +14,8 @@ jobs:
 
   check_quickstarts:
     runs-on: ubuntu-latest
+    outputs:
+      needs_update: ${{ steps.check.outputs.needs_update }}
     steps:
       - uses: actions/checkout@v3
         with:
@@ -23,4 +25,26 @@ jobs:
           git checkout -b pr
           git reset --soft origin/${{ github.base_ref }}
       - run: npm i
-      - run: npm run check-quickstarts
+      - id: check
+        run: |
+          OUTPUT=$(npm run check-quickstarts)
+          if [ "$OUTPUT" = "⚠️  Please update the corresponding quickstarts in the Dashboard" ]; then
+            echo "needs_update=true" >> $GITHUB_OUTPUT
+          else
+            echo "needs_update=false" >> $GITHUB_OUTPUT
+          fi
+
+  share_quickstart_changes:
+    needs: check_quickstarts
+    if: needs.check_quickstarts.outputs.needs_update == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/github-script@v7
+        with:
+          script: |
+            github.rest.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: '⚠️  Please update the corresponding quickstarts in the Dashboard',
+            })

--- a/docs/quickstarts/astro.mdx
+++ b/docs/quickstarts/astro.mdx
@@ -35,6 +35,8 @@ description: Add authentication and user management to your Astro app with Clerk
 
   Clerk's [Astro SDK](/docs/references/astro/overview) provides a set of components, hooks, and stores that make it easy to build authentication and user management features in your Astro app.
 
+  Test
+
   Run the following command to install the SDK:
 
   <CodeBlockTabs options={["npm", "yarn", "pnpm"]}>

--- a/docs/quickstarts/astro.mdx
+++ b/docs/quickstarts/astro.mdx
@@ -35,8 +35,6 @@ description: Add authentication and user management to your Astro app with Clerk
 
   Clerk's [Astro SDK](/docs/references/astro/overview) provides a set of components, hooks, and stores that make it easy to build authentication and user management features in your Astro app.
 
-  Test
-
   Run the following command to install the SDK:
 
   <CodeBlockTabs options={["npm", "yarn", "pnpm"]}>

--- a/scripts/check-quickstarts.mjs
+++ b/scripts/check-quickstarts.mjs
@@ -32,6 +32,8 @@ try {
         }
       })
 
+    // Keep empty string to make the output more readable in the GH Actions comment
+    console.log('')
     console.log('⚠️  Please update the corresponding quickstarts in the Dashboard')
     process.exit(0)
   }

--- a/scripts/check-quickstarts.mjs
+++ b/scripts/check-quickstarts.mjs
@@ -4,22 +4,35 @@ import path from 'path'
 const quickstartsDir = './docs/quickstarts'
 
 try {
-  // Check for changes in the quickstarts directory using git status
-  const gitStatus = execSync(`git status --porcelain ${quickstartsDir}`).toString()
+  let changedFiles = ''
 
-  if (gitStatus.length > 0) {
+  // Check if we're in a PR
+  if (process.env.GITHUB_BASE_REF) {
+    // Get names of files that have changed
+    changedFiles = execSync(
+      `git diff --name-only origin/${process.env.GITHUB_BASE_REF}...HEAD ${quickstartsDir}`,
+    ).toString()
+  } else {
+    // If we aren't in a PR (dev env), check working directory changes
+    changedFiles = execSync(`git status --porcelain ${quickstartsDir}`).toString()
+  }
+  if (changedFiles.length > 0) {
     console.log('⚠️  Changes found in the following quickstarts:')
 
-    // Split the status output into lines and format them
-    gitStatus
+    // Split the output into lines and format them
+    changedFiles
       .split('\n')
       .filter((line) => line.trim())
       .forEach((line) => {
-        const [, filePath] = line.trim().split(/\s+/)
-        console.log(`- ${path.relative(quickstartsDir, filePath)}`)
+        // For PR diff, the line is just the filepath
+        // For local status, we need to extract the filepath from the status line
+        const filePath = process.env.GITHUB_BASE_REF ? line : line.trim().split(/\s+/)[1]
+        if (filePath) {
+          console.log(`- ${path.relative(quickstartsDir, filePath)}`)
+        }
       })
 
-    console.log('⚠️  Please update the corresponding quickstart in the Dashboard')
+    console.log('⚠️  Please update the corresponding quickstarts in the Dashboard')
     process.exit(0)
   }
 


### PR DESCRIPTION
Related to https://github.com/clerk/clerk-docs/pull/1952
We have a script that warns us in development if changes have been made to a quickstart.
This PR updates the script to also check for those changes in the GH PR, not just in local dev.
This PR also updates our lint GH action to post a comment if changes have been made to a quickstart, to remind contributors to also update the Dashboard for the corresponding quickstarts.