### PR TITLE
[fix] Make nextjs quickstart search visible

### DIFF
--- a/docs/quickstarts/nextjs.mdx
+++ b/docs/quickstarts/nextjs.mdx
@@ -1,10 +1,6 @@
 ---
 title: Next.js Quickstart (App Router)
 description: Add authentication and user management to your Next.js app.
-search: false
-metadata:
-    robots:
-        index: false
 ---
 
 Clerk provides a powerful, feature-rich authentication and user management solution for Next.js applications through its official SDK.


### PR DESCRIPTION
In #1699 we had the quickstart hidden from search and crawlers. 