### PR TITLE
docs(javascript): fix wrong type name

### DIFF
--- a/docs/references/javascript/organization/organization.mdx
+++ b/docs/references/javascript/organization/organization.mdx
@@ -381,21 +381,21 @@ An _experimental_ interface that includes information about a user's permission.
   - `id`
   - `string`
 
-  The unique identifier of the role.
+  The unique identifier of the permission.
 
   ---
 
   - `key`
   - `string`
 
-  The unique key of the role.
+  The unique key of the permission.
 
   ---
 
   - `name`
   - `string`
 
-  The name of the role.
+  The name of the permission.
 
   ---
 
@@ -409,7 +409,7 @@ An _experimental_ interface that includes information about a user's permission.
   - `createdAt`
   - `Date`
 
-  The date when the role was created.
+  The date when the permission was created.
 
   ---
 


### PR DESCRIPTION
### 🔎 Previews:

-

### What does this solve?

- Wrong description of properties.

### What changed?

- Fixed some small typos in the `organization.mdx` where it was `role` instead of `permission`.

### Checklist

- [x] I have clicked on "Files changed" and performed a thorough self-review
- [ ] I have added the "deploy-preview" label and added the preview link(s) to this PR description
- [x] All existing checks pass
