### PR TITLE
Update C# icon in nav

### DIFF
--- a/docs/manifest.json
+++ b/docs/manifest.json
@@ -2383,7 +2383,7 @@
             },
             {
               "title": "C#",
-              "icon": "csharp",
+              "icon": "c-sharp",
               "href": "https://github.com/clerk/clerk-sdk-csharp/blob/main/README.md",
               "target": "_blank"
             },


### PR DESCRIPTION
### 🔎 Previews:

- https://clerk.com/docs/pr/1961

### What does this solve?

- The C# icon in the nav is outdated

### What changed?

- Use the `c-sharp` icon which is up to date, instead of the `csharp` icon which is outdated

✨ Please see clerk/clerk#969 for the preview

### Checklist

- [x] I have clicked on "Files changed" and performed a thorough self-review
- [x] I have added the "deploy-preview" label and added the preview link(s) to this PR description
- [x] All existing checks pass
