### PR TITLE
docs: Add `<Waitlist />` Astro and Vue example

### DIFF
--- a/docs/components/waitlist.mdx
+++ b/docs/components/waitlist.mdx
@@ -58,7 +58,7 @@ All props are optional.
 
 The following example includes a basic implementation of the `<Waitlist />` component. You can use this as a starting point for your own implementation.
 
-<Tabs items={["Next.js", "React", "Tanstack Start"]}>
+<Tabs items={["Next.js", "React", "Astro", "Tanstack Start"]}>
   <Tab>
     ```jsx {{ filename: 'app/waitlist/[[...waitlist]]/page.tsx' }}
     import { Waitlist } from '@clerk/nextjs'
@@ -76,6 +76,16 @@ The following example includes a basic implementation of the `<Waitlist />` comp
     export default function WaitlistPage() {
       return <Waitlist />
     }
+    ```
+  </Tab>
+
+  <Tab>
+    ```astro {{ filename: 'pages/waitlist.astro' }}
+    ---
+    import { Waitlist } from '@clerk/astro/components'
+    ---
+
+    <Waitlist />
     ```
   </Tab>
 

--- a/docs/components/waitlist.mdx
+++ b/docs/components/waitlist.mdx
@@ -107,7 +107,7 @@ The following example includes a basic implementation of the `<Waitlist />` comp
   <Tab>
     ```vue {{ filename: 'waitlist.vue' }}
     <script setup lang="ts">
-      import { Waitlist } from '@clerk/vue'
+    import { Waitlist } from '@clerk/vue'
     </script>
 
     <template>

--- a/docs/components/waitlist.mdx
+++ b/docs/components/waitlist.mdx
@@ -58,7 +58,7 @@ All props are optional.
 
 The following example includes a basic implementation of the `<Waitlist />` component. You can use this as a starting point for your own implementation.
 
-<Tabs items={["Next.js", "React", "Astro", "Tanstack Start"]}>
+<Tabs items={["Next.js", "React", "Astro", "Tanstack Start", "Vue"]}>
   <Tab>
     ```jsx {{ filename: 'app/waitlist/[[...waitlist]]/page.tsx' }}
     import { Waitlist } from '@clerk/nextjs'
@@ -101,6 +101,18 @@ The following example includes a basic implementation of the `<Waitlist />` comp
     function WaitlistPage() {
       return <Waitlist />
     }
+    ```
+  </Tab>
+
+  <Tab>
+    ```vue {{ filename: 'waitlist.vue' }}
+    <script setup lang="ts">
+      import { Waitlist } from '@clerk/vue'
+    </script>
+
+    <template>
+      <Waitlist />
+    </template>
     ```
   </Tab>
 </Tabs>

--- a/docs/components/waitlist.mdx
+++ b/docs/components/waitlist.mdx
@@ -60,7 +60,7 @@ The following example includes a basic implementation of the `<Waitlist />` comp
 
 <Tabs items={["Next.js", "React", "Astro", "Tanstack Start", "Vue"]}>
   <Tab>
-    ```jsx {{ filename: 'app/waitlist/[[...waitlist]]/page.tsx' }}
+    ```tsx {{ filename: 'app/waitlist/[[...waitlist]]/page.tsx' }}
     import { Waitlist } from '@clerk/nextjs'
 
     export default function WaitlistPage() {
@@ -70,7 +70,7 @@ The following example includes a basic implementation of the `<Waitlist />` comp
   </Tab>
 
   <Tab>
-    ```jsx {{ filename: 'src/waitlist.tsx' }}
+    ```tsx {{ filename: 'src/waitlist.tsx' }}
     import { Waitlist } from '@clerk/clerk-react'
 
     export default function WaitlistPage() {
@@ -82,10 +82,10 @@ The following example includes a basic implementation of the `<Waitlist />` comp
   <Tab>
     ```astro {{ filename: 'pages/waitlist.astro' }}
     ---
-    import { Waitlist } from '@clerk/astro/components'
+    import { Waitlist as WaitlistAstro } from '@clerk/astro/components'
     ---
 
-    <Waitlist />
+    <WaitlistAstro />
     ```
   </Tab>
 


### PR DESCRIPTION
### 🔎 Previews:

- https://clerk.com/docs/pr/2071/components/waitlist#usage-with-frameworks

### What does this solve?

- We're missing a `<Waitlist />` example for our Astro an Vue SDK

<img width="430" alt="Screenshot 2025-03-03 at 2 30 25 PM" src="https://github.com/user-attachments/assets/74b6a20e-2aca-4f94-b98d-9d329a37a963" />

### What changed?

- Adds a new tab with example for Astro and Vue 👍🏼 

### Checklist

- [x] I have clicked on "Files changed" and performed a thorough self-review
- [x] I have added the "deploy-preview" label and added the preview link(s) to this PR description
- [x] All existing checks pass
