### PR TITLE
(Backend SDK) add callout about clerkclient usage; remove example responses

### DIFF
--- a/docs/_partials/auth-object-table.mdx
+++ b/docs/_partials/auth-object-table.mdx
@@ -1,0 +1,14 @@
+{/* How to access the `Auth` object */}
+
+The `Auth` object is available on the `request` object in server contexts. Some frameworks provide a helper that returns the `Auth` object. See the following table for more information.
+
+| Framework | How to access the `Auth` object |
+| - | - |
+| Next.js App Router | [`auth()`](/docs/references/nextjs/auth) |
+| Next.js Pages Router | [`getAuth()`](/docs/references/nextjs/get-auth) |
+| Astro | [`locals.auth()`](/docs/references/astro/locals#locals-auth) |
+| Express | [`req.auth`](/docs/references/express/overview) |
+| React Router | [`getAuth()`](/docs/references/react-router/get-auth) |
+| Remix | [`getAuth()`](/docs/references/remix/read-session-data#get-auth) |
+| Tanstack Start | [`getAuth()`](/docs/references/tanstack-start/get-auth) |
+| Other | `request.auth` |

--- a/docs/_partials/backend/usage.mdx
+++ b/docs/_partials/backend/usage.mdx
@@ -1,2 +1,2 @@
 > [!NOTE]
-> Importing `clerkClient` varies based on your framework. Refer to the [Backend SDK overview](/docs/references/backend/overview) for usage details, including guidance on [how to access the `clerkClient` object](/docs/references/backend/overview#get-the-user-id-and-other-properties).
+> Importing `clerkClient` varies based on your framework. Refer to the [Backend SDK overview](/docs/references/backend/overview) for usage details, including guidance on [how to access the `userId` and other properties](/docs/references/backend/overview#get-the-user-id-and-other-properties).

--- a/docs/_partials/backend/usage.mdx
+++ b/docs/_partials/backend/usage.mdx
@@ -1,0 +1,2 @@
+> [!NOTE]
+> Importing `clerkClient` varies based on your framework. Refer to the [Backend SDK overview](/docs/references/backend/overview) for usage details, including guidance on [how to access the `clerkClient` object](/docs/references/backend/overview#get-the-user-id-and-other-properties).

--- a/docs/references/backend/allowlist/create-allowlist-identifier.mdx
+++ b/docs/references/backend/allowlist/create-allowlist-identifier.mdx
@@ -5,7 +5,7 @@ description: Use Clerk's Backend SDK to add a new identifier to the allowlist.
 
 {/* clerk/javascript file: https://github.com/clerk/javascript/blob/main/packages/backend/src/api/endpoints/AllowlistIdentifierApi.ts#L22 */}
 
-Adds a new identifier to the allowlist.
+Adds a new identifier to the allowlist. Returns the created [`AllowlistIdentifier`](/docs/references/backend/types/backend-allowlist-identifier) object.
 
 ```ts
 function createAllowlistIdentifier(
@@ -31,22 +31,13 @@ function createAllowlistIdentifier(
 
 ## Example
 
+<Include src="_partials/backend/usage" />
+
 ```tsx
 const response = await clerkClient.allowlistIdentifiers.createAllowlistIdentifier({
   identifier: 'test@example.com',
   notify: false,
 })
-
-console.log(response)
-/*
-_AllowlistIdentifier {
-  id: 'alid_123',
-  identifier: 'test@example.com',
-  createdAt: 1705443883820,
-  updatedAt: 1705443883820,
-  invitationId: undefined
-}
-*/
 ```
 
 ## Backend API (BAPI) endpoint

--- a/docs/references/backend/allowlist/delete-allowlist-identifier.mdx
+++ b/docs/references/backend/allowlist/delete-allowlist-identifier.mdx
@@ -22,21 +22,13 @@ function deleteAllowlistIdentifier(allowlistIdentifierId: string): Promise<Allow
 
 ## Example
 
+<Include src="_partials/backend/usage" />
+
 ```tsx
 const allowlistIdentifierId = 'alid_123'
 
 const response =
   await clerkClient.allowlistIdentifiers.deleteAllowlistIdentifier(allowlistIdentifierId)
-
-console.log(response)
-/*
-DeletedObject {
-  object: 'allowlist_identifier',
-  id: 'alid_123',
-  slug: null,
-  deleted: true
-}
-*/
 ```
 
 ## Backend API (BAPI) endpoint

--- a/docs/references/backend/allowlist/get-allowlist-identifier-list.mdx
+++ b/docs/references/backend/allowlist/get-allowlist-identifier-list.mdx
@@ -5,7 +5,7 @@ description: Use Clerk's Backend SDK to retrieve a list of allowlist identifiers
 
 {/* clerk/javascript file: https://github.com/clerk/javascript/blob/main/packages/backend/src/api/endpoints/AllowlistIdentifierApi.ts#L14 */}
 
-Retrieves the list of all allowlist identifiers.
+Retrieves the list of all allowlist identifiers. Returns a [`PaginatedResourceResponse`](/docs/references/backend/types/paginated-resource-response) object with a `data` property that contains an array of [`AllowlistIdentifier`](/docs/references/backend/types/backend-allowlist-identifier) objects, and a `totalCount` property that indicates the total number of allowlist identifiers in the system.
 
 ```ts
 function getAllowlistIdentifierList(): Promise<PaginatedResourceResponse<AllowlistIdentifier[]>>
@@ -13,26 +13,10 @@ function getAllowlistIdentifierList(): Promise<PaginatedResourceResponse<Allowli
 
 ## Example
 
-In this example, you can see that the returned [`PaginatedResourceResponse`](/docs/references/backend/types/paginated-resource-response) includes `data`, which is an array of all [`AllowlistIdentifier`](/docs/references/backend/types/backend-allowlist-identifier) objects, and `totalCount`, which indicates the total number of allowlist identifiers in the system.
+<Include src="_partials/backend/usage" />
 
 ```tsx
 const response = await clerkClient.allowlistIdentifiers.getAllowlistIdentifierList()
-
-console.log(response)
-/*
-{
-  data: [
-    _AllowlistIdentifier {
-      id: 'alid_123',
-      identifier: 'test@example.com',
-      createdAt: 1705443883820,
-      updatedAt: 1705443883820,
-      invitationId: undefined
-    }
-  ],
-  totalCount: 1
-}
-*/
 ```
 
 ## Backend API (BAPI) endpoint

--- a/docs/references/backend/authenticate-request.mdx
+++ b/docs/references/backend/authenticate-request.mdx
@@ -146,57 +146,59 @@ It is recommended to set these options as [environment variables](/docs/deployme
 
 ## Examples
 
-### With a higher-level SDK
+<Tabs items={["Backend SDK on its own", "With other Clerk SDKs"]}>
+  <Tab>
+    If you are using the [JavaScript Backend SDK](/docs/references/backend/overview) on its own, you need to provide the `secretKey` and `publishableKey` to `createClerkClient()` so that it is passed to `authenticateRequest()`. You can set these values as [environment variables](/docs/deployments/clerk-environment-variables#clerk-publishable-and-secret-keys) and then pass them to the function.
 
-`authenticateRequest()` requires `publishableKey` to be set. If you are importing `clerkClient` from a higher-level SDK, such as Next.js, then `clerkClient` infers the `publishableKey` from your [environment variables](/docs/deployments/clerk-environment-variables#clerk-publishable-and-secret-keys).
+    ```tsx
+    import { createClerkClient } from '@clerk/backend'
 
-```tsx
-import { clerkClient } from '@clerk/nextjs/server'
+    export async function GET(req: Request) {
+      const clerkClient = createClerkClient({
+        secretKey: process.env.CLERK_SECRET_KEY,
+        publishableKey: process.env.CLERK_PUBLISHABLE_KEY,
+      })
 
-const client = await clerkClient()
+      const { isSignedIn } = await clerkClient.authenticateRequest(req, {
+        authorizedParties: ['https://example.com'],
+      })
 
-export async function GET(req: Request) {
-  const { isSignedIn } = await client.authenticateRequest(req, {
-    authorizedParties: ['https://example.com'],
-  })
+      if (!isSignedIn) {
+        return Response.json({ status: 401 })
+      }
 
-  if (!isSignedIn) {
-    return Response.json({ status: 401 })
-  }
+      // Add logic to perform protected actions
 
-  // Perform protected actions
-  // Add logic to perform protected actions
+      return Response.json({ message: 'This is a reply' })
+    }
+    ```
+  </Tab>
 
-  return Response.json({ message: 'This is a reply' })
-}
-```
+  <Tab>
+    `authenticateRequest()` requires `publishableKey` to be set. If you are importing `clerkClient` from a higher-level SDK, such as Next.js, then `clerkClient` infers the `publishableKey` from your [environment variables](/docs/deployments/clerk-environment-variables#clerk-publishable-and-secret-keys). The following example uses Next.js, but the same logic applies for other frameworks.
 
-### With the Backend SDK on its own
+    ```tsx
+    import { clerkClient } from '@clerk/nextjs/server'
 
-If you are using the [JavaScript Backend SDK](/docs/references/backend/overview) on its own, you need to provide the `secretKey` and `publishableKey` to `createClerkClient()` so that it is passed to `authenticateRequest()`. You can set these values as [environment variables](/docs/deployments/clerk-environment-variables#clerk-publishable-and-secret-keys) and then pass them to the function.
+    const client = await clerkClient()
 
-```tsx
-import { createClerkClient } from '@clerk/backend'
+    export async function GET(req: Request) {
+      const { isSignedIn } = await client.authenticateRequest(req, {
+        authorizedParties: ['https://example.com'],
+      })
 
-export async function GET(req: Request) {
-  const clerkClient = createClerkClient({
-    secretKey: process.env.CLERK_SECRET_KEY,
-    publishableKey: process.env.CLERK_PUBLISHABLE_KEY,
-  })
+      if (!isSignedIn) {
+        return Response.json({ status: 401 })
+      }
 
-  const { isSignedIn } = await clerkClient.authenticateRequest(req, {
-    authorizedParties: ['https://example.com'],
-  })
+      // Perform protected actions
+      // Add logic to perform protected actions
 
-  if (!isSignedIn) {
-    return Response.json({ status: 401 })
-  }
-
-  // Add logic to perform protected actions
-
-  return Response.json({ message: 'This is a reply' })
-}
-```
+      return Response.json({ message: 'This is a reply' })
+    }
+    ```
+  </Tab>
+</Tabs>
 
 ### Networkless token verification
 

--- a/docs/references/backend/client/get-client.mdx
+++ b/docs/references/backend/client/get-client.mdx
@@ -22,24 +22,12 @@ function getClient(clientId: string): Promise<Client>
 
 ## Example
 
+<Include src="_partials/backend/usage" />
+
 ```tsx
 const clientId = 'client_123'
 
 const response = await clerkClient.clients.getClient(clientId)
-
-console.log(response)
-/*
-_Client {
-  id: 'client_123',
-  sessionIds: [ 'sess_123' ],
-  sessions: [ [_Session] ],
-  signInId: null,
-  signUpId: null,
-  lastActiveSessionId: 'sess_123',
-  createdAt: 1705529444202,
-  updatedAt: 1705530913279
-}
-*/
 ```
 
 ## Backend API (BAPI) endpoint

--- a/docs/references/backend/client/verify-client.mdx
+++ b/docs/references/backend/client/verify-client.mdx
@@ -22,6 +22,8 @@ function verifyClient(token: string): Promise<Client>
 
 ## Example
 
+<Include src="_partials/backend/usage" />
+
 ```tsx
 const token = 'my-session-token'
 

--- a/docs/references/backend/domains/delete-domain.mdx
+++ b/docs/references/backend/domains/delete-domain.mdx
@@ -3,10 +3,10 @@ title: '`deleteDomain()`'
 description: Use Clerk's Backend SDK to delete a satellite domain for the instance.
 ---
 
-Deletes a satellite domain for the instance. It is currently not possible to delete the instance's primary domain.
+Deletes a satellite domain for the instance. It is currently not possible to delete the instance's primary domain. Returns a [`DeletedObject`](/docs/references/javascript/types/deleted-object).
 
 ```ts
-function deleteDomain(id: string): Promise<User>
+function deleteDomain(id: string): Promise<DeletedObject>
 ```
 
 ## Parameters
@@ -20,20 +20,12 @@ function deleteDomain(id: string): Promise<User>
 
 ## Example
 
+<Include src="_partials/backend/usage" />
+
 ```tsx
 const id = 'test_123'
 
 const response = await clerkClient.users.deleteDomain(id)
-
-console.log(response)
-/*
-_DeletedObject {
-  object: 'domain',
-  id: 'test_123',
-  slug: null,
-  deleted: true
-}
-*/
 ```
 
 ## Backend API (BAPI) endpoint

--- a/docs/references/backend/email-addresses/create-email-address.mdx
+++ b/docs/references/backend/email-addresses/create-email-address.mdx
@@ -43,8 +43,7 @@ function createEmailAddress(params: CreateEmailAddressParams): Promise<EmailAddr
 
 ## Example
 
-> [!NOTE]
-> Learn how to [get the `userId` and other properties](/docs/references/backend/overview#get-the-user-id-and-other-properties).
+<Include src="_partials/backend/usage" />
 
 ```tsx
 const response = await clerkClient.emailAddresses.createEmailAddress({
@@ -53,23 +52,6 @@ const response = await clerkClient.emailAddresses.createEmailAddress({
   primary: true,
   verified: true,
 })
-
-console.log(response)
-/*
-_EmailAddress {
-  id: 'idn_123',
-  emailAddress: 'testclerk123@gmail.com',
-  verification: _Verification {
-    status: 'verified',
-    strategy: 'admin',
-    externalVerificationRedirectURL: null,
-    attempts: null,
-    expireAt: null,
-    nonce: null
-  },
-  linkedTo: []
-}
-*/
 ```
 
 ## Backend API (BAPI) endpoint

--- a/docs/references/backend/email-addresses/delete-email-address.mdx
+++ b/docs/references/backend/email-addresses/delete-email-address.mdx
@@ -22,20 +22,12 @@ function deleteEmailAddress(emailAddressId: string): Promise<EmailAddress>
 
 ## Example
 
+<Include src="_partials/backend/usage" />
+
 ```tsx
 const emailAddressId = 'idn_123'
 
 const response = await clerkClient.emailAddresses.deleteEmailAddress(emailAddressId)
-
-console.log(response)
-/*
-_DeletedObject {
-  object: 'email_address',
-  id: 'idn_123',
-  slug: null,
-  deleted: true
-}
-*/
 ```
 
 ## Backend API (BAPI) endpoint

--- a/docs/references/backend/email-addresses/get-email-address.mdx
+++ b/docs/references/backend/email-addresses/get-email-address.mdx
@@ -22,32 +22,12 @@ function getEmailAddress(emailAddressId: string): Promise<EmailAddress>
 
 ## Example
 
+<Include src="_partials/backend/usage" />
+
 ```tsx
-const emailAddressId = 'idn_2V7JJ2R3O7KWHjCmUuEOJESHlPz'
+const emailAddressId = 'idn_123'
 
 const response = await clerkClient.emailAddresses.getEmailAddress(emailAddressId)
-
-console.log(response)
-/*
-_EmailAddress {
-  id: 'idn_123',
-  emailAddress: 'alexis@clerk.dev',
-  verification: _Verification {
-    status: 'verified',
-    strategy: 'from_oauth_google',
-    externalVerificationRedirectURL: null,
-    attempts: null,
-    expireAt: null,
-    nonce: null
-  },
-  linkedTo: [
-    _IdentificationLink {
-      id: 'idn_123',
-      type: 'oauth_google'
-    }
-  ]
-}
-*/
 ```
 
 ## Backend API (BAPI) endpoint

--- a/docs/references/backend/email-addresses/update-email-address.mdx
+++ b/docs/references/backend/email-addresses/update-email-address.mdx
@@ -32,30 +32,7 @@ function updateEmailAddress(
 
 ## Example
 
-Let's start with an `EmailAddress` object that looks like this:
-
-```js {{ prettier: false }}
-_EmailAddress {
-  id: 'idn_123',
-  emailAddress: 'testclerk123@gmail.com',
-  verification: _Verification {
-    status: 'verified',
-    strategy: 'from_oauth_google',
-    externalVerificationRedirectURL: null,
-    attempts: null,
-    expireAt: null,
-    nonce: null,
-  },
-  linkedTo: [
-    _IdentificationLink {
-      id: 'idn_123',
-      type: 'oauth_google',
-    },
-  ],
-}
-```
-
-Let's update the email address to be unverified:
+<Include src="_partials/backend/usage" />
 
 ```tsx {{ mark: [[12, 13]] }}
 const emailAddressId = 'idn_123'
@@ -63,19 +40,7 @@ const emailAddressId = 'idn_123'
 const params = { verified: false }
 
 const response = await clerkClient.emailAddresses.updateEmailAddress(emailAddressId, params)
-
-console.log(response)
-/*
-_EmailAddress {
-  id: 'idn_123',
-  emailAddress: 'testclerk123@gmail.com',
-  verification: null,
-  linkedTo: []
-}
-*/
 ```
-
-As you can see in the response, the email address is now unverified.
 
 ## Backend API (BAPI) endpoint
 

--- a/docs/references/backend/invitations/create-invitation.mdx
+++ b/docs/references/backend/invitations/create-invitation.mdx
@@ -52,6 +52,8 @@ function createInvitation(params: CreateParams): Promise<Invitation>
 
 ## Example
 
+<Include src="_partials/backend/usage" />
+
 ```tsx
 const response = await clerkClient.invitations.createInvitation({
   emailAddress: 'invite@example.com',
@@ -63,20 +65,6 @@ const response = await clerkClient.invitations.createInvitation({
     },
   },
 })
-
-console.log(response)
-/*
-_Invitation {
-  id: 'inv_123',
-  emailAddress: 'invite@example.com',
-  publicMetadata: { example: 'metadata', example_nested: [Object] },
-  createdAt: 1705531674576,
-  updatedAt: 1705531674576,
-  status: 'pending',
-  url: 'https://clerk.adjective-noun-00.lcl.dev/v1/tickets/accept?ticket=ticketHash',
-  revoked: undefined
-}
-*/
 ```
 
 ## Backend API (BAPI) endpoint

--- a/docs/references/backend/invitations/get-invitation-list.mdx
+++ b/docs/references/backend/invitations/get-invitation-list.mdx
@@ -5,7 +5,7 @@ description: Use Clerk's Backend SDK to retrieve a list of non-revoked invitatio
 
 {/* clerk/javascript file: https://github.com/clerk/javascript/blob/main/packages/backend/src/api/endpoints/InvitationApi.ts#L34 */}
 
-Retrieves a list of non-revoked invitations for your application, sorted by descending creation date.
+Retrieves a list of non-revoked invitations for your application, sorted by descending creation date. Returns a [`PaginatedResourceResponse`](/docs/references/backend/types/paginated-resource-response) object with a `data` property that contains an array of [`Invitation`](/docs/references/backend/types/backend-invitation) objects, and a `totalCount` property that indicates the total number of invitations in the system.
 
 ```ts
 function getInvitationList(
@@ -40,28 +40,10 @@ function getInvitationList(
 
 ### Basic
 
-In the following example, you can see that the returned [`PaginatedResourceResponse`](/docs/references/backend/types/paginated-resource-response) includes `data`, which is an array of [`Invitation`](/docs/references/backend/types/backend-invitation) objects, and `totalCount`, which indicates the total number of invitations in the system.
+<Include src="_partials/backend/usage" />
 
 ```tsx
 const response = await clerkClient.invitations.getInvitationList()
-
-console.log(response)
-/*
-[
-  data: [
-    _Invitation {
-      id: 'inv_123',
-      emailAddress: 'invite@example.com',
-      publicMetadata: [Object],
-      createdAt: 1705531674576,
-      updatedAt: 1705531674576,
-      status: 'pending',
-      revoked: undefined
-    }
-  ],
-  totalCount: 1
-]
-*/
 ```
 
 ### Filter by invitation status
@@ -71,24 +53,6 @@ Retrieves list of invitations that have been revoked.
 ```tsx
 // get all revoked invitations
 const response = await clerkClient.invitations.getInvitationList({ status: 'revoked' })
-
-console.log(response)
-/*
-{
-  data: [
-    _Invitation {
-      id: 'inv_123',
-      emailAddress: 'invite@example.com',
-      publicMetadata: [Object],
-      createdAt: 1705531674576,
-      updatedAt: 1705531674576,
-      status: 'pending',
-      revoked: undefined
-    }
-  ],
-  totalCount: 1
-}
-*/
 ```
 
 ### Limit the number of results

--- a/docs/references/backend/invitations/revoke-invitation.mdx
+++ b/docs/references/backend/invitations/revoke-invitation.mdx
@@ -26,23 +26,12 @@ function revokeInvitation(invitationId: string): Promise<Invitation>
 
 ## Example
 
+<Include src="_partials/backend/usage" />
+
 ```tsx
 const invitationId = 'inv_123'
 
 const response = await clerkClient.invitations.revokeInvitation(invitationId)
-
-console.log(response)
-/*
-_Invitation {
-  id: 'inv_123',
-  emailAddress: 'invite@example.com',
-  publicMetadata: { example: 'metadata', example_nested: [Object] },
-  createdAt: 1705531674576,
-  updatedAt: 1705533499411,
-  status: 'revoked',
-  revoked: true
-}
-*/
 ```
 
 ## Backend API (BAPI) endpoint

--- a/docs/references/backend/organization/create-organization-invitation.mdx
+++ b/docs/references/backend/organization/create-organization-invitation.mdx
@@ -59,6 +59,8 @@ function createOrganizationInvitation(
 
 ## Example
 
+<Include src="_partials/backend/usage" />
+
 ```tsx
 const organizationId = 'org_123'
 
@@ -74,21 +76,6 @@ const response = await clerkClient.organizations.createOrganizationInvitation({
   emailAddress,
   role,
 })
-
-console.log(response)
-/*
-_OrganizationInvitation {
-  id: 'orginv_123',
-  emailAddress: 'testclerk123@clerk.dev',
-  role: 'org:member',
-  organizationId: 'org_123',
-  createdAt: 1705534000014,
-  updatedAt: 1705534000014,
-  status: 'pending',
-  publicMetadata: {},
-  privateMetadata: {}
-}
-*/
 ```
 
 ## Backend API (BAPI) endpoint

--- a/docs/references/backend/organization/create-organization-membership.mdx
+++ b/docs/references/backend/organization/create-organization-membership.mdx
@@ -5,7 +5,7 @@ description: Use Clerk's Backend SDK to create a membership to an organization f
 
 {/* clerk/javascript file: https://github.com/clerk/javascript/blob/main/packages/backend/src/api/endpoints/OrganizationApi.ts#L187 */}
 
-Creates a membership to an organization for a user directly (circumventing the need for an invitation).
+Creates a membership to an organization for a user directly (circumventing the need for an invitation). Returns a [`OrganizationMembership`](/docs/references/backend/types/backend-organization-membership) object.
 
 ```ts
 function createOrganizationMembership(
@@ -38,6 +38,8 @@ function createOrganizationMembership(
 
 ## Example
 
+<Include src="_partials/backend/usage" />
+
 In the following example, an [`OrganizationMembership`](/docs/references/backend/types/backend-organization-membership) is created for a user with the role `org:member`.
 
 ```tsx
@@ -52,41 +54,6 @@ const response = await clerkClient.organizations.createOrganizationMembership({
   userId,
   role,
 })
-
-console.log(response)
-/*
-_OrganizationMembership {
-  id: 'orgmem_123',
-  role: 'org:member',
-  publicMetadata: {},
-  privateMetadata: {},
-  createdAt: 1705534546701,
-  updatedAt: 1705534546701,
-  organization: _Organization {
-    id: 'org_123',
-    name: 'TestOrg',
-    slug: 'test-org',
-    imageUrl: 'https://img.clerk.com/eyJ...',
-    hasImage: false,
-    createdBy: 'user_456',
-    createdAt: 1702488558853,
-    updatedAt: 1705534260298,
-    publicMetadata: {},
-    privateMetadata: {},
-    maxAllowedMemberships: 3,
-    adminDeleteEnabled: true,
-    members_count: undefined
-  },
-  publicUserData: _OrganizationMembershipPublicUserData {
-    identifier: 'testclerk123@gmail.com',
-    firstName: 'Test',
-    lastName: 'Clerk',
-    imageUrl: 'https://img.clerk.com/eyJ...',
-    hasImage: true,
-    userId: 'user_123'
-  }
-}
-*/
 ```
 
 ## Backend API (BAPI) endpoint

--- a/docs/references/backend/organization/create-organization.mdx
+++ b/docs/references/backend/organization/create-organization.mdx
@@ -57,31 +57,14 @@ function createOrganization(params: CreateParams): Promise<Organization>
 
 ## Example
 
+<Include src="_partials/backend/usage" />
+
 ```tsx
 const name = 'test-org'
 
 const createdBy = 'user_123'
 
 const response = await clerkClient.organizations.createOrganization({ name, createdBy })
-
-console.log(response)
-/*
-_Organization {
-  id: 'org_123',
-  name: 'test-org',
-  slug: 'test-org-1705534741',
-  imageUrl: 'https://img.clerk.com/eyJ...',
-  hasImage: false,
-  createdBy: 'user_123',
-  createdAt: 1705534741971,
-  updatedAt: 1705534741971,
-  publicMetadata: {},
-  privateMetadata: {},
-  maxAllowedMemberships: 3,
-  adminDeleteEnabled: true,
-  members_count: undefined
-}
-*/
 ```
 
 ## Backend API (BAPI) endpoint

--- a/docs/references/backend/organization/delete-organization-logo.mdx
+++ b/docs/references/backend/organization/delete-organization-logo.mdx
@@ -20,29 +20,14 @@ function deleteOrganizationLogo(organizationId: string): Promise<Organization>
 
 ## Example
 
+<Include src="_partials/backend/usage" />
+
 ```tsx
 const organizationId = 'org_123'
 
 const response = await clerkClient.organizations.deleteOrganizationLogo(organizationId)
 
 console.log(response)
-/*
-_Organization {
-  id: 'org_123',
-  name: 'test',
-  slug: 'test',
-  imageUrl: 'https://img.clerk.com/eyJ...',
-  hasImage: false,
-  createdBy: 'user_2f9RVdIOe8JzGlfc3HWwXDg1AaX',
-  createdAt: 1718653681849,
-  updatedAt: 1719869217527,
-  publicMetadata: {},
-  privateMetadata: {},
-  maxAllowedMemberships: 5,
-  adminDeleteEnabled: true,
-  membersCount: undefined
-}
-*/
 ```
 
 ## Backend API (BAPI) endpoint

--- a/docs/references/backend/organization/delete-organization-membership.mdx
+++ b/docs/references/backend/organization/delete-organization-membership.mdx
@@ -5,10 +5,10 @@ description: Use Clerk's Backend SDK to remove a user from the specified organiz
 
 {/* clerk/javascript file: https://github.com/clerk/javascript/blob/main/packages/backend/src/api/endpoints/OrganizationApi.ts#L227 */}
 
-Removes a user from the specified organization.
+Removes a user from the specified organization. Returns a [`OrganizationMembership`](/docs/references/backend/types/backend-organization-membership) object.
 
 ```ts
-function getOrganizationList(
+function deleteOrganizationMembership(
   params: DeleteOrganizationMembershipParams,
 ): Promise<OrganizationMembership>
 ```
@@ -31,6 +31,8 @@ function getOrganizationList(
 
 ## Example
 
+<Include src="_partials/backend/usage" />
+
 ```tsx
 const organizationId = 'org_123'
 
@@ -40,41 +42,6 @@ const response = await clerkClient.organizations.deleteOrganizationMembership({
   organizationId,
   userId,
 })
-
-console.log(response)
-/*
-_OrganizationMembership {
-  id: 'orgmem_123',
-  role: 'org:member',
-  publicMetadata: {},
-  privateMetadata: {},
-  createdAt: 1705534546701,
-  updatedAt: 1705534546701,
-  organization: _Organization {
-    id: 'org_123',
-    name: 'Test Org',
-    slug: 'test-org',
-    imageUrl: 'https://img.clerk.com/eyJ...',
-    hasImage: false,
-    createdBy: 'user_456',
-    createdAt: 1702488558853,
-    updatedAt: 1705536790529,
-    publicMetadata: [Object],
-    privateMetadata: {},
-    maxAllowedMemberships: 3,
-    adminDeleteEnabled: true,
-    members_count: undefined
-  },
-  publicUserData: _OrganizationMembershipPublicUserData {
-    identifier: 'testclerk123@gmail.com',
-    firstName: 'Test',
-    lastName: 'Clerk',
-    imageUrl: 'https://img.clerk.com/eyJ...',
-    hasImage: true,
-    userId: 'user_123'
-  }
-}
-*/
 ```
 
 ## Backend API (BAPI) endpoint

--- a/docs/references/backend/organization/delete-organization.mdx
+++ b/docs/references/backend/organization/delete-organization.mdx
@@ -5,10 +5,10 @@ description: Use Clerk's Backend SDK to delete an organization.
 
 {/* clerk/javascript file: https://github.com/clerk/javascript/blob/main/packages/backend/src/api/endpoints/OrganizationApi.ts#L169 */}
 
-Deletes an [`Organization`](/docs/references/backend/types/backend-organization)
+Deletes an [`Organization`](/docs/references/backend/types/backend-organization). Returns a [`DeletedObject`](/docs/references/javascript/types/deleted-object) object.
 
 ```ts
-function deleteOrganization(organizationId: string): Promise<Organization>
+function deleteOrganization(organizationId: string): Promise<DeletedObject>
 ```
 
 ## Parameters
@@ -22,20 +22,12 @@ function deleteOrganization(organizationId: string): Promise<Organization>
 
 ## Example
 
+<Include src="_partials/backend/usage" />
+
 ```tsx
 const organizationId = 'org_123'
 
 const response = await clerkClient.organizations.deleteOrganization(organizationId)
-
-console.log(response)
-/*
-DeletedObject {
-  object: 'organization',
-  id: 'org_123',
-  slug: null,
-  deleted: true
-}
-*/
 ```
 
 ## Backend API (BAPI) endpoint

--- a/docs/references/backend/organization/get-organization-invitation-list.mdx
+++ b/docs/references/backend/organization/get-organization-invitation-list.mdx
@@ -5,7 +5,7 @@ description: Use Clerk's Backend SDK to retrieve a list of organization invitati
 
 {/* clerk/javascript file: https://github.com/clerk/javascript/blob/main/packages/backend/src/api/endpoints/OrganizationApi.ts#L237 */}
 
-Retrieves a list of organization invitations.
+Retrieves a list of organization invitations. Returns a [`PaginatedResourceResponse`](/docs/references/backend/types/paginated-resource-response) object with a `data` property that contains an array of [`OrganizationInvitation`](/docs/references/backend/types/backend-organization-invitation) objects, and a `totalCount` property that indicates the total number of organization invitations in the system for the specified organization.
 
 ```ts
 function getOrganizationInvitationList(
@@ -47,43 +47,12 @@ function getOrganizationInvitationList(
 
 ### Basic
 
-In the following example, you can see that the returned [`PaginatedResourceResponse`](/docs/references/backend/types/paginated-resource-response) includes `data`, which is an array of [`OrganizationInvitation`](/docs/references/backend/types/backend-organization-invitation) objects, and `totalCount`, which indicates the total number of organization invitations in the system for the specified organization.
+<Include src="_partials/backend/usage" />
 
 ```tsx
 const organizationId = 'org_123'
 
 const response = await clerkClient.organizations.getOrganizationInvitationList({ organizationId })
-
-console.log(response)
-/*
-{
-  data: [
-    _OrganizationInvitation {
-      id: 'orginv_123',
-      emailAddress: 'testclerk123@gmail.com',
-      role: 'org:member',
-      organizationId: 'org_123',
-      createdAt: 1705538313485,
-      updatedAt: 1705538313485,
-      status: 'pending',
-      publicMetadata: {},
-      privateMetadata: {}
-    },
-    _OrganizationInvitation {
-      id: 'orginv_456',
-      emailAddress: 'testclerk456@gmail.dev',
-      role: 'org:member',
-      organizationId: 'org_123',
-      createdAt: 1705534000014,
-      updatedAt: 1705534817946,
-      status: 'revoked',
-      publicMetadata: {},
-      privateMetadata: {}
-    }
-  ],
-  totalCount: 2
-}
-*/
 ```
 
 ### Filter by invitation status

--- a/docs/references/backend/organization/get-organization-invitation.mdx
+++ b/docs/references/backend/organization/get-organization-invitation.mdx
@@ -31,6 +31,8 @@ function getOrganizationInvitation(
 
 ## Example
 
+<Include src="_partials/backend/usage" />
+
 ```tsx
 const organizationId = 'org_123'
 
@@ -40,21 +42,6 @@ const response = await clerkClient.organizations.getOrganizationInvitation({
   organizationId,
   invitationId,
 })
-
-console.log(response)
-/*
-_OrganizationInvitation {
-  id: 'orginv_123',
-  emailAddress: 'testclerk123@gmail.com',
-  role: 'org:admin',
-  organizationId: 'org_123',
-  createdAt: 1705533057154,
-  updatedAt: 1705534258644,
-  status: 'accepted',
-  publicMetadata: {},
-  privateMetadata: {}
-}
-*/
 ```
 
 ## Backend API (BAPI) endpoint

--- a/docs/references/backend/organization/get-organization-list.mdx
+++ b/docs/references/backend/organization/get-organization-list.mdx
@@ -5,7 +5,7 @@ description: Use Clerk's Backend SDK to retrieve a list of organizations.
 
 {/* clerk/javascript file: https://github.com/clerk/javascript/blob/main/packages/backend/src/api/endpoints/OrganizationApi.ts#L101 */}
 
-Retrieves a list of organizations.
+Retrieves a list of organizations. Returns a [`PaginatedResourceResponse`](/docs/references/backend/types/paginated-resource-response) object with a `data` property that contains an array of [`Organization`](/docs/references/backend/types/backend-organization) objects, and a `totalCount` property that indicates the total number of organizations in the system.
 
 ```ts
 function getOrganizationList(
@@ -54,52 +54,10 @@ function getOrganizationList(
 
 ### Basic
 
-In the following example, you can see that the returned [`PaginatedResourceResponse`](/docs/references/backend/types/paginated-resource-response) includes `data`, which is an array of [`Organization`](/docs/references/backend/types/backend-organization) objects, and `totalCount`, which indicates the total number of organizations in the system.
-
-While the response can return up to 10 data items, for the sake of brevity, only two are shown in this example response.
+<Include src="_partials/backend/usage" />
 
 ```tsx
 const response = await clerkClient.organizations.getOrganizationList()
-
-console.log(response)
-/*
-{
-  data: [
-    _Organization {
-      id: 'org_123',
-      name: 'Test Org',
-      slug: 'test-org',
-      imageUrl: 'https://img.clerk.com/eyJ...',
-      hasImage: false,
-      createdBy: 'user_123',
-      createdAt: 1705534741971,
-      updatedAt: 1705534741971,
-      publicMetadata: {},
-      privateMetadata: {},
-      maxAllowedMemberships: 3,
-      adminDeleteEnabled: true,
-      members_count: undefined
-    },
-    _Organization {
-      id: 'org_456',
-      name: 'Test Org 2',
-      slug: 'test-org-2',
-      imageUrl: 'https://img.clerk.com/eyJ.',
-      hasImage: false,
-      createdBy: 'user_123',
-      createdAt: 1705526650229,
-      updatedAt: 1705526650229,
-      publicMetadata: {},
-      privateMetadata: {},
-      maxAllowedMemberships: 3,
-      adminDeleteEnabled: true,
-      members_count: undefined
-    },
-    ...
-  ],
-  totalCount: 25,
-}
-*/
 ```
 
 ### Limit the number of results

--- a/docs/references/backend/organization/get-organization-membership-list.mdx
+++ b/docs/references/backend/organization/get-organization-membership-list.mdx
@@ -5,7 +5,7 @@ description: Use Clerk's Backend SDK to retrieve a list of memberships for an or
 
 {/* clerk/javascript file: https://github.com/clerk/javascript/blob/main/packages/backend/src/api/endpoints/OrganizationApi.ts#L176 */}
 
-Retrieves a list of memberships for an organization.
+Retrieves a list of memberships for an organization. Returns a [`PaginatedResourceResponse`](/docs/references/backend/types/paginated-resource-response) object with a `data` property that contains an array of [`OrganizationMembership`](/docs/references/backend/types/backend-organization-membership) objects, and a `totalCount` property that indicates the total number of organization memberships in the system for the specified organization.
 
 ```ts
 function getOrganizationMembershipList(
@@ -47,41 +47,12 @@ function getOrganizationMembershipList(
 
 ### Basic
 
-In the following example, you can see that the returned [`PaginatedResourceResponse`](/docs/references/backend/types/paginated-resource-response) includes `data`, which is an array of [`OrganizationMembership`](/docs/references/backend/types/backend-organization-membership) objects, and `totalCount`, which indicates the total number of organization memberships in the system for the specified organization.
+<Include src="_partials/backend/usage" />
 
 ```tsx
 const organizationId = 'org_2ZUtbk2yvnFGItdeze1ivCh3uqh'
 
 const response = await clerkClient.organizations.getOrganizationMembershipList({ organizationId })
-
-console.log(response)
-/* In this example, you can see that data is an array of OrganizationMembership objects, and is populated with two OrganizationMemberships.
-{
-  data: [
-    _OrganizationMembership {
-      id: 'orgmem_2b6TUmlDXlo3e9XPq3Wd9EyfIfj',
-      role: 'org:member',
-      publicMetadata: {},
-      privateMetadata: {},
-      createdAt: 1705534546701,
-      updatedAt: 1705534546701,
-      organization: [_Organization],
-      publicUserData: [_OrganizationMembershipPublicUserData]
-    },
-    _OrganizationMembership {
-      id: 'orgmem_2ZUtbeklm2DPSy7jsaLLwf6V8Nq',
-      role: 'org:admin',
-      publicMetadata: {},
-      privateMetadata: {},
-      createdAt: 1702488558867,
-      updatedAt: 1702488558867,
-      organization: [_Organization],
-      publicUserData: [_OrganizationMembershipPublicUserData]
-    }
-  ],
-  totalCount: 2
-}
-*/
 ```
 
 ### `getOrganizationMembershipList({ organizationId, limit })`

--- a/docs/references/backend/organization/get-organization.mdx
+++ b/docs/references/backend/organization/get-organization.mdx
@@ -22,31 +22,14 @@ function getOrganization(params: GetOrganizationParams): Promise<Organization>
 
 ## Examples
 
+<Include src="_partials/backend/usage" />
+
 ### Retrieve by ID
 
 ```tsx
 const organizationId = 'org_123'
 
 const response = await clerkClient.organizations.getOrganization({ organizationId })
-
-console.log(response)
-/*
-Organization {
-  id: 'org_123',
-  name: 'Test',
-  slug: 'test',
-  imageUrl: 'https://img.clerk.com/eyJ...',
-  hasImage: false,
-  createdBy: 'user_123',
-  createdAt: 1702488558853,
-  updatedAt: 1705536009506,
-  publicMetadata: {},
-  privateMetadata: {},
-  maxAllowedMemberships: 3,
-  adminDeleteEnabled: true,
-  members_count: undefined
-}
-*/
 ```
 
 ### Retrieve by slug

--- a/docs/references/backend/organization/revoke-organization-invitation.mdx
+++ b/docs/references/backend/organization/revoke-organization-invitation.mdx
@@ -38,7 +38,7 @@ function revokeOrganizationInvitation(
 
 ## Example
 
-In the following example, you can see that the returned [`OrganizationInvitation`](/docs/references/backend/types/backend-organization-invitation) object has a `status` of `'revoked'`.
+<Include src="_partials/backend/usage" />
 
 ```tsx {{ mark: [22] }}
 const organizationId = 'org_123'
@@ -52,21 +52,6 @@ const response = await clerkClient.organizations.revokeOrganizationInvitation({
   invitationId,
   requestingUserId,
 })
-
-console.log(response)
-/*
-_OrganizationInvitation {
-  id: 'orginv_123',
-  emailAddress: 'testclerk123@gmail.com',
-  role: 'org:member',
-  organizationId: 'org_123',
-  createdAt: 1705538313485,
-  updatedAt: 1705538631145,
-  status: 'revoked',
-  publicMetadata: {},
-  privateMetadata: {}
-}
-*/
 ```
 
 ## Backend API (BAPI) endpoint

--- a/docs/references/backend/organization/update-organization-logo.mdx
+++ b/docs/references/backend/organization/update-organization-logo.mdx
@@ -5,7 +5,7 @@ description: Use Clerk's Backend SDK to update an organization's logo.
 
 {/* clerk/javascript file: https://github.com/clerk/javascript/blob/main/packages/backend/src/api/endpoints/OrganizationApi.ts#L136 */}
 
-Updates the organization's logo.
+Updates the organization's logo. Returns an [`Organization`](/docs/references/backend/types/backend-organization) object.
 
 ```ts
 function updateOrganizationLogo(
@@ -32,6 +32,8 @@ function updateOrganizationLogo(
 
 ## Example
 
+<Include src="_partials/backend/usage" />
+
 > [!WARNING]
 > Using Backend SDK methods can contribute towards rate limiting. To set an organization's logo, it's recommended to use the frontend [`organization.setLogo()`](/docs/references/javascript/organization/organization#set-logo) method instead.
 
@@ -49,25 +51,6 @@ const params = {
 }
 
 const response = await clerkClient.organizations.updateOrganizationLogo(organizationId, params)
-
-console.log(response)
-/*
-_Organization {
-  id: 'org_123',
-  name: 'test',
-  slug: 'test',
-  imageUrl: 'https://img.clerk.com/eyJ...',
-  hasImage: true,
-  createdBy: 'user_123',
-  createdAt: 1714572514789,
-  updatedAt: 1715633676620,
-  publicMetadata: {},
-  privateMetadata: {},
-  maxAllowedMemberships: 1,
-  adminDeleteEnabled: true,
-  membersCount: undefined
-}
-*/
 ```
 
 ## Backend API (BAPI) endpoint

--- a/docs/references/backend/organization/update-organization-membership-metadata.mdx
+++ b/docs/references/backend/organization/update-organization-membership-metadata.mdx
@@ -45,7 +45,7 @@ function updateOrganizationMembershipMetadata(
 
 ## Example
 
-In the following example, you can see that the returned [`OrganizationMembership`](/docs/references/backend/types/backend-organization-membership) object has its `publicMetadata` property updated with the new metadata provided.
+<Include src="_partials/backend/usage" />
 
 ```tsx {{ mark: [[8, 10], 18] }}
 const organizationId = 'org_123'
@@ -59,41 +59,6 @@ const response = await clerkClient.organizations.updateOrganizationMembershipMet
     example: 'this value is updated!',
   },
 })
-
-console.log(response)
-/*
-_OrganizationMembership {
-  id: 'orgmem_213',
-  role: 'org:admin',
-  publicMetadata: { example: 'this value is updated!' },
-  privateMetadata: {},
-  createdAt: 1702488558867,
-  updatedAt: 1707231338278,
-  organization: _Organization {
-    id: 'org_123',
-    name: 'test',
-    slug: 'test',
-    imageUrl: 'https://img.clerk.com/eyJ...',
-    hasImage: false,
-    createdBy: 'user_123',
-    createdAt: 1702488558853,
-    updatedAt: 1707231200655,
-    publicMetadata: { example: 'metadata' },
-    privateMetadata: {},
-    maxAllowedMemberships: 3,
-    adminDeleteEnabled: true,
-    members_count: undefined
-  },
-  publicUserData: _OrganizationMembershipPublicUserData {
-    identifier: 'alexis@clerk.dev',
-    firstName: 'Alexis',
-    lastName: 'Aguilar',
-    imageUrl: 'https://img.clerk.com/eyJ...',
-    hasImage: true,
-    userId: 'user_123'
-  }
-}
-*/
 ```
 
 ## Backend API (BAPI) endpoint

--- a/docs/references/backend/organization/update-organization-membership.mdx
+++ b/docs/references/backend/organization/update-organization-membership.mdx
@@ -38,7 +38,7 @@ function updateOrganizationMembership(
 
 ## Example
 
-In the following example, you can see that the returned [`OrganizationMembership`](/docs/references/backend/types/backend-organization-membership) object has its `role` property updated to `org:admin`.
+<Include src="_partials/backend/usage" />
 
 ```tsx {{ mark: [5, 17] }}
 const organizationId = 'org_123'
@@ -52,41 +52,6 @@ const response = await clerkClient.organizations.updateOrganizationMembership({
   userId,
   role,
 })
-
-console.log(response)
-/*
-_OrganizationMembership {
-  id: 'orgmem_123',
-  role: 'org:admin',
-  publicMetadata: {},
-  privateMetadata: {},
-  createdAt: 1702488558867,
-  updatedAt: 1705535333002,
-  organization: _Organization {
-    id: 'org_123',
-    name: 'Test Org',
-    slug: 'test-org',
-    imageUrl: 'https://img.clerk.com/eyJ...',
-    hasImage: false,
-    createdBy: 'user_123',
-    createdAt: 1702488558853,
-    updatedAt: 1705534260298,
-    publicMetadata: {},
-    privateMetadata: {},
-    maxAllowedMemberships: 3,
-    adminDeleteEnabled: true,
-    members_count: undefined
-  },
-  publicUserData: _OrganizationMembershipPublicUserData {
-    identifier: 'alexis@clerk.dev',
-    firstName: 'Alexis',
-    lastName: 'Aguilar',
-    imageUrl: 'https://img.clerk.com/eyJ...',
-    hasImage: true,
-    userId: 'user_123'
-  }
-}
-*/
 ```
 
 ## Backend API (BAPI) endpoint

--- a/docs/references/backend/organization/update-organization-metadata.mdx
+++ b/docs/references/backend/organization/update-organization-metadata.mdx
@@ -39,7 +39,7 @@ function updateOrganizationMetadata(
 
 ## Example
 
-In the following example, you can see that the returned [`Organization`](/docs/references/backend/types/backend-organization) object has its `publicMetadata` property updated with the new metadata provided.
+<Include src="_partials/backend/usage" />
 
 ```tsx {{ mark: [[4, 6], 20] }}
 const organizationId = 'org_123'
@@ -49,25 +49,6 @@ const response = await clerkClient.organizations.updateOrganizationMetadata(orga
     example: 'metadata',
   },
 })
-
-console.log(response)
-/*
-_Organization {
-  id: 'org_123',
-  name: 'test',
-  slug: 'test',
-  imageUrl: 'https://img.clerk.com/eyJ...',
-  hasImage: false,
-  createdBy: 'user_123',
-  createdAt: 1702488558853,
-  updatedAt: 1706722339338,
-  publicMetadata: { example: 'metadata' },
-  privateMetadata: {},
-  maxAllowedMemberships: 3,
-  adminDeleteEnabled: true,
-  members_count: undefined
-}
-*/
 ```
 
 ## Backend API (BAPI) endpoint

--- a/docs/references/backend/organization/update-organization.mdx
+++ b/docs/references/backend/organization/update-organization.mdx
@@ -55,7 +55,7 @@ function updateOrganization(params: UpdateOrganizationParams): Promise<Organizat
 
 ## Example
 
-In the following example, you can see that the returned [`Organization`](/docs/references/backend/types/backend-organization) object has its `name` property updated to `Test Updated`.
+<Include src="_partials/backend/usage" />
 
 ```tsx {{ mark: [3, 11] }}
 const organizationId = 'org_123'
@@ -63,25 +63,6 @@ const organizationId = 'org_123'
 const name = 'Test Updated'
 
 const response = await clerkClient.organizations.updateOrganization(organizationId, { name })
-
-console.log(response)
-/*
-_Organization {
-  id: 'org_123',
-  name: 'Test Updated',
-  slug: 'test',
-  imageUrl: 'https://img.clerk.com/eyJ...',
-  hasImage: false,
-  createdBy: 'user_123',
-  createdAt: 1702488558853,
-  updatedAt: 1705536790529,
-  publicMetadata: { example: 'metadata' },
-  privateMetadata: {},
-  maxAllowedMemberships: 3,
-  adminDeleteEnabled: true,
-  members_count: undefined
-}
-*/
 ```
 
 ## Backend API (BAPI) endpoint

--- a/docs/references/backend/overview.mdx
+++ b/docs/references/backend/overview.mdx
@@ -293,42 +293,28 @@ The following options are available:
 
 ## Get the `userId` and other properties
 
-To access the [properties](/docs/references/backend/types/auth-object#auth-object-properties) of the authenticated user, such as their `userId` or `sessionId`, see the following examples:
+The [`Auth`](/docs/references/backend/types/auth-object) object contains important information like the current user's session ID, user ID, and organization ID.
 
-<Tabs items={["Next.js", "Backend SDKs"]}>
-  <Tab>
-    The following example uses the Next.js [`auth()`](/docs/references/nextjs/auth){{ target: '_blank' }} helper to access the `userId`.
+<Include src="_partials/auth-object-table" />
 
-    ```ts
-    import { auth, clerkClient } from '@clerk/nextjs/server'
+For example, in a Next.js App Router route handler, you can use the [`auth()`](/docs/references/nextjs/auth) helper to get the user's ID, and then use the Backend SDK's [`getUser()`](/docs/references/backend/user/get-user) method to get the [Backend User object](/docs/references/backend/types/backend-user).
 
-    export async function GET() {
-      const { userId } = await auth()
+```tsx {{ filename: 'app/api/example/route.ts' }}
+import { auth, clerkClient } from '@clerk/nextjs/server'
 
-      if (!userId) {
-        return Response.json({ error: 'Unauthorized' }, { status: 401 })
-      }
+export async function GET() {
+  // Use `auth()` to get the user's ID
+  const { userId } = await auth()
 
-      const client = await clerkClient()
+  // Protect the route by checking if the user is signed in
+  if (!userId) {
+    return new NextResponse('Unauthorized', { status: 401 })
+  }
 
-      const user = await client.users.getUser(userId)
+  // Use the Backend SDK's `getUser()` method to get the Backend User object
+  const user = await clerkClient.users.getUser(userId)
 
-      return Response.json({ user })
-    }
-    ```
-  </Tab>
-
-  <Tab>
-    The following example uses `req.auth` to access the `userId`.
-
-    For some backend SDKs, such as Fastify, you will need to use `getAuth()` instead of `req.auth`.
-
-    ```ts
-    const { userId } = req.auth
-
-    const response = await clerkClient.users.getUser(userId)
-
-    console.log(response)
-    ```
-  </Tab>
-</Tabs>
+  // Return the Backend User object
+  return NextResponse.json({ user: user }, { status: 200 })
+}
+```

--- a/docs/references/backend/phone-numbers/create-phone-number.mdx
+++ b/docs/references/backend/phone-numbers/create-phone-number.mdx
@@ -50,8 +50,7 @@ function createPhoneNumber(params: CreatePhoneNumberParams): Promise<PhoneNumber
 
 ## Example
 
-> [!NOTE]
-> Learn how to [get the `userId` and other properties](/docs/references/backend/overview#get-the-user-id-and-other-properties).
+<Include src="_partials/backend/usage" />
 
 ```tsx
 const response = await clerkClient.phoneNumbers.createPhoneNumber({
@@ -60,25 +59,6 @@ const response = await clerkClient.phoneNumbers.createPhoneNumber({
   primary: true,
   verified: true,
 })
-
-console.log(response)
-/*
-_PhoneNumber {
-  id: 'idn_123',
-  phoneNumber: '15551234567',
-  reservedForSecondFactor: false,
-  defaultSecondFactor: false,
-  verification: _Verification {
-    status: 'verified',
-    strategy: 'admin',
-    externalVerificationRedirectURL: null,
-    attempts: null,
-    expireAt: null,
-    nonce: null
-  },
-  linkedTo: []
-}
-*/
 ```
 
 ## Backend API (BAPI) endpoint

--- a/docs/references/backend/phone-numbers/delete-phone-number.mdx
+++ b/docs/references/backend/phone-numbers/delete-phone-number.mdx
@@ -22,20 +22,12 @@ function deletePhoneNumber(phoneNumberId: string): Promise<PhoneNumber>
 
 ## Example
 
+<Include src="_partials/backend/usage" />
+
 ```tsx
 const phoneNumberId = 'idn_123'
 
 const response = await clerkClient.phoneNumbers.deletePhoneNumber(phoneNumberId)
-
-console.log(response)
-/*
-_DeletedObject {
-  object: 'phone_number',
-  id: 'idn_123',
-  slug: null,
-  deleted: true
-}
-*/
 ```
 
 ## Backend API (BAPI) endpoint

--- a/docs/references/backend/phone-numbers/get-phone-number.mdx
+++ b/docs/references/backend/phone-numbers/get-phone-number.mdx
@@ -22,29 +22,12 @@ function getPhoneNumber(phoneNumberId: string): Promise<PhoneNumber>
 
 ## Example
 
+<Include src="_partials/backend/usage" />
+
 ```tsx
 const phoneNumberId = 'idn_123'
 
 const response = await clerkClient.phoneNumbers.getPhoneNumber(phoneNumberId)
-
-console.log(response)
-/*
-_PhoneNumber {
-  id: 'idn_123',
-  phoneNumber: '15551234567',
-  reservedForSecondFactor: false,
-  defaultSecondFactor: false,
-  verification: _Verification {
-    status: 'verified',
-    strategy: 'admin',
-    externalVerificationRedirectURL: null,
-    attempts: null,
-    expireAt: null,
-    nonce: null
-  },
-  linkedTo: []
-}
-*/
 ```
 
 ## Backend API (BAPI) endpoint

--- a/docs/references/backend/phone-numbers/update-phone-number.mdx
+++ b/docs/references/backend/phone-numbers/update-phone-number.mdx
@@ -39,27 +39,7 @@ function updatePhoneNumber(
 
 ## Example
 
-Let's start with a `PhoneNumber` object that looks like this:
-
-```js {{ prettier: false }}
-_PhoneNumber {
-  id: 'idn_123',
-  phoneNumber: '15551234567',
-  reservedForSecondFactor: false,
-  defaultSecondFactor: false,
-  verification: _Verification {
-    status: 'verified',
-    strategy: 'admin',
-    externalVerificationRedirectURL: null,
-    attempts: null,
-    expireAt: null,
-    nonce: null,
-  },
-  linkedTo: [],
-}
-```
-
-Let's update the phone number to be unverified:
+<Include src="_partials/backend/usage" />
 
 ```tsx {{ mark: [3, [14, 15]] }}
 const phoneNumberId = 'idn_123'
@@ -67,21 +47,7 @@ const phoneNumberId = 'idn_123'
 const params = { verified: false }
 
 const response = await clerkClient.phoneNumbers.updatePhoneNumber(phoneNumberId, params)
-
-console.log(response)
-/*
-_PhoneNumber {
-  id: 'idn_123',
-  phoneNumber: '15551234567',
-  reservedForSecondFactor: false,
-  defaultSecondFactor: false,
-  verification: null,
-  linkedTo: []
-}
-*/
 ```
-
-As you can see in the response, the phone number is now unverified.
 
 ## Backend API (BAPI) endpoint
 

--- a/docs/references/backend/redirect-urls/create-redirect-url.mdx
+++ b/docs/references/backend/redirect-urls/create-redirect-url.mdx
@@ -22,20 +22,12 @@ function createRedirectUrl(params: CreateRedirectUrlParams): Promise<RedirectUrl
 
 ## Example
 
+<Include src="_partials/backend/usage" />
+
 ```tsx
 const response = await clerkClient.redirectUrls.createRedirectUrl({
   url: 'https://example.com',
 })
-
-console.log(response)
-/*
-_RedirectUrl {
-  id: 'ru_123',
-  url: 'https://example.com',
-  createdAt: 1707151695693,
-  updatedAt: 1707151695693
-}
-*/
 ```
 
 ## Backend API (BAPI) endpoint

--- a/docs/references/backend/redirect-urls/delete-redirect-url.mdx
+++ b/docs/references/backend/redirect-urls/delete-redirect-url.mdx
@@ -22,20 +22,12 @@ function deleteRedirectUrl(redirectUrlId: string): Promise<RedirectUrl>
 
 ## Example
 
+<Include src="_partials/backend/usage" />
+
 ```tsx
 const redirectUrlId = 'ru_123'
 
 const response = await clerkClient.redirectUrls.deleteRedirectUrl(redirectUrlId)
-
-console.log(response)
-/*
-_DeletedObject {
-  object: 'redirect_url',
-  id: 'ru_123',
-  slug: null,
-  deleted: true
-}
-*/
 ```
 
 ## Backend API (BAPI) endpoint

--- a/docs/references/backend/redirect-urls/get-redirect-url-list.mdx
+++ b/docs/references/backend/redirect-urls/get-redirect-url-list.mdx
@@ -5,7 +5,7 @@ description: Use Clerk's Backend SDK to retrieve a list of white-listed redirect
 
 {/* clerk/javascript file: https://github.com/clerk/javascript/blob/main/packages/backend/src/api/endpoints/RedirectUrlApi.ts#L13 */}
 
-Retrieves a list of all white-listed redirect URLs.
+Retrieves a list of all white-listed redirect URLs. Returns a [`PaginatedResourceResponse`](/docs/references/backend/types/paginated-resource-response) object with a `data` property that contains an array of [`RedirectUrl`](/docs/references/backend/types/backend-redirect-url) objects, and a `totalCount` property that indicates the total number of redirect URLs for the application.
 
 ```tsx
 function getRedirectUrlList(): () => Promise<PaginatedResourceResponse<RedirectUrl[]>>
@@ -13,25 +13,10 @@ function getRedirectUrlList(): () => Promise<PaginatedResourceResponse<RedirectU
 
 ## Example
 
-In this example, you can see that the returned [`PaginatedResourceResponse`](/docs/references/backend/types/paginated-resource-response) includes `data`, which is an array of [`RedirectUrl`](/docs/references/backend/types/backend-redirect-url) objects, and `totalCount`, which indicates the total number of redirect URLs for the application.
+<Include src="_partials/backend/usage" />
 
 ```tsx
 const response = await clerkClient.redirectUrls.getRedirectUrlList()
-
-console.log(response)
-/*
-{
-  data: [
-    _RedirectUrl {
-      id: 'ru_123',
-      url: 'https://example.com',
-      createdAt: 1707151695693,
-      updatedAt: 1707151695693
-    }
-  ],
-  totalCount: 1
-}
-*/
 ```
 
 ## Backend API (BAPI) endpoint

--- a/docs/references/backend/redirect-urls/get-redirect-url.mdx
+++ b/docs/references/backend/redirect-urls/get-redirect-url.mdx
@@ -22,20 +22,12 @@ function getRedirectUrl(redirectUrlId: string): Promise<RedirectUrl>
 
 ## Example
 
+<Include src="_partials/backend/usage" />
+
 ```tsx
 const redirectUrlId = 'ru_123'
 
 const response = await clerkClient.redirectUrls.getRedirectUrl(redirectUrlId)
-
-console.log(response)
-/*
-_RedirectUrl {
-  id: 'ru_123',
-  url: 'https://example.com',
-  createdAt: 1707151695693,
-  updatedAt: 1707151695693
-}
-*/
 ```
 
 ## Backend API (BAPI) endpoint

--- a/docs/references/backend/saml-connections/create-saml-connection.mdx
+++ b/docs/references/backend/saml-connections/create-saml-connection.mdx
@@ -83,6 +83,8 @@ function createSamlConnection(params: CreateSamlConnectionParams): Promise<SamlC
 
 ## Example
 
+<Include src="_partials/backend/usage" />
+
 ```tsx
 const response = await clerkClient.samlConnections.createSamlConnection({
   name: 'test-okta',
@@ -95,33 +97,6 @@ const response = await clerkClient.samlConnections.createSamlConnection({
     lastName: 'user.lastName',
   },
 })
-
-console.log(response)
-/*
-{
-  object: 'saml_connection',
-  id: 'samlc_123',
-  name: 'test-okta',
-  domain: 'clerk.dev',
-  idp_entity_id: 'http://www.okta.com/exk...',
-  idp_sso_url: 'https://trial-000000.okta.com/app/trial-000000_clerkdocstest_1/exk.../sso/saml',
-  idp_certificate: 'MII...',
-  idp_metadata_url: 'https://trial-000000.okta.com/app/exk.../sso/saml/metadata',
-  idp_metadata: null,
-  acs_url: 'https://prepared-phoenix-00.clerk.accounts.dev/v1/saml/acs/samlc_123',
-  sp_entity_id: 'https://prepared-phoenix-00.clerk.accounts.dev/saml/samlc_123',
-  sp_metadata_url: 'https://prepared-phoenix-00.clerk.accounts.dev/v1/saml/metadata/samlc_123.xml',
-  attribute_mapping: { user_id: '', email_address: '', first_name: '', last_name: '' },
-  active: false,
-  provider: 'saml_okta',
-  user_count: 0,
-  sync_user_attributes: true,
-  allow_subdomains: false,
-  allow_idp_initiated: false,
-  created_at: 1720032705432,
-  updated_at: 1720032705432
-}
-*/
 ```
 
 ## Backend API (BAPI) endpoint

--- a/docs/references/backend/saml-connections/delete-saml-connection.mdx
+++ b/docs/references/backend/saml-connections/delete-saml-connection.mdx
@@ -3,10 +3,10 @@ title: '`deleteSamlConnection()`'
 description: Use Clerk's Backend SDK to delete a SAML connection.
 ---
 
-Deletes a [`SamlConnection`](/docs/references/backend/types/saml-connection) by its ID.
+Deletes a [`SamlConnection`](/docs/references/backend/types/saml-connection) by its ID. Returns a [`DeletedObject`](/docs/references/backend/types/deleted-object) object.
 
 ```ts
-function deleteSamlConnection(samlConnectionId: string): Promise<Organization>
+function deleteSamlConnection(samlConnectionId: string): Promise<DeletedObject>
 ```
 
 ## Parameters
@@ -20,20 +20,12 @@ function deleteSamlConnection(samlConnectionId: string): Promise<Organization>
 
 ## Example
 
+<Include src="_partials/backend/usage" />
+
 ```tsx
 const samlConnectionId = 'samlc_123'
 
 const response = await clerkClient.samlConnections.deleteSamlConnection(samlConnectionId)
-
-console.log(response)
-/*
-_DeletedObject {
-  object: 'saml_connection',
-  id: 'samlc_123',
-  slug: null,
-  deleted: true
-}
-*/
 ```
 
 ## Backend API (BAPI) endpoint

--- a/docs/references/backend/saml-connections/get-saml-connection-list.mdx
+++ b/docs/references/backend/saml-connections/get-saml-connection-list.mdx
@@ -3,7 +3,7 @@ title: '`getSamlConnectionList()`'
 description: Use Clerk's Backend SDK to retrieve the list of SAML connections for an instance.
 ---
 
-Retrieves the list of SAML connections for an instance.
+Retrieves the list of SAML connections for an instance. Returns a [`PaginatedResourceResponse`](/docs/references/backend/types/paginated-resource-response) object with a `data` property that contains an array of [`SamlConnection`](/docs/references/backend/types/saml-connection) objects, and a `totalCount` property that indicates the total number of SAML connections for the instance.
 
 ```ts
 function getSamlConnectionList(params: SamlConnectionListParams = {}): Promise<SamlConnection[]>
@@ -29,44 +29,10 @@ function getSamlConnectionList(params: SamlConnectionListParams = {}): Promise<S
 
 ### Basic
 
-In this example, you can see that the returned response includes `data`, which is an array of [`SamlConnection`](/docs/references/backend/types/saml-connection) objects, and `totalCount`, which indicates the total number of connections.
-
-While the response can return up to 10 data items, for the sake of brevity, only one is shown in this example response.
+<Include src="_partials/backend/usage" />
 
 ```tsx
 const response = await clerkClient.samlConnections.getSamlConnectionList()
-
-console.log(response)
-/*
-{
-  data: [
-    {
-      object: 'saml_connection',
-      id: 'samlc_123',
-      name: 'test-okta',
-      domain: 'clerk.dev',
-      idp_entity_id: 'http://www.okta.com/exk...',
-      idp_sso_url: 'https://trial-000000.okta.com/app/trial-000000_clerkdocstest_1/exk.../sso/saml',
-      idp_certificate: 'MII...',
-      idp_metadata_url: 'https://trial-000000.okta.com/app/exk.../sso/saml/metadata',
-      idp_metadata: null,
-      acs_url: 'https://prepared-phoenix-00.clerk.accounts.dev/v1/saml/acs/samlc_123',
-      sp_entity_id: 'https://prepared-phoenix-00.clerk.accounts.dev/saml/samlc_123',
-      sp_metadata_url: 'https://prepared-phoenix-00.clerk.accounts.dev/v1/saml/metadata/samlc_123.xml',
-      attribute_mapping: { user_id: '', email_address: '', first_name: '', last_name: '' },
-      active: false,
-      provider: 'saml_okta',
-      user_count: 0,
-      sync_user_attributes: true,
-      allow_subdomains: false,
-      allow_idp_initiated: false,
-      created_at: 1720032705432,
-      updated_at: 1720032705432
-    }
-  ],
-  totalCount: 1
-}
-*/
 ```
 
 ### Limit the number of results

--- a/docs/references/backend/saml-connections/get-saml-connection.mdx
+++ b/docs/references/backend/saml-connections/get-saml-connection.mdx
@@ -20,37 +20,12 @@ function getSamlConnection(samlConnectionId: string): Promise<SamlConnection>
 
 ## Example
 
+<Include src="_partials/backend/usage" />
+
 ```tsx
 const samlConnectionId = 'samlc_123'
 
 const response = await clerkClient.samlConnections.getSamlConnection(samlConnectionId)
-
-console.log(response)
-/*
-{
-  object: 'saml_connection',
-  id: 'samlc_123',
-  name: 'test-okta',
-  domain: 'clerk.dev',
-  idp_entity_id: 'http://www.okta.com/exk...',
-  idp_sso_url: 'https://trial-000000.okta.com/app/trial-000000_clerkdocstest_1/exk.../sso/saml',
-  idp_certificate: 'MII...',
-  idp_metadata_url: 'https://trial-000000.okta.com/app/exk.../sso/saml/metadata',
-  idp_metadata: null,
-  acs_url: 'https://prepared-phoenix-00.clerk.accounts.dev/v1/saml/acs/samlc_123',
-  sp_entity_id: 'https://prepared-phoenix-00.clerk.accounts.dev/saml/samlc_123',
-  sp_metadata_url: 'https://prepared-phoenix-00.clerk.accounts.dev/v1/saml/metadata/samlc_123.xml',
-  attribute_mapping: { user_id: '', email_address: '', first_name: '', last_name: '' },
-  active: false,
-  provider: 'saml_okta',
-  user_count: 0,
-  sync_user_attributes: true,
-  allow_subdomains: false,
-  allow_idp_initiated: false,
-  created_at: 1720032705432,
-  updated_at: 1720032705432
-}
-*/
 ```
 
 ## Backend API (BAPI) endpoint

--- a/docs/references/backend/saml-connections/update-saml-connection.mdx
+++ b/docs/references/backend/saml-connections/update-saml-connection.mdx
@@ -114,41 +114,14 @@ function updateSamlConnection(
 
 ## Example
 
-In this example, the name of the SAML connection is updated.
+<Include src="_partials/backend/usage" />
 
-```tsx {{ mark: [[3, 5], 12] }}
+```tsx
 const samlConnectionId = 'samlc_123'
 
 const response = await clerkClient.samlConnections.updateSamlConnection(samlConnectionId, {
   name: 'Updated SAML Connection',
 })
-
-console.log(response)
-/*
-{
-  object: 'saml_connection',
-  id: 'samlc_123',
-  name: 'Updated SAML Connection',
-  domain: 'clerk.dev',
-  idp_entity_id: 'http://www.okta.com/exk...',
-  idp_sso_url: 'https://trial-000000.okta.com/app/trial-000000_clerkdocstest_1/exk.../sso/saml',
-  idp_certificate: 'MII...',
-  idp_metadata_url: 'https://trial-000000.okta.com/app/exk.../sso/saml/metadata',
-  idp_metadata: null,
-  acs_url: 'https://prepared-phoenix-00.clerk.accounts.dev/v1/saml/acs/samlc_123',
-  sp_entity_id: 'https://prepared-phoenix-00.clerk.accounts.dev/saml/samlc_123',
-  sp_metadata_url: 'https://prepared-phoenix-00.clerk.accounts.dev/v1/saml/metadata/samlc_123.xml',
-  attribute_mapping: { user_id: '', email_address: '', first_name: '', last_name: '' },
-  active: false,
-  provider: 'saml_okta',
-  user_count: 0,
-  sync_user_attributes: true,
-  allow_subdomains: false,
-  allow_idp_initiated: false,
-  created_at: 1720032705432,
-  updated_at: 1720032705432
-}
-*/
 ```
 
 ## Backend API (BAPI) endpoint

--- a/docs/references/backend/sessions/get-session-list.mdx
+++ b/docs/references/backend/sessions/get-session-list.mdx
@@ -5,7 +5,7 @@ description: Use Clerk's Backend SDK to retrieve a list of sessions.
 
 {/* clerk/javascript file: https://github.com/clerk/javascript/blob/main/packages/backend/src/api/endpoints/SessionApi.ts/#L18 */}
 
-Retrieves a list of sessions.
+Retrieves a list of sessions. Returns a [`PaginatedResourceResponse`](/docs/references/backend/types/paginated-resource-response) object with a `data` property that contains an array of [`Session`](/docs/references/backend/types/backend-session) objects, and a `totalCount` property that indicates the total number of sessions for the specified user.
 
 ```ts
 function getSessionList(
@@ -77,8 +77,7 @@ type SessionStatus =
 
 ## Examples
 
-> [!NOTE]
-> Learn how to [get the `userId` and other properties](/docs/references/backend/overview#get-the-user-id-and-other-properties).
+<Include src="_partials/backend/usage" />
 
 Retrieve a list of sessions for a specific `userId`:
 
@@ -98,26 +97,6 @@ const userId = 'user_123'
 const status = 'expired'
 
 const response = await clerkClient.sessions.getSessionList({ userId, status })
-
-console.log(response)
-/*
-{
-  data: [
-    _Session {
-      id: 'sess_123',
-      clientId: 'client_123',
-      userId: 'user_123',
-      status: 'expired',
-      lastActiveAt: 1705100946532,
-      expireAt: 1705344214310,
-      abandonAt: 1707331414310,
-      createdAt: 1704739414310,
-      updatedAt: 1705101240159
-    }
-  ],
-  totalCount: 1
-}
-*/
 ```
 
 ## Backend API (BAPI) endpoint

--- a/docs/references/backend/sessions/get-session.mdx
+++ b/docs/references/backend/sessions/get-session.mdx
@@ -22,28 +22,12 @@ function getSession(sessionId: string): Promise<Session>
 
 ## Example
 
-> [!NOTE]
-> Learn how to [get the `sessionId` and other properties](/docs/references/backend/overview#get-the-user-id-and-other-properties).
+<Include src="_partials/backend/usage" />
 
 ```tsx
 const sessionId = 'sess_123'
 
 const response = await clerkClient.sessions.getSession(sessionId)
-
-console.log(response)
-/*
-_Session {
-  id: 'sess_123',
-  clientId: 'client_123',
-  userId: 'user_123',
-  status: 'active',
-  lastActiveAt: 1705593792894,
-  expireAt: 1706135713248,
-  abandonAt: 1708122913248,
-  createdAt: 1705530913248,
-  updatedAt: 1705593792894
-}
-*/
 ```
 
 ## Backend API (BAPI) endpoint

--- a/docs/references/backend/sessions/get-token.mdx
+++ b/docs/references/backend/sessions/get-token.mdx
@@ -29,20 +29,14 @@ function getToken(sessionId: string, template: string): Promise<Token>
 
 ## Example
 
-> [!NOTE]
-> Learn how to [get the `sessionId` and other properties](/docs/references/backend/overview#get-the-user-id-and-other-properties).
+<Include src="_partials/backend/usage" />
 
 ```js
 const sessionId = 'sess_123'
-const template = 'test'
-const response = await clerkClient.sessions.getToken(sessionId, template)
 
-console.log(response)
-/*
-_Token {
-  jwt: 'eyJhbG...'
-}
-*/
+const template = 'test'
+
+const response = await clerkClient.sessions.getToken(sessionId, template)
 ```
 
 ## Examples with frameworks

--- a/docs/references/backend/sessions/revoke-session.mdx
+++ b/docs/references/backend/sessions/revoke-session.mdx
@@ -24,28 +24,12 @@ function revokeSession(sessionId: string): Promise<Session>
 
 ## Example
 
-> [!NOTE]
-> Learn how to [get the `sessionId` and other properties](/docs/references/backend/overview#get-the-user-id-and-other-properties).
+<Include src="_partials/backend/usage" />
 
 ```tsx
 const sessionId = 'sess_123'
 
 const response = await clerkClient.sessions.revokeSession(sessionId)
-
-console.log(response)
-/*
-_Session {
-  id: 'sess_123',
-  clientId: 'client_123',
-  userId: 'user_123',
-  status: 'revoked',
-  lastActiveAt: 1705601584837,
-  expireAt: 1706135713248,
-  abandonAt: 1708122913248,
-  createdAt: 1705530913248,
-  updatedAt: 1705601602540
-}
-*/
 ```
 
 ## Backend API (BAPI) endpoint

--- a/docs/references/backend/sessions/verify-session.mdx
+++ b/docs/references/backend/sessions/verify-session.mdx
@@ -10,8 +10,7 @@ Verifies whether a session with a given ID corresponds to the provided session t
 
 ## Example
 
-> [!NOTE]
-> Learn how to [get the `sessionId` and other properties](/docs/references/backend/overview#get-the-user-id-and-other-properties).
+<Include src="_partials/backend/usage" />
 
 ```tsx
 const sessionId = 'my-session-id'

--- a/docs/references/backend/sign-in-tokens/create-sign-in-token.mdx
+++ b/docs/references/backend/sign-in-tokens/create-sign-in-token.mdx
@@ -27,11 +27,10 @@ function createSignInToken(params: CreateSignInTokensParams): Promise<SignInToke
 
 ## Example
 
-> [!NOTE]
-> Learn how to [get the `userId` and other properties](/docs/references/backend/overview#get-the-user-id-and-other-properties).
+<Include src="_partials/backend/usage" />
 
 ```tsx
-const userId = 'user_2f9RVdIOe8JzGlfc3HWwXDg1AaX'
+const userId = 'user_123'
 
 const expiresInSeconds = 60 * 60 * 24 * 7 // 1 week
 
@@ -39,19 +38,6 @@ const response = await clerkClient.signInTokens.createSignInToken({
   userId,
   expiresInSeconds,
 })
-
-console.log(response)
-/*
-_SignInToken {
-  id: 'sit_123',
-  userId: 'user_123',
-  token: 'eyJ...',
-  status: 'pending',
-  url: 'https://prepared-phoenix-00.accounts.dev/sign-in?__clerk_ticket=eyJ...',
-  createdAt: 1719952616214,
-  updatedAt: 1719952616214
-}
-*/
 ```
 
 ## Backend API (BAPI) endpoint

--- a/docs/references/backend/sign-in-tokens/revoke-sign-in-token.mdx
+++ b/docs/references/backend/sign-in-tokens/revoke-sign-in-token.mdx
@@ -20,23 +20,12 @@ function revokeSignInToken(signInTokenId: string): Promise<SignInToken>
 
 ## Example
 
+<Include src="_partials/backend/usage" />
+
 ```tsx
 const signInTokenId = 'sit_123'
 
 const response = await clerkClient.signInTokens.revokeSignInToken(signInTokenId)
-
-console.log(response)
-/*
-_SignInToken {
-  id: 'sit_123',
-  userId: 'user_123',
-  token: undefined,
-  status: 'revoked',
-  url: undefined,
-  createdAt: 1719952616214,
-  updatedAt: 1719953040703
-}
-*/
 ```
 
 ## Backend API (BAPI) endpoint

--- a/docs/references/backend/testing-tokens/create-testing-token.mdx
+++ b/docs/references/backend/testing-tokens/create-testing-token.mdx
@@ -3,7 +3,7 @@ title: '`createTestingToken()`'
 description: Use Clerk's Backend SDK to create a testing token for the instance.
 ---
 
-Creates a Testing Token for the instance.
+Creates a [Testing Token](/docs/testing/overview#testing-tokens) for the instance.
 
 ```ts
 function createTestingToken(): Promise<TestingToken>
@@ -11,16 +11,10 @@ function createTestingToken(): Promise<TestingToken>
 
 ## Example
 
+<Include src="_partials/backend/usage" />
+
 ```tsx
 const response = await clerk.testingTokens.createTestingToken()
-
-console.log(response)
-/*
-_TestingToken {
-  token: '1714041000-6U8-ejqcpDoGT-CDGjrRucyt-p6LoUMDHMMOUK5CjHI',
-  expires_at: 1714044600
-}
-*/
 ```
 
 ## Backend API (BAPI) endpoint

--- a/docs/references/backend/types/auth-object.mdx
+++ b/docs/references/backend/types/auth-object.mdx
@@ -7,18 +7,7 @@ The `Auth` object contains important information like the current user's session
 
 ## How to access the `Auth` object
 
-The `Auth` object is available on the `request` object in server contexts. Some frameworks provide a helper that returns the `Auth` object. See the following table for more information.
-
-| Framework | How to access the `Auth` object |
-| - | - |
-| Next.js App Router | [`auth()`](/docs/references/nextjs/auth) |
-| Next.js Pages Router | [`getAuth()`](/docs/references/nextjs/get-auth) |
-| Astro | [`locals.auth()`](/docs/references/astro/locals#locals-auth) |
-| Express | [`req.auth`](/docs/references/express/overview) |
-| React Router | [`getAuth()`](/docs/references/react-router/get-auth) |
-| Remix | [`getAuth()`](/docs/references/remix/read-session-data#get-auth) |
-| Tanstack Start | [`getAuth()`](/docs/references/tanstack-start/get-auth) |
-| Other | `request.auth` |
+<Include src="_partials/auth-object-table" />
 
 ## Properties
 

--- a/docs/references/backend/user/ban-user.mdx
+++ b/docs/references/backend/user/ban-user.mdx
@@ -22,70 +22,12 @@ function banUser(userId: string): Promise<User>
 
 ## Example
 
-> [!NOTE]
-> Learn how to [get the `userId` and other properties](/docs/references/backend/overview#get-the-user-id-and-other-properties).
+<Include src="_partials/backend/usage" />
 
-```tsx {{ mark: [13] }}
+```tsx
 const userId = 'user_123'
 
 const response = await clerkClient.users.banUser(userId)
-
-console.log(response)
-/*
-_User {
-  id: 'user_123,
-  passwordEnabled: false,
-  totpEnabled: false,
-  backupCodeEnabled: false,
-  twoFactorEnabled: false,
-  banned: true,
-  locked: false,
-  createdAt: 1694181111181,
-  updatedAt: 1708101775581,
-  imageUrl: 'https://img.clerk.com/eyJ...',
-  hasImage: true,
-  primaryEmailAddressId: 'idn_123',
-  primaryPhoneNumberId: null,
-  primaryWeb3WalletId: null,
-  lastSignInAt: 1708101739595,
-  externalId: null,
-  username: null,
-  firstName: 'Alexis',
-  lastName: 'Aguilar',
-  publicMetadata: {},
-  privateMetadata: {},
-  unsafeMetadata: {},
-  emailAddresses: [
-    _EmailAddress {
-      id: 'idn_123',
-      emailAddress: 'alexis@clerk.dev',
-      verification: [_Verification],
-      linkedTo: [Array]
-    }
-  ],
-  phoneNumbers: [],
-  web3Wallets: [],
-  externalAccounts: [
-    _ExternalAccount {
-      id: 'idn_123',
-      provider: undefined,
-      identificationId: undefined,
-      externalId: undefined,
-      approvedScopes: 'email https://www.googleapis.com/auth/userinfo.email https://www.googleapis.com/auth/userinfo.profile openid profile',
-      emailAddress: 'alexis@clerk.dev',
-      firstName: undefined,
-      lastName: undefined,
-      imageUrl: undefined,
-      username: null,
-      publicMetadata: {},
-      label: null,
-      verification: [_Verification]
-    }
-  ],
-  lastActiveAt: 1708041600000,
-  createOrganizationEnabled: true
-}
-*/
 ```
 
 ## Backend API (BAPI) endpoint

--- a/docs/references/backend/user/create-user.mdx
+++ b/docs/references/backend/user/create-user.mdx
@@ -223,60 +223,15 @@ function createUser(params: CreateUserParams): Promise<User>
 
 ## Example
 
-In this example, the application's instance settings have been configured to use email and password as the primary authentication method.
+<Include src="_partials/backend/usage" />
 
-You can see that the returned response is the created `User` object, with `firstName` as `"Test"`, `lastName` as `"User"`, and `emailAddress` as an array of email addresses, which includes `'testclerk123@gmail.com'`.
-
-```tsx {{ mark: [27, 28, [32, 39]] }}
+```tsx
 const response = await clerkClient.users.createUser({
   firstName: 'Test',
   lastName: 'User',
   emailAddress: ['testclerk123@gmail.com'],
   password: 'password',
 })
-
-console.log(response)
-/*
-_User {
-  id: 'user_123',
-  passwordEnabled: true,
-  totpEnabled: false,
-  backupCodeEnabled: false,
-  twoFactorEnabled: false,
-  banned: false,
-  locked: false,
-  createdAt: 1720041242964,
-  updatedAt: 1720041242978,
-  imageUrl: 'https://img.clerk.com/eyJ...',
-  hasImage: false,
-  primaryEmailAddressId: 'idn_123',
-  primaryPhoneNumberId: null,
-  primaryWeb3WalletId: null,
-  lastSignInAt: null,
-  externalId: null,
-  username: null,
-  firstName: 'Test',
-  lastName: 'User',
-  publicMetadata: {},
-  privateMetadata: {},
-  unsafeMetadata: {},
-  emailAddresses: [
-    _EmailAddress {
-      id: 'idn_123',
-      emailAddress: 'testclerk123@gmail.com',
-      verification: [_Verification],
-      linkedTo: []
-    }
-  ],
-  phoneNumbers: [],
-  web3Wallets: [],
-  externalAccounts: [],
-  samlAccounts: [],
-  lastActiveAt: null,
-  createOrganizationEnabled: true,
-  legalAcceptedAt: null
-}
-*/
 ```
 
 ## Backend API (BAPI) endpoint

--- a/docs/references/backend/user/delete-user-profile-image.mdx
+++ b/docs/references/backend/user/delete-user-profile-image.mdx
@@ -5,7 +5,7 @@ description: Use Clerk's Backend SDK to delete a user's profile image.
 
 {/* clerk/javascript file: https://github.com/clerk/javascript/blob/main/packages/backend/src/api/endpoints/UserApi.ts#L158 */}
 
-Deletes a user's profile image.
+Deletes a user's profile image. Returns a [`User`](/docs/references/backend/types/backend-user) object.
 
 ```ts
 function deleteUserProfileImage(userId: string): Promise<User>
@@ -13,8 +13,7 @@ function deleteUserProfileImage(userId: string): Promise<User>
 
 ## Example
 
-> [!NOTE]
-> Learn how to [get the `userId` and other properties](/docs/references/backend/overview#get-the-user-id-and-other-properties).
+<Include src="_partials/backend/usage" />
 
 > [!WARNING]
 > Using Backend SDK methods can contribute towards rate limiting. To remove a user's profile image, it's recommended to use the frontend [`user.setProfileImage({ file: null })`](/docs/references/javascript/user/user#set-profile-image-params) method instead.
@@ -22,64 +21,7 @@ function deleteUserProfileImage(userId: string): Promise<User>
 ```tsx
 const userId = 'user_123'
 
-const response = await clerkClient.users.deleteUserProfileImage(userId, params)
-
-console.log(response)
-/*
-_User {
-  id: 'user_123',
-  passwordEnabled: false,
-  totpEnabled: false,
-  backupCodeEnabled: false,
-  twoFactorEnabled: false,
-  banned: false,
-  createdAt: 1719935072474,
-  updatedAt: 1719935170538,
-  imageUrl: null,
-  hasImage: true,
-  primaryEmailAddressId: 'idn_123',
-  primaryPhoneNumberId: null,
-  primaryWeb3WalletId: null,
-  lastSignInAt: 1719935072492,
-  externalId: null,
-  username: null,
-  firstName: 'Test',
-  lastName: 'Clerk',
-  publicMetadata: {},
-  privateMetadata: {},
-  unsafeMetadata: {},
-  emailAddresses: [
-    _EmailAddress {
-      id: 'idn_123',
-      emailAddress: 'test@gmail.com',
-      verification: [_Verification],
-      linkedTo: [Array]
-    }
-  ],
-  phoneNumbers: [],
-  web3Wallets: [],
-  externalAccounts: [
-    _ExternalAccount {
-      id: 'idn_123',
-      provider: undefined,
-      identificationId: undefined,
-      externalId: undefined,
-      approvedScopes: 'email https://www.googleapis.com/auth/userinfo.email https://www.googleapis.com/auth/userinfo.profile openid profile',
-      emailAddress: 'test@gmail.com',
-      firstName: undefined,
-      lastName: undefined,
-      imageUrl: '',
-      username: null,
-      publicMetadata: {},
-      label: null,
-      verification: [_Verification]
-    }
-  ],
-  samlAccounts: [],
-  lastActiveAt: 1719935072472,
-  createOrganizationEnabled: true
-}
-*/
+const response = await clerkClient.users.deleteUserProfileImage(userId)
 ```
 
 ## Backend API (BAPI) endpoint

--- a/docs/references/backend/user/delete-user.mdx
+++ b/docs/references/backend/user/delete-user.mdx
@@ -22,23 +22,12 @@ function deleteUser(userId: string): Promise<User>
 
 ## Example
 
-> [!NOTE]
-> Learn how to [get the `userId` and other properties](/docs/references/backend/overview#get-the-user-id-and-other-properties).
+<Include src="_partials/backend/usage" />
 
 ```tsx
 const userId = 'user_123'
 
 const response = await clerkClient.users.deleteUser(userId)
-
-console.log(response)
-/*
-_DeletedObject {
-  object: 'user',
-  id: 'user_123',
-  slug: null,
-  deleted: true
-}
-*/
 ```
 
 ## Backend API (BAPI) endpoint

--- a/docs/references/backend/user/disable-user-mfa.mdx
+++ b/docs/references/backend/user/disable-user-mfa.mdx
@@ -5,7 +5,7 @@ description: Use Clerk's Backend SDK to disable all of a user's MFA methods at o
 
 {/* clerk/javascript file: https://github.com/clerk/javascript/blob/main/packages/backend/src/api/endpoints/UserApi.ts#L206 */}
 
-Disable all of a user's MFA methods (e.g. OTP sent via SMS, TOTP on their authenticator app) at once.
+Disable all of a user's MFA methods (e.g. OTP sent via SMS, TOTP on their authenticator app) at once. Returns a [`User`](/docs/references/backend/types/backend-user) object.
 
 ```ts
 function disableUserMFA(userId: string): Promise<User>
@@ -22,18 +22,12 @@ function disableUserMFA(userId: string): Promise<User>
 
 ## Example
 
-> [!NOTE]
-> Learn how to [get the `userId` and other properties](/docs/references/backend/overview#get-the-user-id-and-other-properties).
+<Include src="_partials/backend/usage" />
 
 ```tsx
 const userId = 'user_123'
 
 const response = await clerkClient.users.disableUserMFA(userId)
-
-console.log(response)
-/*
-{ user_id: 'user_123' }
-*/
 ```
 
 ## Backend API (BAPI) endpoint

--- a/docs/references/backend/user/get-count.mdx
+++ b/docs/references/backend/user/get-count.mdx
@@ -66,15 +66,12 @@ The total count of users can be filtered down by adding one or more of these par
 
 ## Examples
 
+<Include src="_partials/backend/usage" />
+
 ### Basic
 
 ```tsx
 const response = await clerkClient.users.getCount()
-
-console.log(response)
-/*
-369
-*/
 ```
 
 ### Filter by query

--- a/docs/references/backend/user/get-organization-membership-list.mdx
+++ b/docs/references/backend/user/get-organization-membership-list.mdx
@@ -5,7 +5,7 @@ description: Use Clerk's Backend SDK to retrieve a list of organization membersh
 
 {/* clerk/javascript file: https://github.com/clerk/javascript/blob/main/packages/backend/src/api/endpoints/UserApi.ts#L214 */}
 
-Retrieves a list of organization memberships for a given user.
+Retrieves a list of organization memberships for a given user. Returns a [`PaginatedResourceResponse`](/docs/references/backend/types/paginated-resource-response) object with a `data` property that contains an array of [`OrganizationMembership`](/docs/references/backend/types/backend-organization-membership) objects, and a `totalCount` property that indicates the total number of organization memberships in the system for the specified organization.
 
 ```ts
 function getOrganizationMembershipList(
@@ -38,46 +38,12 @@ function getOrganizationMembershipList(
 
 ## Examples
 
-> [!NOTE]
-> Learn how to [get the `userId` and other properties](/docs/references/backend/overview#get-the-user-id-and-other-properties).
-
-In this example, the returned [`PaginatedResourceResponse`](/docs/references/backend/types/paginated-resource-response) includes `data`, which is an array of [`OrganizationMembership`](/docs/references/backend/types/backend-organization-membership) objects, and `totalCount`, which indicates the total number of organization memberships in the system for the specified organization.
+<Include src="_partials/backend/usage" />
 
 ```tsx
 const userId = 'user_123'
 
 const response = await clerkClient.users.getOrganizationMembershipList({ userId })
-
-console.log(response)
-/*
-{
-  data: [
-    _OrganizationMembership {
-      id: 'orgmem_123',
-      role: 'org:admin',
-      permissions: [Array],
-      publicMetadata: {},
-      privateMetadata: {},
-      createdAt: 1706722393158,
-      updatedAt: 1706722393158,
-      organization: [_Organization],
-      publicUserData: [_OrganizationMembershipPublicUserData]
-    },
-    _OrganizationMembership {
-      id: 'orgmem_456',
-      role: 'org:admin',
-      permissions: [Array],
-      publicMetadata: {},
-      privateMetadata: {},
-      createdAt: 1706722361154,
-      updatedAt: 1706722361154,
-      organization: [_Organization],
-      publicUserData: [_OrganizationMembershipPublicUserData]
-    }
-  ],
-  totalCount: 2
-}
-*/
 ```
 
 ### Limit the number of results

--- a/docs/references/backend/user/get-user-list.mdx
+++ b/docs/references/backend/user/get-user-list.mdx
@@ -5,7 +5,7 @@ description: Use Clerk's Backend SDK to retrieve a list of users.
 
 {/* clerk/javascript file: https://github.com/clerk/javascript/blob/main/packages/backend/src/api/endpoints/UserApi.ts#L116 */}
 
-Retrieves a list of users.
+Retrieves a list of users. Returns a [`PaginatedResourceResponse`](/docs/references/backend/types/paginated-resource-response) object with a `data` property that contains an array of [`User`](/docs/references/backend/types/backend-user) objects, and a `totalCount` property that indicates the total number of users for the application.
 
 ```tsx
 function getUserList(): (params: UserListParams) => Promise<PaginatedResourceResponse<User[]>>
@@ -101,84 +101,10 @@ function getUserList(): (params: UserListParams) => Promise<PaginatedResourceRes
 
 ### Basic
 
-In this example, you can see that the returned [`PaginatedResourceResponse`](/docs/references/backend/types/paginated-resource-response) includes `data`, which is an array of [`User`](/docs/references/backend/types/backend-user) objects, and `totalCount`, which indicates the total number of users for the application.
-
-While the response can return up to 10 data items, for the sake of brevity, only two are shown in this example response.
+<Include src="_partials/backend/usage" />
 
 ```tsx
 const response = await clerkClient.users.getUserList()
-
-console.log(response)
-/*
-{
-  data: [
-    _User {
-      id: 'user_123',
-      passwordEnabled: false,
-      totpEnabled: false,
-      backupCodeEnabled: false,
-      twoFactorEnabled: false,
-      banned: false,
-      locked: false,
-      createdAt: 1707561967007,
-      updatedAt: 1707561967095,
-      imageUrl: 'https://img.clerk.com/eyJ...',
-      hasImage: true,
-      primaryEmailAddressId: 'idn_123',
-      primaryPhoneNumberId: null,
-      primaryWeb3WalletId: null,
-      lastSignInAt: 1707561967014,
-      externalId: null,
-      username: null,
-      firstName: 'First',
-      lastName: 'Test',
-      publicMetadata: {},
-      privateMetadata: {},
-      unsafeMetadata: {},
-      emailAddresses: [Array],
-      phoneNumbers: [],
-      web3Wallets: [],
-      externalAccounts: [Array],
-      lastActiveAt: 1707523200000,
-      createOrganizationEnabled: true,
-      legalAcceptedAt: null
-    },
-    _User {
-      id: 'user_456',
-      passwordEnabled: false,
-      totpEnabled: false,
-      backupCodeEnabled: false,
-      twoFactorEnabled: false,
-      banned: false,
-      locked: false,
-      createdAt: 1707539597250,
-      updatedAt: 1707539597331,
-      imageUrl: 'https://img.clerk.com/eyJ...',
-      hasImage: true,
-      primaryEmailAddressId: 'idn_456',
-      primaryPhoneNumberId: null,
-      primaryWeb3WalletId: null,
-      lastSignInAt: 1707539597260,
-      externalId: null,
-      username: null,
-      firstName: 'Second',
-      lastName: 'Test',
-      publicMetadata: {},
-      privateMetadata: {},
-      unsafeMetadata: {},
-      emailAddresses: [Array],
-      phoneNumbers: [],
-      web3Wallets: [],
-      externalAccounts: [Array],
-      lastActiveAt: 1707523200000,
-      createOrganizationEnabled: true,
-      legalAcceptedAt: null
-    },
-    ...
-  ],
-  totalCount: 500
-}
-*/
 ```
 
 ### Limit the number of results

--- a/docs/references/backend/user/get-user-oauth-access-token.mdx
+++ b/docs/references/backend/user/get-user-oauth-access-token.mdx
@@ -32,8 +32,7 @@ function getUserOauthAccessToken(
 
 ## Example
 
-> [!NOTE]
-> Learn how to [get the `userId` and other properties](/docs/references/backend/overview#get-the-user-id-and-other-properties).
+<Include src="_partials/backend/usage" />
 
 ```tsx
 const userId = 'user_123'
@@ -41,26 +40,6 @@ const userId = 'user_123'
 const provider = 'oauth_google'
 
 const response = await clerkClient.users.getUserOauthAccessToken(userId, provider)
-
-console.log(response)
-/*
-[
-  _OauthAccessToken {
-    provider: 'oauth_google',
-    token: 'ya29...',
-    publicMetadata: {},
-    label: null,
-    scopes: [
-      'email',
-      'https://www.googleapis.com/auth/userinfo.email',
-      'https://www.googleapis.com/auth/userinfo.profile',
-      'openid',
-      'profile'
-    ],
-    tokenSecret: undefined
-  }
-]
-*/
 ```
 
 You can also explore [the example](/docs/authentication/social-connections/oauth#get-an-o-auth-access-token-for-a-social-sign-in-provider) that demonstrates how this method retrieves a social provider's OAuth access token, enabling access to user data from both the provider and Clerk.

--- a/docs/references/backend/user/get-user.mdx
+++ b/docs/references/backend/user/get-user.mdx
@@ -22,55 +22,12 @@ function getUser(userId: string): Promise<User>
 
 ## Example
 
-> [!NOTE]
-> Learn how to [get the `userId` and other properties](/docs/references/backend/overview#get-the-user-id-and-other-properties).
+<Include src="_partials/backend/usage" />
 
 ```tsx
 const userId = 'user_123'
 
 const response = await clerkClient.users.getUser(userId)
-
-console.log(response)
-/*
-_User {
-  id: 'user_123',
-  passwordEnabled: true,
-  totpEnabled: false,
-  backupCodeEnabled: false,
-  twoFactorEnabled: false,
-  banned: false,
-  locked: false,
-  createdAt: 1708103362688,
-  updatedAt: 1708103362701,
-  imageUrl: 'https://img.clerk.com/eyJ...',
-  hasImage: false,
-  primaryEmailAddressId: 'idn_123',
-  primaryPhoneNumberId: null,
-  primaryWeb3WalletId: null,
-  lastSignInAt: null,
-  externalId: null,
-  username: null,
-  firstName: 'Test',
-  lastName: 'User',
-  publicMetadata: {},
-  privateMetadata: {},
-  unsafeMetadata: {},
-  emailAddresses: [
-    _EmailAddress {
-      id: 'idn_123',
-      emailAddress: 'testclerk123@gmail.com',
-      verification: [_Verification],
-      linkedTo: []
-    }
-  ],
-  phoneNumbers: [],
-  web3Wallets: [],
-  externalAccounts: [],
-  lastActiveAt: null,
-  createOrganizationEnabled: true,
-  legalAcceptedAt: null
-}
-*/
 ```
 
 ## Backend API (BAPI) endpoint

--- a/docs/references/backend/user/lock-user.mdx
+++ b/docs/references/backend/user/lock-user.mdx
@@ -24,70 +24,12 @@ function lockUser(userId: string): Promise<User>
 
 ## Example
 
-> [!NOTE]
-> Learn how to [get the `userId` and other properties](/docs/references/backend/overview#get-the-user-id-and-other-properties).
+<Include src="_partials/backend/usage" />
 
-```tsx {{ mark: [13] }}
+```tsx
 const userId = 'user_123'
 
 const response = await clerkClient.users.lockUser(userId)
-
-console.log(response)
-/*
-_User {
-  id: 'user_123',
-  passwordEnabled: false,
-  totpEnabled: false,
-  backupCodeEnabled: false,
-  twoFactorEnabled: false,
-  banned: false,
-  locked: true,
-  createdAt: 1694181111181,
-  updatedAt: 1708102548373,
-  imageUrl: 'https://img.clerk.com/eyJ...',
-  hasImage: true,
-  primaryEmailAddressId: 'idn_123',
-  primaryPhoneNumberId: null,
-  primaryWeb3WalletId: null,
-  lastSignInAt: 1708101739595,
-  externalId: null,
-  username: null,
-  firstName: 'Alexis',
-  lastName: 'Aguilar',
-  publicMetadata: {},
-  privateMetadata: {},
-  unsafeMetadata: {},
-  emailAddresses: [
-    _EmailAddress {
-      id: 'idn_123',
-      emailAddress: 'alexis@clerk.dev',
-      verification: [_Verification],
-      linkedTo: [Array]
-    }
-  ],
-  phoneNumbers: [],
-  web3Wallets: [],
-  externalAccounts: [
-    _ExternalAccount {
-      id: 'idn_123',
-      provider: undefined,
-      identificationId: undefined,
-      externalId: undefined,
-      approvedScopes: 'email https://www.googleapis.com/auth/userinfo.email https://www.googleapis.com/auth/userinfo.profile openid profile',
-      emailAddress: 'alexis@clerk.dev',
-      firstName: undefined,
-      lastName: undefined,
-      imageUrl: undefined,
-      username: null,
-      publicMetadata: {},
-      label: null,
-      verification: [_Verification]
-    }
-  ],
-  lastActiveAt: 1708041600000,
-  createOrganizationEnabled: true
-}
-*/
 ```
 
 ## Backend API (BAPI) endpoint

--- a/docs/references/backend/user/unban-user.mdx
+++ b/docs/references/backend/user/unban-user.mdx
@@ -22,70 +22,12 @@ function unbanUser(userId: string): Promise<User>
 
 ## Example
 
-> [!NOTE]
-> Learn how to [get the `userId` and other properties](/docs/references/backend/overview#get-the-user-id-and-other-properties).
+<Include src="_partials/backend/usage" />
 
-```tsx {{ mark: [13] }}
+```tsx
 const userId = 'user_123'
 
 const response = await clerkClient.users.unbanUser(userId)
-
-console.log(response)
-/*
-_User {
-  id: 'user_123',
-  passwordEnabled: false,
-  totpEnabled: false,
-  backupCodeEnabled: false,
-  twoFactorEnabled: false,
-  banned: false,
-  locked: false,
-  createdAt: 1694181111181,
-  updatedAt: 1708102137929,
-  imageUrl: 'https://img.clerk.com/eyJ...',
-  hasImage: true,
-  primaryEmailAddressId: 'idn_123',
-  primaryPhoneNumberId: null,
-  primaryWeb3WalletId: null,
-  lastSignInAt: 1708101739595,
-  externalId: null,
-  username: null,
-  firstName: 'Alexis',
-  lastName: 'Aguilar',
-  publicMetadata: {},
-  privateMetadata: {},
-  unsafeMetadata: {},
-  emailAddresses: [
-    _EmailAddress {
-      id: 'idn_123',
-      emailAddress: 'alexis@clerk.dev',
-      verification: [_Verification],
-      linkedTo: [Array]
-    }
-  ],
-  phoneNumbers: [],
-  web3Wallets: [],
-  externalAccounts: [
-    _ExternalAccount {
-      id: 'idn_123',
-      provider: undefined,
-      identificationId: undefined,
-      externalId: undefined,
-      approvedScopes: 'email https://www.googleapis.com/auth/userinfo.email https://www.googleapis.com/auth/userinfo.profile openid profile',
-      emailAddress: 'alexis@clerk.dev',
-      firstName: undefined,
-      lastName: undefined,
-      imageUrl: undefined,
-      username: null,
-      publicMetadata: {},
-      label: null,
-      verification: [_Verification]
-    }
-  ],
-  lastActiveAt: 1708041600000,
-  createOrganizationEnabled: true
-}
-*/
 ```
 
 ## Backend API (BAPI) endpoint

--- a/docs/references/backend/user/unlock-user.mdx
+++ b/docs/references/backend/user/unlock-user.mdx
@@ -22,70 +22,12 @@ function unlockUser(userId: string): Promise<User>
 
 ## Example
 
-> [!NOTE]
-> Learn how to [get the `userId` and other properties](/docs/references/backend/overview#get-the-user-id-and-other-properties).
+<Include src="_partials/backend/usage" />
 
-```tsx {{ mark: [13] }}
+```tsx
 const userId = 'user_123'
 
 const response = await clerkClient.users.unlockUser(userId)
-
-console.log(response)
-/*
-_User {
-  id: 'user_123',
-  passwordEnabled: false,
-  totpEnabled: false,
-  backupCodeEnabled: false,
-  twoFactorEnabled: false,
-  banned: false,
-  locked: false,
-  createdAt: 1694181111181,
-  updatedAt: 1708102548373,
-  imageUrl: 'https://img.clerk.com/eyJ...',
-  hasImage: true,
-  primaryEmailAddressId: 'idn_123,
-  primaryPhoneNumberId: null,
-  primaryWeb3WalletId: null,
-  lastSignInAt: 1708101739595,
-  externalId: null,
-  username: null,
-  firstName: 'Alexis',
-  lastName: 'Aguilar',
-  publicMetadata: {},
-  privateMetadata: {},
-  unsafeMetadata: {},
-  emailAddresses: [
-    _EmailAddress {
-      id: 'idn_123,
-      emailAddress: 'alexis@clerk.dev',
-      verification: [_Verification],
-      linkedTo: [Array]
-    }
-  ],
-  phoneNumbers: [],
-  web3Wallets: [],
-  externalAccounts: [
-    _ExternalAccount {
-      id: 'idn_123',
-      provider: undefined,
-      identificationId: undefined,
-      externalId: undefined,
-      approvedScopes: 'email https://www.googleapis.com/auth/userinfo.email https://www.googleapis.com/auth/userinfo.profile openid profile',
-      emailAddress: 'alexis@clerk.dev',
-      firstName: undefined,
-      lastName: undefined,
-      imageUrl: undefined,
-      username: null,
-      publicMetadata: {},
-      label: null,
-      verification: [_Verification]
-    }
-  ],
-  lastActiveAt: 1708041600000,
-  createOrganizationEnabled: true
-}
-*/
 ```
 
 ## Backend API (BAPI) endpoint

--- a/docs/references/backend/user/update-user-metadata.mdx
+++ b/docs/references/backend/user/update-user-metadata.mdx
@@ -9,6 +9,8 @@ Updates the metadata associated with the specified user by merging existing valu
 
 A "deep" merge will be performed - "deep" means that any nested JSON objects will be merged as well. You can remove metadata keys at any level by setting their value to `null`.
 
+Returns a [`User`](/docs/references/backend/types/backend-user) object.
+
 ```ts
 function updateUserMetadata(userId: string, params: UpdateUserMetadataParams): Promise<User>
 ```
@@ -38,12 +40,9 @@ function updateUserMetadata(userId: string, params: UpdateUserMetadataParams): P
 
 ## Example
 
-> [!NOTE]
-> Learn how to [get the `userId` and other properties](/docs/references/backend/overview#get-the-user-id-and-other-properties).
+<Include src="_partials/backend/usage" />
 
-In the following example, the returned [`User`](/docs/references/backend/types/backend-user) object has its `publicMetadata` property updated with the new metadata provided.
-
-```tsx {{ mark: [[4, 6], 30] }}
+```tsx
 const userId = 'user_123'
 
 const response = await clerkClient.users.updateUserMetadata(userId, {
@@ -51,47 +50,6 @@ const response = await clerkClient.users.updateUserMetadata(userId, {
     example: 'metadata',
   },
 })
-
-console.log(response)
-/*
-_User {
-  id: 'user_123',
-  passwordEnabled: true,
-  totpEnabled: false,
-  backupCodeEnabled: false,
-  twoFactorEnabled: false,
-  banned: false,
-  locked: false,
-  createdAt: 1708103362688,
-  updatedAt: 1708103702285,
-  imageUrl: 'https://img.clerk.com/eyJ...',
-  hasImage: false,
-  primaryEmailAddressId: 'idn_123',
-  primaryPhoneNumberId: null,
-  primaryWeb3WalletId: null,
-  lastSignInAt: null,
-  externalId: null,
-  username: null,
-  firstName: 'Test',
-  lastName: 'Clerk',
-  publicMetadata: { example: 'metadata' },
-  privateMetadata: {},
-  unsafeMetadata: {},
-  emailAddresses: [
-    _EmailAddress {
-      id: 'idn_123',
-      emailAddress: 'testclerk123@gmail.com',
-      verification: [_Verification],
-      linkedTo: []
-    }
-  ],
-  phoneNumbers: [],
-  web3Wallets: [],
-  externalAccounts: [],
-  lastActiveAt: null,
-  createOrganizationEnabled: true
-}
-*/
 ```
 
 ## Backend API (BAPI) endpoint

--- a/docs/references/backend/user/update-user-profile-image.mdx
+++ b/docs/references/backend/user/update-user-profile-image.mdx
@@ -5,7 +5,7 @@ description: Use Clerk's Backend SDK to update a user's profile image.
 
 {/* clerk/javascript file: https://github.com/clerk/javascript/blob/main/packages/backend/src/api/endpoints/UserApi.ts#L158 */}
 
-Updates a user's profile image.
+Updates a user's profile image. Returns a [`User`](/docs/references/backend/types/backend-user) object.
 
 ```ts
 function updateUserProfileImage(userId: string, params: { file: Blob | File }): Promise<User>
@@ -13,8 +13,7 @@ function updateUserProfileImage(userId: string, params: { file: Blob | File }): 
 
 ## Example
 
-> [!NOTE]
-> Learn how to [get the `userId` and other properties](/docs/references/backend/overview#get-the-user-id-and-other-properties).
+<Include src="_partials/backend/usage" />
 
 > [!WARNING]
 > Using Backend SDK methods can contribute towards rate limiting. To set a user's profile image, it's recommended to use the frontend [`user.setProfileImage()`](/docs/references/javascript/user/user#set-profile-image) method instead.
@@ -30,64 +29,6 @@ const params = {
 }
 
 const response = await clerkClient.users.updateUserProfileImage(userId, params)
-
-console.log(response)
-/*
-_User {
-  id: 'user_123',
-  passwordEnabled: false,
-  totpEnabled: false,
-  backupCodeEnabled: false,
-  twoFactorEnabled: false,
-  banned: false,
-  locked: false,
-  createdAt: 1719935072474,
-  updatedAt: 1719935170538,
-  imageUrl: 'https://img.clerk.com/eyJ...',
-  hasImage: true,
-  primaryEmailAddressId: 'idn_123',
-  primaryPhoneNumberId: null,
-  primaryWeb3WalletId: null,
-  lastSignInAt: 1719935072492,
-  externalId: null,
-  username: null,
-  firstName: 'Test',
-  lastName: 'Clerk',
-  publicMetadata: {},
-  privateMetadata: {},
-  unsafeMetadata: {},
-  emailAddresses: [
-    _EmailAddress {
-      id: 'idn_123',
-      emailAddress: 'test@gmail.com',
-      verification: [_Verification],
-      linkedTo: [Array]
-    }
-  ],
-  phoneNumbers: [],
-  web3Wallets: [],
-  externalAccounts: [
-    _ExternalAccount {
-      id: 'idn_123',
-      provider: undefined,
-      identificationId: undefined,
-      externalId: undefined,
-      approvedScopes: 'email https://www.googleapis.com/auth/userinfo.email https://www.googleapis.com/auth/userinfo.profile openid profile',
-      emailAddress: 'test@gmail.com',
-      firstName: undefined,
-      lastName: undefined,
-      imageUrl: '',
-      username: null,
-      publicMetadata: {},
-      label: null,
-      verification: [_Verification]
-    }
-  ],
-  samlAccounts: [],
-  lastActiveAt: 1719935072472,
-  createOrganizationEnabled: true
-}
-*/
 ```
 
 ## Backend API (BAPI) endpoint

--- a/docs/references/backend/user/update-user.mdx
+++ b/docs/references/backend/user/update-user.mdx
@@ -218,73 +218,14 @@ function updateUser(userId: string, params: UpdateUserParams): Promise<User>
 
 ## Example
 
-In this example, you can see that the response is the updated `User` object, with a `firstName` and `lastName` of `"John"` and `"Wick"` respectively.
+<Include src="_partials/backend/usage" />
 
-```tsx {{ mark: [3, [26, 27]] }}
+```tsx
 const userId = 'user_123'
 
 const params = { firstName: 'John', lastName: 'Wick' }
 
 const response = await clerkClient.users.updateUser(userId, params)
-
-console.log(response)
-/*
-_User {
-  id: 'user_123',
-  passwordEnabled: false,
-  totpEnabled: false,
-  backupCodeEnabled: false,
-  twoFactorEnabled: false,
-  banned: false,
-  locked: false,
-  createdAt: 1719935072474,
-  updatedAt: 1720205925110,
-  imageUrl: 'https://img.clerk.com/eyJ...',
-  hasImage: true,
-  primaryEmailAddressId: 'idn_123',
-  primaryPhoneNumberId: null,
-  primaryWeb3WalletId: null,
-  lastSignInAt: 1720205704411,
-  externalId: null,
-  username: null,
-  firstName: 'John',
-  lastName: 'Wick',
-  publicMetadata: {},
-  privateMetadata: {},
-  unsafeMetadata: {},
-  emailAddresses: [
-    _EmailAddress {
-      id: 'idn_123',
-      emailAddress: 'testclerk123@gmail.com',
-      verification: [_Verification],
-      linkedTo: [Array]
-    }
-  ],
-  phoneNumbers: [],
-  web3Wallets: [],
-  externalAccounts: [
-    _ExternalAccount {
-      id: 'idn_123',
-      provider: undefined,
-      identificationId: undefined,
-      externalId: undefined,
-      approvedScopes: 'email https://www.googleapis.com/auth/userinfo.email https://www.googleapis.com/auth/userinfo.profile openid profile',
-      emailAddress: 'testclerk123@gmail.com',
-      firstName: undefined,
-      lastName: undefined,
-      imageUrl: '',
-      username: '',
-      publicMetadata: {},
-      label: null,
-      verification: [_Verification]
-    }
-  ],
-  samlAccounts: [],
-  lastActiveAt: 1720205704451,
-  createOrganizationEnabled: true,
-  legalAcceptedAt: null
-}
-*/
 ```
 
 ## Backend API (BAPI) endpoint

--- a/docs/references/backend/user/verify-password.mdx
+++ b/docs/references/backend/user/verify-password.mdx
@@ -29,19 +29,17 @@ function verifyPassword(params: VerifyPasswordParams): Promise<{ verified: true 
 
 ## Example
 
-> [!NOTE]
-> Learn how to [get the `userId` and other properties](/docs/references/backend/overview#get-the-user-id-and-other-properties).
+<Include src="_partials/backend/usage" />
 
 ```tsx
-const response = await clerkClient.users.verifyPassword({
-  userId: 'user_123',
-  password: 'testpassword123',
-})
+const userId = 'user_123'
 
-console.log(response)
-/*
-{ verified: true }
-*/
+const password = 'testpassword123'
+
+const response = await clerkClient.users.verifyPassword({
+  userId,
+  password,
+})
 ```
 
 ## Backend API (BAPI) endpoint

--- a/docs/references/backend/user/verify-totp.mdx
+++ b/docs/references/backend/user/verify-totp.mdx
@@ -29,22 +29,17 @@ function verifyTOTP(params: VerifyTOTPParams): Promise<{ verified: true; code_ty
 
 ## Example
 
-> [!NOTE]
-> Learn how to [get the `userId` and other properties](/docs/references/backend/overview#get-the-user-id-and-other-properties).
+<Include src="_partials/backend/usage" />
 
 ```tsx
-const response = await clerkClient.users.verifyTOTP({
-  userId: 'user_123',
-  code: '123456',
-})
+const userId = 'user_123'
 
-console.log(response)
-/*
-{
-  verified: true,
-  code_type: 'totp'
-}
-*/
+const code = '123456'
+
+const response = await clerkClient.users.verifyTOTP({
+  userId,
+  code,
+})
 ```
 
 ## Backend API (BAPI) endpoint


### PR DESCRIPTION
### What changed?

- (Overview page) Updates "[Get the userId and other properties](https://clerk.com/docs/references/backend/overview#get-the-user-id-and-other-properties)" section to be more generalized
- Adds partial to add callout to all backend SDK docs about how to use `clerkClient` or access user properties, like `userId`.
- Removes example responses as they are too difficult to maintain and get outdated. Users can either console.log or check BAPI docs themselves for an example response.

### Checklist

- [ ] I have clicked on "Files changed" and performed a thorough self-review
- [ ] I have added the "deploy-preview" label and added the preview link(s) to this PR description
- [ ] All existing checks pass
