### PR TITLE
(expo) include sign out functionality in quickstart

### DIFF
--- a/docs/_partials/expo/sign-out-custom-flow.mdx
+++ b/docs/_partials/expo/sign-out-custom-flow.mdx
@@ -1,0 +1,28 @@
+```tsx {{ filename: 'app/components/SignOutButton.tsx', collapsible: true }}
+import { useClerk } from '@clerk/clerk-expo'
+import * as Linking from 'expo-linking'
+import { Text, TouchableOpacity } from 'react-native'
+
+export const SignOutButton = () => {
+  // Use `useClerk()` to access the `signOut()` function
+  const { signOut } = useClerk()
+
+  const handleSignOut = async () => {
+    try {
+      await signOut()
+      // Redirect to your desired page
+      Linking.openURL(Linking.createURL('/'))
+    } catch (err) {
+      // See https://clerk.com/docs/custom-flows/error-handling
+      // for more info on error handling
+      console.error(JSON.stringify(err, null, 2))
+    }
+  }
+
+  return (
+    <TouchableOpacity onPress={handleSignOut}>
+      <Text>Sign out</Text>
+    </TouchableOpacity>
+  )
+}
+```

--- a/docs/custom-flows/sign-out.mdx
+++ b/docs/custom-flows/sign-out.mdx
@@ -76,31 +76,9 @@ The `signOut()` function signs a user out of all sessions in a [multi-session ap
   </Tab>
 
   <Tab>
-    The [`useClerk()`](/docs/hooks/use-clerk) hook is used to access the `signOut()` function, which is called when the user clicks the sign-out button.
+    The [`useClerk()`](/docs/hooks/use-clerk) hook is used to access the `signOut()` function, which is called when the user clicks the "Sign out" button.
 
-    ```jsx {{ filename: 'SignOutButton.tsx', collapsible: true }}
-    import { useClerk } from '@clerk/clerk-expo'
-    import * as Linking from 'expo-linking'
-    import { Button } from 'react-native'
-
-    export const SignOutButton = () => {
-      const { signOut } = useClerk()
-
-      const handleSignOut = async () => {
-        try {
-          await signOut()
-          // Redirect to your desired page
-          Linking.openURL(Linking.createURL('/'))
-        } catch (err) {
-          // See https://clerk.com/docs/custom-flows/error-handling
-          // for more info on error handling
-          console.error(JSON.stringify(err, null, 2))
-        }
-      }
-
-      return <Button title="Sign out" onPress={handleSignOut} />
-    }
-    ```
+    <Include src="_partials/expo/sign-out-custom-flow" />
   </Tab>
 
   <Tab>

--- a/docs/quickstarts/expo.mdx
+++ b/docs/quickstarts/expo.mdx
@@ -222,9 +222,9 @@ description: Add authentication and user management to your Expo app with Clerk.
 
   ```tsx {{ filename: 'app/(auth)/sign-up.tsx', collapsible: true }}
   import * as React from 'react'
-  import { Text, TextInput, Button, View } from 'react-native'
+  import { Text, TextInput, TouchableOpacity, View } from 'react-native'
   import { useSignUp } from '@clerk/clerk-expo'
-  import { useRouter } from 'expo-router'
+  import { Link, useRouter } from 'expo-router'
 
   export default function SignUpScreen() {
     const { isLoaded, signUp, setActive } = useSignUp()
@@ -238,6 +238,8 @@ description: Add authentication and user management to your Expo app with Clerk.
     // Handle submission of sign-up form
     const onSignUpPress = async () => {
       if (!isLoaded) return
+
+      console.log(emailAddress, password)
 
       // Start sign-up process using email and password provided
       try {
@@ -295,7 +297,9 @@ description: Add authentication and user management to your Expo app with Clerk.
             placeholder="Enter your verification code"
             onChangeText={(code) => setCode(code)}
           />
-          <Button title="Verify" onPress={onVerifyPress} />
+          <TouchableOpacity onPress={onVerifyPress}>
+            <Text>Verify</Text>
+          </TouchableOpacity>
         </>
       )
     }
@@ -316,7 +320,15 @@ description: Add authentication and user management to your Expo app with Clerk.
             secureTextEntry={true}
             onChangeText={(password) => setPassword(password)}
           />
-          <Button title="Continue" onPress={onSignUpPress} />
+          <TouchableOpacity onPress={onSignUpPress}>
+            <Text>Continue</Text>
+          </TouchableOpacity>
+          <View style={{ display: 'flex', flexDirection: 'row', gap: 3 }}>
+            <Text>Already have an account?</Text>
+            <Link href="/sign-in">
+              <Text>Sign in</Text>
+            </Link>
+          </View>
         </>
       </View>
     )
@@ -330,7 +342,7 @@ description: Add authentication and user management to your Expo app with Clerk.
   ```tsx {{ filename: 'app/(auth)/sign-in.tsx', collapsible: true }}
   import { useSignIn } from '@clerk/clerk-expo'
   import { Link, useRouter } from 'expo-router'
-  import { Text, TextInput, Button, View } from 'react-native'
+  import { Text, TextInput, TouchableOpacity, View } from 'react-native'
   import React from 'react'
 
   export default function Page() {
@@ -341,7 +353,7 @@ description: Add authentication and user management to your Expo app with Clerk.
     const [password, setPassword] = React.useState('')
 
     // Handle the submission of the sign-in form
-    const onSignInPress = async () => {
+    const onSignInPress = React.useCallback(async () => {
       if (!isLoaded) return
 
       // Start the sign-in process using the email and password provided
@@ -357,7 +369,7 @@ description: Add authentication and user management to your Expo app with Clerk.
           await setActive({ session: signInAttempt.createdSessionId })
           router.replace('/')
         } else {
-          // If the status isn't complete, check why. User might need to
+          // If the status is not complete, check why. User may need to
           // complete further steps.
           console.error(JSON.stringify(signInAttempt, null, 2))
         }
@@ -366,10 +378,11 @@ description: Add authentication and user management to your Expo app with Clerk.
         // for more info on error handling
         console.error(JSON.stringify(err, null, 2))
       }
-    }
+    }, [isLoaded, emailAddress, password])
 
     return (
       <View>
+        <Text>Sign in</Text>
         <TextInput
           autoCapitalize="none"
           value={emailAddress}
@@ -382,8 +395,10 @@ description: Add authentication and user management to your Expo app with Clerk.
           secureTextEntry={true}
           onChangeText={(password) => setPassword(password)}
         />
-        <Button title="Sign in" onPress={onSignInPress} />
-        <View>
+        <TouchableOpacity onPress={onSignInPress}>
+          <Text>Continue</Text>
+        </TouchableOpacity>
+        <View style={{ display: 'flex', flexDirection: 'row', gap: 3 }}>
           <Text>Don't have an account?</Text>
           <Link href="/sign-up">
             <Text>Sign up</Text>
@@ -395,6 +410,12 @@ description: Add authentication and user management to your Expo app with Clerk.
   ```
 
   For more information about building these custom flows, including guided comments in the code examples, see the [Build a custom email/password authentication flow](/docs/custom-flows/email-password) guide.
+
+  ## Add a sign-out button
+
+  In the `components/` folder, create a `SignOutButton.tsx` file with the following code. The [`useClerk()`](/docs/hooks/use-clerk) hook is used to access the `signOut()` function, which is called when the user clicks the "Sign out" button.
+
+  <Include src="_partials/expo/sign-out-custom-flow" />
 
   ## Conditionally render content
 
@@ -416,12 +437,13 @@ description: Add authentication and user management to your Expo app with Clerk.
   }
   ```
 
-  Then, in the same folder, create an `index.tsx` file with the following code. It displays the user's email if they're signed in, or sign-in and sign-up links if they're not:
+  Then, in the same folder, create an `index.tsx` file with the following code. If the user is signed in, it displays their email and a sign-out button. If they're not signed in, it displays sign-in and sign-up links.
 
   ```tsx {{ filename: 'app/(home)/index.tsx' }}
   import { SignedIn, SignedOut, useUser } from '@clerk/clerk-expo'
   import { Link } from 'expo-router'
   import { Text, View } from 'react-native'
+  import { SignOutButton } from '@/app/components/SignOutButton'
 
   export default function Page() {
     const { user } = useUser()
@@ -430,6 +452,7 @@ description: Add authentication and user management to your Expo app with Clerk.
       <View>
         <SignedIn>
           <Text>Hello {user?.emailAddresses[0].emailAddress}</Text>
+          <SignOutButton />
         </SignedIn>
         <SignedOut>
           <Link href="/(auth)/sign-in">

--- a/docs/references/expo/overview.mdx
+++ b/docs/references/expo/overview.mdx
@@ -28,12 +28,15 @@ Because the Expo SDK is built on top of the Clerk React SDK, you can use the hoo
   - [`<SignedIn>`](/docs/components/control/signed-in)
   - [`<SignedOut>`](/docs/components/control/signed-out)
   - [`<Protect>`](/docs/components/protect)
+  - For other components, see the [custom flows](#custom-flows) section for more information.
 - **Web** apps:
   - All Clerk components are available. See [the component docs](/docs/components/overview) for more information.
 
-## Custom flow examples
+## Custom flows
 
-Clerk's prebuilt components are not supported in native applications. You must use the Clerk API to build custom UI's for flows such as signing in and signing up. See the [custom flow](/docs/custom-flows/overview) guides for more information.
+For **native** applications, Clerk's prebuilt components are not supported. You must use the Clerk API to build custom UI's for flows such as signing in and signing up. See the [custom flow](/docs/custom-flows/overview) guides for more information.
+
+For **web** applications, if Clerk's [prebuilt components](/docs/components/overview) don't meet your specific needs or if you require more control over the logic, you can rebuild the existing Clerk flows using the Clerk API. See the [custom flow](/docs/custom-flows/overview) guides for more information.
 
 ## Deploy your app
 


### PR DESCRIPTION
### What does this solve?

- We've had user complaints about not having sign out functionality, and its fair feedback.

### What changed?

- Adds a step to the quickstart for adding a sign out button
- Updated https://github.com/clerk/clerk-expo-quickstart to match these changes

### Checklist

- [x] I have clicked on "Files changed" and performed a thorough self-review
- [ ] I have added the "deploy-preview" label and added the preview link(s) to this PR description
- [x] All existing checks pass
