### PR TITLE
Update the Elements hrefs in manifest.json

### DIFF
--- a/docs/manifest.json
+++ b/docs/manifest.json
@@ -2742,7 +2742,7 @@
                 [
                   {
                     "title": "Overview",
-                    "href": "/docs/elements/overview"
+                    "href": "/docs/customization/elements/overview"
                   },
                   {
                     "title": "Guides",
@@ -2750,15 +2750,15 @@
                       [
                         {
                           "title": "Build a sign-in flow",
-                          "href": "/docs/elements/guides/sign-in"
+                          "href": "/docs/customization/elements/guides/sign-in"
                         },
                         {
                           "title": "Build a sign-up flow",
-                          "href": "/docs/elements/guides/sign-up"
+                          "href": "/docs/customization/elements/guides/sign-up"
                         },
                         {
                           "title": "Styling",
-                          "href": "/docs/elements/guides/styling"
+                          "href": "/docs/customization/elements/guides/styling"
                         }
                       ]
                     ]
@@ -2769,19 +2769,19 @@
                       [
                         {
                           "title": "Sign-in",
-                          "href": "/docs/elements/examples/sign-in"
+                          "href": "/docs/customization/elements/examples/sign-in"
                         },
                         {
                           "title": "Sign-up",
-                          "href": "/docs/elements/examples/sign-up"
+                          "href": "/docs/customization/elements/examples/sign-up"
                         },
                         {
                           "title": "Primitives",
-                          "href": "/docs/elements/examples/primitives"
+                          "href": "/docs/customization/elements/examples/primitives"
                         },
                         {
                           "title": "shadcn/ui",
-                          "href": "/docs/elements/examples/shadcn-ui"
+                          "href": "/docs/customization/elements/examples/shadcn-ui"
                         }
                       ]
                     ]
@@ -2792,15 +2792,15 @@
                       [
                         {
                           "title": "Common",
-                          "href": "/docs/elements/reference/common"
+                          "href": "/docs/customization/elements/reference/common"
                         },
                         {
                           "title": "Sign-in",
-                          "href": "/docs/elements/reference/sign-in"
+                          "href": "/docs/customization/elements/reference/sign-in"
                         },
                         {
                           "title": "Sign-up",
-                          "href": "/docs/elements/reference/sign-up"
+                          "href": "/docs/customization/elements/reference/sign-up"
                         }
                       ]
                     ]


### PR DESCRIPTION
### 🔎 Previews:

-

### What does this solve?

- The urls for the elements guides have changed, but where not updated in the manifest.json, this causes slower loading times as requests have to go through the redirect catcher.

### What changed?

- Updated Hrefs

### Checklist

- [ ] I have clicked on "Files changed" and performed a thorough self-review
- [ ] I have added the "deploy-preview" label and added the preview link(s) to this PR description
- [ ] All existing checks pass
