### PR TITLE
Fix incorrect method syntax in Clerk Middleware for Nextjs

### DIFF
--- a/docs/references/nextjs/clerk-middleware.mdx
+++ b/docs/references/nextjs/clerk-middleware.mdx
@@ -54,17 +54,17 @@ You can protect routes based on a user's authentication status by checking if th
 
 There are two methods that you can use:
 
-- Use [`auth.protect()`](/docs/references/nextjs/auth#protect) if you want to redirect unauthenticated users to the sign-in route automatically.
+- Use [`auth().protect()`](/docs/references/nextjs/auth#protect) if you want to redirect unauthenticated users to the sign-in route automatically.
 - Use [`auth().userId`](/docs/references/nextjs/auth#retrieving-user-id) if you want more control over what your app does based on user authentication status.
 
-<CodeBlockTabs options={["auth.protect()", "auth().userId()"]}>
+<CodeBlockTabs options={["auth().protect()", "auth().userId()"]}>
   ```tsx {{ filename: 'middleware.ts' }}
   import { clerkMiddleware, createRouteMatcher } from '@clerk/nextjs/server'
 
   const isProtectedRoute = createRouteMatcher(['/dashboard(.*)', '/forum(.*)'])
 
   export default clerkMiddleware(async (auth, req) => {
-    if (isProtectedRoute(req)) await auth.protect()
+    if (isProtectedRoute(req)) await auth().protect()
   })
 
   export const config = {
@@ -109,10 +109,10 @@ You can protect routes based on a user's authorization status by checking if the
 
 There are two methods that you can use:
 
-- Use [`auth.protect()`](/docs/references/nextjs/auth#protect) if you want Clerk to return a `404` if the user does not have the role or permission.
+- Use [`auth().protect()`](/docs/references/nextjs/auth#protect) if you want Clerk to return a `404` if the user does not have the role or permission.
 - Use [`auth().has()`](/docs/references/backend/types/auth-object#has) if you want more control over what your app does based on the authorization status.
 
-<Tabs items={["auth.protect()", "auth().has()"]}>
+<Tabs items={["auth().protect()", "auth().has()"]}>
   <Tab>
     ```tsx {{ filename: 'middleware.ts' }}
     import { clerkMiddleware, createRouteMatcher } from '@clerk/nextjs/server'
@@ -122,7 +122,7 @@ There are two methods that you can use:
     export default clerkMiddleware(async (auth, req) => {
       // Restrict admin routes to users with specific permissions
       if (isProtectedRoute(req)) {
-        await auth.protect((has) => {
+        await auth().protect((has) => {
           return has({ permission: 'org:admin:example1' }) || has({ permission: 'org:admin:example2' })
         })
       }
@@ -188,12 +188,12 @@ const isTenantAdminRoute = createRouteMatcher(['/orgId/(.*)/memberships', '/orgI
 export default clerkMiddleware(async (auth, req) => {
   // Restrict admin routes to users with specific permissions
   if (isTenantAdminRoute(req)) {
-    await auth.protect((has) => {
+    await auth().protect((has) => {
       return has({ permission: 'org:admin:example1' }) || has({ permission: 'org:admin:example2' })
     })
   }
   // Restrict organization routes to signed in users
-  if (isTenantRoute(req)) await auth.protect()
+  if (isTenantRoute(req)) await auth().protect()
 })
 
 export const config = {
@@ -217,7 +217,7 @@ const isPublicRoute = createRouteMatcher(['/sign-in(.*)', '/sign-up(.*)'])
 
 export default clerkMiddleware(async (auth, request) => {
   if (!isPublicRoute(request)) {
-    await auth.protect()
+    await auth().protect()
   }
 })
 
@@ -276,7 +276,7 @@ const intlMiddleware = createMiddleware({
 const isProtectedRoute = createRouteMatcher(['dashboard/(.*)'])
 
 export default clerkMiddleware(async (auth, req) => {
-  if (isProtectedRoute(req)) await auth.protect()
+  if (isProtectedRoute(req)) await auth().protect()
 
   return intlMiddleware(req)
 })


### PR DESCRIPTION
Updated the authentication middleware example to use `auth().protect()` instead of `auth.protect()`, as per the correct method syntax. This ensures consistency with the expected API usage and prevents potential implementation errors.

### 🔎 Previews:
You can preview the github intellisense for reference
![Screenshot 2025-01-30 182739](https://github.com/user-attachments/assets/ce12ca7a-2e35-4ddc-8f89-bc3ef83e2a2d)

-

### What does this solve?

This update corrects the syntax to auth().protect(), ensuring accuracy and preventing confusion for developers using the middleware.

- <!--- Describe your changes in detail. Why does this change need to happen? Include any links to Slack discussions, Linear comments, etc. -->
The authentication middleware documentation previously referenced auth.protect(), which is incorrect and that caused errors. But as I change the auth.protect() to auth().protect(), it works well for me. And I think, this change aligns the documentation with the expected API usage.

### What changed?
Updated instances of auth.protect() to auth().protect() in the documentation.
- <!--- How does this PR solve the problem? -->

### Checklist

- [ ✔️] I have clicked on "Files changed" and performed a thorough self-review
- [✔️ ] I have added the "deploy-preview" label and added the preview link(s) to this PR description
- [ ✔️] All existing checks pass
