### PR TITLE
(/references/javascript/organization/invitations) fix incorrect links

### DIFF
--- a/docs/references/javascript/organization/invitations.mdx
+++ b/docs/references/javascript/organization/invitations.mdx
@@ -12,7 +12,7 @@ The following examples assume:
 
 ## `getInvitations()`
 
-Retrieves the list of invitations for the currently active organization. Returns a [`ClerkPaginatedResponse`](/docs/references/javascript/types/clerk-paginated-response) of [`OrganizationInvitation`](/docs/references/javascript/types/organization-domain) objects.
+Retrieves the list of invitations for the currently active organization. Returns a [`ClerkPaginatedResponse`](/docs/references/javascript/types/clerk-paginated-response) of [`OrganizationInvitation`](/docs/references/javascript/types/organization-invitation) objects.
 
 ```typescript
 function getInvitations(
@@ -87,7 +87,7 @@ if (clerk.user) {
 
 ## `inviteMember()`
 
-Creates and sends an invitation to the target email address for becoming a member with the role passed on the function parameters. Returns an [`OrganizationInvitation`](/docs/references/javascript/types/organization-domain) object.
+Creates and sends an invitation to the target email address for becoming a member with the role passed on the function parameters. Returns an [`OrganizationInvitation`](/docs/references/javascript/types/organization-invitation) object.
 
 ```typescript
 function inviteMember(params: InviteMemberParams): Promise<OrganizationInvitation>
@@ -156,7 +156,7 @@ if (clerk.user) {
 
 ## `inviteMembers()`
 
-Creates and sends an invitation to the target email addresses for becoming a member with the role passed in the parameters. Returns an array of [`OrganizationInvitation`](/docs/references/javascript/types/organization-domain) objects.
+Creates and sends an invitation to the target email addresses for becoming a member with the role passed in the parameters. Returns an array of [`OrganizationInvitation`](/docs/references/javascript/types/organization-invitation) objects.
 
 ```typescript
 function inviteMembers(params: InviteMembersParams): Promise<OrganizationInvitation[]>
@@ -222,5 +222,3 @@ if (clerk.user) {
   clerk.mountSignIn(signInDiv)
 }
 ```
-
-[orginv-ref]: /docs/references/javascript/organization-invitation


### PR DESCRIPTION
Links were to /types/organization-domain and should be to /types/organization-invitation
