### PR TITLE
feat: Clerk as an OpenID Connect provider

### DIFF
--- a/docs/advanced-usage/clerk-idp.mdx
+++ b/docs/advanced-usage/clerk-idp.mdx
@@ -1,20 +1,20 @@
 ---
-title: Clerk as an Identity provider: OAuth 2.0 & OpenID Connect
-description: Learn how to use Clerk to facilitate Single Sign-On (SSO) with other clients that support the OAuth 2.0 and OpenID Connect protocol.
+title: 'Clerk as an Identity Provider: OAuth 2.0 & OpenID Connect'
+description: Learn how to use Clerk as an Identity Provider to facilitate Single Sign-On (SSO) with other clients that support the OAuth 2.0 and OpenID Connect protocol.
 ---
 
 > [!WARNING]
 > **This feature is not designed for handling authentication directly in your application.** To handle authentication _in your_ application, you can [configure one of the many social providers that Clerk offers](/docs/authentication/social-connections/oauth#configuration), such as Google.
 
-Clerk can be configured as an OAuth 2.0 and OpenID Connect provider to facilitate Single Sign-On (SSO) with other clients that support the protocols. This feature allows users to authenticate to other applications using their Clerk credentials, enabling user information sharing between your Clerk application and OAuth clients.
+Clerk can be configured as an OAuth 2.0 and OpenID Connect (OIDC) provider to facilitate Single Sign-On (SSO) with other clients that support the protocols. This feature allows users to authenticate to other applications using their Clerk credentials, enabling user information sharing between your Clerk application and OAuth clients.
 
-## When should you use Clerk as an Identity provider?
+## When should you use Clerk as an Identity Provider?
 
-You can use Clerk as an Identity provider if you want your users to authenticate to a third party site or a tool using their credentials from your application. **This is not the same as supporting an OAuth provider, such as Google, in your application. If you want your users to be able to sign in to your application with an OAuth provider, see the [dedicated guide](/docs/authentication/social-connections/oauth).**
+You can use Clerk as an Identity Provider (IdP) if you want your users to authenticate to a third party site or a tool using their credentials from your application. **This is not the same as supporting an OAuth provider, such as Google, in your application. If you want your users to be able to sign in to your application with an OAuth provider, see the [dedicated guide](/docs/authentication/social-connections/oauth).**
 
 ## How it works
 
-Clerk is the OAuth 2.0 and OpenID Connect provider for your application. The "client" is the third party site or tool that you want your users to authenticate to.
+Clerk is the OAuth 2.0 and OIDC provider for your application. The "client" is the third party site or tool that you want your users to authenticate to.
 
 In order to make your Clerk instance operate as a provider, create an OAuth application in the Clerk Dashboard. Then, configure the client to work with your Clerk instance, using the necessary data from your Clerk OAuth application.
 
@@ -25,9 +25,9 @@ To create an OAuth application,
 1. In the Clerk Dashboard, navigate to the [**OAuth Applications**](https://dashboard.clerk.com/last-active?path=user-authentication/oauth-applications) page.
 1. Select the **Add OAuth application** button. A modal will open.
 1. Complete the following fields:
-   - `Name` - Helps you to identify your application.
+   - `Name` - Helps you identify your application.
    - `Scopes` - The scopes that you would like to leverage.
-1. Select the **Create** button. You'll be redirected to your app's settings page.
+1. Select **Create**. You'll be redirected to your app's settings page.
 1. In the **Redirect URI** field, add the redirect URI that the client provides. This is the URL that Clerk will redirect to after the user has authenticated.
 
 > [!WARNING]
@@ -44,19 +44,19 @@ Now that you have set up a Clerk OAuth application, you will need to configure a
 - **Token URL**: Used by the client to exchange an authorization code for an access token and a refresh token.
 - **User Info URL**: Used by the client to retrieve additional user data upon authentication.
 
-### OAuth 2.0 Scopes
+### Scopes
 
-OAuth 2.0 scopes define the level of access and specific user data that will be shared with the client application during authentication. The following scopes are currently supported:
+Scopes define the level of access and specific user data that will be shared with the client application during authentication. The following scopes are currently supported:
 
 | Scope | Access |
 | - | - |
-| `profile` | Grant access to the user personal information, such as first and last name, avatar and username |
-| `email` | Grant access to the user email address |
-| `public_metadata` | Grant access to the user public and unsafe metadata |
-| `private_metadata` | Grant access to the user private metadata |
+| `profile` | Grant access to the user's personal information, such as first and last name, avatar, and username |
+| `email` | Grant access to the user's email address |
+| `public_metadata` | Grant access to the user's public and unsafe metadata |
+| `private_metadata` | Grant access to the user's private metadata |
 | `openid` | Enables the OpenID Connect flow |
 
-### Get user information
+## OAuth 2.0
 
 After a user has successfully completed an OAuth 2.0 flow, you can retrieve additional user information from Clerk's [`/oauth/userinfo`](/docs/reference/frontend-api/tag/OAuth2-Identify-Provider#operation/getOAuthUserInfo){{ target: '_blank' }} endpoint, based on the granted scopes. When making the request to this endpoint, you must include the Clerk access token in the `Authorization` header.
 
@@ -65,52 +65,16 @@ The `/oauth/userinfo` endpoint provides the following user properties, depending
 | Property | Description |
 | - | - |
 | `user_id` | The ID of the user |
-| `given_name` | The first name of the user |
-| `family_name` | The last name of the user |
-| `name` | The full name of the user |
-| `picture` | The avatar URL of the user |
-| `preferred_username` | The username of the user |
-| `email` | The primary email address of the user |
-| `email_verified` | Whether the primary email address of the user is verified |
-| `public_metadata` | The public metadata of the user |
-| `private_metadata` | The private metadata of the user |
-| `unsafe_metadata` | The unsafe metadata of the user |
-
-### ID Token
-
-The ID Token is a regular JSON Web Token (JWT) that contains user profile information. After a user successfully authenticates using the OpenID Connect flow, they receive an ID Token along with other tokens.
-
-> [!WARNING]
-> You MUST validate the ID Token, before using any of the user information that contains. To do that, you can use your instance's public key.
-
-It follows the format of JSON Web Tokens (JWTs), which includes the standard JWT claims, along with some additional claims representing the authenticated user profile information.
-
-The standard claims are the following:
-
-| Standard claim | Description |
-| - | - |
-| `iss` | The Issuer of the token, which matches your Clerk Frontend API url |
-| `sub` | The Subject of the token, which matches the authenticated user ID |
-| `aud` | The intended Audience of the token, which matches the used Client ID |
-| `exp` | The Expiration Time of the token |
-| `iat` | At which time the token was Issued At |
-| `jti` | A unique identifier for the token |
-
-Depending on the granted scopes, the extra claims are the following:
-
-| Additional claim | Description |
-| - | - |
-| `nonce` | The nonce provided and used during the request |
-| `family_name` | The last name of the user |
-| `given_name` | The first name of the user |
-| `name` | The full name of the user |
-| `picture` | The avatar URL of the user |
-| `preferred_username` | The username of the user |
-| `email` | The primary email address of the user |
-| `email_verified` | Whether the primary email address of the user is verified |
-| `public_metadata` | The public metadata of the user |
-| `private_metadata` | The private metadata of the user |
-| `unsafe_metadata` | The unsafe metadata of the user |
+| `given_name` | The user's first name |
+| `family_name` | The user's last name |
+| `name` | The user's full name |
+| `picture` | The user's avatar URL |
+| `preferred_username` | The user's username |
+| `email` | The user's primary email address |
+| `email_verified` | Whether the user's primary email address is verified |
+| `public_metadata` | The user's public metadata |
+| `private_metadata` | The user's private metadata |
+| `unsafe_metadata` | The user's unsafe metadata |
 
 ### Get token information
 
@@ -121,23 +85,63 @@ The endpoint returns detailed token information such as if the token is still ac
 > [!WARNING]
 > This endpoint is protected. You must provide your Clerk Client ID and Client Secret credentials to authenticate.
 
-### OAuth 2.0 grant types
+### Grant types
 
-Clerk OAuth 2.0 provider supports the following flows and grant types:
+Clerk's OAuth 2.0 IdP implementation supports the following authorization flows and grant types:
 
 - [Authorization Code](https://oauth.net/2/grant-types/authorization-code/)
 - [PKCE](https://oauth.net/2/pkce/)
 - [Refresh token](https://oauth.net/2/grant-types/refresh-token/)
 
-### OpenID Connect prompt
+## OpenID Connect (OIDC)
 
-As part of an OpenID Connect request, you can indicate the desired sign in experience for the user, by using the `prompt` parameter. We are currently supporting the following values:
+After a user successfully authenticates using the OIDC flow, they receive an ID token along with other tokens.
 
-1. `none`: The user doesn't interact with the provider, thus they need to have an active session already. If not, the provider responds with an error
-1. `login`: The user is forced to re-authenticate, even if they have already an active session. If there was already an active session, the provider ends it
+The ID token is a JWT (JSON Web Token) that contains standard JWT claims as defined in RFC 7519, as well as additional custom claims that represent the authenticated user's profile information. The token is signed using your instance's private key and can be verified using the corresponding public key.
+
+{/* TODO: How do they use the public key to validate the token? */}
+
+> [!WARNING]
+> You MUST validate the ID token before using any of the user information that contains. To do that, you can use your instance's public key.
+
+The ID token includes the following standard claims:
+
+| Standard claim | Description |
+| - | - |
+| `iss` | The issuer of the token, which matches your Clerk Frontend API URL |
+| `sub` | The subject of the token, which matches the authenticated user ID |
+| `aud` | The intended audience of the token, which matches the used Client ID |
+| `exp` | The expiration time of the token |
+| `iat` | The time at which the token was issued |
+| `jti` | A unique identifier for the token |
+
+Depending on the granted scopes, the ID token can include the following additional claims:
+
+| Additional claim | Description |
+| - | - |
+| `nonce` | The nonce provided and used during the request |
+| `family_name` | The user's last name |
+| `given_name` | The user's first name |
+| `name` | The user's full name |
+| `picture` | The user's avatar URL |
+| `preferred_username` | The user's username |
+| `email` | The user's primary email address |
+| `email_verified` | Whether the user's primary email address is verified |
+| `public_metadata` | The user's public metadata |
+| `private_metadata` | The user's private metadata |
+| `unsafe_metadata` | The user's unsafe metadata |
+
+### OIDC prompt
+
+{/* TODO: Where do they use the `prompt` parameter? */}
+
+As part of an OIDC request, you can indicate the desired sign-in experience for the user by using the `prompt` parameter. The following values are supported:
+
+- `none`: The user doesn't interact with the provider, thus they need to have an active session already. If not, the provider responds with an error.
+- `login`: The user is forced to re-authenticate, even if they already have an active session. If there was already an active session, the provider ends it.
 
 ## Frequently asked questions (FAQ)
 
 ### When do the tokens expire?
 
-Authorization codes expire after 10 minutes. Access tokens expire after 2 hours. Refresh tokens expire after 3 days. ID Tokens expire after 1 hour.
+Authorization codes expire after 10 minutes. Access tokens expire after 2 hours. Refresh tokens expire after 3 days. ID tokens expire after 1 hour.

--- a/docs/advanced-usage/clerk-idp.mdx
+++ b/docs/advanced-usage/clerk-idp.mdx
@@ -1,22 +1,22 @@
 ---
-title: Use Clerk as an OAuth 2.0 provider
-description: Learn how to use Clerk to facilitate Single Sign-On (SSO) with other clients that support the OAuth 2.0 protocol.
+title: Clerk as an Identity provider: OAuth 2.0 & OpenID Connect
+description: Learn how to use Clerk to facilitate Single Sign-On (SSO) with other clients that support the OAuth 2.0 and OpenID Connect protocol.
 ---
 
 > [!WARNING]
 > **This feature is not designed for handling authentication directly in your application.** To handle authentication _in your_ application, you can [configure one of the many social providers that Clerk offers](/docs/authentication/social-connections/oauth#configuration), such as Google.
 
-Clerk can be configured as an OAuth 2.0 provider to facilitate Single Sign-On (SSO) with other clients that support the OAuth 2.0 protocol. This feature allows users to authenticate to other applications using their Clerk credentials, enabling user information sharing between your Clerk application and OAuth clients.
+Clerk can be configured as an OAuth 2.0 and OpenID Connect provider to facilitate Single Sign-On (SSO) with other clients that support the protocols. This feature allows users to authenticate to other applications using their Clerk credentials, enabling user information sharing between your Clerk application and OAuth clients.
 
-## When should you use Clerk as an OAuth 2.0 provider?
+## When should you use Clerk as an Identity provider?
 
-You can use Clerk as an OAuth 2.0 provider if you want your users to authenticate to a third party site or a tool using their credentials from your application. **This is not the same as supporting an OAuth provider, such as Google, in your application. If you want your users to be able to sign in to your application with an OAuth provider, see the [dedicated guide](/docs/authentication/social-connections/oauth).**
+You can use Clerk as an Identity provider if you want your users to authenticate to a third party site or a tool using their credentials from your application. **This is not the same as supporting an OAuth provider, such as Google, in your application. If you want your users to be able to sign in to your application with an OAuth provider, see the [dedicated guide](/docs/authentication/social-connections/oauth).**
 
 ## How it works
 
-Clerk is the OAuth 2.0 provider for your application. The "client" is the third party site or tool that you want your users to authenticate to.
+Clerk is the OAuth 2.0 and OpenID Connect provider for your application. The "client" is the third party site or tool that you want your users to authenticate to.
 
-In order to make your Clerk instance operate as an OAuth 2.0 provider, create an OAuth application in the Clerk Dashboard. Then, configure the client to work with your Clerk instance, using the necessary data from your Clerk OAuth application.
+In order to make your Clerk instance operate as a provider, create an OAuth application in the Clerk Dashboard. Then, configure the client to work with your Clerk instance, using the necessary data from your Clerk OAuth application.
 
 ### Create a Clerk OAuth application
 
@@ -39,10 +39,10 @@ Now that you have set up a Clerk OAuth application, you will need to configure a
 
 - **Client ID**: Public identifier of your Clerk OAuth application.
 - **Client Secret**: Confidential secret used to authenticate your Clerk OAuth application.
+- **Discovery URL**: Used by the client to retrieve the configuration data of the Clerk OAuth application.
 - **Authorize URL**: Used by the client to request authorization from your user.
 - **Token URL**: Used by the client to exchange an authorization code for an access token and a refresh token.
 - **User Info URL**: Used by the client to retrieve additional user data upon authentication.
-- **Discovery URL**: Used by the client to retrieve the configuration data of the Clerk OAuth application.
 
 ### OAuth 2.0 Scopes
 
@@ -54,6 +54,7 @@ OAuth 2.0 scopes define the level of access and specific user data that will be 
 | `email` | Grant access to the user email address |
 | `public_metadata` | Grant access to the user public and unsafe metadata |
 | `private_metadata` | Grant access to the user private metadata |
+| `openid` | Enables the OpenID Connect flow |
 
 ### Get user information
 
@@ -66,6 +67,42 @@ The `/oauth/userinfo` endpoint provides the following user properties, depending
 | `user_id` | The ID of the user |
 | `given_name` | The first name of the user |
 | `family_name` | The last name of the user |
+| `name` | The full name of the user |
+| `picture` | The avatar URL of the user |
+| `preferred_username` | The username of the user |
+| `email` | The primary email address of the user |
+| `email_verified` | Whether the primary email address of the user is verified |
+| `public_metadata` | The public metadata of the user |
+| `private_metadata` | The private metadata of the user |
+| `unsafe_metadata` | The unsafe metadata of the user |
+
+### ID Token
+
+The ID Token is a regular JSON Web Token (JWT) that contains user profile information. After a user successfully authenticates using the OpenID Connect flow, they receive an ID Token along with other tokens.
+
+> [!WARNING]
+> You MUST validate the ID Token, before using any of the user information that contains. To do that, you can use your instance's public key.
+
+It follows the format of JSON Web Tokens (JWTs), which includes the standard JWT claims, along with some additional claims representing the authenticated user profile information.
+
+The standard claims are the following:
+
+| Standard claim | Description |
+| - | - |
+| `iss` | The Issuer of the token, which matches your Clerk Frontend API url |
+| `sub` | The Subject of the token, which matches the authenticated user ID |
+| `aud` | The intended Audience of the token, which matches the used Client ID |
+| `exp` | The Expiration Time of the token |
+| `iat` | At which time the token was Issued At |
+| `jti` | A unique identifier for the token |
+
+Depending on the granted scopes, the extra claims are the following:
+
+| Additional claim | Description |
+| - | - |
+| `nonce` | The nonce provided and used during the request |
+| `family_name` | The last name of the user |
+| `given_name` | The first name of the user |
 | `name` | The full name of the user |
 | `picture` | The avatar URL of the user |
 | `preferred_username` | The username of the user |
@@ -92,12 +129,15 @@ Clerk OAuth 2.0 provider supports the following flows and grant types:
 - [PKCE](https://oauth.net/2/pkce/)
 - [Refresh token](https://oauth.net/2/grant-types/refresh-token/)
 
+### OpenID Connect prompt
+
+As part of an OpenID Connect request, you can indicate the desired sign in experience for the user, by using the `prompt` parameter. We are currently supporting the following values:
+
+1. `none`: The user doesn't interact with the provider, thus they need to have an active session already. If not, the provider responds with an error
+1. `login`: The user is forced to re-authenticate, even if they have already an active session. If there was already an active session, the provider ends it
+
 ## Frequently asked questions (FAQ)
 
 ### When do the tokens expire?
 
-Authorization codes expire after 10 minutes. Access tokens expire after 2 hours. Refresh tokens expire after 3 days.
-
-### Is OpenID Connect (OIDC) supported?
-
-At this time, OIDC is not supported.
+Authorization codes expire after 10 minutes. Access tokens expire after 2 hours. Refresh tokens expire after 3 days. ID Tokens expire after 1 hour.

--- a/docs/advanced-usage/clerk-idp.mdx
+++ b/docs/advanced-usage/clerk-idp.mdx
@@ -58,7 +58,9 @@ Scopes define the level of access and specific user data that will be shared wit
 
 ## OAuth 2.0
 
-After a user has successfully completed an OAuth 2.0 flow, you can retrieve additional user information from Clerk's [`/oauth/userinfo`](/docs/reference/frontend-api/tag/OAuth2-Identify-Provider#operation/getOAuthUserInfo){{ target: '_blank' }} endpoint, based on the granted scopes. When making the request to this endpoint, you must include the Clerk access token in the `Authorization` header.
+### Get additional user information
+
+After a user has successfully completed an OAuth 2.0 flow, you can retrieve additional user information from Clerk's [`/oauth/userinfo`](/docs/reference/frontend-api/tag/OAuth2-Identify-Provider#operation/getOAuthUserInfo){{ target: '_blank' }} endpoint. When making the request to this endpoint, you must include the Clerk access token in the `Authorization` header.
 
 The `/oauth/userinfo` endpoint provides the following user properties, depending on the granted scopes:
 
@@ -132,8 +134,6 @@ Depending on the granted scopes, the ID token can include the following addition
 | `unsafe_metadata` | The user's unsafe metadata |
 
 ### OIDC prompt
-
-{/* TODO: Where do they use the `prompt` parameter? */}
 
 As part of an OIDC request, you can indicate the desired sign-in experience for the user by using the `prompt` parameter. The following values are supported:
 

--- a/docs/advanced-usage/clerk-idp.mdx
+++ b/docs/advanced-usage/clerk-idp.mdx
@@ -99,12 +99,9 @@ Clerk's OAuth 2.0 IdP implementation supports the following authorization flows 
 
 After a user successfully authenticates using the OIDC flow, they receive an ID token along with other tokens.
 
-The ID token is a JWT (JSON Web Token) that contains standard JWT claims as defined in RFC 7519, as well as additional custom claims that represent the authenticated user's profile information. The token is signed using your instance's private key and can be verified using the corresponding public key.
+The ID token is a JWT (JSON Web Token) that contains standard JWT claims as defined in RFC 7519, as well as additional custom claims that represent the authenticated user's profile information. The token is signed using your instance's private key.
 
-{/* TODO: How do they use the public key to validate the token? */}
-
-> [!WARNING]
-> You MUST validate the ID token before using any of the user information that contains. To do that, you can use your instance's public key.
+You must validate the ID token before using any of the user information it contains. Validation requires verifying the token signature using your instance's public key. You can find your instance's public key at `https://clerk.<INSERT_YOUR_APP_DOMAIN>.com/.well-known/jwks.json`.
 
 The ID token includes the following standard claims:
 

--- a/docs/manifest.json
+++ b/docs/manifest.json
@@ -3499,7 +3499,7 @@
               "items": [
                 [
                   {
-                    "title": "Clerk as an OAuth 2.0 provider",
+                    "title": "Clerk as an Identity provider: OAuth 2.0 & OpenID Connect",
                     "href": "/docs/advanced-usage/clerk-idp"
                   },
                   {


### PR DESCRIPTION
### 🔎 Previews:

- https://clerk.com/docs/pr/1968

### What does this solve?

- Now you can use your Clerk instance, not only as an OAuth 2.0 provider, but also as an OpenID Connect (OIDC) provider

### What changed?

- We enhance the existing docs page, with the necessary data for the OpenID Connect flows

### Checklist

- [ ] I have clicked on "Files changed" and performed a thorough self-review
- [ ] I have added the "deploy-preview" label and added the preview link(s) to this PR description
- [ ] All existing checks pass
