### PR TITLE
[DO NOT MERGE] Updated Supabase integration doc

### DIFF
--- a/docs/integrations/databases/supabase.mdx
+++ b/docs/integrations/databases/supabase.mdx
@@ -184,6 +184,7 @@ For interacting with the Supabase dashboard, you can either use the **Supabase i
   1. Select the **New template** button, then select **Supabase** from the list of options.
   1. Configure your template:
      - The value of the **Name** field will be required when using the template in your code. For this tutorial, name it `supabase`.
+     - Toggle the **Custom signing key** option.
      - **Signing algorithm** will be `HS256` by default. This algorithm is required to use JWTs with Supabase. [Learn more in their docs](https://supabase.com/docs/guides/resources/glossary#jwt-signing-secret).
      - Under **Signing key**, add the value of your Supabase **JWT Secret Key** from [the previous step](#get-your-supabase-jwt-secret-key).
      - You can leave all other fields at their default settings or customize them to your needs. See the [JWT template guide](/docs/backend-requests/jwt-templates#creating-a-template) to learn more about these settings.


### PR DESCRIPTION
> [!IMPORTANT]
> 🔎 Previews:
>
> - https://clerk.com/docs/pr/2069/integrations/databases/supabase

### Explanation:

We _may_ enable auto-creation of the Supabase JWT template automatically upon BAPI request which requires the customer signing key option to be disabled. If the template is updated, the current docs will not properly guide the user and may cause confusion.

### This PR:

- Adds a step to enable the Custom signing key option in the Supabase integration guide.

### Checklist

- [ ] I have clicked on "Files changed" and performed a thorough self-review
- [ ] I have added the "deploy-preview" label and added the preview link(s) to this PR description
- [ ] All existing checks pass
