### PR TITLE
chore: Add appropriate links from breaking API changes to overview

### DIFF
--- a/docs/versioning/available-versions.mdx
+++ b/docs/versioning/available-versions.mdx
@@ -3,7 +3,7 @@ title: Available versions
 description: A list of the available API versions and their breaking changes.
 ---
 
-Below is a list of all the available API versions with their respective breaking changes.
+Below is a list of all the available API versions with their respective breaking changes. For information on how to apply the appropriate version, see [Versioning overview](/docs/versioning/overview).
 
 ### 2024-10-01
 


### PR DESCRIPTION
### 🔎 Previews:

-

### What does this solve?

- OpenAPI specs link directly to the breaking changes vs how to use API versioning. This adds a direct link to the overview to surface this better.

### What changed?

- <!--- How does this PR solve the problem? -->

### Checklist

- [ ] I have clicked on "Files changed" and performed a thorough self-review
- [ ] I have added the "deploy-preview" label and added the preview link(s) to this PR description
- [ ] All existing checks pass

Fixes ECO-442
