### PR TITLE
fix headings that include "returns" in the text

### DIFF
--- a/docs/references/astro/auth-store.mdx
+++ b/docs/references/astro/auth-store.mdx
@@ -5,7 +5,7 @@ description: Clerk's $authStore nanostore provides a convenient way to access th
 
 The `$authStore` store provides a convenient way to access the current auth state and helper methods for managing the active session.
 
-## `$authStore.get()` returns
+## Returns
 
 <Properties>
   - `userId`


### PR DESCRIPTION
Audited headings that include "returns" in it to ensure they are absolutely necessary. 