### PR TITLE
(custom-flows/user-impersonation) mention needing to create the custom perm

### DIFF
--- a/docs/custom-flows/user-impersonation.mdx
+++ b/docs/custom-flows/user-impersonation.mdx
@@ -11,7 +11,7 @@ This guide will walk you through how to build a custom flow that handles user im
 
 <Tabs items={["Next.js", "Expo"]}>
   <Tab>
-    The following example builds a dashboard that is only accessible to users with the `admin:impersonate` [permission](/docs/organizations/roles-permissions#custom-permissions). You can modify the [authorization checks](/docs/organizations/verify-user-permissions) to fit your use case.
+    The following example builds a dashboard that is only accessible to users with the `org:admin:impersonate` permission. To use this example, you must first [create the custom `org:admin:impersonate` permission](/docs/organizations/roles-permissions#custom-permissions). Or you can modify the [authorization checks](/docs/organizations/verify-user-permissions) to fit your use case.
 
     In the dashboard, the user will see a list of the application's users. When the user chooses to impersonate a user, they will be signed in as that user and redirected to the homepage.
 


### PR DESCRIPTION
### What does this solve?

User feedback tickets reads:
> Please call out that both (impersonation and custom roles) features shown in this example are add-on's. You'll want to also talk about how to create the custom role that you've shown, otherwise I don't think it will work as shown?

### What changed?

- Adds copy to indicate to the user that for the guide, they must create the custom permission.

### Checklist

- [x] I have clicked on "Files changed" and performed a thorough self-review
- [ ] I have added the "deploy-preview" label and added the preview link(s) to this PR description
- [x] All existing checks pass
