### PR TITLE
Clarify why Chrome Extensions dont allow OAuth/SAML

### DIFF
--- a/docs/references/chrome-extension/overview.mdx
+++ b/docs/references/chrome-extension/overview.mdx
@@ -59,11 +59,11 @@ A Chrome Extension can be identified by its unique CRX ID, similar to how a webs
 
 Unfortunately, no. Clerk has strict security restrictions on the allowed origins for requests from the application or extension to Clerk's API. Since a content script could run on any domain, there is no way to enforce origin restrictions.
 
-### Why can't I use OAuth, SAML, or Email Links with the extension popup or side panel?
+### Why can't I use OAuth, SAML, or email links with the extension popup or side panel?
 
-OAuth and SAML require a redirect back from the Identity Provider (IdP), which is not currently supported in popups or side panels.
+OAuth and SAML require a redirect back from the Identity Provider (IdP), which is not currently supported by Google Chrome.
 
-Email Links require the popup to remain open while the user checks their email, copies the link, and returns to paste it. Since popups close as soon as a user clicks outside of them, this flow is not possible. The sign-in status resets when the popup closes.
+Email links require the popup to remain open while the user checks their email, copies the link, and returns to paste it. Since popups close as soon as a user clicks outside of them, this flow is not possible. The sign-in status resets when the popup closes.
 
 ### Why aren't options like Google One Tap or Web3 available in a popup or side panel?
 


### PR DESCRIPTION
It's Google's fault, not ours