### PR TITLE
Remove broken link from navigation/manifest

### DIFF
--- a/docs/manifest.json
+++ b/docs/manifest.json
@@ -1026,11 +1026,6 @@
         "items": [
           [
             {
-              "title": "Keyless Mode",
-              "tag": "(Beta)",
-              "href": "/docs/keyless-mode"
-            },
-            {
               "title": "Multi-tenant architecture",
               "href": "/docs/guides/multi-tenant-architecture"
             },


### PR DESCRIPTION
### What does this solve?

- The "Keyless Mode" link in the navigation links to a page that doesn't exist

### What changed?

- Removed the "Keyless Mode" link from the navigation (`manifest.json`)

### Checklist

- [x] I have clicked on "Files changed" and performed a thorough self-review
- [x] I have added the "deploy-preview" label and added the preview link(s) to this PR description
- [x] All existing checks pass
