### PR TITLE
Update "API Key Changes" in manifest to redirected href

### DIFF
--- a/docs/manifest.json
+++ b/docs/manifest.json
@@ -3239,10 +3239,6 @@
                     "items": [
                       [
                         {
-                          "title": "API Key Changes",
-                          "href": "/docs/deployments/clerk-environment-variables"
-                        },
-                        {
                           "title": "URL-based session syncing",
                           "href": "/docs/upgrade-guides/url-based-session-syncing"
                         },

--- a/docs/manifest.json
+++ b/docs/manifest.json
@@ -3240,7 +3240,7 @@
                       [
                         {
                           "title": "API Key Changes",
-                          "href": "/docs/upgrade-guides/api-keys"
+                          "href": "/docs/deployments/clerk-environment-variables"
                         },
                         {
                           "title": "URL-based session syncing",


### PR DESCRIPTION
### 🔎 Previews:

- https://clerk.com/docs/pr/2042/deployments/clerk-environment-variables

### What does this solve?

The link `/docs/upgrade-guides/api-keys` gets redirected to `/docs/deployments/clerk-environment-variables` so faster to just have it link directly. It's possible instead we just want to remove this item? instead of having it duplicated as "Clerk environment variables" also links to `/docs/deployments/clerk-environment-variables`.

### What changed?

- Updated link in manifest

### Checklist

- [x] I have clicked on "Files changed" and performed a thorough self-review
- [x] I have added the "deploy-preview" label and added the preview link(s) to this PR description
- [x] All existing checks pass
