### PR TITLE
(custom-flows/email-links) fix import issues

### DIFF
--- a/docs/custom-flows/email-links.mdx
+++ b/docs/custom-flows/email-links.mdx
@@ -83,7 +83,8 @@ Clerk provides a highly flexible API that allows you to hook into any of the abo
   ```jsx
   import React from 'react'
   import { useRouter } from 'next/router'
-  import { EmailLinkErrorCode, isEmailLinkError, useClerk, useSignUp } from '@clerk/nextjs'
+  import { useClerk, useSignUp } from '@clerk/nextjs'
+  import { EmailLinkErrorCodeStatus, isEmailLinkError } from '@clerk/nextjs/errors'
 
   // pages/sign-up.jsx
   // Render the sign up form.
@@ -183,7 +184,7 @@ Clerk provides a highly flexible API that allows you to hook into any of the abo
         } catch (err) {
           // Verification has failed.
           let status = 'failed'
-          if (isEmailLinkError(err) && err.code === EmailLinkErrorCode.Expired) {
+          if (isEmailLinkError(err) && err.code === EmailLinkErrorCodeStatus.Expired) {
             status = 'expired'
           }
           setVerificationStatus(status)
@@ -214,14 +215,13 @@ Clerk provides a highly flexible API that allows you to hook into any of the abo
   import {
     ClerkProvider,
     ClerkLoaded,
-    EmailLinkErrorCode,
-    isEmailLinkError,
     UserButton,
     useClerk,
     useSignUp,
     SignedOut,
     SignedIn,
   } from '@clerk/clerk-react'
+  import { EmailLinkErrorCodeStatus, isEmailLinkError } from '@clerk/clerk-react/errors'
 
   const publishableKey = process.env.REACT_APP_CLERK_PUBLISHABLE_KEY
 
@@ -356,7 +356,7 @@ Clerk provides a highly flexible API that allows you to hook into any of the abo
         } catch (err) {
           // Verification has failed.
           let status = 'failed'
-          if (isEmailLinkError(err) && err.code === EmailLinkErrorCode.Expired) {
+          if (isEmailLinkError(err) && err.code === EmailLinkErrorCodeStatus.Expired) {
             status = 'expired'
           }
           setVerificationStatus(status)
@@ -426,7 +426,8 @@ Clerk provides a highly flexible API that allows you to hook into any of the abo
   ```jsx
   import React from 'react'
   import { useRouter } from 'next/router'
-  import { EmailLinkErrorCode, isEmailLinkError, useClerk, useSignIn } from '@clerk/nextjs'
+  import { useClerk, useSignIn } from '@clerk/nextjs'
+  import { EmailLinkErrorCodeStatus, isEmailLinkError } from '@clerk/nextjs/errors'
 
   // pages/sign-in.jsx
   // Render the sign in form.
@@ -523,7 +524,7 @@ Clerk provides a highly flexible API that allows you to hook into any of the abo
         } catch (err) {
           // Verification has failed.
           let status = 'failed'
-          if (isEmailLinkError(err) && err.code === EmailLinkErrorCode.Expired) {
+          if (isEmailLinkError(err) && err.code === EmailLinkErrorCodeStatus.Expired) {
             status = 'expired'
           }
           setVerificationStatus(status)
@@ -554,12 +555,11 @@ Clerk provides a highly flexible API that allows you to hook into any of the abo
   import {
     ClerkProvider,
     ClerkLoaded,
-    EmailLinkErrorCode,
-    isEmailLinkError,
     UserButton,
     useClerk,
     useSignIn,
   } from '@clerk/clerk-react'
+  import { EmailLinkErrorCodeStatus, isEmailLinkError } from '@clerk/clerk-react/errors'
 
   const publishableKey = process.env.REACT_APP_CLERK_PUBLISHABLE_KEY
 
@@ -695,7 +695,7 @@ Clerk provides a highly flexible API that allows you to hook into any of the abo
         } catch (err) {
           // Verification has failed.
           let status = 'failed'
-          if (isEmailLinkError(err) && err.code === EmailLinkErrorCode.Expired) {
+          if (isEmailLinkError(err) && err.code === EmailLinkErrorCodeStatus.Expired) {
             status = 'expired'
           }
           setVerificationStatus(status)


### PR DESCRIPTION
I'm aware of https://github.com/clerk/clerk-docs/pull/1433, which is revamping the same doc. Please disregard this PR if #1433 is going to be merged timely. Otherwise, this PR could be a good quick fix.

### What does this solve?

- Imports used in Email Links custom flow docs is broken as of `@clerk/clerk-react` v5.23 and `@clerk/nextjs` 6.12.

### What changed?

- Fixed imports which is now exported from `@clerk/clerk-react` and `@clerk/nextjs/errors`.
- Replaced depreciated `EmailLinkErrorCode` with `EmailLinkErrorCodeStatus`.

### Checklist

- [x] I have clicked on "Files changed" and performed a thorough self-review
- [ ] I have added the "deploy-preview" label and added the preview link(s) to this PR description
- [ ] All existing checks pass
