### PR TITLE
(/components/user/user-button) fix incorrect prop description

### DIFF
--- a/docs/components/user/user-button.mdx
+++ b/docs/components/user/user-button.mdx
@@ -17,14 +17,14 @@ All props are optional.
   - `afterMultiSessionSingleSignOutUrl` (deprecated)
   - `string`
 
-  The full URL or path to navigate to after a signing out from a currently active account in a multi-session app. **Deprecated - Move `afterSignOutUrl` to `<ClerkProvider/>`.**
+  **Deprecated. Move `afterMultiSessionSingleSignOutUrl` to [`<ClerkProvider />`](/docs/components/clerk-provider).** The full URL or path to navigate to after a signing out from a currently active account in a multi-session app.
 
   ---
 
   - `afterSignOutUrl` (deprecated)
   - `string`
 
-  The full URL or path to navigate to after a successful sign-out. **Deprecated - Move `afterSignOutUrl` to `<ClerkProvider/>`.**
+  **Deprecated. Move `afterSignOutUrl` to [`<ClerkProvider />`](/docs/components/clerk-provider).** The full URL or path to navigate to after a successful sign-out.
 
   ---
 
@@ -66,14 +66,14 @@ All props are optional.
   - `userProfileMode`
   - `'modal' | 'navigation'`
 
-  Controls whether clicking the **Manage your account** button will cause the [`<UserProfile />`](/docs/components/user/user-profile) component to open as a modal, or if the browser will navigate to the `userProfileUrl` where `<UserProfile />` is mounted as a page.<br />Defaults to: `'modal'`.
+  Controls whether selecting the **Manage your account** button will cause the [`<UserProfile />`](/docs/components/user/user-profile) component to open as a modal, or if the browser will navigate to the `userProfileUrl` where `<UserProfile />` is mounted as a page. Defaults to: `'modal'`.
 
   ---
 
   - `userProfileProps`
   - `object`
 
-  Specify options for the underlying [`<UserProfile />`](/docs/components/user/user-profile) component.<br />For example: `{additionalOAuthScopes: {google: ['foo', 'bar'], github: ['qux']}}`.
+  Specify options for the underlying [`<UserProfile />`](/docs/components/user/user-profile) component. For example: `{additionalOAuthScopes: {google: ['foo', 'bar'], github: ['qux']}}`.
 
   ---
 


### PR DESCRIPTION
### 🔎 Previews:

-

### What does this solve?

- The `afterMultiSessionSingleSignOutUrl` prop description said to move `afterSignOutUrl`. It was referencing the wrong prop.

### Checklist

- [ ] I have clicked on "Files changed" and performed a thorough self-review
- [ ] I have added the "deploy-preview" label and added the preview link(s) to this PR description
- [ ] All existing checks pass
