### PR TITLE
(/customization/user-profile) fix broken javascript example

### DIFF
--- a/docs/customization/user-profile.mdx
+++ b/docs/customization/user-profile.mdx
@@ -208,7 +208,7 @@ The following example demonstrates two ways that you can render content in the `
 
 ### JavaScript example
 
-To add custom pages to the `<UserProfile />` component using the [JavaScript SDK](/docs/references/javascript/overview), you can pass the `customPages` property to the `mountUserProfile()` or `openUserProfile()` method, as shown in the following example:
+To add custom pages to the `<UserProfile />` component using the [JavaScript SDK](/docs/references/javascript/overview), you can pass the `customPages` property to the `mountUserProfile()` method, as shown in the following example:
 
 ```js {{ filename: 'main.js' }}
 import { Clerk } from '@clerk/clerk-js'

--- a/docs/customization/user-profile.mdx
+++ b/docs/customization/user-profile.mdx
@@ -224,7 +224,7 @@ document.getElementById('app').innerHTML = `
 
 const userProfileDiv = document.getElementById('user-profile')
 
-clerk.openUserProfile(userProfileDiv, {
+clerk.mountUserProfile(userProfileDiv, {
   customPages: [
     {
       url: 'custom-page',


### PR DESCRIPTION
### 🔎 Previews:

https://clerk.com/docs/pr/1994

### What does this solve?
We've had a handful of folks attempting to utilize the JavaScript example on this page and reporting that the feature is broken or bugged. This will solve the broken behavior experienced from our users.

 <!--- Describe your changes in detail. Why does this change need to happen? Include any links to Slack discussions, Linear comments, etc. -->

After testing and reproducing the behavior we found the current example in the docs doesn't work. The former example reflects using the openUserProfile() method which opens this component as a modal. Custom pages cannot be mounted this way. Adjusted example to utilize the mountUserProfile() instead which works as intended.

### What changed?
- Change `clerk.openUserProfile()` -> `clerk.mountUserProfile()`

 <!--- How does this PR solve the problem? -->
This change reflects the correct method to use in the example code we provide.

### Checklist

- [x] I have clicked on "Files changed" and performed a thorough self-review
- [x] I have added the "deploy-preview" label and added the preview link(s) to this PR description
- [x] All existing checks pass
