### PR TITLE
fix useOrganization() table

### DIFF
--- a/docs/guides/custom-types.mdx
+++ b/docs/guides/custom-types.mdx
@@ -15,7 +15,7 @@ Clerk provides TypeScript interfaces that you can use to define custom types for
 - `UserPrivateMetadata`
 - `UserUnsafeMetadata`
 
-## Example
+## Example: custom JWT claims
 
 To override an interface, you must define a global type, as shown in the following example:
 
@@ -34,6 +34,24 @@ declare global {
     metadata: {
       onboardingComplete?: boolean
     }
+  }
+}
+```
+
+## Example: custom roles and permissions
+
+When defining custom types for roles and permissions:
+
+- Custom permissions are merged with [system permissions](/docs/organizations/roles-permissions#system-permissions)
+- Custom roles completely replace default roles (`org:admin` and `org:member`)
+
+```tsx {{ filename: 'types/globals.d.ts' }}
+export {}
+
+declare global {
+  interface ClerkAuthorization {
+    permission: 'org:quiz:create' | 'org:quiz:grade' | 'org:quiz:read' | 'org:quiz:fill'
+    role: 'org:super_admin' | 'org:teacher' | 'org:student'
   }
 }
 ```

--- a/docs/references/backend/types/auth-object.mdx
+++ b/docs/references/backend/types/auth-object.mdx
@@ -45,7 +45,7 @@ The `Auth` object is available on the `request` object in server contexts. Some 
   ---
 
   - `orgRole`
-  - <code>[OrganizationCustomRoleKey](#organization-custom-role-key) | undefined</code>
+  - <code>[OrganizationCustomRoleKey](/docs/references/javascript/types/organization-custom-role-key) | undefined</code>
 
   The current user's role in their active organization.
 
@@ -59,7 +59,7 @@ The `Auth` object is available on the `request` object in server contexts. Some 
   ---
 
   - `orgPermissions`
-  - <code>[OrganizationCustomPermissionKey](#organization-custom-permission-key)\[] | undefined</code>
+  - <code>[OrganizationCustomPermissionKey](/docs/references/javascript/types/organization-custom-permission-key)\[] | undefined</code>
 
   The current user's active organization permissions.
 
@@ -105,18 +105,6 @@ The `Auth` object is available on the `request` object in server contexts. Some 
 
   Used to help debug issues when using Clerk in development.
 </Properties>
-
-### `OrganizationCustomRoleKey`
-
-The `orgRole` property on the `Auth` object has the type `OrganizationCustomRoleKey`.
-
-`OrganizationCustomRoleKey` is a string that represents the user's role in the organization. Clerk provides the [default roles](/docs/organizations/roles-permissions#default-roles) `org:admin` and `org:member`. However, you can create [custom roles](/docs/organizations/create-roles-permissions) as well.
-
-### `OrganizationCustomPermissionKey`
-
-The `orgPermissions` property on the `Auth` object has the type `OrganizationCustomPermissionKey`.
-
-`OrganizationCustomPermissionKey` is a string representing a user's permission in an organization. Clerk provides [default system permissions](/docs/organizations/roles-permissions#system-permissions) and allows you to create [custom permissions](/docs/organizations/create-roles-permissions#create-a-new-permission-for-your-organization).
 
 ### `has()`
 

--- a/docs/references/javascript/organization/members.mdx
+++ b/docs/references/javascript/organization/members.mdx
@@ -38,14 +38,10 @@ function getMemberships(
   ---
 
   - `role?`
-  - <code>[OrganizationCustomRoleKey](#organization-custom-role-key)\[]</code>
+  - <code>[OrganizationCustomRoleKey](/docs/references/javascript/types/organization-custom-role-key)\[]</code>
 
   The [roles](/docs/organizations/roles-permissions) of memberships that will be included in the response.
 </Properties>
-
-#### `OrganizationCustomRoleKey`
-
-`OrganizationCustomRoleKey` is a string that represents the user's role in the organization. Clerk provides the [default roles](/docs/organizations/roles-permissions#default-roles) `org:admin` and `org:member`. However, you can create [custom roles](/docs/organizations/create-roles-permissions) as well.
 
 ## `addMember()`
 

--- a/docs/references/javascript/types/organization-custom-permission-key.mdx
+++ b/docs/references/javascript/types/organization-custom-permission-key.mdx
@@ -1,0 +1,8 @@
+---
+title: '`OrganizationCustomPermissionKey`'
+description: A type that represents a user's permission in an organization.
+---
+
+`OrganizationCustomPermissionKey` is a type that represents a user's permission in an organization. It will be string unless the developer has provided their own types through [`ClerkAuthorization`](/docs/guides/custom-types#example-custom-roles-and-permissions).
+
+Clerk provides [default system permissions](/docs/organizations/roles-permissions#system-permissions). However, you can create [custom permissions](/docs/organizations/create-roles-permissions#create-a-new-permission-for-your-organization) as well.

--- a/docs/references/javascript/types/organization-custom-role-key.mdx
+++ b/docs/references/javascript/types/organization-custom-role-key.mdx
@@ -1,0 +1,8 @@
+---
+title: '`OrganizationCustomRoleKey`'
+description: A type that represents the user's role in an organization.
+---
+
+`OrganizationCustomRoleKey` is a type that represents the user's role in an organization. It will be string unless the developer has provided their own types through [`ClerkAuthorization`](/docs/guides/custom-types#example-custom-roles-and-permissions).
+
+Clerk provides the [default roles](/docs/organizations/roles-permissions#default-roles) `org:admin` and `org:member`. However, you can create [custom roles](/docs/organizations/create-roles-permissions) as well.

--- a/docs/references/javascript/types/organization-invitation.mdx
+++ b/docs/references/javascript/types/organization-invitation.mdx
@@ -37,7 +37,7 @@ The `OrganizationInvitation` object is the model around an organization invitati
   ---
 
   - `role`
-  - [`OrganizationCustomRoleKey`](#organization-custom-role-key)
+  - [`OrganizationCustomRoleKey`](/docs/references/javascript/types/organization-custom-role-key)
 
   The [role](/docs/organizations/roles-permissions) of the current user in the organization.
 
@@ -62,10 +62,6 @@ The `OrganizationInvitation` object is the model around an organization invitati
 
   The date when the invitation was last updated.
 </Properties>
-
-### `OrganizationCustomRoleKey`
-
-`OrganizationCustomRoleKey` is a string that represents the user's role in the organization. Clerk provides the [default roles](/docs/organizations/roles-permissions#default-roles) `org:admin` and `org:member`. However, you can create [custom roles](/docs/organizations/create-roles-permissions) as well.
 
 ## Methods
 

--- a/docs/references/javascript/types/user-organization-invitation.mdx
+++ b/docs/references/javascript/types/user-organization-invitation.mdx
@@ -43,7 +43,7 @@ The `UserOrganizationInvitation` object is the model around a user's invitation 
   ---
 
   - `role`
-  - [`OrganizationCustomRoleKey`](#organization-custom-role-key)
+  - [`OrganizationCustomRoleKey`](/docs/references/javascript/types/organization-custom-role-key)
 
   The [role](/docs/organizations/roles-permissions) of the current user in the organization.
 
@@ -68,10 +68,6 @@ The `UserOrganizationInvitation` object is the model around a user's invitation 
 
   The date when the invitation was last updated.
 </Properties>
-
-### `OrganizationCustomRoleKey`
-
-`OrganizationCustomRoleKey` is a string that represents the user's role in the organization. Clerk provides the [default roles](/docs/organizations/roles-permissions#default-roles) `org:admin` and `org:member`. However, you can create [custom roles](/docs/organizations/create-roles-permissions) as well.
 
 ## Methods
 

--- a/docs/references/react/use-organization.mdx
+++ b/docs/references/react/use-organization.mdx
@@ -121,28 +121,28 @@ Optional properties that are shared across the `invitations`, `membershipRequest
   ---
 
   - `memberships`
-  - `PaginatedResourcesWithDefault<OrganizationMembershipResource>` ([`PaginatedResources`](#paginated-resources) of [`OrganizationMembership`](/docs/references/javascript/types/organization-membership))
+  - <code>[PaginatedResources](#paginated-resources)[\<OrganizationMembership>](/docs/references/javascript/types/organization-membership)</code>
 
   Includes a paginated list of the organization's memberships.
 
   ---
 
   - `invitations`
-  - `PaginatedResourcesWithDefault<OrganizationInvitationResource>` ([`PaginatedResources`](#paginated-resources) of [`OrganizationInvitation`](/docs/references/javascript/types/organization-invitation))
+  - <code>[PaginatedResources](#paginated-resources)[\<OrganizationInvitation>](/docs/references/javascript/types/organization-invitation)</code>
 
   Includes a paginated list of the organization's invitations.
 
   ---
 
   - `membershipRequests`
-  - `PaginatedResourcesWithDefault<OrganizationMembershipRequestResource>` ([`PaginatedResources`](#paginated-resources) of [`OrganizationMembershipRequest`](/docs/references/javascript/types/organization-membership-request))
+  - <code>[PaginatedResources](#paginated-resources)[\<OrganizationMembershipRequest>](/docs/references/javascript/types/organization-membership-request)</code>
 
   Includes a paginated list of the organization's membership requests.
 
   ---
 
   - `domains`
-  - `PaginatedResourcesWithDefault<OrganizationDomainResource>` ([`PaginatedResources`](#paginated-resources) of [`OrganizationDomain`](/docs/references/javascript/types/organization-domain))
+  - <code>[PaginatedResources](#paginated-resources)[\<OrganizationDomain>](/docs/references/javascript/types/organization-domain)</code>
 
   Includes a paginated list of the organization's domains.
 </Properties>

--- a/docs/references/react/use-organization.mdx
+++ b/docs/references/react/use-organization.mdx
@@ -13,7 +13,7 @@ The `useOrganization()` hook retrieves attributes of the currently active organi
 
 <Properties>
   - `invitations`
-  - `true | { status?: OrganizationInvitationStatus } & { SharedProperties }`
+  - `true | { status?: 'pending' | 'accepted' | 'revoked' } & { SharedProperties }`
 
   If set to `true`, all default properties will be used.
 

--- a/docs/references/react/use-organization.mdx
+++ b/docs/references/react/use-organization.mdx
@@ -13,36 +13,55 @@ The `useOrganization()` hook retrieves attributes of the currently active organi
   - `invitations`
   - `true | { status?: OrganizationInvitationStatus } & { SharedProperties }`
 
-  If set to `true`, all default properties will be used. Otherwise, accepts an object with an optional `status` property of type [`OrganizationInvitationStatus`](#organization-invitation-status) and any of the properties described in [Shared properties](#shared-properties).
+  If set to `true`, all default properties will be used.
+
+  Otherwise, accepts an object with the following optional properties:
+
+  - `status`: A string that filters the invitations by the provided status.
+  - Any of the properties described in [Shared properties](#shared-properties).
 
   ---
 
   - `membershipRequests`
-  - `true | { status?: OrganizationInvitationStatus } & { SharedProperties }`
+  - `true | { status?: 'pending' | 'accepted' | 'revoked' } & { SharedProperties }`
 
-  If set to `true`, all default properties will be used. Otherwise, accepts an object with an optional `status` property of type [`OrganizationInvitationStatus`](#organization-invitation-status) and any of the properties described in [Shared properties](#shared-properties).
+  If set to `true`, all default properties will be used. Otherwise, accepts an object with the following optional properties:
+
+  - `status`: A string that filters the membership requests by the provided status.
+  - Any of the properties described in [Shared properties](#shared-properties).
 
   ---
 
   - `memberships`
   - `true | { role?: OrganizationCustomRoleKey[]; query?: string } & { SharedProperties }`
 
-    If set to `true`, all default properties will be used. Otherwise, accepts an object with an optional `role` property of type [`OrganizationCustomRoleKey[]`](#organization-custom-role-key) and any of the properties described in [Shared properties](#shared-properties).
+  If set to `true`, all default properties will be used.
+
+  Otherwise, accepts an object with the following optional properties:
+
+  - `role`: An array of [`OrganizationCustomRoleKey`](/docs/references/javascript/types/organization-custom-role-key).
+  - `query`: A string that filters the memberships by the provided string.
+  - Any of the properties described in [Shared properties](#shared-properties).
 
   ---
 
   - `domains`
-  - `true | { enrollmentMode?: OrganizationEnrollmentMode } & { SharedProperties }`
+  - `true | { enrollmentMode?: 'manual_invitation' | 'automatic_invitation' | 'automatic_suggestion' } & { SharedProperties }`
 
-    If set to `true`, all default properties will be used. Otherwise, accepts an object with an optional `enrollmentMode` property of type [`OrganizationEnrollmentMode`](#organization-enrollment-mode) and any of the properties described in [Shared properties](#shared-properties).
+  If set to `true`, all default properties will be used.
+
+  Otherwise, accepts an object with the following optional properties:
+
+  - `enrollmentMode`: A string that filters the domains by the provided enrollment mode.
+  - Any of the properties described in [Shared properties](#shared-properties).
 </Properties>
 
 > [!WARNING]
-> By default, the `memberships`, `invitations`, `membershipRequests`, and `domains` attributes aren't populated. You must pass `true` or an object with the desired [properties](#shared-properties) to fetch and paginate the data.
+> By default, the `memberships`, `invitations`, `membershipRequests`, and `domains` attributes aren't populated. To fetch and paginate the data, you must pass `true` or an object with the desired properties.
 
 ### Shared properties
 
-Properties that are shared across the `invitations`, `membershipRequests`, `memberships`, and `domains` properties.
+Optional properties that are shared across the `invitations`, `membershipRequests`, `memberships`, and `domains` properties.
 
 <Properties>
   - `initialPage`
@@ -71,35 +90,6 @@ Properties that are shared across the `invitations`, `membershipRequests`, `memb
 
   If `true`, newly fetched data will be appended to the existing list rather than replacing it. Useful for implementing infinite scroll functionality. Defaults to `false`.
 </Properties>
-
-### `OrganizationInvitationStatus`
-
-`useOrganization()` accepts `status` as a property for the `invitations` and `membershipRequests` parameters.
-
-`status` is a string that can be one of the following:
-
-```typescript
-type OrganizationInvitationStatus = 'pending' | 'accepted' | 'revoked'
-```
-
-### `OrganizationCustomRoleKey`
-
-`useOrganization` accepts `role` as a property for the `memberships` parameter.
-
-`role` is a string that represents the user's role in the organization. Clerk provides the [default roles](/docs/organizations/roles-permissions#default-roles) `org:admin` and `org:member`. However, you can create [custom roles](/docs/organizations/create-roles-permissions) as well.
-
-### `OrganizationEnrollmentMode`
-
-`useOrganization()` accepts `enrollmentMode` as a property for the `domains` paramater.
-
-`enrollmentMode` is a string that can be one of the following:
-
-```typescript
-type OrganizationEnrollmentMode =
-  | 'manual_invitation'
-  | 'automatic_invitation'
-  | 'automatic_suggestion'
-```
 
 > [!NOTE]
 > These attributes are updating automatically and will re-render their respective components whenever you set a different organization using the [`setActive({ organization })`](/docs/references/javascript/clerk/session-methods#set-active) method or update any of the memberships or invitations. No need for you to manage updating anything manually.

--- a/docs/references/react/use-organization.mdx
+++ b/docs/references/react/use-organization.mdx
@@ -1,6 +1,8 @@
 ---
 title: useOrganization()
 description: Access and manage the currently active organization in your React application with Clerk's useOrganization() hook.
+search:
+  rank: 1
 ---
 
 The `useOrganization()` hook retrieves attributes of the currently active organization.

--- a/docs/references/react/use-organization.mdx
+++ b/docs/references/react/use-organization.mdx
@@ -25,7 +25,7 @@ The `useOrganization()` hook retrieves attributes of the currently active organi
   ---
 
   - `memberships`
-  - `true | { role?: OrganizationCustomRoleKey[] } & { SharedProperties }`
+  - `true | { role?: OrganizationCustomRoleKey[]; query?: string } & { SharedProperties }`
 
     If set to `true`, all default properties will be used. Otherwise, accepts an object with an optional `role` property of type [`OrganizationCustomRoleKey[]`](#organization-custom-role-key) and any of the properties described in [Shared properties](#shared-properties).
 


### PR DESCRIPTION
### 🔎 Previews:

- https://clerk.com/docs/pr/2038/references/react/use-organization

### What does this solve?

- The `useOrganization()` table wasn't rendering properly

### What changed?

- Fixes the table
- Reorganizes the table to be more visually palatable (using lists in the property descriptions)
- Created type references for `OrganizationCustomRoleKey` and `OrganizationCustomPermissionKey`
  - Removes sections like "OrganizationCustomRoleKey" and "OrganizationCustomPermissionKey"
  - Updates tables across docs to link to these references
- Adds a section to our "Custom types" guide to demonstrate how to define custom types for roles and permissions (as related to `OrganizationCustomRoleKey` and `OrganizationCustomPermissionKey`)

### Checklist

- [x] I have clicked on "Files changed" and performed a thorough self-review
- [x] I have added the "deploy-preview" label and added the preview link(s) to this PR description
- [x] All existing checks pass
