### PR TITLE
Fix dashboard link in ClerkProvider partial

### DIFF
--- a/docs/_partials/clerk-provider/properties.mdx
+++ b/docs/_partials/clerk-provider/properties.mdx
@@ -102,7 +102,7 @@
   - `publishableKey`
   - `string`
 
-  The Clerk Publishable Key for your instance. This can be found on the [**API keys**](https://dashboard.clerk.com/last-activepath=api-keys) page in the Clerk Dashboard.
+  The Clerk Publishable Key for your instance. This can be found on the [**API keys**](https://dashboard.clerk.com/last-active?path=api-keys) page in the Clerk Dashboard.
 
   ---
 


### PR DESCRIPTION
### What does this solve?

- Broken link in `docs/_partials/clerk-provider/properties.mdx`

### What changed?

```diff
- /last-activepath=api-keys
+ /last-active?path=api-keys
```

### Checklist

- [x] I have clicked on "Files changed" and performed a thorough self-review
- [x] I have added the "deploy-preview" label and added the preview link(s) to this PR description
- [x] All existing checks pass
