### PR TITLE
Add 'dont-redeploy' label to opt out of redeployment on pr merge to main

### DIFF
--- a/.github/workflows/redeploy.yml
+++ b/.github/workflows/redeploy.yml
@@ -12,9 +12,40 @@ on:
 jobs:
   redeploy:
     runs-on: ubuntu-latest
+    permissions:
+      pull-requests: read
     env:
       DEPLOY_HOOK: ${{ github.ref == 'refs/heads/main' && secrets.WEBSITE_DEPLOY_HOOK || secrets.WEBSITE_DEPLOY_HOOK_CORE_1 }}
     steps:
+      - name: Check for dont-redeploy label
+        id: check-label
+        uses: actions/github-script@v7
+        with:
+          script: |
+            // For workflow_dispatch or direct pushes without PRs, we should always deploy
+            if (!context.payload.pull_request) {
+              return {shouldDeploy: true};
+            }
+
+            // Get the PR associated with this commit (if any)
+            const associatedPRs = await github.rest.repos.listPullRequestsAssociatedWithCommit({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              commit_sha: context.sha
+            });
+
+            if (associatedPRs.data.length === 0) {
+              // No associated PR found, safe to deploy
+              return {shouldDeploy: true};
+            }
+
+            // Check the labels on the associated PR
+            const pr = associatedPRs.data[0];
+            const hasDoNotDeployLabel = pr.labels.some(label => label.name === 'dont-redeploy');
+
+            return {shouldDeploy: !hasDoNotDeployLabel};
+
       - name: Trigger redeploy
+        if: ${{ fromJSON(steps.check-label.outputs.result).shouldDeploy }}
         run: |
           curl -X POST ${{ env.DEPLOY_HOOK }}


### PR DESCRIPTION
### 🔎 Previews:

-

### What does this solve?

- Currently if you have a change that spans both `clerk` and `clerk-docs` you need to create two prs. This causes an issue where one of the prs needs to be merged before the other, and will leave clerk.com in a broken state temporarily.
- Alternatively you could code `clerk` to have a migration stage, where it accepts both the old way `clerk-docs` works and the new way, but this increases complexity and takes more effort

So given you want to make an update that spans both repos, heres the flow:

1. Create a pr in `clerk` and a pr in `clerk-docs`
2. Apply the 'dont-redeploy' label to `clerk-docs`
3. Wait / get both prs approved, not just one & ensure both don't have merge conflicts with main
4. Merge `clerk-docs` first, and given the 'dont-redeploy' label is applied clerk.com shouldn't change
5. Merge `clerk` pr, this time a re-deployment of clerk.com will happen, pulling in the updated `clerk-docs`
6. Sit back and relax

### What changed?

- Adds a step to the github action to check if the pull request has the 'dont-redeploy' label on it

### Checklist

- [ ] I have clicked on "Files changed" and performed a thorough self-review
- [ ] I have added the "deploy-preview" label and added the preview link(s) to this PR description
- [ ] All existing checks pass
