### PR TITLE
Align with dashboard updates to API keys page

### DIFF
--- a/docs/_partials/clerk-middleware-options.mdx
+++ b/docs/_partials/clerk-middleware-options.mdx
@@ -39,7 +39,7 @@ The `clerkMiddleware()` function accepts an optional object. The following optio
   - `jwtKey`
   - `string`
 
-  Used to verify the session token in a networkless manner. Supply the PEM public key from the **[**API keys**](https://dashboard.clerk.com/last-active?path=api-keys) page -> Show JWT public key -> PEM Public Key** section in the Clerk Dashboard. **It's recommended to use [the environment variable](/docs/deployments/clerk-environment-variables) instead.** For more information, refer to [Manual JWT verification](/docs/backend-requests/manual-jwt).
+  Used to verify the session token in a networkless manner. Supply the **JWKS Public Key** from the [**API keys**](https://dashboard.clerk.com/last-active?path=api-keys) page in the Clerk Dashboard. **It's recommended to use [the environment variable](/docs/deployments/clerk-environment-variables) instead.** For more information, refer to [Manual JWT verification](/docs/backend-requests/manual-jwt).
 
   ---
 

--- a/docs/_partials/clerk-options.mdx
+++ b/docs/_partials/clerk-options.mdx
@@ -9,7 +9,7 @@
   - `jwtKey?`
   - `string`
 
-  The PEM public key from the **[**API keys**](https://dashboard.clerk.com/last-active?path=api-keys) page -> Show JWT public key -> PEM Public Key** section in the Clerk Dashboard. For more information, refer to [Manual JWT verification](/docs/backend-requests/manual-jwt).
+  The **JWKS Public Key** from the [**API keys**](https://dashboard.clerk.com/last-active?path=api-keys) in the Clerk Dashboard. For more information, refer to [Manual JWT verification](/docs/backend-requests/manual-jwt).
 
   ---
 

--- a/docs/_partials/root-auth-loader.mdx
+++ b/docs/_partials/root-auth-loader.mdx
@@ -32,7 +32,7 @@ The `rootAuthLoader()` function accepts an optional object. The following option
   - `jwtKey`
   - `string`
 
-  Used to verify the session token in a networkless manner. Supply the PEM public key from the **[**API keys**](https://dashboard.clerk.com/last-active?path=api-keys) page -> Show JWT public key -> PEM Public Key** section in the Clerk Dashboard. **It's recommended to use [the environment variable](/docs/deployments/clerk-environment-variables#api-and-sdk-configuration) instead.** For more information, refer to [Manual JWT verification](/docs/backend-requests/manual-jwt).
+  Used to verify the session token in a networkless manner. Supply the **JWKS Public Key** from the [**API keys**](https://dashboard.clerk.com/last-active?path=api-keys) page in the Clerk Dashboard. **It's recommended to use [the environment variable](/docs/deployments/clerk-environment-variables#api-and-sdk-configuration) instead.** For more information, refer to [Manual JWT verification](/docs/backend-requests/manual-jwt).
 
   ---
 

--- a/docs/backend-requests/manual-jwt.mdx
+++ b/docs/backend-requests/manual-jwt.mdx
@@ -27,8 +27,8 @@ The following example uses the `authenticateRequest()` method to verify the sess
   Use one of the three ways to obtain your public key:
 
   1. Use the Backend API in JSON Web Key Set (JWKS) format at the following endpoint [https://api.clerk.com/v1/jwks](https://clerk.com/docs/reference/backend-api/tag/JWKS#operation/GetJWKS).
-  1. Use your **Frontend API URL** in JWKS format, also known as **JWKS URL**. The format is `https://<YOUR_FRONTEND_API>/.well-known/jwks.json`. To retrieve your **JWKS URL**, navigate to the [**API keys**](https://dashboard.clerk.com/last-active?path=api-keys) page in the Clerk Dashboard and select **Show JWT public key**.
-  1. Use your **PEM Public Key**. To retrieve it, navigate to the [**API keys**](https://dashboard.clerk.com/last-active?path=api-keys) page in the Clerk Dashboard and select **Show JWT Public Key**.
+  1. Use your **Frontend API URL** in JWKS format, also known as the **JWKS URL**. The format is your Frontend API URL with `/.well-known/jwks.json` appended to it. Your **Frontend API URL** or **JWKS URL** can be found on the [**API keys**](https://dashboard.clerk.com/last-active?path=api-keys) page in the Clerk Dashboard.
+  1. Use your **JWKS Public Key**, which can be found on the [**API keys**](https://dashboard.clerk.com/last-active?path=api-keys) page in the Clerk Dashboard.
 
   ### Verify the token signature
 

--- a/docs/integrations/databases/fauna.mdx
+++ b/docs/integrations/databases/fauna.mdx
@@ -38,10 +38,7 @@ This guide will walk you through the steps to integrate Fauna with Clerk in your
 
   <SignedOut>
     1. In the Clerk Dashboard, navigate to the [**API keys**](https://dashboard.clerk.com/last-active?path=api-keys) page.
-    1. In the navigation sidenav, select **Show API URLs**.
-    1. Copy the **Frontend API URL**.
-    1. In the navigation sidenav, select **Show JWT public key**.
-    1. Copy the **JWKS URL**.
+    1. Copy the **Frontend API URL** and **JWKS URL**.
     1. Paste your keys into your `.env` file.
 
     The final result should resemble the following:

--- a/docs/integrations/databases/hasura.mdx
+++ b/docs/integrations/databases/hasura.mdx
@@ -23,9 +23,7 @@ By default, Clerk will sign the JWT with a private key automatically generated f
 
 The next step is to provide Hasura with the public keys used to verify the JWT issued by Clerk. Assuming you didn’t use a custom signing key, set the **JWKS Endpoint** field to the JSON Web Key Set (JWKS) URL Clerk automatically created with your Frontend API at `https://<YOUR_FRONTEND_API>/.well-known/jwks.json`
 
-You can find this URL on the [**API keys**](https://dashboard.clerk.com/last-active?path=api-keys) page in the Clerk Dashboard. In the left sidenav, select **Show JWT public key**. Copy the **JWKS URL**.
-
-![The API keys page in the Clerk Dashboard. A red box outlines the 'Advanced' drop down button. A red arrow is pointing to the copy button next to 'JWKS URL' in the 'JWT public key' section](/docs/images/integrations/jwks-url.webp)
+You can find the **JWKS URL** on the [**API keys**](https://dashboard.clerk.com/last-active?path=api-keys) page in the Clerk Dashboard.
 
 You can set up your project either with Hasura Cloud or you can [run the Hasura GraphQL engine locally using Docker Compose](https://hasura.io/docs/2.0/getting-started/docker-simple).
 

--- a/docs/integrations/databases/nhost.mdx
+++ b/docs/integrations/databases/nhost.mdx
@@ -21,15 +21,13 @@ The Nhost template will pre-populate the default claims required by Nhost and Ha
 
 The next step is to provide Nhost with the public keys used to verify the JWT issued by Clerk. Assuming you didn’t use a custom signing key, set the **JWKS Endpoint** field to the JSON Web Key Set (JWKS) URL Clerk automatically created with your Frontend API at `https://<YOUR_FRONTEND_API>/.well-known/jwks.json`
 
-You can find this URL on the [**API keys**](https://dashboard.clerk.com/last-active?path=api-keys) page in the Clerk Dashboard. In the left sidenav, select **Show JWT public key**. Copy the **JWKS URL**.
-
-![The API keys page in the Clerk Dashboard. A red box outlines the 'Advanced' drop down button. A red arrow is pointing to the copy button next to 'JWKS URL' in the 'JWT public key' section](/docs/images/integrations/jwks-url.webp)
+You can find the **JWKS URL** on the [**API keys**](https://dashboard.clerk.com/last-active?path=api-keys) page in the Clerk Dashboard.
 
 From your Nhost dashboard, navigate to **Settings** --> **Environment variables**.
 
 ![The Environment variables page in the Nhost dashboard](/docs/images/integrations/nhost/nhost-env-var.webp)
 
-Next to the **NOHST\_JWT\_SECRET**, select **Edit** and paste in the **JWKS URL** that you copied from the Clerk Dashboard.
+Next to the **NHOST\_JWT\_SECRET**, select **Edit** and paste in the **JWKS URL** that you copied from the Clerk Dashboard.
 
 ### With custom signing key
 

--- a/docs/organizations/invitations.mdx
+++ b/docs/organizations/invitations.mdx
@@ -86,7 +86,6 @@ Once the user visits the invitation link, they will be redirected to the page yo
 > [!TIP]
 >
 > - To test redirect URLs in your development environment, pass your port. For example, `http://localhost:3000/accept-invitation`.
-> - To use Clerk's Account Portal, pass your Clerk Frontend API URL as the base URL. For example, `https://prepared-phoenix-98.clerk.accounts.dev/accept-invitation` redirects the user to the Account Portal sign-up page. You can find your Frontend API URL on the [**API keys**](https://dashboard.clerk.com/last-active?path=api-keys) page in the Clerk Dashboard. In the left sidenav, select **Show API URLs**.
 
 ### Invitation metadata
 

--- a/docs/references/backend/authenticate-request.mdx
+++ b/docs/references/backend/authenticate-request.mdx
@@ -57,7 +57,7 @@ It is recommended to set these options as [environment variables](/docs/deployme
   - `jwtKey?`
   - `string`
 
-  Used to verify the session token in a networkless manner. Supply the PEM public key from the **[**API keys**](https://dashboard.clerk.com/last-active?path=api-keys) page -> Show JWT public key -> PEM Public Key** section in the Clerk Dashboard. For more information, refer to [Manual JWT verification](/docs/backend-requests/manual-jwt).
+  Used to verify the session token in a networkless manner. Supply the **JWKS Public Key** from the [**API keys**](https://dashboard.clerk.com/last-active?path=api-keys) page in the Clerk Dashboard. For more information, refer to [Manual JWT verification](/docs/backend-requests/manual-jwt).
 
   ---
 

--- a/docs/references/backend/verify-token.mdx
+++ b/docs/references/backend/verify-token.mdx
@@ -65,7 +65,7 @@ It is recommended to set these options as [environment variables](/docs/deployme
   - `jwtKey?`
   - `string`
 
-  Used to verify the session token in a networkless manner. Supply the PEM public key from the **[**API keys**](https://dashboard.clerk.com/last-active?path=api-keys) page -> Show JWT public key -> PEM Public Key** section in the Clerk Dashboard. For more information, refer to [Manual JWT verification](/docs/backend-requests/manual-jwt).
+  Used to verify the session token in a networkless manner. Supply the **JWKS Public Key** from the [**API keys**](https://dashboard.clerk.com/last-active?path=api-keys) page in the Clerk Dashboard. For more information, refer to [Manual JWT verification](/docs/backend-requests/manual-jwt).
 
   ---
 
@@ -102,7 +102,7 @@ The following example demonstrates how to use the [JavaScript Backend SDK](/docs
 
 In the following example:
 
-1. The PEM public key from the Clerk Dashboard is set in the environment variable `CLERK_JWT_KEY`.
+1. The **JWKS Public Key** from the Clerk Dashboard is set in the environment variable `CLERK_JWT_KEY`.
 1. The session token is retrieved from the `__session` cookie or the Authorization header.
 1. The token is verified in a networkless manner by passing the `jwtKey` prop.
 1. The `authorizedParties` prop is passed to verify that the session token is generated from the expected frontend application.

--- a/docs/users/invitations.mdx
+++ b/docs/users/invitations.mdx
@@ -64,7 +64,9 @@ curl https://api.clerk.com/v1/invitations -X POST -d '{"email_address": "email@e
 Once the user visits the invitation link, they will be redirected to the page you specified, which means you must handle the sign-up flow in your code for that page. You can either embed the [`<SignUp />`](/docs/components/authentication/sign-up) component on that page, or if the prebuilt component doesn't meet your specific needs or if you require more control over the logic, you can build a [custom flow](/docs/custom-flows/application-invitations).
 
 > [!TIP]
-> To test redirect URLs in your development environment, you can pass your port (`http://localhost:3000`). If you want to use the Account Portal, you can pass your Clerk Frontend API URL as the base URL. For example, `https://prepared-phoenix-98.clerk.accounts.dev/sign-up` redirects the user to the Account Portal sign-up page. You can find your Frontend API URL on the [**API keys**](https://dashboard.clerk.com/last-active?path=api-keys) page in the Clerk Dashboard. On the left side, select **Show API URLs**.
+>
+> - To test redirect URLs in your development environment, pass your port (e.g. `http://localhost:3000`).
+> - To use the Account Portal, pass the URL provided by Clerk on the [**Account Portal**](https://dashboard.clerk.com/last-active?path=account-portal) page in the Clerk Dashboard. For example, `https://prepared-phoenix-98.accounts.dev/sign-up` redirects the user to the Account Portal sign-up page.
 
 ### Invitation metadata
 


### PR DESCRIPTION
### What does this solve?

- Changes to the Clerk Dashboard's API keys page was made. The sidebar is now on the right, and there is no longer a "Show JWT public key" option anymore.
<img width="1512" alt="Screenshot 2025-02-25 at 16 47 11" src="https://github.com/user-attachments/assets/4f69994c-9541-4bdc-a30e-b21e30ee9b84" />

### Checklist

- [x] I have clicked on "Files changed" and performed a thorough self-review
- [ ] I have added the "deploy-preview" label and added the preview link(s) to this PR description
- [ ] All existing checks pass
