### PR TITLE
Correct the redirectUrl for the Enterprise SSO custom flow.

### DIFF
--- a/docs/custom-flows/enterprise-connections.mdx
+++ b/docs/custom-flows/enterprise-connections.mdx
@@ -45,7 +45,7 @@ The following example shows two files:
             .authenticateWithRedirect({
               identifier: email,
               strategy: 'enterprise_sso',
-              redirectUrl: '/sso-callback',
+              redirectUrl: '/sign-up/sso-callback',
               redirectUrlComplete: '/',
             })
             .then((res) => {
@@ -111,7 +111,7 @@ The following example demonstrates how to handle these cases in your sign-in flo
           .authenticateWithRedirect({
             identifier: email,
             strategy: 'enterprise_sso',
-            redirectUrl: '/sso-callback',
+            redirectUrl: '/sign-up/sso-callback',
             redirectUrlComplete: '/',
           })
           .then((res) => {


### PR DESCRIPTION
### 🔎 Previews:

- https://clerk.com/docs/pr/1960/custom-flows/enterprise-connections

### What does this solve?

- Tried to create a custom enterprise sso flow today with the example and the redirect back to /sso-callback resulted in a 404 because the walkthrough has the sso callback page at /sign-up/sso-callback.

### What changed?

- I updated the redirectUrl to be /sign-up/sso-callback which is consistent with our custom OAuth flow doc.

### Checklist

- [X] I have clicked on "Files changed" and performed a thorough self-review
- [X] I have added the "deploy-preview" label and added the preview link(s) to this PR description
- [X] All existing checks pass
