### PR TITLE
fix: remove useCallback from Expo quickstart

### DIFF
--- a/docs/quickstarts/expo.mdx
+++ b/docs/quickstarts/expo.mdx
@@ -363,7 +363,7 @@ description: Add authentication and user management to your Expo app with Clerk.
     const [password, setPassword] = React.useState('')
 
     // Handle the submission of the sign-in form
-    const onSignInPress = React.useCallback(async () => {
+    const onSignInPress = async () => {
       if (!isLoaded) return
 
       // Start the sign-in process using the email and password provided
@@ -388,7 +388,7 @@ description: Add authentication and user management to your Expo app with Clerk.
         // for more info on error handling
         console.error(JSON.stringify(err, null, 2))
       }
-    }, [isLoaded, signIn, emailAddress, password, setActive, router])
+    }
 
     return (
       <View>

--- a/docs/quickstarts/expo.mdx
+++ b/docs/quickstarts/expo.mdx
@@ -388,7 +388,7 @@ description: Add authentication and user management to your Expo app with Clerk.
         // for more info on error handling
         console.error(JSON.stringify(err, null, 2))
       }
-    }, [isLoaded, emailAddress, password])
+    }, [isLoaded, signIn, emailAddress, password, setActive, router])
 
     return (
       <View>


### PR DESCRIPTION
### 🔎 Previews:

-

### What does this solve?

- Make docs more user-friendly and prevent issues caused by incorrect memoization when copying and pasting code.

### What changed?

- add missing dependencies for useCallback on expo quick-start

### Docs review update:

- we can remove the useCallback() altogether!

### Checklist

- [x] I have clicked on "Files changed" and performed a thorough self-review
- [ ] I have added the "deploy-preview" label and added the preview link(s) to this PR description
- [ ] All existing checks pass
