### PR TITLE
fix link to swift reference docs

### DIFF
--- a/docs/references/ios/overview.mdx
+++ b/docs/references/ios/overview.mdx
@@ -10,7 +10,7 @@ The Clerk iOS SDK gives you access to prebuilt components, React hooks, and help
 
 ## SDK Reference
 
-The full SDK Reference is available on [Swift Package Index](https://swiftpackageindex.com/clerk/clerk-ios/main/documentation/clerksdk).
+The full SDK Reference is available on [Swift Package Index](https://swiftpackageindex.com/clerk/clerk-ios/main/documentation/clerk).
 
 ## Installation with Swift Package Manager
 


### PR DESCRIPTION
### 🔎 Previews:

-

### What does this solve?

- We changed the name of the swift package, so the existing link to its docs broke

### What changed?

- The link to the swift docs is now correct

### Checklist

- [ ] I have clicked on "Files changed" and performed a thorough self-review
- [ ] I have added the "deploy-preview" label and added the preview link(s) to this PR description
- [ ] All existing checks pass
