### PR TITLE
feat: Webhook instance ID

### DIFF
--- a/docs/webhooks/overview.mdx
+++ b/docs/webhooks/overview.mdx
@@ -31,6 +31,8 @@ The payload of a webhook is a JSON object that contains the following properties
 - `data`: contains the actual payload sent by Clerk. The payload can be a different object depending on the `event` type. For example, for `user.*` events, the payload will always be the [User](/docs/references/javascript/user/user) object.
 - `object`: always set to `event`.
 - `type`: the type of event that triggered the webhook.
+- `timestamp`: timestamp in seconds of when the event occurred.
+- `instance_id`: the identifier of your Clerk instance.
 
 The following example shows the payload of a `user.created` event:
 
@@ -74,7 +76,9 @@ The following example shows the payload of a `user.created` event:
     "username": null,
     "web3_wallets": []
   },
+  "instance_id": "ins_29w83yT7CwllvXylYLxcslj88O9",
   "object": "event",
+  "timestamp": 1654012591835,
   "type": "user.created"
 }
 ```

--- a/docs/webhooks/overview.mdx
+++ b/docs/webhooks/overview.mdx
@@ -76,7 +76,7 @@ The following example shows the payload of a `user.created` event:
     "username": null,
     "web3_wallets": []
   },
-  "instance_id": "ins_29w83yT7CwllvXylYLxcslj88O9",
+  "instance_id": "ins_123",
   "object": "event",
   "timestamp": 1654012591835,
   "type": "user.created"

--- a/docs/webhooks/overview.mdx
+++ b/docs/webhooks/overview.mdx
@@ -31,7 +31,7 @@ The payload of a webhook is a JSON object that contains the following properties
 - `data`: contains the actual payload sent by Clerk. The payload can be a different object depending on the `event` type. For example, for `user.*` events, the payload will always be the [User](/docs/references/javascript/user/user) object.
 - `object`: always set to `event`.
 - `type`: the type of event that triggered the webhook.
-- `timestamp`: timestamp in seconds of when the event occurred.
+- `timestamp`: timestamp in milliseconds of when the event occurred.
 - `instance_id`: the identifier of your Clerk instance.
 
 The following example shows the payload of a `user.created` event:


### PR DESCRIPTION
### 🔎 Previews:

- https://clerk.com/docs/pr/1985

### What does this solve?

Adds information about the instance_id key in the webhooks payload.

### What changed?

Added explanation of what the `instance_id` field is and updated the example payload.

### Checklist

- [x] I have clicked on "Files changed" and performed a thorough self-review
- [x] I have added the "deploy-preview" label and added the preview link(s) to this PR description
- [x] All existing checks pass
