### PR TITLE
docs: Simplify Expo quickstart

### DIFF
--- a/docs/quickstarts/expo.mdx
+++ b/docs/quickstarts/expo.mdx
@@ -64,30 +64,6 @@ description: Add authentication and user management to your Expo app with Clerk.
     ```
   </CodeBlockTabs>
 
-  ## Install `@clerk/types` (optional)
-
-  Clerk's `@clerk/types` package provides TypeScript type definitions.
-
-  Add the package to your project by running the following command:
-
-  <CodeBlockTabs options={["npm", "yarn", "pnpm", "bun"]}>
-    ```bash {{ filename: 'terminal' }}
-    npm install @clerk/types
-    ```
-
-    ```bash {{ filename: 'terminal' }}
-    yarn add @clerk/types
-    ```
-
-    ```bash {{ filename: 'terminal' }}
-    pnpm add @clerk/types
-    ```
-
-    ```bash {{ filename: 'terminal' }}
-    bun add @clerk/types
-    ```
-  </CodeBlockTabs>
-
   ## Set your Clerk API keys
 
   <SignedIn>

--- a/docs/quickstarts/expo.mdx
+++ b/docs/quickstarts/expo.mdx
@@ -169,7 +169,7 @@ description: Add authentication and user management to your Expo app with Clerk.
   1. Update your root layout to use the token cache:
      ```tsx {{ filename: 'app/_layout.tsx', mark: [1, 13] }}
      import { tokenCache } from '@/cache'
-     import { ClerkProvider, ClerkLoaded } from '@clerk/clerk-expo'
+     import { ClerkProvider } from '@clerk/clerk-expo'
      import { Slot } from 'expo-router'
 
      export default function RootLayout() {
@@ -181,9 +181,7 @@ description: Add authentication and user management to your Expo app with Clerk.
 
        return (
          <ClerkProvider tokenCache={tokenCache} publishableKey={publishableKey}>
-           <ClerkLoaded>
-             <Slot />
-           </ClerkLoaded>
+           <Slot />
          </ClerkProvider>
        )
      }

--- a/docs/quickstarts/expo.mdx
+++ b/docs/quickstarts/expo.mdx
@@ -23,7 +23,7 @@ description: Add authentication and user management to your Expo app with Clerk.
     },
   ]}
 >
-  - Install `@clerk/expo`
+  - Install `@clerk/clerk-expo`
   - Set your Clerk API keys
   - Add `<ClerkProvider>`
   - Protect specific pages with authentication

--- a/docs/quickstarts/expo.mdx
+++ b/docs/quickstarts/expo.mdx
@@ -88,12 +88,10 @@ description: Add authentication and user management to your Expo app with Clerk.
 
   You must pass your Publishable Key as a prop to the `<ClerkProvider>` component.
 
-  Clerk also provides [`<ClerkLoaded>`](/docs/components/control/clerk-loaded), which won't render its children until the Clerk API has loaded.
-
-  Add both components to your root layout as shown in the following example:
+  Add the component to your root layout as shown in the following example:
 
   ```tsx {{ filename: 'app/_layout.tsx' }}
-  import { ClerkProvider, ClerkLoaded } from '@clerk/clerk-expo'
+  import { ClerkProvider } from '@clerk/clerk-expo'
   import { Slot } from 'expo-router'
 
   export default function RootLayout() {
@@ -105,9 +103,7 @@ description: Add authentication and user management to your Expo app with Clerk.
 
     return (
       <ClerkProvider publishableKey={publishableKey}>
-        <ClerkLoaded>
-          <Slot />
-        </ClerkLoaded>
+        <Slot />
       </ClerkProvider>
     )
   }


### PR DESCRIPTION
### 🔎 Previews:

- https://clerk.com/docs/pr/2103/quickstarts/expo

### What does this solve?

- Simplifies the Expo quickstart a bit

### What changed?

- Removed installation of `@clerk/types` step. Installing `@clerk/clerk-expo` includes `@clerk/types` by default, so they can just import if needed. Also, it raises the question on why do we have the step here but not in other SDKs.
- `<ClerkLoaded>` wrapping root layout means the entire app won't render until Clerk is loaded, which sounds like an anti-pattern. I tried our quickstart and removed this, everything is still expected to work 👍🏼 🫡 

### Checklist

- [x] I have clicked on "Files changed" and performed a thorough self-review
- [x] I have added the "deploy-preview" label and added the preview link(s) to this PR description
- [x] All existing checks pass
