### PR TITLE
update ios sign in with apple guide

### DIFF
--- a/docs/references/ios/sign-in-with-apple.mdx
+++ b/docs/references/ios/sign-in-with-apple.mdx
@@ -31,13 +31,13 @@ This guide will teach you how to add native Sign in with Apple to your Clerk app
 
   ## Build your sign-in flow
 
-  Once you have obtained your [Apple ID Credential](https://developer.apple.com/documentation/authenticationservices/asauthorizationappleidcredential), you can use it to authenticate with Clerk by calling [`SignIn.create(strategy:)`](https://swiftpackageindex.com/clerk/clerk-ios/main/documentation/clerksdk/signin/create\(strategy:\)) with a strategy of `.idToken` followed by `.authenticateWithIdToken()`.
+  Once you have obtained your [Apple ID Credential](https://developer.apple.com/documentation/authenticationservices/asauthorizationappleidcredential), you can use it to authenticate with Clerk by calling [`SignIn.authenticateWithIdToken(provider:idToken:)`](https://swiftpackageindex.com/clerk/clerk-ios/main/documentation/clerk/signin/authenticatewithidtoken\(provider:idtoken:\)) with a provider of `.apple` and the `idToken` you have obtained.
 
-  The following example uses Apple's built-in `SignInWithAppleButton` to obtain an Apple ID Credential and calls `SignIn.create(strategy:)` and `.authenticateWithIdToken()` to authenticate with Clerk.
+  The following example uses Apple's built-in `SignInWithAppleButton` to obtain an Apple ID Credential and calls `SignIn.authenticateWithIdToken(provider:idToken:)` to authenticate with Clerk.
 
   ```swift {{ filename: 'SignInWithAppleView.swift' }}
   import SwiftUI
-  import ClerkSDK
+  import Clerk
   import AuthenticationServices
 
   struct SignInWithAppleView: View {
@@ -61,9 +61,7 @@ This guide will teach you how to add native Sign in with Apple to your Clerk app
           }
 
           // Authenticate with Clerk
-          let authResult = try await SignIn
-            .create(strategy: .idToken(provider: .apple, idToken: idToken))
-            .authenticateWithIdToken()
+          let authResult = try await SignIn.authenticateWithIdToken(provider: .apple, idToken: idToken)
         }
       }
     }


### PR DESCRIPTION
### 🔎 Previews:

- https://clerk.com/docs/pr/1984/references/ios/sign-in-with-apple

### What does this solve?

- Updates the iOS Sign in with Apple guide to account for recent changes to the sdk.

### Checklist

- [x] I have clicked on "Files changed" and performed a thorough self-review
- [x] I have added the "deploy-preview" label and added the preview link(s) to this PR description
- [x] All existing checks pass
