### PR TITLE
(quickstarts/express) Add missing `getAuth` import

### DIFF
--- a/docs/quickstarts/express.mdx
+++ b/docs/quickstarts/express.mdx
@@ -116,7 +116,7 @@ Learn how to integrate Clerk into your Express backend for secure user authentic
   ```ts {{ filename: 'index.ts' }}
   import 'dotenv/config'
   import express from 'express'
-  import { clerkClient, requireAuth } from '@clerk/express'
+  import { clerkClient, requireAuth, getAuth } from '@clerk/express'
 
   const app = express()
   const PORT = 3000


### PR DESCRIPTION
Directly using getAuth, as mentioned in the docs creates a reference error with the message: `ReferenceError: getAuth is not defined`. However, importing and destructuring it alongside clerkMiddleware and requireAuth as `import { clerkMiddleware, requireAuth, getAuth } from "@clerk/express";` resolves the issue

### 🔎 Previews:

- [Clerk Express Quickstart - Protect Your Routes Using requireAuth](https://clerk.com/docs/quickstarts/express#protect-your-routes-using-require-auth)

### What does this solve?

- Directly using `getAuth` as documented results in a `ReferenceError: getAuth is not defined`.  
- This occurs because `getAuth` is not automatically available in the scope unless explicitly imported.  
- By importing `getAuth` alongside `clerkMiddleware` and `requireAuth` as:  
  ```js
  import { clerkMiddleware, requireAuth, getAuth } from "@clerk/express";
  ```
- the issue is resolved, ensuring that `getAuth` is correctly recognized.

### What changed?

- Updated the import statement to explicitly include `getAuth`.
- Ensured that `getAuth` is properly available in the module scope to prevent reference errors.

### Checklist

- [x] I have clicked on "Files changed" and performed a thorough self-review
- [x] I have added the "deploy-preview" label and added the preview link(s) to this PR description
- [x] All existing checks pass
