### PR TITLE
docs(expo): Add guide for accessing Clerk outside components in Expo

### DIFF
--- a/docs/manifest.json
+++ b/docs/manifest.json
@@ -678,8 +678,8 @@
                           "href": "/docs/references/expo/offline-support"
                         },
                         {
-                          "title": "Accessing Clerk outside components",
-                          "href": "/docs/references/expo/accessing-clerk-outside-components"
+                          "title": "Access the `Clerk` object outside of components",
+                          "href": "/docs/references/expo/access-clerk-outside-components"
                         }
                       ]
                     ]

--- a/docs/manifest.json
+++ b/docs/manifest.json
@@ -676,6 +676,10 @@
                         {
                           "title": "Offline support",
                           "href": "/docs/references/expo/offline-support"
+                        },
+                        {
+                          "title": "Accessing Clerk outside components",
+                          "href": "/docs/references/expo/accessing-clerk-outside-components"
                         }
                       ]
                     ]

--- a/docs/references/expo/access-clerk-outside-components.mdx
+++ b/docs/references/expo/access-clerk-outside-components.mdx
@@ -1,11 +1,9 @@
 ---
-title: Accessing Clerk outside components
+title: Access the Clerk object outside of components
 description: Learn how to access and use the Clerk instance outside of React components in Expo applications.
 ---
 
-When building Expo applications, you might need to access the [`Clerk`](/docs/references/javascript/clerk) instance outside of React components, such as in utility functions or background tasks.
-
-You can access the `Clerk` instance using the `getClerkInstance()` function:
+The [`Clerk`](/docs/references/javascript/clerk) object is accessible using the [`useClerk()`](/docs/hooks/use-clerk) hook. However, if you need to access the [`Clerk`](/docs/references/javascript/clerk) object outside of React components, such as in utility functions or background tasks, you can use the `getClerkInstance()` function.
 
 <Tabs items={["Fetch", "Axios"]}>
   <Tab>

--- a/docs/references/expo/accessing-clerk-outside-components.mdx
+++ b/docs/references/expo/accessing-clerk-outside-components.mdx
@@ -9,16 +9,17 @@ You can access the Clerk instance using the `getClerkInstance()` function:
 
 <Tabs items={["Fetch", "Axios"]}>
   <Tab>
-    ```ts {{ filename: 'utils/authenticatedFetch.ts' }}
+    ```ts
     import { getClerkInstance } from '@clerk/clerk-expo'
 
-    export async function authenticatedFetch() {
+    export async function fetchFoo() {
       const clerkInstance = getClerkInstance()
       // Use `getToken()` to get the current session token
       const token = await clerkInstance.session?.getToken()
 
       const response = await fetch('/api/foo', {
         headers: {
+          // Include the session token as a Bearer token in the Authorization header
           Authorization: `Bearer ${token}`,
           'Content-Type': 'application/json',
         },
@@ -35,25 +36,27 @@ You can access the Clerk instance using the `getClerkInstance()` function:
   </Tab>
 
   <Tab>
-    ```tsx {{ filename: 'utils/axios.ts' }}
+    ```ts
     import axios from 'axios'
     import { getClerkInstance } from '@clerk/clerk-expo'
 
-    // Create axios instance with custom config
-    export const axiosInstance = axios.create({
-      baseURL: 'https://api.example.com',
-      headers: {
-        'Content-Type': 'application/json',
-      },
-    })
+    export async function fetchFoo() {
+      try {
+        const data = await axios.get('/api/foo')
+        return data
+      } catch (error) {
+        throw new Error(`API Error: ${error.response.status} ${error.response.statusText}`)
+      }
+    }
 
     // Intercept requests and modify them to include the current session token
-    axiosInstance.interceptors.request.use(async (config) => {
+    axios.interceptors.request.use(async (config) => {
       const clerkInstance = getClerkInstance()
       // Use `getToken()` to get the current session token
       const token = await clerkInstance.session?.getToken()
 
       if (token) {
+        // Include the session token as a Bearer token in the Authorization header
         config.headers.Authorization = `Bearer ${token}`
       }
 

--- a/docs/references/expo/accessing-clerk-outside-components.mdx
+++ b/docs/references/expo/accessing-clerk-outside-components.mdx
@@ -45,7 +45,11 @@ You can access the Clerk instance using the `getClerkInstance()` function:
         const data = await axios.get('/api/foo')
         return data
       } catch (error) {
-        throw new Error(`API Error: ${error.response.status} ${error.response.statusText}`)
+        if (axios.isAxiosError(error) && error.response) {
+          throw new Error(`API Error: ${error.response.status} ${error.response.statusText}`)
+        }
+
+        throw new Error('Unknown error')
       }
     }
 

--- a/docs/references/expo/accessing-clerk-outside-components.mdx
+++ b/docs/references/expo/accessing-clerk-outside-components.mdx
@@ -9,12 +9,12 @@ You can access the Clerk instance using the `getClerkInstance` function:
 
 <Tabs items={["Fetch", "Axios"]}>
   <Tab>
-    ```ts {{ filename: 'lib/authenticatedFetch.ts' }}
+    ```ts {{ filename: 'utils/authenticatedFetch.ts' }}
     import { getClerkInstance } from '@clerk/clerk-expo'
 
     export async function authenticatedFetch() {
       const clerkInstance = getClerkInstance()
-      // Get the current session token
+      // Use `getToken()` to get the current session token
       const token = await clerkInstance.session?.getToken()
       
       const response = await fetch('/api/foo', {
@@ -25,7 +25,8 @@ You can access the Clerk instance using the `getClerkInstance` function:
       })
 
       if (!response.ok) {
-        throw new Error(`API Error: ${response.status}`)
+        // Include status code and status text in error message
+        throw new Error(`API Error: ${response.status} ${response.statusText}`)
       }
 
       return response.json()
@@ -34,7 +35,7 @@ You can access the Clerk instance using the `getClerkInstance` function:
   </Tab>
 
   <Tab>
-    ```tsx {{ filename: 'lib/axios.ts' }}
+    ```tsx {{ filename: 'utils/axios.ts' }}
     import axios from 'axios'
     import { getClerkInstance } from '@clerk/clerk-expo'
 
@@ -46,9 +47,10 @@ You can access the Clerk instance using the `getClerkInstance` function:
       },
     })
 
-    // Add current session token to requests
+    // Intercept requests and modify them to include the current session token
     axiosInstance.interceptors.request.use(async (config) => {
       const clerkInstance = getClerkInstance()
+      // Use `getToken()` to get the current session token
       const token = await clerkInstance.session?.getToken()
       
       if (token) {

--- a/docs/references/expo/accessing-clerk-outside-components.mdx
+++ b/docs/references/expo/accessing-clerk-outside-components.mdx
@@ -5,7 +5,7 @@ description: Learn how to access and use the Clerk instance outside of React com
 
 When building Expo applications, you might need to access the Clerk instance outside of React components, such as in utility functions or background tasks.
 
-You can access the Clerk instance using the `getClerkInstance` function:
+You can access the Clerk instance using the `getClerkInstance()` function:
 
 <Tabs items={["Fetch", "Axios"]}>
   <Tab>
@@ -16,7 +16,7 @@ You can access the Clerk instance using the `getClerkInstance` function:
       const clerkInstance = getClerkInstance()
       // Use `getToken()` to get the current session token
       const token = await clerkInstance.session?.getToken()
-      
+
       const response = await fetch('/api/foo', {
         headers: {
           Authorization: `Bearer ${token}`,
@@ -52,11 +52,11 @@ You can access the Clerk instance using the `getClerkInstance` function:
       const clerkInstance = getClerkInstance()
       // Use `getToken()` to get the current session token
       const token = await clerkInstance.session?.getToken()
-      
+
       if (token) {
         config.headers.Authorization = `Bearer ${token}`
       }
-      
+
       return config
     })
     ```

--- a/docs/references/expo/accessing-clerk-outside-components.mdx
+++ b/docs/references/expo/accessing-clerk-outside-components.mdx
@@ -3,96 +3,9 @@ title: Accessing Clerk outside components
 description: Learn how to access and use the Clerk instance outside of React components in Expo applications.
 ---
 
-When building Expo applications, you might need to access the Clerk instance outside of React components, such as in utility functions or background tasks. This guide shows you how to set up and use the Clerk instance.
+When building Expo applications, you might need to access the Clerk instance outside of React components, such as in utility functions or background tasks.
 
-First, create and export a Clerk instance using the `getClerkInstance` function:
-
-```ts {{ filename: 'lib/clerk.ts' }}
-import { getClerkInstance } from '@clerk/clerk-expo'
-
-const publishableKey = process.env.EXPO_PUBLIC_CLERK_PUBLISHABLE_KEY
-
-// Create a singleton instance with your publishable key
-export const clerkInstance = getClerkInstance({ publishableKey })
-```
-
-Then, pass the instance to the `<ClerkProvider>` component under the `Clerk` prop in your root layout:
-
-```tsx {{ filename: 'app/_layout.tsx' }}
-import { ClerkProvider, ClerkLoaded } from '@clerk/clerk-expo'
-import { clerkInstance } from '@/lib/clerk'
-
-const publishableKey = process.env.EXPO_PUBLIC_CLERK_PUBLISHABLE_KEY
-
-export default function RootLayout() {
-  return (
-    <ClerkProvider 
-      publishableKey={publishableKey} 
-      Clerk={clerkInstance}
-    >
-      <ClerkLoaded>
-        <Slot />
-      </ClerkLoaded>
-    </ClerkProvider>
-  )
-}
-```
-
-You can now use this instance throughout your application. Here are some examples:
-
-<Tabs items={["Fetch", "Axios"]}>
-  <Tab>
-    ```ts {{ filename: 'lib/authenticatedFetch.ts' }}
-    import { clerkInstance } from './clerk'
-
-    export async function authenticatedFetch() {
-      // Use the Clerk instance to get the current session token
-      const token = await clerkInstance.session?.getToken()
-      
-      const response = await fetch('/api/foo', {
-        headers: {
-          Authorization: `Bearer ${token}`,
-          'Content-Type': 'application/json',
-        },
-      })
-
-      if (!response.ok) {
-        throw new Error(`API Error: ${response.status}`)
-      }
-
-      return response.json()
-    }
-    ```
-  </Tab>
-
-  <Tab>
-    ```tsx {{ filename: 'lib/axios.ts' }}
-    import axios from 'axios'
-    import { clerkInstance } from './clerk'
-
-    // Create axios instance with custom config
-    export const axiosInstance = axios.create({
-      baseURL: 'https://api.example.com',
-      headers: {
-        'Content-Type': 'application/json',
-      },
-    })
-
-    // Add current session token to requests
-    axiosInstance.interceptors.request.use(async (config) => {
-      const token = await clerkInstance.session?.getToken()
-      
-      if (token) {
-        config.headers.Authorization = `Bearer ${token}`
-      }
-      
-      return config
-    })
-    ```
-  </Tab>
-</Tabs>
-
-If you're certain that your code will run after the `<ClerkProvider>` component has rendered, you can call `getClerkInstance()` without options and without passing it to the `<ClerkProvider>` component. However, keep in mind that this will throw an error if called before the provider is rendered.
+You can access the Clerk instance using the `getClerkInstance` function:
 
 <Tabs items={["Fetch", "Axios"]}>
   <Tab>
@@ -100,8 +13,9 @@ If you're certain that your code will run after the `<ClerkProvider>` component 
     import { getClerkInstance } from '@clerk/clerk-expo'
 
     export async function authenticatedFetch() {
-      // Use the Clerk instance to get the current session token
-      const token = await getClerkInstance().session?.getToken()
+      const clerkInstance = getClerkInstance()
+      // Get the current session token
+      const token = await clerkInstance.session?.getToken()
       
       const response = await fetch('/api/foo', {
         headers: {

--- a/docs/references/expo/accessing-clerk-outside-components.mdx
+++ b/docs/references/expo/accessing-clerk-outside-components.mdx
@@ -16,7 +16,7 @@ const publishableKey = process.env.EXPO_PUBLIC_CLERK_PUBLISHABLE_KEY
 export const clerkInstance = getClerkInstance({ publishableKey })
 ```
 
-Then, pass the instance to `<ClerkProvider>` in your root layout:
+Then, pass the instance to the `<ClerkProvider>` component under the `Clerk` prop in your root layout:
 
 ```tsx {{ filename: 'app/_layout.tsx' }}
 import { ClerkProvider, ClerkLoaded } from '@clerk/clerk-expo'

--- a/docs/references/expo/accessing-clerk-outside-components.mdx
+++ b/docs/references/expo/accessing-clerk-outside-components.mdx
@@ -1,0 +1,148 @@
+---
+title: Accessing Clerk Outside Components
+description: Learn how to access and use the Clerk instance outside of React components in Expo applications.
+---
+
+When building Expo applications, you might need to access the Clerk instance outside of React components, such as in utility functions or background tasks. This guide shows you how to set up and use the Clerk instance.
+
+First, create and export a Clerk instance using the `getClerkInstance` function:
+
+```ts {{ filename: 'lib/clerk.ts' }}
+import { getClerkInstance } from '@clerk/clerk-expo'
+
+const publishableKey = process.env.EXPO_PUBLIC_CLERK_PUBLISHABLE_KEY
+
+// Create a singleton instance with your publishable key
+export const clerkInstance = getClerkInstance({ publishableKey })
+```
+
+Then, pass the instance to `<ClerkProvider>` in your root layout:
+
+```tsx {{ filename: 'app/_layout.tsx' }}
+import { ClerkProvider, ClerkLoaded } from '@clerk/clerk-expo'
+import { clerkInstance } from '@/lib/clerk'
+
+const publishableKey = process.env.EXPO_PUBLIC_CLERK_PUBLISHABLE_KEY
+
+export default function RootLayout() {
+  return (
+    <ClerkProvider 
+      publishableKey={publishableKey} 
+      Clerk={clerkInstance}
+    >
+      <ClerkLoaded>
+        <Slot />
+      </ClerkLoaded>
+    </ClerkProvider>
+  )
+}
+```
+
+You can now use this instance throughout your application. Here are some examples:
+
+<Tabs items={["Fetch", "Axios"]}>
+  <Tab>
+    ```ts {{ filename: 'lib/authenticatedFetch.ts' }}
+    import { clerkInstance } from './clerk'
+
+    export async function authenticatedFetch() {
+      // Use the Clerk instance to get the current session token
+      const token = await clerkInstance.session?.getToken()
+      
+      const response = await fetch('/api/foo', {
+        headers: {
+          Authorization: `Bearer ${token}`,
+          'Content-Type': 'application/json',
+        },
+      })
+
+      if (!response.ok) {
+        throw new Error(`API Error: ${response.status}`)
+      }
+
+      return response.json()
+    }
+    ```
+  </Tab>
+
+  <Tab>
+    ```tsx {{ filename: 'lib/axios.ts' }}
+    import axios from 'axios'
+    import { clerkInstance } from './clerk'
+
+    // Create axios instance with custom config
+    export const axiosInstance = axios.create({
+      baseURL: 'https://api.example.com',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+    })
+
+    // Add current session token to requests
+    axiosInstance.interceptors.request.use(async (config) => {
+      const token = await clerkInstance.session?.getToken()
+      
+      if (token) {
+        config.headers.Authorization = `Bearer ${token}`
+      }
+      
+      return config
+    })
+    ```
+  </Tab>
+</Tabs>
+
+If you're certain that your code will run after the `<ClerkProvider>` component has rendered, you can call `getClerkInstance()` without options and without passing it to the `<ClerkProvider>` component. However, keep in mind that this will throw an error if called before the provider is rendered.
+
+<Tabs items={["Fetch", "Axios"]}>
+  <Tab>
+    ```ts {{ filename: 'lib/authenticatedFetch.ts' }}
+    import { getClerkInstance } from '@clerk/clerk-expo'
+
+    export async function authenticatedFetch() {
+      // Use the Clerk instance to get the current session token
+      const token = await getClerkInstance().session?.getToken()
+      
+      const response = await fetch('/api/foo', {
+        headers: {
+          Authorization: `Bearer ${token}`,
+          'Content-Type': 'application/json',
+        },
+      })
+
+      if (!response.ok) {
+        throw new Error(`API Error: ${response.status}`)
+      }
+
+      return response.json()
+    }
+    ```
+  </Tab>
+
+  <Tab>
+    ```tsx {{ filename: 'lib/axios.ts' }}
+    import axios from 'axios'
+    import { getClerkInstance } from '@clerk/clerk-expo'
+
+    // Create axios instance with custom config
+    export const axiosInstance = axios.create({
+      baseURL: 'https://api.example.com',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+    })
+
+    // Add current session token to requests
+    axiosInstance.interceptors.request.use(async (config) => {
+      const clerkInstance = getClerkInstance()
+      const token = await clerkInstance.session?.getToken()
+      
+      if (token) {
+        config.headers.Authorization = `Bearer ${token}`
+      }
+      
+      return config
+    })
+    ```
+  </Tab>
+</Tabs>

--- a/docs/references/expo/accessing-clerk-outside-components.mdx
+++ b/docs/references/expo/accessing-clerk-outside-components.mdx
@@ -1,5 +1,5 @@
 ---
-title: Accessing Clerk Outside Components
+title: Accessing Clerk outside components
 description: Learn how to access and use the Clerk instance outside of React components in Expo applications.
 ---
 

--- a/docs/references/expo/accessing-clerk-outside-components.mdx
+++ b/docs/references/expo/accessing-clerk-outside-components.mdx
@@ -3,9 +3,9 @@ title: Accessing Clerk outside components
 description: Learn how to access and use the Clerk instance outside of React components in Expo applications.
 ---
 
-When building Expo applications, you might need to access the Clerk instance outside of React components, such as in utility functions or background tasks.
+When building Expo applications, you might need to access the [`Clerk`](/docs/references/javascript/clerk) instance outside of React components, such as in utility functions or background tasks.
 
-You can access the Clerk instance using the `getClerkInstance()` function:
+You can access the `Clerk` instance using the `getClerkInstance()` function:
 
 <Tabs items={["Fetch", "Axios"]}>
   <Tab>


### PR DESCRIPTION
### 🔎 Previews:

- https://clerk.com/docs/pr/2102/references/expo/accessing-clerk-outside-components

https://github.com/user-attachments/assets/40d92a80-ccda-477a-b95e-427e5da97e40

Demo repo: https://github.com/wobsoriano/clerk-docs-2102

### What does this solve?

- We have a [massive discussion](https://github.com/orgs/clerk/discussions/1751#discussioncomment-10162453) on how to access the Clerk instance outside of React components in Expo applications. We have the `getClerkInstance()` available [since last year](https://github.com/clerk/javascript/pull/3420), but it's not documented and is hard for customers to find.

### What changed?

- This PR adds a dedicated Expo guide with some practical examples on how to access Clerk instance outside of components.

### Checklist

- [x] I have clicked on "Files changed" and performed a thorough self-review
- [x] I have added the "deploy-preview" label and added the preview link(s) to this PR description
- [x] All existing checks pass