### PR TITLE
Clarify custom redirect URLs (env var usage)

### DIFF
--- a/docs/_partials/environment-variables.mdx
+++ b/docs/_partials/environment-variables.mdx
@@ -1,3 +1,5 @@
+For the `FORCE` and `FALLBACK` variables, it's recommended to define both sign-up and sign-in variables, as some users may choose to sign up instead after attempting to sign in, and vice versa.
+
 <Tabs items={["General", "Next.js"]}>
   <Tab>
     | Variable | Description | Example |

--- a/docs/components/authentication/sign-in.mdx
+++ b/docs/components/authentication/sign-in.mdx
@@ -121,9 +121,7 @@ The following example includes basic implementation of the `<SignIn />` componen
     export default function Home() {
       const { user } = useUser()
 
-      if (!user) {
-        return <SignIn />
-      }
+      if (!user) return <SignIn />
 
       return <div>Welcome!</div>
     }
@@ -216,158 +214,160 @@ The following example includes basic implementation of the `<SignIn />` componen
   </Tab>
 </Tabs>
 
-## Usage with JavaScript
+<If sdk="javascript">
+  ## Usage with JavaScript
 
-The following methods available on an instance of the [`Clerk`](/docs/references/javascript/clerk) class are used to render and control the `<SignIn />` component:
+  The following methods available on an instance of the [`Clerk`](/docs/references/javascript/clerk) class are used to render and control the `<SignIn />` component:
 
-- [`mountSignIn()`](#mount-sign-in)
-- [`unmountSignIn()`](#unmount-sign-in)
-- [`openSignIn()`](#open-sign-in)
-- [`closeSignIn()`](#close-sign-in)
+  - [`mountSignIn()`](#mount-sign-in)
+  - [`unmountSignIn()`](#unmount-sign-in)
+  - [`openSignIn()`](#open-sign-in)
+  - [`closeSignIn()`](#close-sign-in)
 
-The following examples assume that you have followed the [quickstart](/docs/quickstarts/javascript) in order to add Clerk to your JavaScript application.
+  The following examples assume that you have followed the [quickstart](/docs/quickstarts/javascript) in order to add Clerk to your JavaScript application.
 
-### `mountSignIn()`
+  ### `mountSignIn()`
 
-Render the `<SignIn />` component to an HTML `<div>` element.
+  Render the `<SignIn />` component to an HTML `<div>` element.
 
-```typescript
-function mountSignIn(node: HTMLDivElement, props?: SignInProps): void
-```
+  ```typescript
+  function mountSignIn(node: HTMLDivElement, props?: SignInProps): void
+  ```
 
-#### `mountSignIn()` params
+  #### `mountSignIn()` params
 
-<Properties>
-  - `node`
-  - [`HTMLDivElement`](https://developer.mozilla.org/en-US/docs/Web/API/HTMLDivElement)
+  <Properties>
+    - `node`
+    - [`HTMLDivElement`](https://developer.mozilla.org/en-US/docs/Web/API/HTMLDivElement)
 
-  The container `<div>` element used to render in the `<SignIn />` component
+    The container `<div>` element used to render in the `<SignIn />` component
 
-  ---
+    ---
 
-  - `props?`
-  - [`SignInProps`](#properties)
+    - `props?`
+    - [`SignInProps`](#properties)
 
-  The properties to pass to the `<SignIn />` component
-</Properties>
+    The properties to pass to the `<SignIn />` component
+  </Properties>
 
-#### `mountSignIn()` usage
+  #### `mountSignIn()` usage
 
-```js {{ filename: 'main.js', mark: [15] }}
-import { Clerk } from '@clerk/clerk-js'
+  ```js {{ filename: 'main.js', mark: [15] }}
+  import { Clerk } from '@clerk/clerk-js'
 
-// Initialize Clerk with your Clerk Publishable Key
-const clerkPubKey = import.meta.env.VITE_CLERK_PUBLISHABLE_KEY
+  // Initialize Clerk with your Clerk Publishable Key
+  const clerkPubKey = import.meta.env.VITE_CLERK_PUBLISHABLE_KEY
 
-const clerk = new Clerk(clerkPubKey)
-await clerk.load()
+  const clerk = new Clerk(clerkPubKey)
+  await clerk.load()
 
-document.getElementById('app').innerHTML = `
-  <div id="sign-in"></div>
-`
+  document.getElementById('app').innerHTML = `
+    <div id="sign-in"></div>
+  `
 
-const signInDiv = document.getElementById('sign-in')
+  const signInDiv = document.getElementById('sign-in')
 
-clerk.mountSignIn(signInDiv)
-```
+  clerk.mountSignIn(signInDiv)
+  ```
 
-### `unmountSignIn()`
+  ### `unmountSignIn()`
 
-Unmount and run cleanup on an existing `<SignIn />` component instance.
+  Unmount and run cleanup on an existing `<SignIn />` component instance.
 
-```typescript
-function unmountSignIn(node: HTMLDivElement): void
-```
+  ```typescript
+  function unmountSignIn(node: HTMLDivElement): void
+  ```
 
-#### `unmountSignIn()` params
+  #### `unmountSignIn()` params
 
-<Properties>
-  - `node`
-  - [`HTMLDivElement`](https://developer.mozilla.org/en-US/docs/Web/API/HTMLDivElement)
+  <Properties>
+    - `node`
+    - [`HTMLDivElement`](https://developer.mozilla.org/en-US/docs/Web/API/HTMLDivElement)
 
-  The container `<div>` element with a rendered `<SignIn />` component instance
-</Properties>
+    The container `<div>` element with a rendered `<SignIn />` component instance
+  </Properties>
 
-#### `unmountSignIn()` usage
+  #### `unmountSignIn()` usage
 
-```js {{ filename: 'index.js', mark: [19] }}
-import { Clerk } from '@clerk/clerk-js'
+  ```js {{ filename: 'index.js', mark: [19] }}
+  import { Clerk } from '@clerk/clerk-js'
 
-// Initialize Clerk with your Clerk Publishable Key
-const clerkPubKey = import.meta.env.VITE_CLERK_PUBLISHABLE_KEY
+  // Initialize Clerk with your Clerk Publishable Key
+  const clerkPubKey = import.meta.env.VITE_CLERK_PUBLISHABLE_KEY
 
-const clerk = new Clerk(clerkPubKey)
-await clerk.load()
+  const clerk = new Clerk(clerkPubKey)
+  await clerk.load()
 
-document.getElementById('app').innerHTML = `
-  <div id="sign-in"></div>
-`
+  document.getElementById('app').innerHTML = `
+    <div id="sign-in"></div>
+  `
 
-const signInDiv = document.getElementById('sign-in')
+  const signInDiv = document.getElementById('sign-in')
 
-clerk.mountSignIn(signInDiv)
+  clerk.mountSignIn(signInDiv)
 
-// ...
+  // ...
 
-clerk.unmountSignIn(signInDiv)
-```
+  clerk.unmountSignIn(signInDiv)
+  ```
 
-### `openSignIn()`
+  ### `openSignIn()`
 
-Opens the `<SignIn />` component as an overlay at the root of your HTML `body` element.
+  Opens the `<SignIn />` component as an overlay at the root of your HTML `body` element.
 
-```typescript
-function openSignIn(props?: SignInProps): void
-```
+  ```typescript
+  function openSignIn(props?: SignInProps): void
+  ```
 
-#### `openSignIn()` params
+  #### `openSignIn()` params
 
-<Properties>
-  - `props?`
-  - [`SignInProps`](#properties)
+  <Properties>
+    - `props?`
+    - [`SignInProps`](#properties)
 
-  The properties to pass to the `<SignIn />` component.
-</Properties>
+    The properties to pass to the `<SignIn />` component.
+  </Properties>
 
-#### `openSignIn()` usage
+  #### `openSignIn()` usage
 
-```js {{ filename: 'main.js', mark: [9] }}
-import { Clerk } from '@clerk/clerk-js'
+  ```js {{ filename: 'main.js', mark: [9] }}
+  import { Clerk } from '@clerk/clerk-js'
 
-// Initialize Clerk with your Clerk Publishable Key
-const clerkPubKey = import.meta.env.VITE_CLERK_PUBLISHABLE_KEY
+  // Initialize Clerk with your Clerk Publishable Key
+  const clerkPubKey = import.meta.env.VITE_CLERK_PUBLISHABLE_KEY
 
-const clerk = new Clerk(clerkPubKey)
-await clerk.load()
+  const clerk = new Clerk(clerkPubKey)
+  await clerk.load()
 
-clerk.openSignIn()
-```
+  clerk.openSignIn()
+  ```
 
-### `closeSignIn()`
+  ### `closeSignIn()`
 
-Closes the sign in overlay.
+  Closes the sign in overlay.
 
-```typescript
-function closeSignIn(): void
-```
+  ```typescript
+  function closeSignIn(): void
+  ```
 
-#### `closeSignIn()` usage
+  #### `closeSignIn()` usage
 
-```js {{ filename: 'index.js', mark: [13] }}
-import { Clerk } from '@clerk/clerk-js'
+  ```js {{ filename: 'index.js', mark: [13] }}
+  import { Clerk } from '@clerk/clerk-js'
 
-// Initialize Clerk with your Clerk Publishable Key
-const clerkPubKey = import.meta.env.VITE_CLERK_PUBLISHABLE_KEY
+  // Initialize Clerk with your Clerk Publishable Key
+  const clerkPubKey = import.meta.env.VITE_CLERK_PUBLISHABLE_KEY
 
-const clerk = new Clerk(clerkPubKey)
-await clerk.load()
+  const clerk = new Clerk(clerkPubKey)
+  await clerk.load()
 
-clerk.openSignIn()
+  clerk.openSignIn()
 
-// ...
+  // ...
 
-clerk.closeSignIn()
-```
+  clerk.closeSignIn()
+  ```
+</If>
 
 ## Customization
 

--- a/docs/components/authentication/sign-in.mdx
+++ b/docs/components/authentication/sign-in.mdx
@@ -372,3 +372,5 @@ The following example includes basic implementation of the `<SignIn />` componen
 ## Customization
 
 To learn about how to customize Clerk components, see the [customization documentation](/docs/customization/overview).
+
+If Clerk's prebuilt components don't meet your specific needs or if you require more control over the logic, you can rebuild the existing Clerk flows using the Clerk API. For more information, see the [custom flow guides](/docs/custom-flows/overview).

--- a/docs/components/authentication/sign-in.mdx
+++ b/docs/components/authentication/sign-in.mdx
@@ -102,7 +102,7 @@ All props are optional.
   - `withSignUp`
   - `boolean`
 
-  Opt into sign-in-or-up flow by setting this prop to `true`. Defaults to `false`. When true, if a user does not exist, they will be prompted to sign up. If a user exists, they will be prompted to sign in.
+  Opt into sign-in-or-up flow by setting this prop to `true`. When `true`, if a user does not exist, they will be prompted to sign up. If a user exists, they will be prompted to sign in. Defaults to `true` if the `CLERK_SIGN_UP_URL` environment variable is set. Otherwise, defaults to `false`.
 </Properties>
 
 ## Usage with frameworks

--- a/docs/components/authentication/sign-in.mdx
+++ b/docs/components/authentication/sign-in.mdx
@@ -22,52 +22,24 @@ All props are optional.
 
   ---
 
-  - `routing`
-  - `'hash' | 'path'`
+  - `fallback`
+  - `ReactNode`
 
-  The [routing](/docs/guides/routing) strategy for your pages. Defaults to `'path'` for frameworks that handle routing, such as Next.js and Remix. Defaults to `hash` for all other SDK's, such as React.
-
-  ---
-
-  - `path`
-  - `string`
-
-  The path where the component is mounted on when `routing` is set to `path`. It is ignored in hash-based routing. For example: `/sign-in`.
+  An optional element to be rendered while the component is mounting.
 
   ---
 
-  - `signUpUrl`
-  - `string`
-
-  Used for the 'Sign Up' link that's rendered. The full URL or path to the sign-up page. It's recommended to use [the environment variable](/docs/deployments/clerk-environment-variables#sign-in-and-sign-up-redirects) instead.
-
-  ---
-
-  - `forceRedirectUrl?`
-  - `string`
-
-  If provided, this URL will always be redirected to after the user signs in. It's recommended to use [the environment variable](/docs/deployments/clerk-environment-variables#sign-in-and-sign-up-redirects) instead.
-
-  ---
-
-  - `fallbackRedirectUrl?`
+  - `fallbackRedirectUrl`
   - `string`
 
   The fallback URL to redirect to after the user signs in, if there's no `redirect_url` in the path already. Defaults to `/`. It's recommended to use [the environment variable](/docs/deployments/clerk-environment-variables#sign-in-and-sign-up-redirects) instead.
 
   ---
 
-  - `signUpForceRedirectUrl?`
+  - `forceRedirectUrl`
   - `string`
 
-  Used for the 'Sign Up' link that's rendered. If provided, this URL will always used as the redirect destination after the user signs up. It's recommended to use [the environment variable](/docs/deployments/clerk-environment-variables#sign-in-and-sign-up-redirects) instead.
-
-  ---
-
-  - `signUpFallbackRedirectUrl?`
-  - `string`
-
-  Used for the 'Sign Up' link that's rendered. The fallback URL to redirect to after the user signs up, if there's no `redirect_url` in the path already. Defaults to `/`. It's recommended to use [the environment variable](/docs/deployments/clerk-environment-variables#sign-in-and-sign-up-redirects) instead.
+  If provided, this URL will always be redirected to after the user signs in. It's recommended to use [the environment variable](/docs/deployments/clerk-environment-variables#sign-in-and-sign-up-redirects) instead.
 
   ---
 
@@ -78,42 +50,70 @@ All props are optional.
 
   ---
 
-  - `transferable?`
+  - `path`
+  - `string`
+
+  The path where the component is mounted on when `routing` is set to `path`. It is ignored in hash-based routing. For example: `/sign-in`.
+
+  ---
+
+  - `routing`
+  - `'hash' | 'path'`
+
+  The [routing](/docs/guides/routing) strategy for your pages. Defaults to `'path'` for frameworks that handle routing, such as Next.js and Remix. Defaults to `hash` for all other SDK's, such as React.
+
+  ---
+
+  - `signUpFallbackRedirectUrl`
+  - `string`
+
+  The fallback URL to redirect to after the user signs up, if there's no `redirect_url` in the path already. Used for the 'Don't have an account? Sign up' link that's rendered. Defaults to `/`. It's recommended to use [the environment variable](/docs/deployments/clerk-environment-variables#sign-in-and-sign-up-redirects) instead.
+
+  ---
+
+  - `signUpForceRedirectUrl`
+  - `string`
+
+  If provided, this URL will always used as the redirect destination after the user signs up. Used for the 'Don't have an account? Sign up' link that's rendered. It's recommended to use [the environment variable](/docs/deployments/clerk-environment-variables#sign-in-and-sign-up-redirects) instead.
+
+  ---
+
+  - `signUpUrl`
+  - `string`
+
+  The full URL or path to the sign-up page. Used for the 'Don't have an account? Sign up' link that's rendered. It's recommended to use [the environment variable](/docs/deployments/clerk-environment-variables#sign-in-and-sign-up-redirects) instead.
+
+  ---
+
+  - `transferable`
   - `boolean`
 
   Indicates whether or not sign in attempts are transferable to the sign up flow. Defaults to `true`. When set to `false`, prevents opaque sign ups when a user attempts to sign in via OAuth with an email that doesn't exist. See [OAuth account transfer flows](/docs/custom-flows/oauth-connections#o-auth-account-transfer-flows) for more information.
 
   ---
 
-  - `waitlistUrl?`
+  - `waitlistUrl`
   - `string`
 
   Full URL or path to the waitlist page. Use this property to provide the target of the 'Waitlist' link that's rendered. If `undefined`, will redirect to the [Account Portal waitlist page](/docs/account-portal/overview#waitlist). If you've passed the `waitlistUrl` prop to the [`<ClerkProvider>`](/docs/components/clerk-provider) component, it will infer from that, and you can omit this prop.
 
   ---
 
-  - `withSignUp?`
+  - `withSignUp`
   - `boolean`
 
   Opt into sign-in-or-up flow by setting this prop to `true`. Defaults to `false`. When true, if a user does not exist, they will be prompted to sign up. If a user exists, they will be prompted to sign in.
-
-  ---
-
-  - `fallback?`
-  - `ReactNode`
-
-  An optional element to be rendered while the component is mounting.
 </Properties>
 
 ## Usage with frameworks
 
 The following example includes basic implementation of the `<SignIn />` component. You can use this as a starting point for your own implementation.
 
-<Tabs items={["Next.js", "React", "Astro", "Remix", "Tanstack Start", "Vue"]}>
+<Tabs items={["Next.js", "Astro", "Expo", "React", "React Router", "Remix", "Tanstack Start", "Vue"]}>
   <Tab>
     The following example demonstrates how you can use the `<SignIn />` component on a public page.
 
-    If you would like to create a dedicated `/sign-in` page in your Next.js application, see the [dedicated guide](/docs/references/nextjs/custom-sign-in-or-up-page).
+    If you would like to create a dedicated `/sign-in` page in your Next.js application, there are a few requirements you must follow. See the [dedicated guide](/docs/references/nextjs/custom-sign-in-or-up-page) for more information.
 
     ```tsx {{ filename: 'app/page.tsx' }}
     import { SignIn, useUser } from '@clerk/nextjs'
@@ -131,16 +131,6 @@ The following example includes basic implementation of the `<SignIn />` componen
   </Tab>
 
   <Tab>
-    ```jsx {{ filename: 'src/sign-in.tsx' }}
-    import { SignIn } from '@clerk/clerk-react'
-
-    const SignInPage = () => <SignIn />
-
-    export default SignInPage
-    ```
-  </Tab>
-
-  <Tab>
     ```astro {{ filename: 'pages/sign-in.astro' }}
     ---
     import { SignIn } from '@clerk/astro/components'
@@ -151,7 +141,43 @@ The following example includes basic implementation of the `<SignIn />` componen
   </Tab>
 
   <Tab>
-    ```jsx {{ filename: 'app/routes/sign-in/$.tsx' }}
+    If you would like to create a dedicated `/sign-in` page in your Expo Web application, there are a few requirements you must follow. See the [dedicated guide](/docs/references/expo/web-support/custom-sign-in-or-up-page) for more information.
+
+    ```tsx {{ filename: '/app/sign-in.web.tsx' }}
+    import { SignIn } from '@clerk/clerk-expo/web'
+
+    export default function SignInPage() {
+      return <SignIn />
+    }
+    ```
+  </Tab>
+
+  <Tab>
+    ```jsx {{ filename: 'src/sign-in.tsx' }}
+    import { SignIn } from '@clerk/clerk-react'
+
+    const SignInPage = () => <SignIn />
+
+    export default SignInPage
+    ```
+  </Tab>
+
+  <Tab>
+    If you would like to create a dedicated `/sign-in` page in your React Router application, there are a few requirements you must follow. See the [dedicated guide](/docs/references/react-router/custom-sign-in-or-up-page) for more information.
+
+    ```tsx {{ filename: 'app/routes/sign-in.tsx' }}
+    import { SignIn } from '@clerk/react-router'
+
+    export default function SignInPage() {
+      return <SignIn />
+    }
+    ```
+  </Tab>
+
+  <Tab>
+    If you would like to create a dedicated `/sign-in` page in your Remix application, there are a few requirements you must follow. See the [dedicated guide](/docs/references/remix/custom-sign-in-or-up-page) for more information.
+
+    ```tsx {{ filename: 'app/routes/sign-in/$.tsx' }}
     import { SignIn } from '@clerk/remix'
 
     export default function SignInPage() {
@@ -161,6 +187,8 @@ The following example includes basic implementation of the `<SignIn />` componen
   </Tab>
 
   <Tab>
+    If you would like to create a dedicated `/sign-in` page in your TanStack Start application, there are a few requirements you must follow. See the [dedicated guide](/docs/references/tanstack-start/custom-sign-in-or-up-page) for more information.
+
     ```tsx {{ filename: 'app/routes/sign-in.tsx' }}
     import { SignIn } from '@clerk/tanstack-start'
     import { createFileRoute } from '@tanstack/react-router'

--- a/docs/components/authentication/sign-up.mdx
+++ b/docs/components/authentication/sign-up.mdx
@@ -346,3 +346,5 @@ The following example includes basic implementation of the `<SignUp />` componen
 ## Customization
 
 To learn about how to customize Clerk components, see the [customization documentation](/docs/customization/overview).
+
+If Clerk's prebuilt components don't meet your specific needs or if you require more control over the logic, you can rebuild the existing Clerk flows using the Clerk API. For more information, see the [custom flow guides](/docs/custom-flows/overview).

--- a/docs/components/authentication/sign-up.mdx
+++ b/docs/components/authentication/sign-up.mdx
@@ -22,52 +22,24 @@ All props are optional.
 
   ---
 
-  - `routing`
-  - `'hash' | 'path'`
+  - `fallback`
+  - `ReactNode`
 
-  The [routing](/docs/guides/routing) strategy for your pages.  Defaults to `'path'` for frameworks that handle routing, such as Next.js and Remix. Defaults to `hash` for all other SDK's, such as React.
-
-  ---
-
-  - `path`
-  - `string`
-
-  The path where the component is mounted on when `routing` is set to `path`. It is ignored in hash-based routing. For example: `/sign-up`.
+  An optional element to be rendered while the component is mounting.
 
   ---
 
-  - `signInUrl`
-  - `string`
-
-  Used for the 'Sign In' link that's rendered. The full URL or path to the sign-in page. It's recommended to use [the environment variable](/docs/deployments/clerk-environment-variables#sign-in-and-sign-up-redirects) instead.
-
-  ---
-
-  - `forceRedirectUrl?`
-  - `string`
-
-  If provided, this URL will always be used as the redirect destination after the user signs up. It's recommended to use [the environment variable](/docs/deployments/clerk-environment-variables#sign-in-and-sign-up-redirects) instead.
-
-  ---
-
-  - `fallbackRedirectUrl?`
+  - `fallbackRedirectUrl`
   - `string`
 
   The fallback URL to redirect to after the user signs up, if there's no `redirect_url` in the path already. Defaults to `/`. It's recommended to use [the environment variable](/docs/deployments/clerk-environment-variables#sign-in-and-sign-up-redirects) instead.
 
   ---
 
-  - `signInForceRedirectUrl?`
+  - `forceRedirectUrl`
   - `string`
 
-  Used for the 'Sign In' link that's rendered. If provided, this URL will always be redirected to after the user signs in. It's recommended to use [the environment variable](/docs/deployments/clerk-environment-variables#sign-in-and-sign-up-redirects) instead.
-
-  ---
-
-  - `signInFallbackRedirectUrl?`
-  - `string`
-
-  Used for the 'Sign In' link that's rendered. The fallback URL to redirect to after the user signs in, if there's no `redirect_url` in the path already. Defaults to `/`. It's recommended to use [the environment variable](/docs/deployments/clerk-environment-variables#sign-in-and-sign-up-redirects) instead.
+  If provided, this URL will always be used as the redirect destination after the user signs up. It's recommended to use [the environment variable](/docs/deployments/clerk-environment-variables#sign-in-and-sign-up-redirects) instead.
 
   ---
 
@@ -78,17 +50,45 @@ All props are optional.
 
   ---
 
+  - `path`
+  - `string`
+
+  The path where the component is mounted on when `routing` is set to `path`. It is ignored in hash-based routing. For example: `/sign-up`.
+
+  ---
+
+  - `routing`
+  - `'hash' | 'path'`
+
+  The [routing](/docs/guides/routing) strategy for your pages.  Defaults to `'path'` for frameworks that handle routing, such as Next.js and Remix. Defaults to `hash` for all other SDK's, such as React.
+
+  ---
+
+  - `signInFallbackRedirectUrl`
+  - `string`
+
+  The fallback URL to redirect to after the user signs in, if there's no `redirect_url` in the path already. Used for the 'Already have an account? Sign in' link that's rendered.  Defaults to `/`. It's recommended to use [the environment variable](/docs/deployments/clerk-environment-variables#sign-in-and-sign-up-redirects) instead.
+
+  ---
+
+  - `signInForceRedirectUrl?`
+  - `string`
+
+  If provided, this URL will always be redirected to after the user signs in. Used for the 'Already have an account? Sign in' link that's rendered. It's recommended to use [the environment variable](/docs/deployments/clerk-environment-variables#sign-in-and-sign-up-redirects) instead.
+
+  ---
+
+  - `signInUrl`
+  - `string`
+
+  The full URL or path to the sign-in page. Used for the 'Already have an account? Sign in' link that's rendered. It's recommended to use [the environment variable](/docs/deployments/clerk-environment-variables#sign-in-and-sign-up-redirects) instead.
+
+  ---
+
   - `unsafeMetadata`
   - [`SignUpUnsafeMetadata`](/docs/references/javascript/types/metadata#sign-up-unsafe-metadata)
 
   Metadata that can be read and set from the frontend and the backend. Once the sign-up is complete, the value of this field will be automatically copied to the created user's unsafe metadata (`User.unsafeMetadata`). One common use case is to collect custom information about the user during the sign-up process and store it in this property. Read more about [unsafe metadata](/docs/users/metadata#unsafe-metadata).
-
-  ---
-
-  - `fallback?`
-  - `ReactNode`
-
-  An optional element to be rendered while the component is mounting.
 </Properties>
 
 ## Usage with frameworks

--- a/docs/components/authentication/sign-up.mdx
+++ b/docs/components/authentication/sign-up.mdx
@@ -95,11 +95,11 @@ All props are optional.
 
 The following example includes basic implementation of the `<SignUp />` component. You can use this as a starting point for your own implementation.
 
-<Tabs items={["Next.js", "React", "Astro", "Remix", "Tanstack Start", "Vue"]}>
+<Tabs items={["Next.js", "Astro", "React", "React Router","Remix", "Tanstack Start", "Vue"]}>
   <Tab>
     The following example demonstrates how you can use the `<SignUp />` component on a public page.
 
-    If you would like to create a dedicated `/sign-up` page in your Next.js application, see the [dedicated guide](/docs/references/nextjs/custom-sign-up-page).
+    If you would like to create a dedicated `/sign-up` page in your Next.js application, there are a few requirements you must follow. See the [dedicated guide](/docs/references/nextjs/custom-sign-up-page) for more information.
 
     ```tsx {{ filename: 'app/page.tsx' }}
     import { SignUp, useUser } from '@clerk/nextjs'
@@ -107,22 +107,10 @@ The following example includes basic implementation of the `<SignUp />` componen
     export default function Home() {
       const { user } = useUser()
 
-      if (!user) {
-        return <SignUp />
-      }
+      if (!user) return <SignUp />
 
       return <div>Welcome!</div>
     }
-    ```
-  </Tab>
-
-  <Tab>
-    ```jsx {{ filename: 'src/sign-up.tsx' }}
-    import { SignUp } from '@clerk/clerk-react'
-
-    const SignUpPage = () => <SignUp />
-
-    export default SignUpPage
     ```
   </Tab>
 
@@ -137,20 +125,42 @@ The following example includes basic implementation of the `<SignUp />` componen
   </Tab>
 
   <Tab>
-    ```jsx {{ filename: 'app/routes/sign-up/$.tsx' }}
-    import { SignUp } from '@clerk/remix'
+    ```jsx {{ filename: 'src/sign-up.tsx' }}
+    import { SignUp } from '@clerk/clerk-react'
+
+    const SignUpPage = () => <SignUp />
+
+    export default SignUpPage
+    ```
+  </Tab>
+
+  <Tab>
+    If you would like to create a dedicated `/sign-up` page in your React Router application, there are a few requirements you must follow. See the [dedicated guide](/docs/references/react-router/custom-sign-up-page) for more information.
+
+    ```tsx {{ filename: 'app/routes/sign-up.tsx' }}
+    import { SignUp } from '@clerk/react-router'
 
     export default function SignUpPage() {
-      return (
-        <div style={{ border: '2px solid blue', padding: '2rem' }}>
-          <SignUp />
-        </div>
-      )
+      return <SignUp />
     }
     ```
   </Tab>
 
   <Tab>
+    If you would like to create a dedicated `/sign-up` page in your Remix application, there are a few requirements you must follow. See the [dedicated guide](/docs/references/remix/custom-sign-up-page) for more information.
+
+    ```jsx {{ filename: 'app/routes/sign-up/$.tsx' }}
+    import { SignUp } from '@clerk/remix'
+
+    export default function SignUpPage() {
+      return <SignUp />
+    }
+    ```
+  </Tab>
+
+  <Tab>
+    If you would like to create a dedicated `/sign-up` page in your Tanstack Start application, there are a few requirements you must follow. See the [dedicated guide](/docs/references/tanstack-start/custom-sign-up-page) for more information.
+
     ```tsx {{ filename: 'app/routes/sign-up.tsx' }}
     import { SignUp } from '@clerk/tanstack-start'
     import { createFileRoute } from '@tanstack/react-router'
@@ -178,158 +188,160 @@ The following example includes basic implementation of the `<SignUp />` componen
   </Tab>
 </Tabs>
 
-## Usage with JavaScript
+<If sdk="javascript">
+  ## Usage with JavaScript
 
-The following methods available on an instance of the [`Clerk`](/docs/references/javascript/clerk) class are used to render and control the `<SignUp />` component:
+  The following methods available on an instance of the [`Clerk`](/docs/references/javascript/clerk) class are used to render and control the `<SignUp />` component:
 
-- [`mountSignUp()`](#mount-sign-up)
-- [`unmountSignUp()`](#unmount-sign-up)
-- [`openSignUp()`](#open-sign-up)
-- [`closeSignUp()`](#close-sign-up)
+  - [`mountSignUp()`](#mount-sign-up)
+  - [`unmountSignUp()`](#unmount-sign-up)
+  - [`openSignUp()`](#open-sign-up)
+  - [`closeSignUp()`](#close-sign-up)
 
-The following examples assume that you have followed the [quickstart](/docs/quickstarts/javascript) in order to add Clerk to your JavaScript application.
+  The following examples assume that you have followed the [quickstart](/docs/quickstarts/javascript) in order to add Clerk to your JavaScript application.
 
-### `mountSignUp()`
+  ### `mountSignUp()`
 
-Render the `<SignUp />` component to an HTML `<div>` element.
+  Render the `<SignUp />` component to an HTML `<div>` element.
 
-```typescript
-function mountSignUp(node: HTMLDivElement, props?: SignUpProps): void
-```
+  ```typescript
+  function mountSignUp(node: HTMLDivElement, props?: SignUpProps): void
+  ```
 
-#### `mountSignUp()` params
+  #### `mountSignUp()` params
 
-<Properties>
-  - `node `
-  - [`HTMLDivElement`](https://developer.mozilla.org/en-US/docs/Web/API/HTMLDivElement)
+  <Properties>
+    - `node `
+    - [`HTMLDivElement`](https://developer.mozilla.org/en-US/docs/Web/API/HTMLDivElement)
 
-  The `<div>` element used to render in the `<SignUp />` component
+    The `<div>` element used to render in the `<SignUp />` component
 
-  ---
+    ---
 
-  - `props?`
-  - [`SignUpProps`](#sign-up-props)
+    - `props?`
+    - [`SignUpProps`](#sign-up-props)
 
-  The properties to pass to the `<SignUp />` component.
-</Properties>
+    The properties to pass to the `<SignUp />` component.
+  </Properties>
 
-#### `mountSignUp()` usage
+  #### `mountSignUp()` usage
 
-```typescript {{ filename: 'main.ts', mark: [15] }}
-import { Clerk } from '@clerk/clerk-js'
+  ```typescript {{ filename: 'main.ts', mark: [15] }}
+  import { Clerk } from '@clerk/clerk-js'
 
-// Initialize Clerk with your Clerk Publishable Key
-const clerkPubKey = import.meta.env.VITE_CLERK_PUBLISHABLE_KEY
+  // Initialize Clerk with your Clerk Publishable Key
+  const clerkPubKey = import.meta.env.VITE_CLERK_PUBLISHABLE_KEY
 
-const clerk = new Clerk(clerkPubKey)
-await clerk.load()
+  const clerk = new Clerk(clerkPubKey)
+  await clerk.load()
 
-document.getElementById('app').innerHTML = `
-  <div id="sign-up"></div>
-`
+  document.getElementById('app').innerHTML = `
+    <div id="sign-up"></div>
+  `
 
-const signUpDiv = document.getElementById('sign-up')
+  const signUpDiv = document.getElementById('sign-up')
 
-clerk.mountSignUp(signUpDiv)
-```
+  clerk.mountSignUp(signUpDiv)
+  ```
 
-### `unmountSignUp()`
+  ### `unmountSignUp()`
 
-Unmount and run cleanup on an existing `<SignUp />` component instance.
+  Unmount and run cleanup on an existing `<SignUp />` component instance.
 
-```typescript
-function unmountSignUp(node: HTMLDivElement): void
-```
+  ```typescript
+  function unmountSignUp(node: HTMLDivElement): void
+  ```
 
-#### `unmountSignUp()` params
+  #### `unmountSignUp()` params
 
-<Properties>
-  - `node `
-  - [`HTMLDivElement`](https://developer.mozilla.org/en-US/docs/Web/API/HTMLDivElement)
+  <Properties>
+    - `node `
+    - [`HTMLDivElement`](https://developer.mozilla.org/en-US/docs/Web/API/HTMLDivElement)
 
-  The container `<div>` element with a rendered `<SignUp />` component instance
-</Properties>
+    The container `<div>` element with a rendered `<SignUp />` component instance
+  </Properties>
 
-#### `unmountSignUp()` usage
+  #### `unmountSignUp()` usage
 
-```typescript {{ filename: 'main.ts', mark: [19] }}
-import { Clerk } from '@clerk/clerk-js'
+  ```typescript {{ filename: 'main.ts', mark: [19] }}
+  import { Clerk } from '@clerk/clerk-js'
 
-// Initialize Clerk with your Clerk Publishable Key
-const clerkPubKey = import.meta.env.VITE_CLERK_PUBLISHABLE_KEY
+  // Initialize Clerk with your Clerk Publishable Key
+  const clerkPubKey = import.meta.env.VITE_CLERK_PUBLISHABLE_KEY
 
-const clerk = new Clerk(clerkPubKey)
-await clerk.load()
+  const clerk = new Clerk(clerkPubKey)
+  await clerk.load()
 
-document.getElementById('app').innerHTML = `
-  <div id="sign-up"></div>
-`
+  document.getElementById('app').innerHTML = `
+    <div id="sign-up"></div>
+  `
 
-const signUpDiv = document.getElementById('sign-up')
+  const signUpDiv = document.getElementById('sign-up')
 
-clerk.mountSignUp(signUpDiv)
+  clerk.mountSignUp(signUpDiv)
 
-// ...
+  // ...
 
-clerk.unmountSignUp(signUpDiv)
-```
+  clerk.unmountSignUp(signUpDiv)
+  ```
 
-### `openSignUp()`
+  ### `openSignUp()`
 
-Opens the `<SignUp />` component as an overlay at the root of your HTML `body` element.
+  Opens the `<SignUp />` component as an overlay at the root of your HTML `body` element.
 
-```typescript
-function openSignUp(props?: SignUpProps): void
-```
+  ```typescript
+  function openSignUp(props?: SignUpProps): void
+  ```
 
-#### `openSignUp()` params
+  #### `openSignUp()` params
 
-<Properties>
-  - `props?`
-  - [`SignUpProps`](#sign-up-props)
+  <Properties>
+    - `props?`
+    - [`SignUpProps`](#sign-up-props)
 
-  The properties to pass to the `<SignUp />` component
-</Properties>
+    The properties to pass to the `<SignUp />` component
+  </Properties>
 
-#### `openSignUp()` usage
+  #### `openSignUp()` usage
 
-```js {{ filename: 'main.js', mark: [9] }}
-import { Clerk } from '@clerk/clerk-js'
+  ```js {{ filename: 'main.js', mark: [9] }}
+  import { Clerk } from '@clerk/clerk-js'
 
-// Initialize Clerk with your Clerk Publishable Key
-const clerkPubKey = import.meta.env.VITE_CLERK_PUBLISHABLE_KEY
+  // Initialize Clerk with your Clerk Publishable Key
+  const clerkPubKey = import.meta.env.VITE_CLERK_PUBLISHABLE_KEY
 
-const clerk = new Clerk(clerkPubKey)
-await clerk.load()
+  const clerk = new Clerk(clerkPubKey)
+  await clerk.load()
 
-clerk.openSignUp()
-```
+  clerk.openSignUp()
+  ```
 
-### `closeSignUp()`
+  ### `closeSignUp()`
 
-Closes the sign up overlay.
+  Closes the sign up overlay.
 
-```typescript
-function closeSignUp(): void
-```
+  ```typescript
+  function closeSignUp(): void
+  ```
 
-#### `closeSignUp()` usage
+  #### `closeSignUp()` usage
 
-```js {{ filename: 'main.js', mark: [13] }}
-import { Clerk } from '@clerk/clerk-js'
+  ```js {{ filename: 'main.js', mark: [13] }}
+  import { Clerk } from '@clerk/clerk-js'
 
-// Initialize Clerk with your Clerk Publishable Key
-const clerkPubKey = import.meta.env.VITE_CLERK_PUBLISHABLE_KEY
+  // Initialize Clerk with your Clerk Publishable Key
+  const clerkPubKey = import.meta.env.VITE_CLERK_PUBLISHABLE_KEY
 
-const clerk = new Clerk(clerkPubKey)
-await clerk.load()
+  const clerk = new Clerk(clerkPubKey)
+  await clerk.load()
 
-clerk.openSignUp()
+  clerk.openSignUp()
 
-// ...
+  // ...
 
-clerk.closeSignUp()
-```
+  clerk.closeSignUp()
+  ```
+</If>
 
 ## Customization
 

--- a/docs/components/waitlist.mdx
+++ b/docs/components/waitlist.mdx
@@ -24,6 +24,13 @@ Before using the `<Waitlist />` component, you must enable **Waitlist** mode in 
 All props are optional.
 
 <Properties>
+  - `afterJoinWaitlistUrl`
+  - `string`
+
+  The full URL or path to navigate to after joining the waitlist.
+
+  ---
+
   - `appearance`
   - <code>[Appearance](/docs/customization/overview) | undefined</code>
 
@@ -31,24 +38,17 @@ All props are optional.
 
   ---
 
-  - `afterJoinWaitlistUrl`
-  - `string`
+  - `fallback?`
+  - `ReactNode`
 
-  Full URL or path to navigate to after joining the waitlist.
+  An optional element to be rendered while the component is mounting.
 
   ---
 
   - `signInUrl`
   - `string`
 
-  Full URL or path to the sign in page. Use this property to provide the target of the 'Sign In' link that's rendered. It's recommended to use [the environment variable](/docs/deployments/clerk-environment-variables#sign-in-and-sign-up-redirects) instead.
-
-  ---
-
-  - `fallback?`
-  - `ReactNode`
-
-  An optional element to be rendered while the component is mounting.
+  The full URL or path to the sign in page. Used for the 'Already have an account? Sign in' link that's rendered. It's recommended to use [the environment variable](/docs/deployments/clerk-environment-variables#sign-in-and-sign-up-redirects) instead.
 </Properties>
 
 ## Usage with frameworks

--- a/docs/deployments/clerk-environment-variables.mdx
+++ b/docs/deployments/clerk-environment-variables.mdx
@@ -17,7 +17,7 @@ If you're building a pure React app, you should use the props on the components 
 
 Components, such as [`<ClerkProvider>`](/docs/components/clerk-provider), [`<SignIn>`](/docs/components/authentication/sign-in), and more, provide props for you to specify where users will be redirected. For example, `<ClerkProvider>` has the `signInFallbackRedirectUrl` and `signUpFallbackRedirectUrl` props.
 
-However, it's recommended to use environment variables instead of these props whenever possible.
+However, **it's recommended to use environment variables instead of these props whenever possible.**
 
 <Include src="_partials/environment-variables" />
 
@@ -122,7 +122,7 @@ The following environment variables are deprecated but still supported to avoid 
   <Tab>
     | Variable | Description |
     | - | - |
-    | `CLERK_AFTER_SIGN_UP_URL` | Full URL or path to navigate to after successful sign up. Defaults to `/`. `CLERK_SIGN_UP_FALLBACK_URL` and `CLERK_SIGN_UP_FORCE_REDIRECT_URL` have priority and should be used instead. |
+    | `CLERK_AFTER_SIGN_UP_URL` | Full URL or path to navigate to after successful sign up. Defaults to `/`. `CLERK_SIGN_UP_FALLBACK_REDIRECT_URL` and `CLERK_SIGN_UP_FORCE_REDIRECT_URL` have priority and should be used instead. |
     | `CLERK_AFTER_SIGN_IN_URL` | Full URL or path to navigate to after successful sign in. Defaults to `/`. `CLERK_SIGN_IN_FALLBACK_REDIRECT_URL` and `CLERK_SIGN_IN_FORCE_REDIRECT_URL` have priority and should be used instead. |
   </Tab>
 

--- a/docs/guides/custom-redirects.mdx
+++ b/docs/guides/custom-redirects.mdx
@@ -17,7 +17,7 @@ However, you can customize this behavior to redirect users to a specific page by
 
 ## Environment variables
 
-The following environment variables are available for customizing your redirect URLs. It is recommended to define both sign-up and sign-in variables, as some users may choose to sign up instead after attempting to sign in, and vice versa. For example, if you define `CLERK_SIGN_IN_URL`, you should also define `CLERK_SIGN_UP_URL`.
+The following environment variables are available for customizing your redirect URLs.
 
 <Include src="_partials/environment-variables" />
 

--- a/docs/guides/custom-redirects.mdx
+++ b/docs/guides/custom-redirects.mdx
@@ -17,7 +17,7 @@ However, you can customize this behavior to redirect users to a specific page by
 
 ## Environment variables
 
-The following environment variables are available for customizing your redirect URLs:
+The following environment variables are available for customizing your redirect URLs. It is recommended to define both sign-up and sign-in variables, as some users may choose to sign up instead after attempting to sign in, and vice versa. For example, if you define `CLERK_SIGN_IN_URL`, you should also define `CLERK_SIGN_UP_URL`.
 
 <Include src="_partials/environment-variables" />
 
@@ -33,20 +33,20 @@ This section describes the properties available for customizing your redirect UR
 The "fallback redirect URL" props will only be used if there is no `redirect_url` value. This can happen if the user has navigated directly to the sign up or sign in page.
 
 - `fallbackRedirectUrl` - Used by sign-in and sign-up related components.
-- `signInFallbackRedirectUrl` - Used for the 'Sign In' link that's rendered on sign-up components, such as `<SignUp />` and `<SignUpButton>`.
-- `signUpFallbackRedirectUrl` - Used for the 'Sign Up' link that's rendered on sign-in components, such as `<SignIn />` and `<SignInButton>`.
+- `signInFallbackRedirectUrl` - Used for the 'Already have an account? Sign in' link that's rendered on sign-up components, such as `<SignUp />` and `<SignUpButton>`.
+- `signUpFallbackRedirectUrl` - Used for the 'Don't have an account? Sign up' link that's rendered on sign-in components, such as `<SignIn />` and `<SignInButton>`.
 
 ### Force redirect URL props
 
 The "force redirect URL" props will _always_ redirect to the provided URL after sign up or sign in, regardless of what page the user was on before, and will override the `redirect_url` value if present.
 
 - `forceRedirectUrl` - Used by sign-in and sign-up related components.
-- `signInForceRedirectUrl` - Used for the 'Sign In' link that's rendered on sign-up components, such as `<SignUp />` and `<SignUpButton>`.
-- `signUpForceRedirectUrl` - Used for the 'Sign Up' link that's rendered on sign-in components, such as `<SignIn />` and `<SignInButton>`.
+- `signInForceRedirectUrl` - Used for the 'Already have an account? Sign in' link that's rendered on sign-up components, such as `<SignUp />` and `<SignUpButton>`.
+- `signUpForceRedirectUrl` - Used for the 'Don't have an account? Sign up' link that's rendered on sign-in components, such as `<SignIn />` and `<SignInButton>`.
 
 ### Set the props
 
-It is recommended to define both `signInFallbackRedirectUrl` and `signUpFallbackRedirectUrl` props, or `signInForceRedirectUrl` and `signUpForceRedirectUrl` props, as some users may choose to sign up instead after attempting to sign in, and vice versa.
+It is recommended to define both sign-up and sign-in variables, as some users may choose to sign up instead after attempting to sign in, and vice versa. For example, if you define `signInFallbackRedirectUrl`, you should also define `signUpFallbackRedirectUrl`.
 
 The following components accept the redirect URL props:
 

--- a/docs/references/expo/web-support/custom-sign-in-or-up-page.mdx
+++ b/docs/references/expo/web-support/custom-sign-in-or-up-page.mdx
@@ -1,9 +1,11 @@
 ---
-title: Build your own sign-in-or-up page with prebuilt components on web
-description: Learn how to add custom sign-in-or-up page to your Expo app with Clerk's prebuilt components.
+title: Build your own sign-in-or-up page for your Expo web app
+description: Learn how to add custom sign-in-or-up page to your Expo web app with Clerk's prebuilt components.
 ---
 
-This guide shows you how to use the [`<SignIn />`](/docs/components/authentication/sign-in) prebuilt component in order to build custom sign-in-or-up page for your Expo **web** app.
+This guide shows you how to use the [`<SignIn />`](/docs/components/authentication/sign-in) prebuilt component in order to build custom page that **allows users to sign in or sign up within a single flow**.
+
+To set up separate sign-in and sign-up pages, follow this guide, and then follow the [custom sign-up page guide](/docs/references/expo/web-support/custom-sign-up-page).
 
 This guide uses [Expo Router](https://docs.expo.dev/router/introduction/) and the [platform-specific extensions](https://docs.expo.dev/router/create-pages/#platform-specific-extensions) to build the sign-in-or-up page specifically for the **web** platform.
 

--- a/docs/references/expo/web-support/custom-sign-up-page.mdx
+++ b/docs/references/expo/web-support/custom-sign-up-page.mdx
@@ -3,9 +3,11 @@ title: Build your own sign-up page with prebuilt components on web
 description: Learn how to add custom sign-up page to your Expo app with Clerk's prebuilt components.
 ---
 
-This guide shows you how to use the [`<SignUp />`](/docs/components/authentication/sign-up) prebuilt component in order to build custom sign-up page for your Expo **web** app.
+By default, the [`<SignIn />`](/docs/references/expo/web-support/custom-sign-in-or-up-page) component handles signing in and signing up, but if you'd like to have a dedicated sign-up page, this guide shows you how to use the [`<SignUp />`](/docs/components/authentication/sign-up) component to build a custom sign-up page.
 
-This guide uses [Expo Router](https://docs.expo.dev/router/introduction/) and the [platform-specific extensions](https://docs.expo.dev/router/create-pages/#platform-specific-extensions) to build the sign-in-or-up page specifically for the **web** platform.
+To set up a single sign-in-or-up page, follow the [custom sign-in-or-up page guide](/docs/references/expo/web-support/custom-sign-in-or-up-page).
+
+This guide uses [Expo Router](https://docs.expo.dev/router/introduction/) and the [platform-specific extensions](https://docs.expo.dev/router/create-pages/#platform-specific-extensions) to build the sign-up page specifically for the **web** platform.
 
 <Steps>
   ## Build a sign-up page

--- a/docs/references/nextjs/custom-sign-in-or-up-page.mdx
+++ b/docs/references/nextjs/custom-sign-in-or-up-page.mdx
@@ -3,9 +3,9 @@ title: Build your own sign-in-or-up page for your Next.js app with Clerk
 description: Learn how to add a custom sign-in-or-up page to your Next.js app with Clerk's prebuilt components.
 ---
 
-This guide shows you how to use the [`<SignIn />`](/docs/components/authentication/sign-in) component with the [Next.js optional catch-all route](https://nextjs.org/docs/pages/building-your-application/routing/dynamic-routes#catch-all-segments) in order to build a custom page for your Next.js app that allows users to sign in or sign up within a single flow.
+This guide shows you how to use the [`<SignIn />`](/docs/components/authentication/sign-in) component to build a custom page that **allows users to sign in or sign up within a single flow**.
 
-If the prebuilt components don't meet your specific needs or if you require more control over the logic, you can rebuild the existing Clerk flows using the Clerk API. For more information, see the [custom flow guides](/docs/custom-flows/overview).
+To set up separate sign-in and sign-up pages, follow this guide, and then follow the [custom sign-up page guide](/docs/references/nextjs/custom-sign-up-page).
 
 > [!NOTE]
 > Just getting started with Clerk and Next.js? See the [quickstart tutorial](/docs/quickstarts/nextjs)!
@@ -13,7 +13,7 @@ If the prebuilt components don't meet your specific needs or if you require more
 <Steps>
   ## Build a sign-in-or-up page
 
-  The following example demonstrates how to render the [`<SignIn />`](/docs/components/authentication/sign-up) component to allow users to both sign-in or sign-up from a single flow.
+  The following example demonstrates how to render the [`<SignIn />`](/docs/components/authentication/sign-in) component on a dedicated page using the [Next.js optional catch-all route](https://nextjs.org/docs/pages/building-your-application/routing/dynamic-routes#catch-all-segments).
 
   ```tsx {{ filename: 'app/sign-in/[[...sign-in]]/page.tsx' }}
   import { SignIn } from '@clerk/nextjs'

--- a/docs/references/nextjs/custom-sign-in-or-up-page.mdx
+++ b/docs/references/nextjs/custom-sign-in-or-up-page.mdx
@@ -56,10 +56,16 @@ If the prebuilt components don't meet your specific needs or if you require more
 
   ## Update your environment variables
 
-  Update your environment variables to point to your custom sign-in page. Learn more about the available [environment variables](/docs/deployments/clerk-environment-variables).
+  - Set the `CLERK_SIGN_IN_URL` environment variable to tell Clerk where the `<SignIn />` component is being hosted.
+  - Set `CLERK_SIGN_IN_FALLBACK_REDIRECT_URL` as a fallback URL incase users visit the `/sign-in` route directly.
+  - Set `CLERK_SIGN_UP_FALLBACK_REDIRECT_URL` as a fallback URL incase users select the 'Don't have an account? Sign up' link at the bottom of the component.
+
+  Learn more about these environment variables and how to customize Clerk's redirect behavior in the [dedicated guide](/docs/guides/custom-redirects).
 
   ```env {{ filename: '.env' }}
   NEXT_PUBLIC_CLERK_SIGN_IN_URL=/sign-in
+  NEXT_PUBLIC_CLERK_SIGN_IN_FALLBACK_REDIRECT_URL=/
+  NEXT_PUBLIC_CLERK_SIGN_UP_FALLBACK_REDIRECT_URL=/
   ```
 
   ## Visit your new page

--- a/docs/references/nextjs/custom-sign-up-page.mdx
+++ b/docs/references/nextjs/custom-sign-up-page.mdx
@@ -59,11 +59,16 @@ If the prebuilt components don't meet your specific needs or if you require more
 
   ## Update your environment variables
 
-  Update your environment variables to point to your custom sign-in and sign-up pages. Learn more about the available [environment variables](/docs/deployments/clerk-environment-variables).
+  - Set the `CLERK_SIGN_UP_URL` environment variable to tell Clerk where the `<SignUp />` component is being hosted.
+  - Set `CLERK_SIGN_UP_FALLBACK_REDIRECT_URL` as a fallback URL incase users visit the `/sign-up` route directly.
+  - Set `CLERK_SIGN_IN_FALLBACK_REDIRECT_URL` as a fallback URL incase users select the 'Already have an account? Sign in' link at the bottom of the component.
 
-  ```env {{ filename: '.env', ins: [2] }}
-  NEXT_PUBLIC_CLERK_SIGN_IN_URL=/sign-in
+  Learn more about these environment variables and how to customize Clerk's redirect behavior in the [dedicated guide](/docs/guides/custom-redirects).
+
+  ```env {{ filename: '.env' }}
   NEXT_PUBLIC_CLERK_SIGN_UP_URL=/sign-up
+  NEXT_PUBLIC_CLERK_SIGN_UP_FALLBACK_REDIRECT_URL=/
+  NEXT_PUBLIC_CLERK_SIGN_IN_FALLBACK_REDIRECT_URL=/
   ```
 
   ## Visit your new page

--- a/docs/references/nextjs/custom-sign-up-page.mdx
+++ b/docs/references/nextjs/custom-sign-up-page.mdx
@@ -3,9 +3,9 @@ title: Build your own sign-up page for your Next.js app with Clerk
 description: Learn how to add a custom sign-up page to your Next.js app with Clerk's prebuilt components.
 ---
 
-By default, the [`<SignIn />`](/docs/references/nextjs/custom-sign-in-or-up-page) component handles signing-in or signing-up, but if you'd like to have a dedicated sign-up page, this guide shows you how to use the [`<SignUp />`](/docs/components/authentication/sign-up) component with the [Next.js optional catch-all route](https://nextjs.org/docs/pages/building-your-application/routing/dynamic-routes#catch-all-segments) in order to build custom sign-up page for your Next.js app.
+By default, the [`<SignIn />`](/docs/references/nextjs/custom-sign-in-or-up-page) component handles signing in and signing up, but if you'd like to have a dedicated sign-up page, this guide shows you how to use the [`<SignUp />`](/docs/components/authentication/sign-up) component to build a custom sign-up page.
 
-If the prebuilt components don't meet your specific needs or if you require more control over the logic, you can rebuild the existing Clerk flows using the Clerk API. For more information, see the [custom flow guides](/docs/custom-flows/overview).
+To set up a single sign-in-or-up page, follow the [custom sign-in-or-up page guide](/docs/references/nextjs/custom-sign-in-or-up-page).
 
 > [!NOTE]
 > Just getting started with Clerk and Next.js? See the [quickstart tutorial](/docs/quickstarts/nextjs)!
@@ -13,7 +13,7 @@ If the prebuilt components don't meet your specific needs or if you require more
 <Steps>
   ## Build a sign-up page
 
-  The following example demonstrates how to render the [`<SignUp />`](/docs/components/authentication/sign-up) component.
+  The following example demonstrates how to render the [`<SignUp />`](/docs/components/authentication/sign-up) component on a dedicated sign-up page using the [Next.js optional catch-all route](https://nextjs.org/docs/pages/building-your-application/routing/dynamic-routes#catch-all-segments).
 
   ```tsx {{ filename: 'app/sign-up/[[...sign-up]]/page.tsx' }}
   import { SignUp } from '@clerk/nextjs'

--- a/docs/references/react-router/custom-sign-in-or-up-page.mdx
+++ b/docs/references/react-router/custom-sign-in-or-up-page.mdx
@@ -40,11 +40,16 @@ If the prebuilt components don’t fully meet your needs or you want greater con
 
   ## Configure redirect behavior
 
-  Update your environment variables to point to your custom sign-in-or-up page. Learn more about the available [environment variables](/docs/deployments/clerk-environment-variables).
+  - Set the `CLERK_SIGN_IN_URL` environment variable to tell Clerk where the `<SignIn />` component is being hosted.
+  - Set `CLERK_SIGN_IN_FALLBACK_REDIRECT_URL` as a fallback URL incase users visit the `/sign-in` route directly.
+  - Set `CLERK_SIGN_UP_FALLBACK_REDIRECT_URL` as a fallback URL incase users select the 'Don't have an account? Sign up' link at the bottom of the component.
+
+  Learn more about these environment variables and how to customize Clerk's redirect behavior in the [dedicated guide](/docs/guides/custom-redirects).
 
   ```env {{ filename: '.env' }}
-  CLERK_SIGN_IN_FALLBACK_URL=/
   CLERK_SIGN_IN_URL=/sign-in
+  CLERK_SIGN_IN_FALLBACK_REDIRECT_URL=/
+  CLERK_SIGN_UP_FALLBACK_REDIRECT_URL=/
   ```
 
   ## Visit your new page

--- a/docs/references/react-router/custom-sign-in-or-up-page.mdx
+++ b/docs/references/react-router/custom-sign-in-or-up-page.mdx
@@ -3,14 +3,14 @@ title: Build your own sign-in-or-up page for your React Router app with Clerk
 description: Learn how to add a custom sign-in-or-up page to your React Router app with Clerk's prebuilt components.
 ---
 
-This guide shows you how to use the [`<SignIn />`](/docs/components/authentication/sign-in) component with the [React Router Splat route](https://reactrouter.com/start/framework/routing#splats) in order to build a custom page for your Next.js app that allows users to sign in or sign up within a single flow.
+This guide shows you how to use the [`<SignIn />`](/docs/components/authentication/sign-in) component to build a custom page **that allows users to sign in or sign up within a single flow**.
 
-If the prebuilt components don’t fully meet your needs or you want greater control over the logic, you can recreate Clerk’s existing flows using the Clerk API.  For more information, see the [custom flow guides](/docs/custom-flows/overview).
+To set up separate sign-in and sign-up pages, follow this guide, and then follow the [custom sign-up page guide](/docs/references/react-router/custom-sign-up-page).
 
 <Steps>
   ## Build a sign-in-or-up page
 
-  The following example demonstrates how to render the [`<SignIn />`](/docs/components/authentication/sign-up) component to allow users to both sign-in or sign-up from a single flow.
+  The following example demonstrates how to render the [`<SignIn />`](/docs/components/authentication/sign-in) component on a dedicated page using the [React Router Splat route](https://reactrouter.com/start/framework/routing#splats).
 
   ```tsx {{ filename: 'app/routes/sign-in.tsx' }}
   import { SignIn } from '@clerk/react-router'

--- a/docs/references/react-router/custom-sign-up-page.mdx
+++ b/docs/references/react-router/custom-sign-up-page.mdx
@@ -41,13 +41,16 @@ If the prebuilt components don't meet your specific needs or if you require more
 
   ## Configure redirect behavior
 
-  Update your environment variables to point to your custom sign-up page. Learn more about the available [environment variables](/docs/deployments/clerk-environment-variables).
+  - Set the `CLERK_SIGN_UP_URL` environment variable to tell Clerk where the `<SignUp />` component is being hosted.
+  - Set `CLERK_SIGN_UP_FALLBACK_REDIRECT_URL` as a fallback URL incase users visit the `/sign-up` route directly.
+  - Set `CLERK_SIGN_IN_FALLBACK_REDIRECT_URL` as a fallback URL incase users select the 'Already have an account? Sign in' link at the bottom of the component.
 
-  ```env {{ filename: '.env', mark: [2, 4] }}
-  CLERK_SIGN_IN_FALLBACK_REDIRECT_URL=/
-  CLERK_SIGN_UP_FALLBACK_REDIRECT_URL=/
-  CLERK_SIGN_IN_URL=/sign-in
+  Learn more about these environment variables and how to customize Clerk's redirect behavior in the [dedicated guide](/docs/guides/custom-redirects).
+
+  ```env {{ filename: '.env' }}
   CLERK_SIGN_UP_URL=/sign-up
+  CLERK_SIGN_UP_FALLBACK_REDIRECT_URL=/
+  CLERK_SIGN_IN_FALLBACK_REDIRECT_URL=/
   ```
 
   These values control the behavior of the `<SignUp />` and `<SignIn />` components and when you visit the respective links at the bottom of each component.

--- a/docs/references/react-router/custom-sign-up-page.mdx
+++ b/docs/references/react-router/custom-sign-up-page.mdx
@@ -3,14 +3,17 @@ title: Build your own sign-up page for your React Router app with Clerk
 description: Learn how to add a custom sign-up page to your React Router app with Clerk's prebuilt components.
 ---
 
-By default, the [`<SignIn />`](/docs/references/react-router/custom-sign-in-or-up-page) component handles signing-in or signing-up, but if you'd like to have a dedicated sign-up page, this guide shows you how to use the [`<SignUp />`](/docs/components/authentication/sign-up) component with the [React Router Splat route](https://reactrouter.com/start/framework/routing#splats) in order to build custom sign-up page for your React Router app.
+By default, the [`<SignIn />`](/docs/references/react-router/custom-sign-in-or-up-page) component handles signing in and signing up, but if you'd like to have a dedicated sign-up page, this guide shows you how to use the [`<SignUp />`](/docs/components/authentication/sign-up) component to build a custom sign-up page.
 
-If the prebuilt components don't meet your specific needs or if you require more control over the logic, you can rebuild the existing Clerk flows using the Clerk API. For more information, see the [custom flow guides](/docs/custom-flows/overview).
+To set up a single sign-in-or-up page, follow the [custom sign-in-or-up page guide](/docs/references/react-router/custom-sign-in-or-up-page).
+
+> [!NOTE]
+> Just getting started with Clerk and React Router? See the [quickstart tutorial](/docs/quickstarts/react-router)!
 
 <Steps>
   ## Build a sign-up page
 
-  The following example demonstrates how to render the [`<SignUp />`](/docs/components/authentication/sign-up) component.
+  The following example demonstrates how to render the [`<SignUp />`](/docs/components/authentication/sign-up) component on a dedicated sign-up page using the [React Router Splat route](https://reactrouter.com/start/framework/routing#splats).
 
   ```tsx {{ filename: 'app/routes/sign-up.tsx' }}
   import { SignUp } from '@clerk/react-router'

--- a/docs/references/remix/custom-sign-in-or-up-page.mdx
+++ b/docs/references/remix/custom-sign-in-or-up-page.mdx
@@ -27,22 +27,28 @@ If Clerk's prebuilt components don't meet your specific needs or if you require 
 
   <Tabs items={["SSR Mode", "SPA Mode"]}>
     <Tab>
-      For SSR Mode, add environment variables for the `signIn` and `afterSignIn` paths:
+      - Set the `CLERK_SIGN_IN_URL` environment variable to tell Clerk where the `<SignIn />` component is being hosted.
+      - Set `CLERK_SIGN_IN_FALLBACK_REDIRECT_URL` as a fallback URL incase users visit the `/sign-in` route directly.
+      - Set `CLERK_SIGN_UP_FALLBACK_REDIRECT_URL` as a fallback URL incase users select the 'Don't have an account? Sign up' link at the bottom of the component.
+
+      Learn more about these environment variables and how to customize Clerk's redirect behavior in the [dedicated guide](/docs/guides/custom-redirects).
 
       ```env {{ filename: '.env' }}
       CLERK_SIGN_IN_URL=/sign-in
-      CLERK_SIGN_IN_FALLBACK_URL=/
+      CLERK_SIGN_IN_FALLBACK_REDIRECT_URL=/
+      CLERK_SIGN_UP_FALLBACK_REDIRECT_URL=/
       ```
     </Tab>
 
     <Tab>
-      For SPA Mode, add paths to your `ClerkApp` options to control the behavior of the components when you sign in or sign up and when you click on the respective links at the bottom of each component.
+      Add the `signInUrl` property to your `ClerkApp` options to tell Clerk where the `<SignIn />` component is being hosted. Also, set a fallback URL incase users visit the `/sign-in` route directly. Learn more about these environment variables and how to customize Clerk's redirect behavior in the [dedicated guide](/docs/guides/custom-redirects).
 
       ```ts {{ filename: 'app/root.tsx', mark: [[3, 4]] }}
       export default ClerkApp(App, {
         publishableKey: PUBLISHABLE_KEY,
         signInUrl: '/sign-in',
         signInFallbackRedirectUrl: '/',
+        signUpFallbackRedirectUrl: '/',
       })
       ```
     </Tab>

--- a/docs/references/remix/custom-sign-in-or-up-page.mdx
+++ b/docs/references/remix/custom-sign-in-or-up-page.mdx
@@ -3,9 +3,9 @@ title: Build your own sign-in-or-up page for your Remix app with Clerk
 description: Learn how to add a custom sign-in-or-up page to your Remix app with Clerk's prebuilt components.
 ---
 
-This guide shows you how to use the [`<SignIn />`](/docs/components/authentication/sign-in) component with the [Remix optional route](https://reactrouter.com/en/main/route/route#optional-segments) in order to build a custom page for that allows users to sign in or sign up within a single flow for your Remix app.
+This guide shows you how to use the [`<SignIn />`](/docs/components/authentication/sign-in) component to build a custom page **that allows users to sign in or sign up within a single flow**.
 
-If Clerk's prebuilt components don't meet your specific needs or if you require more control over the logic, you can rebuild the existing Clerk flows using the Clerk API. For more information, see the [custom flow guides](/docs/custom-flows/overview).
+To set up separate sign-in and sign-up pages, follow this guide, and then follow the [custom sign-up page guide](/docs/references/remix/custom-sign-up-page).
 
 > [!NOTE]
 > Just getting started with Clerk and Remix? See the [quickstart tutorial](/docs/quickstarts/remix)!
@@ -13,7 +13,7 @@ If Clerk's prebuilt components don't meet your specific needs or if you require 
 <Steps>
   ## Build a sign-in-or-up page
 
-  The following example demonstrates how to render the [`<SignIn />`](/docs/components/authentication/sign-up) component to allow users to both sign-in or sign-up from a single flow.
+  The following example demonstrates how to render the [`<SignIn />`](/docs/components/authentication/sign-in) component on a dedicated page using the [Remix optional route](https://reactrouter.com/en/main/route/route#optional-segments).
 
   ```tsx {{ filename: 'app/routes/sign-in.$.tsx' }}
   import { SignIn } from '@clerk/remix'

--- a/docs/references/remix/custom-sign-in-or-up-page.mdx
+++ b/docs/references/remix/custom-sign-in-or-up-page.mdx
@@ -41,7 +41,11 @@ If Clerk's prebuilt components don't meet your specific needs or if you require 
     </Tab>
 
     <Tab>
-      Add the `signInUrl` property to your `ClerkApp` options to tell Clerk where the `<SignIn />` component is being hosted. Also, set a fallback URL incase users visit the `/sign-in` route directly. Learn more about these environment variables and how to customize Clerk's redirect behavior in the [dedicated guide](/docs/guides/custom-redirects).
+      - Set the `signInUrl` property to your `ClerkApp` options to tell Clerk where the `<SignIn />` component is being hosted.
+      - Set the `signInFallbackRedirectUrl` property to a fallback URL incase users visit the `/sign-in` route directly.
+      - Set the `signUpFallbackRedirectUrl` property to a fallback URL incase users select the 'Don't have an account? Sign up' link at the bottom of the component.
+
+      Learn more about these environment variables and how to customize Clerk's redirect behavior in the [dedicated guide](/docs/guides/custom-redirects).
 
       ```ts {{ filename: 'app/root.tsx', mark: [[3, 4]] }}
       export default ClerkApp(App, {

--- a/docs/references/remix/custom-sign-up-page.mdx
+++ b/docs/references/remix/custom-sign-up-page.mdx
@@ -27,13 +27,16 @@ If the prebuilt components don't meet your specific needs or if you require more
 
   <Tabs items={["SSR Mode", "SPA Mode"]}>
     <Tab>
-      For SSR Mode, add environment variables for the `signUp` and `afterSignUp` paths:
+      - Set the `CLERK_SIGN_UP_URL` environment variable to tell Clerk where the `<SignUp />` component is being hosted.
+      - Set `CLERK_SIGN_UP_FALLBACK_REDIRECT_URL` as a fallback URL incase users visit the `/sign-up` route directly.
+      - Set `CLERK_SIGN_IN_FALLBACK_REDIRECT_URL` as a fallback URL incase users select the 'Already have an account? Sign in' link at the bottom of the component.
 
-      ```env {{ filename: '.env', mark: [2, 4] }}
-      CLERK_SIGN_IN_URL=/sign-in
+      Learn more about these environment variables and how to customize Clerk's redirect behavior in the [dedicated guide](/docs/guides/custom-redirects).
+
+      ```env {{ filename: '.env' }}
       CLERK_SIGN_UP_URL=/sign-up
-      CLERK_SIGN_IN_FALLBACK_URL=/
-      CLERK_SIGN_UP_FALLBACK_URL=/
+      CLERK_SIGN_UP_FALLBACK_REDIRECT_URL=/
+      CLERK_SIGN_IN_FALLBACK_REDIRECT_URL=/
       ```
     </Tab>
 

--- a/docs/references/remix/custom-sign-up-page.mdx
+++ b/docs/references/remix/custom-sign-up-page.mdx
@@ -41,15 +41,18 @@ If the prebuilt components don't meet your specific needs or if you require more
     </Tab>
 
     <Tab>
-      For SPA Mode, add paths to your `ClerkApp` options to control the behavior of the components when you sign in or sign up and when you click on the respective links at the bottom of each component.
+      - Set the `signUpUrl` property to your `ClerkApp` options to tell Clerk where the `<SignUp />` component is being hosted.
+      - Set the `signUpFallbackRedirectUrl` property to a fallback URL incase users visit the `/sign-up` route directly.
+      - Set the `signInFallbackRedirectUrl` property to a fallback URL incase users select the 'Already have an account? Sign in' link at the bottom of the component.
 
-      ```ts {{ filename: 'app/root.tsx', mark: [4, 6] }}
+      Learn more about these environment variables and how to customize Clerk's redirect behavior in the [dedicated guide](/docs/guides/custom-redirects).
+
+      ```ts {{ filename: 'app/root.tsx' }}
       export default ClerkApp(App, {
         publishableKey: PUBLISHABLE_KEY,
-        signInUrl: '/sign-in',
         signUpUrl: '/sign-up',
-        signInFallbackRedirectUrl: '/',
         signUpFallbackRedirectUrl: '/',
+        signInFallbackRedirectUrl: '/',
       })
       ```
     </Tab>

--- a/docs/references/remix/custom-sign-up-page.mdx
+++ b/docs/references/remix/custom-sign-up-page.mdx
@@ -3,17 +3,17 @@ title: Build your own sign-up page for your Remix app with Clerk
 description: Learn how to add a custom sign-up page to your Remix app with Clerk's prebuilt components.
 ---
 
-By default, the [`<SignIn />`](/docs/references/remix/custom-sign-in-or-up-page) component handles signing-in or signing-up, but if you'd like to have a dedicated sign-up page, this guide shows you how to use the [`<SignUp />`](/docs/components/authentication/sign-up) component with the [Next.js optional catch-all route](https://reactrouter.com/en/main/route/route#optional-segments) in order to build custom sign-up page for your Remix app.
+By default, the [`<SignIn />`](/docs/references/remix/custom-sign-in-or-up-page) component handles signing in and signing up, but if you'd like to have a dedicated sign-up page, this guide shows you how to use the [`<SignUp />`](/docs/components/authentication/sign-up) component to build a custom sign-up page.
 
-If the prebuilt components don't meet your specific needs or if you require more control over the logic, you can rebuild the existing Clerk flows using the Clerk API. For more information, see the [custom flow guides](/docs/custom-flows/overview).
+To set up a single sign-in-or-up page, follow the [custom sign-in-or-up page guide](/docs/references/remix/custom-sign-in-or-up-page).
 
 > [!NOTE]
-> Just getting started with Clerk and Next.js? See the [quickstart tutorial](/docs/quickstarts/remix)!
+> Just getting started with Clerk and Remix? See the [quickstart tutorial](/docs/quickstarts/remix)!
 
 <Steps>
   ## Build a sign-up page
 
-  The following example demonstrates how to render the [`<SignUp />`](/docs/components/authentication/sign-up) component.
+  The following example demonstrates how to render the [`<SignUp />`](/docs/components/authentication/sign-up) component on a dedicated sign-up page using the [Remix optional route](https://reactrouter.com/en/main/route/route#optional-segments).
 
   ```tsx {{ filename: 'app/routes/sign-up.$.tsx' }}
   import { SignUp } from '@clerk/remix'

--- a/docs/references/tanstack-start/custom-sign-in-or-up-page.mdx
+++ b/docs/references/tanstack-start/custom-sign-in-or-up-page.mdx
@@ -30,11 +30,16 @@ If Clerk's prebuilt components don't meet your specific needs or if you require 
 
   ## Configure your sign-in-or-up page
 
-  To tell Clerk where to find your sign-in-or-up page, set the following [environment variables](/docs/deployments/clerk-environment-variables#sign-in-and-sign-up-redirects):
+  - Set the `CLERK_SIGN_IN_URL` environment variable to tell Clerk where the `<SignIn />` component is being hosted.
+  - Set `CLERK_SIGN_IN_FALLBACK_REDIRECT_URL` as a fallback URL incase users visit the `/sign-in` route directly.
+  - Set `CLERK_SIGN_UP_FALLBACK_REDIRECT_URL` as a fallback URL incase users select the 'Don't have an account? Sign up' link at the bottom of the component.
+
+  Learn more about these environment variables and how to customize Clerk's redirect behavior in the [dedicated guide](/docs/guides/custom-redirects).
 
   ```env {{ filename: '.env' }}
   CLERK_SIGN_IN_URL=/sign-in
   CLERK_SIGN_IN_FALLBACK_REDIRECT_URL=/
+  CLERK_SIGN_UP_FALLBACK_REDIRECT_URL=/
   ```
 
   ## Visit your new page

--- a/docs/references/tanstack-start/custom-sign-in-or-up-page.mdx
+++ b/docs/references/tanstack-start/custom-sign-in-or-up-page.mdx
@@ -3,9 +3,9 @@ title: Build your own sign-in-or-up page for your TanStack Start app with Clerk
 description: Learn how to add a custom sign-in-or-up page to your TanStack Start app with Clerk's prebuilt components.
 ---
 
-This guide shows you how to use the [`<SignIn />`](/docs/components/authentication/sign-in) component with the [Tanstack Router catch-all route](https://tanstack.com/router/latest/docs/framework/react/guide/code-based-routing#splat--catch-all-routes) in order to build a custom page for your TanStack Start app that allows users to sign in or sign up within a single flow.
+This guide shows you how to use the [`<SignIn />`](/docs/components/authentication/sign-in) component to build a custom page **that allows users to sign in or sign up within a single flow**.
 
-If Clerk's prebuilt components don't meet your specific needs or if you require more control over the logic, you can rebuild the existing Clerk flows using the Clerk API. For more information, see the [custom flow guides](/docs/custom-flows/overview).
+To set up separate sign-in and sign-up pages, follow this guide, and then follow the [custom sign-up page guide](/docs/references/tanstack-start/custom-sign-up-page).
 
 > [!NOTE]
 > Just getting started with Clerk and TanStack Start? See the [quickstart tutorial](/docs/quickstarts/tanstack-start)!
@@ -13,7 +13,7 @@ If Clerk's prebuilt components don't meet your specific needs or if you require 
 <Steps>
   ## Build a sign-in-or-up page
 
-  The following example demonstrates how to render the [`<SignIn />`](/docs/components/authentication/sign-up) component to allow users to both sign-in or sign-up from a single flow.
+  The following example demonstrates how to render the [`<SignIn />`](/docs/components/authentication/sign-in) component on a dedicated page using the [TanStack Router catch-all route](https://tanstack.com/router/latest/docs/framework/react/guide/code-based-routing#splat--catch-all-routes).
 
   ```tsx {{ filename: 'app/routes/sign-in.$.tsx' }}
   import { SignIn } from '@clerk/tanstack-start'

--- a/docs/references/tanstack-start/custom-sign-up-page.mdx
+++ b/docs/references/tanstack-start/custom-sign-up-page.mdx
@@ -3,9 +3,9 @@ title: Build your own sign-up page for your TanStack Start app with Clerk
 description: Learn how to add a custom sign-up page to your TanStack Start app with Clerk's prebuilt components.
 ---
 
-By default, the [`<SignIn />`](/docs/references/nextjs/custom-sign-in-or-up-page) component handles signing-in or signing-up, but if you'd like to have a dedicated sign-up page, this guide shows you how to use the [`<SignUp />`](/docs/components/authentication/sign-up) component with the [TanStack Router catch-all route](https://tanstack.com/router/latest/docs/framework/react/guide/code-based-routing#splat--catch-all-routes) in order to build custom sign-up page for your TanStack Start app.
+By default, the [`<SignIn />`](/docs/references/tanstack-start/custom-sign-in-or-up-page) component handles signing in and signing up, but if you'd like to have a dedicated sign-up page, this guide shows you how to use the [`<SignUp />`](/docs/components/authentication/sign-up) component to build a custom sign-up page.
 
-If Clerk's prebuilt components don't meet your specific needs or if you require more control over the logic, you can rebuild the existing Clerk flows using the Clerk API. For more information, see the [custom flow guides](/docs/custom-flows/overview).
+To set up a single sign-in-or-up page, follow the [custom sign-in-or-up page guide](/docs/references/tanstack-start/custom-sign-in-or-up-page).
 
 > [!NOTE]
 > Just getting started with Clerk and TanStack Start? See the [quickstart tutorial](/docs/quickstarts/tanstack-start)!
@@ -13,7 +13,7 @@ If Clerk's prebuilt components don't meet your specific needs or if you require 
 <Steps>
   ## Build a sign-up page
 
-  The following example demonstrates how to render the [`<SignUp />`](/docs/components/authentication/sign-up) component.
+  The following example demonstrates how to render the [`<SignUp />`](/docs/components/authentication/sign-up) component on a dedicated sign-up page using the [TanStack Router catch-all route](https://tanstack.com/router/latest/docs/framework/react/guide/code-based-routing#splat--catch-all-routes).
 
   ```tsx {{ filename: 'app/routes/sign-up.$.tsx' }}
   import { SignUp } from '@clerk/tanstack-start'

--- a/docs/references/tanstack-start/custom-sign-up-page.mdx
+++ b/docs/references/tanstack-start/custom-sign-up-page.mdx
@@ -30,13 +30,16 @@ If Clerk's prebuilt components don't meet your specific needs or if you require 
 
   ## Configure your sign-up page
 
-  To tell Clerk where to find your sign-up page, set the following [environment variables](/docs/deployments/clerk-environment-variables#sign-in-and-sign-up-redirects):
+  - Set the `CLERK_SIGN_UP_URL` environment variable to tell Clerk where the `<SignUp />` component is being hosted.
+  - Set `CLERK_SIGN_UP_FALLBACK_REDIRECT_URL` as a fallback URL incase users visit the `/sign-up` route directly.
+  - Set `CLERK_SIGN_IN_FALLBACK_REDIRECT_URL` as a fallback URL incase users select the 'Already have an account? Sign in' link at the bottom of the component.
 
-  ```env {{ filename: '.env', mark: [2, 4] }}
-  CLERK_SIGN_IN_URL=/sign-in
+  Learn more about these environment variables and how to customize Clerk's redirect behavior in the [dedicated guide](/docs/guides/custom-redirects).
+
+  ```env {{ filename: '.env' }}
   CLERK_SIGN_UP_URL=/sign-up
-  CLERK_SIGN_IN_FALLBACK_REDIRECT_URL=/
   CLERK_SIGN_UP_FALLBACK_REDIRECT_URL=/
+  CLERK_SIGN_IN_FALLBACK_REDIRECT_URL=/
   ```
 
   ## Visit your new pages


### PR DESCRIPTION
### What does this solve?

A [user's feedback ticket](https://linear.app/clerk/issue/DOCS-10002/feedback-for-upgrade-guidescore-2nextjs) inspired me to investigate how we explain our custom redirect URLs (using env vars).

### What changed?

- Clarified what these env vars are used for
  - E.g. "Used for the 'Sign In' link" --> "Used for the 'Already have an account? Sign in' link"
- Fixed `CLERK_SIGN_UP_FALLBACK_URL` to `CLERK_SIGN_UP_FALLBACK_REDIRECT_URL`

In the `<SignIn/>` and `<SignUp/>` component references:
- Put prop tables in alphabetical order
- Updated prop descriptions
- Added links to the redirect URL guide where the examples are for each SDK, so that users can find these guides more easily.
- Updated `withSignUp` prop description
- Added `<If sdk="javascript">` to the JavaScript sections of the component references

In the `/custom-sign-in-or-up-page` guides:
- Removed noise about catch-all routes from the intro paragraph (moved to the first step of each guide)
- Removed paragraph about custom flows (moved to the component references "Customization" section)
- Clarified what each of the env vars are used for (why they need to be set)

In the `/custom-sign-up-page` guides:
- Removed paragraph about custom flows
- Added paragraph to guide users to the appropriate `/custom-sign-in-or-up-page` guide:
  > To set up a single sign-in-or-up page, follow the [custom sign-in-or-up page guide](#). 