### PR TITLE
Update sync-data.mdx

### DIFF
--- a/docs/webhooks/sync-data.mdx
+++ b/docs/webhooks/sync-data.mdx
@@ -209,7 +209,7 @@ These steps apply to any Clerk event. To make the setup process easier, it's rec
           // If successful, the payload will be available from 'evt'
           // If verification fails, error out and return error code
           try {
-            evt = wh.verify(payload, {
+            evt = wh.verify(JSON.stringify(payload), {
               'svix-id': svix_id as string,
               'svix-timestamp': svix_timestamp as string,
               'svix-signature': svix_signature as string,


### PR DESCRIPTION
Error: Could not verify webhook: Expected payload to be of type string or Buffer. Please refer to https://docs.svix.com/receiving/verifying-payloads/how for more information.

This was the error occuring because of payload can be Buffer or string only so i used json.stringify to fix that and it worked

### What does this solve?
The error occurred because the payload was required to be either a Buffer or a string, but it was in an incompatible format. To resolve this, I used ` JSON.stringify ` to convert the payload into a valid string format, which successfully fixed the issue.

- <!--- Describe your changes in detail. Why does this change need to happen? Include any links to Slack discussions, Linear comments, etc. -->

`payload` -> ` JSON.stringify(payload)`

### What changed?

- <!--- How does this PR solve the problem? -->

Error: Could not verify webhook: Expected payload to be of type string or Buffer. Please refer to https://docs.svix.com/receiving/verifying-payloads/how for more information.

Solved this error while using clerk with Nodejs and Ts

### Checklist

- [✅] I have clicked on "Files changed" and performed a thorough self-review
- [ ] I have added the "deploy-preview" label and added the preview link(s) to this PR description
- [ ] All existing checks pass
