### PR TITLE
Fix link in JavaScript reference overview

### DIFF
--- a/docs/references/javascript/overview.mdx
+++ b/docs/references/javascript/overview.mdx
@@ -23,7 +23,7 @@ To utilize these methods and attributes, Clerk has a wide array of classes you w
 - [`OrganizationInvitation`](/docs/references/javascript/types/organization-invitation)
 - [`OrganizationMembership`](/docs/references/javascript/types/organization-membership)
 - [`Session`](/docs/references/javascript/session)
-- [`SessionWithActivities`](docs/references/javascript/types/session-with-activities)
+- [`SessionWithActivities`](/docs/references/javascript/types/session-with-activities)
 - [`Client`](/docs/references/javascript/client)
 - [`ExternalAccount`](/docs/references/javascript/types/external-account)
 - [`SignIn`](/docs/references/javascript/sign-in/sign-in)


### PR DESCRIPTION
### What does this solve?

- Broken link at `/docs/references/javascript/overview`

### What changed?

```diff
- docs/references/javascript/types/session-with-activities
+ /docs/references/javascript/types/session-with-activities
```
