### PR TITLE
fix: `<If>` usage for `javascript`

### DIFF
--- a/docs/components/authentication/sign-in.mdx
+++ b/docs/components/authentication/sign-in.mdx
@@ -214,7 +214,7 @@ The following example includes basic implementation of the `<SignIn />` componen
   </Tab>
 </Tabs>
 
-<If sdk="javascript">
+<If sdk="javascript-frontend">
   ## Usage with JavaScript
 
   The following methods available on an instance of the [`Clerk`](/docs/references/javascript/clerk) class are used to render and control the `<SignIn />` component:

--- a/docs/components/authentication/sign-up.mdx
+++ b/docs/components/authentication/sign-up.mdx
@@ -188,7 +188,7 @@ The following example includes basic implementation of the `<SignUp />` componen
   </Tab>
 </Tabs>
 
-<If sdk="javascript">
+<If sdk="javascript-frontend">
   ## Usage with JavaScript
 
   The following methods available on an instance of the [`Clerk`](/docs/references/javascript/clerk) class are used to render and control the `<SignUp />` component:


### PR DESCRIPTION
I saw builds fail because of incorrect prop:

```
items passed to <If /> "javascript" are not a valid SDK. Valid SDKs are "nextjs", "react", "javascript-frontend", "astro", "csharp", "chrome-extension", "expo", "expressjs", "fastify", "go", "ios", "javascript-backend", "nuxt", "python", "react-router", "remix", "ruby", "tanstack-start", "vue", "sdk-development", "community-sdk"
```