### PR TITLE
(chore) favor req over request in code examples

### DIFF
--- a/docs/advanced-usage/satellite-domains.mdx
+++ b/docs/advanced-usage/satellite-domains.mdx
@@ -330,8 +330,8 @@ To access authentication state from a satellite domain, users will be transparen
             export const loader = (args) => {
               return rootAuthLoader(
                 args,
-                ({ request }) => {
-                  const { userId, sessionId, getToken } = request.auth
+                ({ req }) => {
+                  const { userId, sessionId, getToken } = req.auth
                   return json({
                     message: `Hello from the root loader :)`,
                     ENV: getBrowserEnvironment(),
@@ -358,8 +358,8 @@ To access authentication state from a satellite domain, users will be transparen
             export const loader = (args) => {
               return rootAuthLoader(
                 args,
-                ({ request }) => {
-                  const { userId, sessionId, getToken } = request.auth
+                ({ req }) => {
+                  const { userId, sessionId, getToken } = req.auth
                   return json({
                     message: `Hello from the root loader :)`,
                     ENV: getBrowserEnvironment(),

--- a/docs/advanced-usage/using-proxies.mdx
+++ b/docs/advanced-usage/using-proxies.mdx
@@ -109,18 +109,18 @@ When using a proxy, all requests to the Frontend API will be made through your d
       import { NextResponse } from 'next/server'
       import { clerkMiddleware } from '@clerk/nextjs/server'
 
-      export default clerkMiddleware((auth, request) => {
-        if (request.nextUrl.pathname.match('__clerk')) {
-          const proxyHeaders = new Headers(request.headers)
+      export default clerkMiddleware((auth, req) => {
+        if (req.nextUrl.pathname.match('__clerk')) {
+          const proxyHeaders = new Headers(req.headers)
           proxyHeaders.set('Clerk-Proxy-Url', process.env.NEXT_PUBLIC_CLERK_PROXY_URL || '')
           proxyHeaders.set('Clerk-Secret-Key', process.env.CLERK_SECRET_KEY || '')
-          if (request.ip) {
-            proxyHeaders.set('X-Forwarded-For', request.ip)
+          if (req.ip) {
+            proxyHeaders.set('X-Forwarded-For', req.ip)
           } else {
-            proxyHeaders.set('X-Forwarded-For', request.headers.get('X-Forwarded-For') || '')
+            proxyHeaders.set('X-Forwarded-For', req.headers.get('X-Forwarded-For') || '')
           }
 
-          const proxyUrl = new URL(request.url)
+          const proxyUrl = new URL(req.url)
           proxyUrl.host = 'frontend-api.clerk.dev'
           proxyUrl.port = '443'
           proxyUrl.protocol = 'https'
@@ -246,8 +246,8 @@ When using a proxy, all requests to the Frontend API will be made through your d
       export const loader = (args) => {
         return rootAuthLoader(
           args,
-          ({ request }) => {
-            const { userId, sessionId, getToken } = request.auth
+          ({ req }) => {
+            const { userId, sessionId, getToken } = req.auth
             return json({
               message: `Hello from the root loader :)`,
               ENV: getBrowserEnvironment(),

--- a/docs/custom-flows/user-impersonation.mdx
+++ b/docs/custom-flows/user-impersonation.mdx
@@ -228,8 +228,8 @@ This guide will walk you through how to build a custom flow that handles user im
       Create the `generateActorToken+api.tsx` file with the following code. This creates an API route that will call Clerk's Backend API [`/actor_tokens`](/docs/reference/backend-api/tag/Actor-Tokens#operation/CreateActorToken) endpoint to create an actor token.
 
       ```tsx {{ filename: 'app/generateActorToken+api.tsx', collapsible: true }}
-      export async function POST(request: Request) {
-        const { actorId, userId } = await request.json()
+      export async function POST(req: Request) {
+        const { actorId, userId } = await req.json()
 
         try {
           // Create an actor token using Clerk's Backend API

--- a/docs/references/backend/types/auth-object.mdx
+++ b/docs/references/backend/types/auth-object.mdx
@@ -281,8 +281,8 @@ The `Auth` object is not available in the frontend. To use the `getToken()` meth
     import { createAPIFileRoute } from '@tanstack/start/api'
 
     export const Route = createAPIFileRoute('/api/example')({
-      GET: async ({ request, params }) => {
-        const { userId, getToken } = await getAuth(request)
+      GET: async ({ req, params }) => {
+        const { userId, getToken } = await getAuth(req)
 
         if (!userId) {
           return json({ error: 'Unauthorized' }, { status: 401 })
@@ -302,7 +302,7 @@ The `Auth` object is not available in the frontend. To use the `getToken()` meth
   </Tab>
 
   <Tab>
-    To use the `getToken()` method in the backend, you can access it using the `Auth` object returned by the request.
+    To use the `getToken()` method in the backend, you can access it using the `Auth` object returned by the `request` object.
 
     ```js {{ filename: 'getToken.ts' }}
     app.get('/api/get-token', async (req, res) => {

--- a/docs/references/express/overview.mdx
+++ b/docs/references/express/overview.mdx
@@ -10,7 +10,7 @@ The Clerk Express SDK provides a powerful set of tools and utilities to seamless
 
 ## `clerkMiddleware()`
 
-The `clerkMiddleware()` function checks the request's cookies and headers for a session JWT and if found, attaches the [`Auth`](/docs/references/backend/types/auth-object#auth-object) object to the request object under the `auth` key.
+The `clerkMiddleware()` function checks the request's cookies and headers for a session JWT and if found, attaches the [`Auth`](/docs/references/backend/types/auth-object#auth-object) object to the `request` object under the `auth` key.
 
 ```js
 import { clerkMiddleware } from '@clerk/express'
@@ -91,7 +91,7 @@ app.listen(PORT, () => {
 
 ## `getAuth()`
 
-The `getAuth()` helper retrieves authentication state from the request object. See the [Next.js reference documentation](https://clerk.com/docs/references/nextjs/get-auth) for more examples on how to use the returned `auth` object.
+The `getAuth()` helper retrieves authentication state from the `request` object. See the [Next.js reference documentation](https://clerk.com/docs/references/nextjs/get-auth) for more examples on how to use the returned `auth` object.
 
 The following example uses `requireAuth()` to protect the route based on _authentication_ status, and then uses `getAuth()` to protect the route based on _authorization_ status.
 

--- a/docs/references/fastify/overview.mdx
+++ b/docs/references/fastify/overview.mdx
@@ -51,8 +51,8 @@ const fastify = Fastify({ logger: true })
 const protectedRoutes: FastifyPluginCallback = (instance, options, done) => {
   instance.register(clerkPlugin)
 
-  instance.get('/protected', async (request, reply) => {
-    const { userId } = getAuth(request)
+  instance.get('/protected', async (req, reply) => {
+    const { userId } = getAuth(req)
 
     // Protect the route from unauthenticated users
     if (!userId) {
@@ -69,7 +69,7 @@ const protectedRoutes: FastifyPluginCallback = (instance, options, done) => {
 }
 
 const publicRoutes: FastifyPluginCallback = (instance, options, done) => {
-  instance.get('/', async (request, reply) => {
+  instance.get('/', async (req, reply) => {
     reply.send({ message: 'This is a public route.' })
   })
 

--- a/docs/references/nextjs/clerk-middleware.mdx
+++ b/docs/references/nextjs/clerk-middleware.mdx
@@ -215,8 +215,8 @@ import { clerkMiddleware, createRouteMatcher } from '@clerk/nextjs/server'
 
 const isPublicRoute = createRouteMatcher(['/sign-in(.*)', '/sign-up(.*)'])
 
-export default clerkMiddleware(async (auth, request) => {
-  if (!isPublicRoute(request)) {
+export default clerkMiddleware(async (auth, req) => {
+  if (!isPublicRoute(req)) {
     await auth.protect()
   }
 })

--- a/docs/references/nextjs/custom-sign-in-or-up-page.mdx
+++ b/docs/references/nextjs/custom-sign-in-or-up-page.mdx
@@ -38,8 +38,8 @@ To set up separate sign-in and sign-up pages, follow this guide, and then follow
 
   const isPublicRoute = createRouteMatcher(['/sign-in(.*)'])
 
-  export default clerkMiddleware(async (auth, request) => {
-    if (!isPublicRoute(request)) {
+  export default clerkMiddleware(async (auth, req) => {
+    if (!isPublicRoute(req)) {
       await auth.protect()
     }
   })

--- a/docs/references/nextjs/custom-sign-up-page.mdx
+++ b/docs/references/nextjs/custom-sign-up-page.mdx
@@ -41,8 +41,8 @@ To set up a single sign-in-or-up page, follow the [custom sign-in-or-up page gui
     '/sign-up(.*)'
   ])
 
-  export default clerkMiddleware(async (auth, request) => {
-    if (!isPublicRoute(request)) {
+  export default clerkMiddleware(async (auth, req) => {
+    if (!isPublicRoute(req)) {
       await auth.protect()
     }
   })

--- a/docs/references/react-router/root-auth-loader.mdx
+++ b/docs/references/react-router/root-auth-loader.mdx
@@ -36,8 +36,8 @@ import { rootAuthLoader } from '@clerk/react-router/ssr.server'
 import type { Route } from './+types/root'
 
 export async function loader(args: Route.LoaderArgs) {
-  return rootAuthLoader(args, ({ request, context, params }) => {
-    const { sessionId, userId, getToken } = request.auth
+  return rootAuthLoader(args, ({ req, context, params }) => {
+    const { sessionId, userId, getToken } = req.auth
     // Add logic to fetch data
     return { yourData: 'here' }
   })
@@ -55,8 +55,8 @@ import type { Route } from './+types/root'
 export async function loader(args: Route.LoaderArgs) {
   return rootAuthLoader(
     args,
-    ({ request, context, params }) => {
-      const { sessionId, userId, getToken } = request.auth
+    ({ req, context, params }) => {
+      const { sessionId, userId, getToken } = req.auth
       // Add logic to fetch data
       return { yourData: 'here' }
     },

--- a/docs/references/remix/root-auth-loader.mdx
+++ b/docs/references/remix/root-auth-loader.mdx
@@ -38,8 +38,8 @@ If you need to load in additional data, you can pass a callback to `rootAuthLoad
 // Your imports
 
 export const loader: LoaderFunction = (args) => {
-  return rootAuthLoader(args, ({ request }) => {
-    const { sessionId, userId, getToken } = request.auth
+  return rootAuthLoader(args, ({ req }) => {
+    const { sessionId, userId, getToken } = req.auth
     // Add logic to fetch data
     return { yourData: 'here' }
   })
@@ -58,8 +58,8 @@ To pass configuration [options](#root-auth-loader-options) to `rootAuthLoader()`
 export const loader: LoaderFunction = (args) => {
   return rootAuthLoader(
     args,
-    ({ request }) => {
-      const { sessionId, userId, getToken } = request.auth
+    ({ req }) => {
+      const { sessionId, userId, getToken } = req.auth
       // Add logic to fetch data
       return { yourData: 'here' }
     },

--- a/docs/references/tanstack-start/read-session-data.mdx
+++ b/docs/references/tanstack-start/read-session-data.mdx
@@ -73,9 +73,9 @@ In the following example, the `userId` is passed to the Backend SDK's `getUser()
     import { createAPIFileRoute } from '@tanstack/start/api'
 
     export const Route = createAPIFileRoute('/api/example')({
-      GET: async ({ request, params }) => {
+      GET: async ({ req, params }) => {
         // Use `getAuth()` to retrieve the user's ID
-        const { userId } = await getAuth(request)
+        const { userId } = await getAuth(req)
 
         // Protect the API route by checking if the user is signed in
         if (!userId) {

--- a/docs/security/clerk-csp.mdx
+++ b/docs/security/clerk-csp.mdx
@@ -65,11 +65,11 @@ If you'd like to implement a [strict-dynamic CSP](https://content-security-polic
 import { NextResponse } from 'next/server'
 import { clerkMiddleware } from '@clerk/nextjs/server'
 
-export default clerkMiddleware((auth, request) => {
-  return applyCsp(request)
+export default clerkMiddleware((auth, req) => {
+  return applyCsp(req)
 })
 
-function applyCsp(request) {
+function applyCsp(req) {
   // create a randomly generated nonce value
   const nonce = Buffer.from(crypto.randomUUID()).toString('base64')
 
@@ -90,7 +90,7 @@ function applyCsp(request) {
   const contentSecurityPolicyHeaderValue = cspHeader.replace(/\s{2,}/g, ' ').trim()
 
   // set the nonce and csp values in the request headers
-  const requestHeaders = new Headers(request.headers)
+  const requestHeaders = new Headers(req.headers)
   requestHeaders.set('x-nonce', nonce)
   requestHeaders.set('Content-Security-Policy', contentSecurityPolicyHeaderValue)
 

--- a/docs/users/metadata.mdx
+++ b/docs/users/metadata.mdx
@@ -23,8 +23,8 @@ Private metadata is only accessible by the backend, which makes this useful for 
 <Tabs items={["Fullstack SDKs", "Express", "Go", "Ruby", "cURL"]}>
   <Tab>
     ```ts {{ filename: 'route.ts' }}
-    export async function POST(request) {
-      const { stripeId, userId } = await request.json()
+    export async function POST(req) {
+      const { stripeId, userId } = await req.json()
 
       await clerkClient.users.updateUserMetadata(userId, {
         privateMetadata: {
@@ -118,8 +118,8 @@ You can retrieve the private metadata for a user by using the JavaScript Backend
 <Tabs items={["Fullstack SDKs", "Express", "Go", "Ruby", "cURL"]}>
   <Tab>
     ```ts {{ filename: 'route.ts' }}
-    export async function GET(request) {
-      const { userId } = await request.json()
+    export async function GET(req) {
+      const { userId } = await req.json()
 
       const user = await clerkClient.users.getUser(userId)
 
@@ -191,8 +191,8 @@ Public metadata is accessible by both the frontend and the backend, but can only
 <Tabs items={["Fullstack SDKs", "Express", "Go", "Ruby", "cURL"]}>
   <Tab>
     ```ts {{ filename: 'route.ts' }}
-    export async function POST(request) {
-      const { stripeId, userId } = await request.json()
+    export async function POST(req) {
+      const { stripeId, userId } = await req.json()
 
       await clerkClient.users.updateUserMetadata(userId, {
         publicMetadata: {
@@ -302,8 +302,8 @@ The following examples demonstrate how to update `unsafeMetadata` using [the Bac
 <Tabs items={["Fullstack SDKs", "Express", "Go", "Ruby", "cURL"]}>
   <Tab>
     ```ts {{ filename: 'route.ts' }}
-    export async function POST(request) {
-      const { userId } = await request.json()
+    export async function POST(req) {
+      const { userId } = await req.json()
 
       await clerkClient.users.updateUserMetadata(userId, {
         unsafeMetadata: {


### PR DESCRIPTION
### What does this solve?

- sometimes, we use `request` or we shorthand it to `req`

### What changed?

- updates the docs to consistently use `req`

### Checklist

- [ ] I have clicked on "Files changed" and performed a thorough self-review
- [ ] I have added the "deploy-preview" label and added the preview link(s) to this PR description
- [ ] All existing checks pass
