### PR TITLE
Update trpc.mdx to work better with Next 15 and tRPC 11

### DIFF
--- a/docs/references/nextjs/trpc.mdx
+++ b/docs/references/nextjs/trpc.mdx
@@ -36,10 +36,10 @@ description: Learn how to integrate Clerk into your Next.js Pages Router applica
   ```ts {{ filename: 'src/server/context.ts' }}
   import * as trpc from '@trpc/server'
   import * as trpcNext from '@trpc/server/adapters/next'
-  import { getAuth } from '@clerk/nextjs/server'
+  import { auth } from '@clerk/nextjs/server'
 
-  export const createContext = async (opts: trpcNext.CreateNextContextOptions) => {
-    return { auth: getAuth(opts.req) }
+  export const createContext = async () => {
+    return { auth: await auth() }
   }
 
   export type Context = trpc.inferAsyncReturnType<typeof createContext>
@@ -120,7 +120,7 @@ description: Learn how to integrate Clerk into your Next.js Pages Router applica
 
   Once you have created your procedure, you can use it in any router.
 
-  In the following example, the protected procedure is used to return a secret message that includes the user's ID. If the user is not signed in, the `hello` procedure will return an `UNAUTHORIZED` error, as configured in the step above.
+  In the following example, the protected procedure is used to return a secret message that includes the user's ID. If the user is not signed in, the `hello` procedure will return an `UNAUTHORIZED` error, as configured in the step above. Since the protectedProcedure checks for authentication, you are guaranteed to have a defined `ctx.auth` object and can omit the `?` we used previously.
 
   ```ts {{ filename: 'src/server/routers/index.ts' }}
   import { router, protectedProcedure } from '../trpc'
@@ -128,7 +128,7 @@ description: Learn how to integrate Clerk into your Next.js Pages Router applica
   export const protectedRouter = router({
     hello: protectedProcedure.query(({ ctx }) => {
       return {
-        secret: `${ctx.auth?.userId} is using a protected procedure`,
+        secret: `${ctx.auth.userId} is using a protected procedure`,
       }
     }),
   })


### PR DESCRIPTION
### What does this solve?

- Update documentation to integrate Clerk with tRPC in v11
- In the most recent version of tRPC, the `createContext` function is not always given the options arg which causes issues when used in server components. Provided the routes used are also in the app router, using `auth()` results in more consistent behavior and fixes type errors.

### What changed?

- <!--- How does this PR solve the problem? -->

### Checklist

- [x] I have clicked on "Files changed" and performed a thorough self-review
- [ ] I have added the "deploy-preview" label and added the preview link(s) to this PR description
- [ ] All existing checks pass
