### PR TITLE
add csp step to deployment guide

### DIFF
--- a/docs/deployments/overview.mdx
+++ b/docs/deployments/overview.mdx
@@ -36,6 +36,10 @@ In development, for most social providers, Clerk provides you with a set of shar
 
 In production, these are not secure and you will need to provide your own. Each [OAuth provider](/docs/authentication/social-connections/oauth) has a dedicated guide on how to set up OAuth credentials for Clerk production apps.
 
+## Content Security Policy (CSP)
+
+If you're using a CSP, follow the instructions in the [CSP guide](/docs/security/clerk-csp).
+
 ## DNS records
 
 Clerk uses DNS records to provide session management and emails verified from your domain.

--- a/docs/deployments/overview.mdx
+++ b/docs/deployments/overview.mdx
@@ -28,7 +28,7 @@ A common mistake when deploying to production is **forgetting to change your API
 1. **Secret Key:** Formatted as `sk_test_` in development and `sk_live_` in production. These values are used to access Clerk's Backend API.
 
 > [!TIP]
-> Be sure to update these values in your hosting provider's environment variables.
+> Be sure to update these values in your hosting provider's environment variables, and also to redeploy your app.
 
 ## OAuth credentials
 


### PR DESCRIPTION
### What does this solve?

https://linear.app/clerk/issue/DOCS-9978/add-csp-to-deployment-docs
https://linear.app/clerk/issue/DOCS-9977/make-sure-to-mention-to-re-deploy-after-changing-keys

### What changed?

- Links users to CSP guide in our Deployment guide, so that they don't forget to update their CSP headers
- In Deployment guide, reminds users to redeploy after changing keys

FIXES DOCS-9978, DOCS-9977