### PR TITLE
(/react/use-organization) add correct types for the returns

### DIFF
--- a/docs/references/react/use-organization.mdx
+++ b/docs/references/react/use-organization.mdx
@@ -129,28 +129,28 @@ type OrganizationEnrollmentMode =
   ---
 
   - `memberships`
-  - [`PaginatedResources`](#paginated-resources)
+  - `PaginatedResourcesWithDefault<OrganizationMembershipResource>` ([`PaginatedResources`](#paginated-resources) of [`OrganizationMembership`](/docs/references/javascript/types/organization-membership))
 
   Includes a paginated list of the organization's memberships.
 
   ---
 
   - `invitations`
-  - [`PaginatedResources`](#paginated-resources)
+  - `PaginatedResourcesWithDefault<OrganizationInvitationResource>` ([`PaginatedResources`](#paginated-resources) of [`OrganizationInvitation`](/docs/references/javascript/types/organization-invitation))
 
   Includes a paginated list of the organization's invitations.
 
   ---
 
   - `membershipRequests`
-  - [`PaginatedResources`](#paginated-resources)
+  - `PaginatedResourcesWithDefault<OrganizationMembershipRequestResource>` ([`PaginatedResources`](#paginated-resources) of [`OrganizationMembershipRequest`](/docs/references/javascript/types/organization-membership-request))
 
   Includes a paginated list of the organization's membership requests.
 
   ---
 
   - `domains`
-  - [`PaginatedResources`](#paginated-resources)
+  - `PaginatedResourcesWithDefault<OrganizationDomainResource>` ([`PaginatedResources`](#paginated-resources) of [`OrganizationDomain`](/docs/references/javascript/types/organization-domain))
 
   Includes a paginated list of the organization's domains.
 </Properties>
@@ -159,9 +159,9 @@ type OrganizationEnrollmentMode =
 
 <Properties>
   - `data`
-  - `any[]`
+  - `T[]`
 
-  An array that contains the fetched data.
+  An array that contains the fetched data. For example, for the `memberships` attribute, `data` will be an array of [`OrganizationMembership`](/docs/references/javascript/types/organization-membership) objects.
 
   ---
 


### PR DESCRIPTION
Adds correct types with appropriate reference links for the return properties.
