### PR TITLE
Switch nextjs file paths to not use src folder

### DIFF
--- a/docs/hooks/use-auth.mdx
+++ b/docs/hooks/use-auth.mdx
@@ -126,7 +126,7 @@ The following example demonstrates how to use the `useAuth()` hook to access the
   </Tab>
 
   <Tab>
-    ```tsx {{ filename: 'src/app/external-data/page.tsx' }}
+    ```tsx {{ filename: 'app/external-data/page.tsx' }}
     'use client'
 
     import { useAuth } from '@clerk/nextjs'

--- a/docs/hooks/use-clerk.mdx
+++ b/docs/hooks/use-clerk.mdx
@@ -30,7 +30,7 @@ The following example uses the `useClerk()` hook to access the `clerk` object. T
   </Tab>
 
   <Tab>
-    ```tsx {{ filename: 'src/app/page.tsx' }}
+    ```tsx {{ filename: 'app/page.tsx' }}
     'use client'
 
     import { useClerk } from '@clerk/nextjs'

--- a/docs/hooks/use-organization-list.mdx
+++ b/docs/hooks/use-organization-list.mdx
@@ -192,7 +192,7 @@ The following example demonstrates how to use the `infinite` property to fetch a
   </Tab>
 
   <Tab>
-    ```tsx {{ filename: 'src/components/JoinedOrganizations.tsx' }}
+    ```tsx {{ filename: 'components/JoinedOrganizations.tsx' }}
     'use client'
 
     import { useOrganizationList } from '@clerk/nextjs'
@@ -288,7 +288,7 @@ Notice the difference between this example's pagination and the infinite paginat
   </Tab>
 
   <Tab>
-    ```tsx {{ filename: 'src/components/UserInvitationsTable.tsx' }}
+    ```tsx {{ filename: 'components/UserInvitationsTable.tsx' }}
     'use client'
 
     import { useOrganizationList } from '@clerk/nextjs'

--- a/docs/hooks/use-organization.mdx
+++ b/docs/hooks/use-organization.mdx
@@ -203,7 +203,7 @@ The following example demonstrates how to use the `infinite` property to fetch a
   </Tab>
 
   <Tab>
-    ```tsx {{ filename: 'src/app/users/page.tsx' }}
+    ```tsx {{ filename: 'app/users/page.tsx' }}
     'use client'
 
     import { useOrganization } from '@clerk/nextjs'
@@ -295,7 +295,7 @@ Notice the difference between this example's pagination and the infinite paginat
   </Tab>
 
   <Tab>
-    ```tsx {{ filename: 'src/app/users/page.tsx' }}
+    ```tsx {{ filename: 'app/users/page.tsx' }}
     'use client'
 
     import { useOrganization } from '@clerk/nextjs'

--- a/docs/hooks/use-reverification.mdx
+++ b/docs/hooks/use-reverification.mdx
@@ -75,7 +75,7 @@ In the following example, `myFetcher` would be a function in your backend that f
   </Tab>
 
   <Tab>
-    ```tsx {{ filename: 'src/components/MyButton.tsx' }}
+    ```tsx {{ filename: 'components/MyButton.tsx' }}
     'use client'
 
     import { useReverification } from '@clerk/nextjs'
@@ -128,7 +128,7 @@ In this example, `myFetcher` would be a function in your backend that fetches da
   </Tab>
 
   <Tab>
-    ```tsx {{ filename: 'src/components/MyButton.tsx' }}
+    ```tsx {{ filename: 'components/MyButton.tsx' }}
     'use client'
 
     import { useReverification } from '@clerk/nextjs'

--- a/docs/hooks/use-session-list.mdx
+++ b/docs/hooks/use-session-list.mdx
@@ -57,7 +57,7 @@ The following example uses `useSessionList()` to get a list of sessions that hav
   </Tab>
 
   <Tab>
-    ```tsx {{ filename: 'src/app/page.tsx' }}
+    ```tsx {{ filename: 'app/page.tsx' }}
     'use client'
 
     import { useSessionList } from '@clerk/nextjs'

--- a/docs/hooks/use-session.mdx
+++ b/docs/hooks/use-session.mdx
@@ -61,7 +61,7 @@ The following example uses the `useSession()` hook to access the `Session` objec
   </Tab>
 
   <Tab>
-    ```tsx {{ filename: 'src/app/page.tsx' }}
+    ```tsx {{ filename: 'app/page.tsx' }}
     'use client'
 
     import { useSession } from '@clerk/nextjs'

--- a/docs/hooks/use-sign-in.mdx
+++ b/docs/hooks/use-sign-in.mdx
@@ -53,7 +53,7 @@ The following example uses the `useSignIn()` hook to access the [`SignIn`](/docs
   </Tab>
 
   <Tab>
-    ```tsx {{ filename: 'src/app/sign-in/page.tsx' }}
+    ```tsx {{ filename: 'app/sign-in/page.tsx' }}
     'use client'
 
     import { useSignIn } from '@clerk/nextjs'

--- a/docs/hooks/use-sign-up.mdx
+++ b/docs/hooks/use-sign-up.mdx
@@ -53,7 +53,7 @@ The following example uses the `useSignUp()` hook to access the [`SignUp`](/docs
   </Tab>
 
   <Tab>
-    ```tsx {{ filename: 'src/app/sign-up/page.tsx' }}
+    ```tsx {{ filename: 'app/sign-up/page.tsx' }}
     'use client'
 
     import { useSignUp } from '@clerk/nextjs'

--- a/docs/hooks/use-user.mdx
+++ b/docs/hooks/use-user.mdx
@@ -72,7 +72,7 @@ The following example uses the `useUser()` hook to access the [`User`](/docs/ref
   </Tab>
 
   <Tab>
-    ```tsx {{ filename: 'src/app/page.tsx' }}
+    ```tsx {{ filename: 'app/page.tsx' }}
     'use client'
 
     import { useUser } from '@clerk/nextjs'
@@ -149,7 +149,7 @@ The following example uses the `useUser()` hook to access the [`User`](/docs/ref
   </Tab>
 
   <Tab>
-    ```tsx {{ filename: 'src/app/page.tsx' }}
+    ```tsx {{ filename: 'app/page.tsx' }}
     'use client'
 
     import { useUser } from '@clerk/nextjs'


### PR DESCRIPTION
### 🔎 Previews:

- https://clerk.com/docs/pr/2092/hooks/use-user
- https://clerk.com/docs/pr/2092/hooks/use-clerk
- https://clerk.com/docs/pr/2092/hooks/use-auth
- https://clerk.com/docs/pr/2092/hooks/use-sign-in
- https://clerk.com/docs/pr/2092/hooks/use-sign-up
- https://clerk.com/docs/pr/2092/hooks/use-session
- https://clerk.com/docs/pr/2092/hooks/use-session-list
- https://clerk.com/docs/pr/2092/hooks/use-organization
- https://clerk.com/docs/pr/2092/hooks/use-organization-list
- https://clerk.com/docs/pr/2092/hooks/use-reverification

### What does this solve?

- For the nextjs examples in the docs we don't use the `src` folder

### What changed?

- updates the paths

### Checklist

- [x] I have clicked on "Files changed" and performed a thorough self-review
- [x] I have added the "deploy-preview" label and added the preview link(s) to this PR description
- [x] All existing checks pass
