### PR TITLE
Move the "Node to Express Migration" docs title up in to the markdown frontmatter

### DIFF
--- a/docs/upgrade-guides/node-to-express.mdx
+++ b/docs/upgrade-guides/node-to-express.mdx
@@ -1,8 +1,7 @@
 ---
+title: Upgrade from Clerk's Node SDK to the Express SDK
 description: Learn how to upgrade from the Clerk's Node SDK to the Express SDK.
 ---
-
-# Upgrade from Clerk's Node SDK to the Express SDK
 
 ## Install the Express SDK
 


### PR DESCRIPTION
### 🔎 Previews:

- https://clerk.com/docs/pr/2052/upgrade-guides/node-to-express

### What does this solve?

- I am validating that all docs have a title, this guide is failing due to the title not being in the frontmatter

### What changed?

- Moved the title up in to the frontmatter

### Checklist

- [x] I have clicked on "Files changed" and performed a thorough self-review
- [x] I have added the "deploy-preview" label and added the preview link(s) to this PR description
- [x] All existing checks pass
