### PR TITLE
Include port on Next.js proxy example

### DIFF
--- a/docs/advanced-usage/using-proxies.mdx
+++ b/docs/advanced-usage/using-proxies.mdx
@@ -122,6 +122,7 @@ When using a proxy, all requests to the Frontend API will be made through your d
 
           const proxyUrl = new URL(request.url)
           proxyUrl.host = 'frontend-api.clerk.dev'
+          proxyUrl.port = "443"
           proxyUrl.protocol = 'https'
           proxyUrl.pathname = proxyUrl.pathname.replace('/__clerk', '')
 


### PR DESCRIPTION
### 🔎 Previews:

-

### What does this solve?

The current Clerk docs do not specify a port for the Next.js proxy. As the url is taken from the request url, any port that the user is accessing the server from (or more likely, the port that a reverse proxy listens to) gets used on the clerk request. So you end up with frontend-api.clerk.dev:8080 being fetched.

### What changed?

I have added a specification of the correct SSL port.

### Checklist

- [x] I have clicked on "Files changed" and performed a thorough self-review
- [ ] I have added the "deploy-preview" label and added the preview link(s) to this PR description
- [ ] All existing checks pass
