### PR TITLE
fix incorrect indentations in tables

### DIFF
--- a/docs/components/control/authenticate-with-callback.mdx
+++ b/docs/components/control/authenticate-with-callback.mdx
@@ -13,14 +13,14 @@ This component automatically handles the OAuth callback, completing the authenti
   - `signInUrl?`
   - `string`
 
-  Full URL or path where the SignIn component is mounted.
+  The full URL or path where the `<SignIn />` component is mounted.
 
   ---
 
   - `signUpUrl?`
   - `string`
 
-  Full URL or path where the SignUp component is mounted.
+  The full URL or path where the `<SignUp />` component is mounted.
 
   ---
 
@@ -55,42 +55,42 @@ This component automatically handles the OAuth callback, completing the authenti
   - `firstFactorUrl`
   - `string | undefined`
 
-  Full URL or path to navigate during sign in, if identifier verification is required.
+  The full URL or path to navigate to during sign in, if first factor verification is required.
 
   ---
 
   - `secondFactorUrl`
   - `string | undefined`
 
-  Full URL or path to navigate during sign in, if 2FA is enabled.
+  The full URL or path to navigate to during sign in, if [multi-factor authentication](/docs/authentication/configuration/sign-up-sign-in-options#multi-factor-authentication) is enabled.
 
   ---
 
   - `resetPasswordUrl`
   - `string`
 
-  Full URL or path to navigate during sign in, if the user is required to reset their password.
+  The full URL or path to navigate to during sign in, if the user is required to reset their password.
 
   ---
 
   - `continueSignUpUrl`
   - `string | undefined | null`
 
-  Full URL or path to navigate after an incomplete sign up.
+  The full URL or path to navigate to if the sign up requires additional information.
 
   ---
 
   - `verifyEmailAddressUrl`
   - `string | undefined | null`
 
-  Full URL or path to navigate after requesting email verification.
+  The full URL or path to navigate to after requesting email verification.
 
   ---
 
   - `verifyPhoneNumberUrl`
   - `string | undefined | null`
 
-  Full URL or path to navigate after requesting phone verification.
+  The full URL or path to navigate to after requesting phone verification.
 </Properties>
 
 ## Usage

--- a/docs/references/react/use-auth.mdx
+++ b/docs/references/react/use-auth.mdx
@@ -11,7 +11,7 @@ The `useAuth()` hook provides access to the current user's authentication state 
   - `isLoaded`
   - `boolean`
 
-    A boolean that indicates whether Clerk has completed initialization. Initially `false`, becomes `true` once Clerk loads.
+  A boolean that indicates whether Clerk has completed initialization. Initially `false`, becomes `true` once Clerk loads.
 
   ---
 

--- a/docs/references/react/use-organization-list.mdx
+++ b/docs/references/react/use-organization-list.mdx
@@ -84,7 +84,7 @@ type OrganizationSuggestionStatus = 'pending' | 'accepted'
   - `isLoaded`
   - `boolean`
 
-    A boolean that indicates whether Clerk has completed initialization. Initially `false`, becomes `true` once Clerk loads.
+  A boolean that indicates whether Clerk has completed initialization. Initially `false`, becomes `true` once Clerk loads.
 
   ---
 

--- a/docs/references/react/use-organization.mdx
+++ b/docs/references/react/use-organization.mdx
@@ -110,7 +110,7 @@ type OrganizationEnrollmentMode =
   - `isLoaded`
   - `boolean`
 
-    A boolean that indicates whether Clerk has completed initialization. Initially `false`, becomes `true` once Clerk loads.
+  A boolean that indicates whether Clerk has completed initialization. Initially `false`, becomes `true` once Clerk loads.
 
   ---
 

--- a/docs/references/react/use-session-list.mdx
+++ b/docs/references/react/use-session-list.mdx
@@ -11,7 +11,7 @@ The `useSessionList()` hook returns an array of [`Session`](/docs/references/jav
   - `isLoaded`
   - `boolean`
 
-    A boolean that indicates whether Clerk has completed initialization. Initially `false`, becomes `true` once Clerk loads.
+  A boolean that indicates whether Clerk has completed initialization. Initially `false`, becomes `true` once Clerk loads.
 
   ---
 

--- a/docs/references/react/use-session.mdx
+++ b/docs/references/react/use-session.mdx
@@ -11,7 +11,7 @@ The `useSession()` hook provides access to the current user's [`Session`](/docs/
   - `isLoaded`
   - `boolean`
 
-    A boolean that indicates whether Clerk has completed initialization. Initially `false`, becomes `true` once Clerk loads.
+  A boolean that indicates whether Clerk has completed initialization. Initially `false`, becomes `true` once Clerk loads.
 
   ---
 

--- a/docs/references/react/use-sign-in.mdx
+++ b/docs/references/react/use-sign-in.mdx
@@ -11,7 +11,7 @@ The `useSignIn()` hook provides access to the [`SignIn`](/docs/references/javasc
   - `isLoaded`
   - `boolean`
 
-    A boolean that indicates whether Clerk has completed initialization. Initially `false`, becomes `true` once Clerk loads.
+  A boolean that indicates whether Clerk has completed initialization. Initially `false`, becomes `true` once Clerk loads.
 
   ---
 

--- a/docs/references/react/use-sign-up.mdx
+++ b/docs/references/react/use-sign-up.mdx
@@ -11,7 +11,7 @@ The `useSignUp()` hook provides access to the [`SignUp`](/docs/references/javasc
   - `isLoaded`
   - `boolean`
 
-    A boolean that indicates whether Clerk has completed initialization. Initially `false`, becomes `true` once Clerk loads.
+  A boolean that indicates whether Clerk has completed initialization. Initially `false`, becomes `true` once Clerk loads.
 
   ---
 

--- a/docs/references/react/use-user.mdx
+++ b/docs/references/react/use-user.mdx
@@ -11,7 +11,7 @@ The `useUser()` hook provides access to the current user's [`User`](/docs/refere
   - `isLoaded`
   - `boolean`
 
-    A boolean that indicates whether Clerk has completed initialization. Initially `false`, becomes `true` once Clerk loads.
+  A boolean that indicates whether Clerk has completed initialization. Initially `false`, becomes `true` once Clerk loads.
 
   ---
 

--- a/docs/references/vue/use-user.mdx
+++ b/docs/references/vue/use-user.mdx
@@ -25,7 +25,7 @@ The `useUser()` composable provides access to the current user's [`User`](/docs/
   - `isSignedIn`
   - `Ref<boolean>`
 
-    Indicates whether a user is currently signed in.
+  Indicates whether a user is currently signed in.
 </Properties>
 
 ## How to use the `useUser()` composable


### PR DESCRIPTION
### 🔎 Previews:

- https://clerk.com/docs/pr/1958/references/react/use-auth

### What does this solve?

I noticed on https://clerk.com/docs/references/react/use-auth that the description for `isLoaded` was missing. I figured the wrong indentation caused that.

Update (Alexis): found a few more in other tables.

### What changed?

- <!--- How does this PR solve the problem? -->

### Checklist

- [x] I have clicked on "Files changed" and performed a thorough self-review
- [x] I have added the "deploy-preview" label and added the preview link(s) to this PR description
- [x] All existing checks pass
