### PR TITLE
(quickstarts/nextjs) restore tutorialhero component

### DIFF
--- a/docs/quickstarts/nextjs.mdx
+++ b/docs/quickstarts/nextjs.mdx
@@ -3,7 +3,18 @@ title: Next.js Quickstart (App Router)
 description: Add authentication and user management to your Next.js app.
 ---
 
-Clerk provides a powerful, feature-rich authentication and user management solution for Next.js applications through its official SDK.
+<TutorialHero
+  exampleRepo={[{
+      title: "App Router Quickstart Repo",
+      link: "https://github.com/clerk/clerk-nextjs-app-quickstart"
+    }
+  ]}
+>
+  - Install `@clerk/nextjs`
+  - Add `clerkMiddleware()`
+  - Add `<ClerkProvider>` and Clerk components
+  - Create your first user
+</TutorialHero>
 
 <Steps>
   ## Create a new Next.js application


### PR DESCRIPTION
### 🔎 Previews:

-

### What does this solve?

- Recently, we removed the TutorialHero component for the App Router quickstart because there was no longer a "Before you start" section. However, that's an optional prop, and I do think we should use this component to incite consistency amongst our tutorials.

### What changed?

- Restored the TutorialHero component for the App Router quickstart

### Checklist

- [ ] I have clicked on "Files changed" and performed a thorough self-review
- [ ] I have added the "deploy-preview" label and added the preview link(s) to this PR description
- [ ] All existing checks pass
