### PR TITLE
remove the framework prop from tutorialhero

### DIFF
--- a/docs/quickstarts/astro.mdx
+++ b/docs/quickstarts/astro.mdx
@@ -4,7 +4,6 @@ description: Add authentication and user management to your Astro app with Clerk
 ---
 
 <TutorialHero
-  framework="astro"
   beforeYouStart={[
     {
       title: "Set up a Clerk application",

--- a/docs/quickstarts/expo.mdx
+++ b/docs/quickstarts/expo.mdx
@@ -4,7 +4,6 @@ description: Add authentication and user management to your Expo app with Clerk.
 ---
 
 <TutorialHero
-  framework="expo"
   exampleRepo={[
     {
       title: "Expo quickstart repo",

--- a/docs/quickstarts/express.mdx
+++ b/docs/quickstarts/express.mdx
@@ -4,7 +4,6 @@ description: Learn how to use Clerk to quickly and easily add secure authenticat
 ---
 
 <TutorialHero
-  framework="express"
   exampleRepo={[
     {
       title: "Express Quickstart Repo",

--- a/docs/quickstarts/fastify.mdx
+++ b/docs/quickstarts/fastify.mdx
@@ -4,7 +4,6 @@ description: Learn how to integrate Clerk for secure authentication and user man
 ---
 
 <TutorialHero
-  framework="react"
   exampleRepo={[
     {
       title: "Fastify Quickstart",

--- a/docs/quickstarts/ios.mdx
+++ b/docs/quickstarts/ios.mdx
@@ -7,7 +7,6 @@ description: Add authentication and user management to your iOS app with Clerk.
 > The Clerk iOS SDK is currently in beta. It is **not yet recommended for production use**.
 
 <TutorialHero
-  framework="iOS"
   beforeYouStart={[
     {
       title: "Set up a Clerk application",

--- a/docs/quickstarts/javascript.mdx
+++ b/docs/quickstarts/javascript.mdx
@@ -4,7 +4,6 @@ description: Add authentication and user management to your JavaScript app with 
 ---
 
 <TutorialHero
-  framework="javascript"
   exampleRepo={[
     {
       title: "JavaScript Quickstart Repo",

--- a/docs/quickstarts/nextjs-pages-router.mdx
+++ b/docs/quickstarts/nextjs-pages-router.mdx
@@ -4,7 +4,6 @@ description: Add authentication and user management to your Next.js app with Cle
 ---
 
 <TutorialHero
-  framework="nextjs"
   beforeYouStart={[
     {
       title: "Set up a Clerk application",
@@ -16,6 +15,11 @@ description: Add authentication and user management to your Next.js app with Cle
       link: "https://nextjs.org/docs/getting-started/installation",
       icon: "nextjs",
     },
+  ]}
+  exampleRepo={[{
+      title: "Pages Router Quickstart Repo",
+      link: "https://github.com/clerk/clerk-nextjs-pages-quickstart"
+    }
   ]}
 >
   - Install `@clerk/nextjs`

--- a/docs/quickstarts/nuxt.mdx
+++ b/docs/quickstarts/nuxt.mdx
@@ -4,7 +4,6 @@ description: Add authentication and user management to your Nuxt app with Clerk.
 ---
 
 <TutorialHero
-  framework="vue"
   exampleRepo={[
     {
       title: "Nuxt Quickstart Repo",

--- a/docs/quickstarts/react-router.mdx
+++ b/docs/quickstarts/react-router.mdx
@@ -4,7 +4,6 @@ description: Learn how to use Clerk to quickly and easily add secure authenticat
 ---
 
 <TutorialHero
-  framework="react-router"
   exampleRepo={[
     {
       title: "React Router Quickstart Repo",

--- a/docs/quickstarts/react.mdx
+++ b/docs/quickstarts/react.mdx
@@ -4,7 +4,6 @@ description: Add authentication and user management to your React app with Clerk
 ---
 
 <TutorialHero
-  framework="react"
   exampleRepo={[
     {
       title: "React Quickstart Repo",

--- a/docs/quickstarts/remix.mdx
+++ b/docs/quickstarts/remix.mdx
@@ -4,7 +4,6 @@ description: Learn how to use Clerk to quickly and easily add secure authenticat
 ---
 
 <TutorialHero
-  framework="remix"
   exampleRepo={[
     {
       title: "Remix Quickstart Repo",

--- a/docs/quickstarts/ruby.mdx
+++ b/docs/quickstarts/ruby.mdx
@@ -4,7 +4,6 @@ description: Learn how to use Clerk to quickly and easily add secure authenticat
 ---
 
 <TutorialHero
-  framework="ruby"
   exampleRepo={[
     {
       title: "Ruby Quickstart Repo",

--- a/docs/quickstarts/tanstack-start.mdx
+++ b/docs/quickstarts/tanstack-start.mdx
@@ -7,7 +7,6 @@ description: Learn how to use Clerk to quickly and easily add secure authenticat
 > The TanStack Start SDK is currently in beta. **It is not yet recommended for production use**.
 
 <TutorialHero
-  framework="react"
   exampleRepo={[
     {
       title: "TanStack Start Quickstart Repo",

--- a/docs/quickstarts/vue.mdx
+++ b/docs/quickstarts/vue.mdx
@@ -4,7 +4,6 @@ description: Add authentication and user management to your Vue app with Clerk.
 ---
 
 <TutorialHero
-  framework="vue"
   exampleRepo={[
     {
       title: "Vue Quickstart Repo",

--- a/docs/references/nextjs/authjs-migration.mdx
+++ b/docs/references/nextjs/authjs-migration.mdx
@@ -4,7 +4,6 @@ description: Learn how to migrate an application using Auth.js to use Clerk for 
 ---
 
 <TutorialHero
-  framework="authjs"
   exampleRepoTitle="Migration Script Repository"
   exampleRepo={[
     {

--- a/docs/references/react-router/library-mode.mdx
+++ b/docs/references/react-router/library-mode.mdx
@@ -4,7 +4,6 @@ description: Learn how to use Clerk with React Router in library mode to add aut
 ---
 
 <TutorialHero
-  framework="react-router"
   beforeYouStart={[
     {
       title: "Set up a Clerk application",

--- a/docs/references/remix/spa-mode.mdx
+++ b/docs/references/remix/spa-mode.mdx
@@ -4,7 +4,6 @@ description: Clerk supports Remix SPA mode out-of-the-box.
 ---
 
 <TutorialHero
-  framework="remix"
   beforeYouStart={[
     {
       title: "Set up a Clerk application",


### PR DESCRIPTION
### 🔎 Previews:

-

### What does this solve?

Before, we needed to tell the <TutorialHero /> component whether the framework was Nextjs or not. If it was Nextjs, the component would supply the App Router and Pages Router repos to the exampleRepo prop

Now, Nextjs has separate App Router vs Pages Router quickstarts, so we no longer need to support nextjs specificity in the <TutorialHero />

### What changed?

- Removes the `framework` prop from the `<TutorialHero />` component
- Explicitly passes the example repository to the Nextjs Pages Router `<TutorialHero />` component (as its not automatically supplied based on the `framework` prop anymore)

### Related

https://github.com/clerk/clerk/pull/997

### Checklist

- [x] I have clicked on "Files changed" and performed a thorough self-review
- [x] I have added the "deploy-preview" label and added the preview link(s) to this PR description
- [x] All existing checks pass
