### PR TITLE
(ios) remove mention of components from overview

### DIFF
--- a/docs/references/ios/overview.mdx
+++ b/docs/references/ios/overview.mdx
@@ -3,7 +3,7 @@ title: Clerk iOS SDK (beta)
 description: The Clerk iOS SDK gives you access to prebuilt components, React hooks, and helpers to make user authentication easier.
 ---
 
-The Clerk iOS SDK gives you access to prebuilt components, React hooks, and helpers to make user authentication easier. Refer to the [quickstart guide](/docs/quickstarts/ios) to get started.
+The Clerk iOS SDK provides a set of tools and utilities for handling authentication and user management. Refer to the [quickstart guide](/docs/quickstarts/ios) to get started.
 
 ## SDK Reference
 


### PR DESCRIPTION
### What does this solve?

- iOS does not support hooks. It also doesn't support components yet. The copy was a bad copy and paste when updating all SDK overviews

### What changed?

- updates the copy to be accurate to what the iOS SDK offers

### Checklist

- [x] I have clicked on "Files changed" and performed a thorough self-review
- [ ] I have added the "deploy-preview" label and added the preview link(s) to this PR description
- [x] All existing checks pass
