### PR TITLE
Fix `clerk-sdk-go` link

### DIFF
--- a/docs/references/sdk/types.mdx
+++ b/docs/references/sdk/types.mdx
@@ -31,7 +31,7 @@ Backend-only SDKs are used in frameworks to build APIs without directly serving 
 
 **Examples:** Express.js/Hono with a Vite React/Vue frontend
 
-**SDK Examples:** [`@clerk/express`](https://github.com/clerk/javascript/tree/main/packages/express), `@hono/clerk-auth`, [`clerk-sdk-go`](https://github.com/clerk/clerk_go)
+**SDK Examples:** [`@clerk/express`](https://github.com/clerk/javascript/tree/main/packages/express), `@hono/clerk-auth`, [`clerk-sdk-go`](https://github.com/clerk/clerk-sdk-go)
 
 ## Fullstack
 


### PR DESCRIPTION
This PR corrects a link to `clerk-sdk-go` in `docs/references/sdk/types.mdx`