### PR TITLE
Add package manager tabs to Next.js quickstart

### DIFF
--- a/docs/quickstarts/nextjs.mdx
+++ b/docs/quickstarts/nextjs.mdx
@@ -21,9 +21,24 @@ description: Add authentication and user management to your Next.js app.
 
   Run the following command to [create a new Next.js application](https://nextjs.org/docs/getting-started/installation):
 
-  ```bash {{ filename: 'terminal' }}
-  npx create-next-app@latest
-  ```
+  
+  <CodeBlockTabs options={["npm", "yarn", "pnpm", "bun"]}>
+    ```bash {{ filename: 'terminal' }}
+    npm create next-app@latest
+    ```
+
+    ```bash {{ filename: 'terminal' }}
+    yarn create next-app
+    ```
+
+    ```bash {{ filename: 'terminal' }}
+    pnpm create next-app
+    ```
+
+    ```bash {{ filename: 'terminal' }}
+    bun create next-app
+    ```
+  </CodeBlockTabs>
 
   ## Install `@clerk/nextjs`
 

--- a/docs/quickstarts/nextjs.mdx
+++ b/docs/quickstarts/nextjs.mdx
@@ -21,7 +21,6 @@ description: Add authentication and user management to your Next.js app.
 
   Run the following command to [create a new Next.js application](https://nextjs.org/docs/getting-started/installation):
 
-  
   <CodeBlockTabs options={["npm", "yarn", "pnpm", "bun"]}>
     ```bash {{ filename: 'terminal' }}
     npm create next-app@latest


### PR DESCRIPTION
### 🔎 Previews:

- https://clerk.com/docs/pr/2076/quickstarts/nextjs

### What does this solve?

- Currently we only give a command for creating the nextjs app with npx, this doesn't align with the rest of the guide that has examples for the four major package managers

### What changed?

- Based on the react quickstart which has all four package managers, I used the `create` command that each package manager exposes.

### Checklist

- [x] I have clicked on "Files changed" and performed a thorough self-review
- [x] I have added the "deploy-preview" label and added the preview link(s) to this PR description
- [x] All existing checks pass
