### PR TITLE
remove ios beta warnings

### DIFF
--- a/docs/quickstarts/ios.mdx
+++ b/docs/quickstarts/ios.mdx
@@ -3,9 +3,6 @@ title: iOS Quickstart (beta)
 description: Add authentication and user management to your iOS app with Clerk.
 ---
 
-> [!WARNING]
-> The Clerk iOS SDK is currently in beta. It is **not yet recommended for production use**.
-
 <TutorialHero
   beforeYouStart={[
     {

--- a/docs/references/ios/overview.mdx
+++ b/docs/references/ios/overview.mdx
@@ -3,9 +3,6 @@ title: Clerk iOS SDK (beta)
 description: The Clerk iOS SDK gives you access to prebuilt components, React hooks, and helpers to make user authentication easier.
 ---
 
-> [!WARNING]
-> The Clerk iOS SDK is currently in beta. It is **not yet recommended for production use**.
-
 The Clerk iOS SDK gives you access to prebuilt components, React hooks, and helpers to make user authentication easier. Refer to the [quickstart guide](/docs/quickstarts/ios) to get started.
 
 ## SDK Reference

--- a/docs/references/ios/sign-in-with-apple.mdx
+++ b/docs/references/ios/sign-in-with-apple.mdx
@@ -3,9 +3,6 @@ title: Sign in with Apple
 description: Learn how to use Clerk to natively Sign in with Apple.
 ---
 
-> [!WARNING]
-> The Clerk iOS SDK is currently in beta. It is **not yet recommended for production use**.
-
 This guide will teach you how to add native Sign in with Apple to your Clerk apps on Apple platforms.
 
 <Steps>


### PR DESCRIPTION
### 🔎 Previews:

- https://clerk.com/docs/pr/1997/quickstarts/ios
- https://clerk.com/docs/pr/1997/references/ios/overview
- https://clerk.com/docs/pr/1997/references/ios/sign-in-with-apple

### What does this solve?

- While the iOS SDK is still technically in beta (though not for long 😏), it is considered stable.

### Checklist

- [x] I have clicked on "Files changed" and performed a thorough self-review
- [x] I have added the "deploy-preview" label and added the preview link(s) to this PR description
- [x] All existing checks pass
