### PR TITLE
Rewrite Azure SAML docs for application owners

### DIFF
--- a/docs/authentication/enterprise-connections/saml/azure.mdx
+++ b/docs/authentication/enterprise-connections/saml/azure.mdx
@@ -37,7 +37,7 @@ This process requires configuration changes in both the Clerk dashboard, and in 
   1. Select **Add connection**. You'll be redirected to the connection's configuration page. Note that the connection is disabled by default.
   1. In the **Service Provider Configuration** section, note the **Reply URL (Assertion Consumer Service URL)** and **Identifier (Entity ID)**. These will need to be added to your customer's Microsoft Entra ID application.
 
-  ## Configure the third-party Identity Provider
+  ## Configure SAML application
 
   Now that the enterprise connection is configured in Clerk and the Reply URL and Identifier are known, the customer's Azure application needs to be configured. At a high level, the process is:
 

--- a/docs/authentication/enterprise-connections/saml/azure.mdx
+++ b/docs/authentication/enterprise-connections/saml/azure.mdx
@@ -50,9 +50,9 @@ This process requires configuration changes in both the Clerk Dashboard, and in 
   You are welcome the use the below email template with detailed instructions. They contain the following
   template strings that you should replace with your actual values:
 
-  - [YOUR_APPLICATION_NAME]
-  - [YOUR_CLERK_ENTITY_ID]
-  - [YOUR_CLERK_REPLY_URL]
+  - \[YOUR\_APPLICATION\_NAME]
+  - \[YOUR\_CLERK\_ENTITY\_ID]
+  - \[YOUR\_CLERK\_REPLY\_URL]
 
   <Copyable as="html">
     Here are the instructions for setting up SAML SSO with Microsoft Azure Entra ID:
@@ -64,9 +64,9 @@ This process requires configuration changes in both the Clerk Dashboard, and in 
     1. Select **New application**. You'll be redirected to the **Browse Microsoft Entra Gallery** page.
     1. Select **Create your own application**.
     1. In the modal that opens:
-        - **Name** of your application (likely [YOUR_APPLICATION_NAME]).
-        - Select **Integrate any other application you don't find in the gallery (Non-gallery)**.
-        - Select **Create**.
+       - **Name** of your application (likely \[YOUR\_APPLICATION\_NAME]).
+       - Select **Integrate any other application you don't find in the gallery (Non-gallery)**.
+       - Select **Create**.
 
     **Step 2: Assign your users or groups in Microsoft**
 
@@ -87,7 +87,7 @@ This process requires configuration changes in both the Clerk Dashboard, and in 
     1. Select **Edit**. The **Basic SAML Configuration** panel will open.
     1. Add the following **Identifier (Entity ID)** and **Reply URL (Assertion Consumer Service URL)** values. These values will be saved automatically.
        - **Identifier (Entity ID)**: `[YOUR_CLERK_ENTITY_ID]`
-        - **Reply URL (Assertion Consumer Service URL)**: `[YOUR_CLERK_REPLY_URL]`
+       - **Reply URL (Assertion Consumer Service URL)**: `[YOUR_CLERK_REPLY_URL]`
     1. Select **Save** at the top of the panel. Close the panel.
 
     **Step 4: Verify correct configuration of attributes and claims**
@@ -95,16 +95,19 @@ This process requires configuration changes in both the Clerk Dashboard, and in 
     We expect your SAML responses to have the following specific attributes:
 
     Email address (required). This is the email address that your users will use to authenticate into your app:
-      - Claim name: `http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress`
-      - Value: `user.mail`
+
+    - Claim name: `http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress`
+    - Value: `user.mail`
 
     First name (optional):
-      - Claim name: `http://schemas.xmlsoap.org/ws/2005/05/identity/claims/givenname`
-      - Value: `user.givenname`
+
+    - Claim name: `http://schemas.xmlsoap.org/ws/2005/05/identity/claims/givenname`
+    - Value: `user.givenname`
 
     First name (optional):
-      - Claim name: `http://schemas.xmlsoap.org/ws/2005/05/identity/claims/surname`
-      - Value: `user.surname`
+
+    - Claim name: `http://schemas.xmlsoap.org/ws/2005/05/identity/claims/surname`
+    - Value: `user.surname`
 
     These are the defaults, and probably won't need you to change them. However, many SAML configuration errors are due to incorrect attribute mappings, so it's worth double-checking. Here's how:
 
@@ -116,14 +119,13 @@ This process requires configuration changes in both the Clerk Dashboard, and in 
 
     1. Still on the **Set up Single Sign-On with SAML** page, find the **SAML Certificates** section.
     1. Copy the **App Federation Metadata Url**, and reply to this email with it. This is the final piece of information we need to enable SAML.
-
   </Copyable>
 
   ## Add App Federation Metadata URL in the Dashboard
 
   After following the instructions in the email, your customer should have sent you the Microsoft app's **App Federation Metadata URL**. Now, you're going to add it to the Clerk connection, completing the SAML connection configuration.
 
-  1. Navigate to the [**SSO connections**](https://dashboard.clerk.com/last-active?path=user-authentication/sso-connections) page in the Clerk Dashboard. 
+  1. Navigate to the [**SSO connections**](https://dashboard.clerk.com/last-active?path=user-authentication/sso-connections) page in the Clerk Dashboard.
   1. Select the SAML connection.
   1. In the **Identity Provider Configuration** section, under **App Federation Metadata Url**, paste the **App Federation Metadata URL**.
   1. Select **Fetch & save**.
@@ -139,5 +141,4 @@ This process requires configuration changes in both the Clerk Dashboard, and in 
 
   1. Navigate back to the Clerk Dashboard where you should still have the connection's configuration page open. If not, navigate to the [**SSO connections**](https://dashboard.clerk.com/last-active?path=user-authentication/sso-connections) page and select the connection.
   1. At the top of the page, toggle on **Enable connection** and select **Save**.
-
 </Steps>

--- a/docs/authentication/enterprise-connections/saml/azure.mdx
+++ b/docs/authentication/enterprise-connections/saml/azure.mdx
@@ -45,7 +45,7 @@ This process requires configuration changes in both the Clerk dashboard, and in 
   - Assign selected users or groups to that Azure application.
   - Add the Entity ID and Reply URL from Clerk to the Azure application's SAML configuration.
   - Verify that the attribute mappings are correct
-  - Obtain and share the application's metadata URL
+  - Obtain and share the Identity Provider's application's metadata URL
 
   You are welcome the use the below email template with detailed instructions. They contain the following
   template strings that you should replace with your actual values:

--- a/docs/authentication/enterprise-connections/saml/azure.mdx
+++ b/docs/authentication/enterprise-connections/saml/azure.mdx
@@ -17,7 +17,7 @@ description: Learn how to allow users to sign up and sign in to your Clerk app w
     }
   ]}
 >
-  - Create a SAML SSO connection for your customer
+  - Create a SSO connection via Clerk Dashboard
   - Give your customer instructions on how to connect Microsoft Azure Entra ID to your app
   - Enable and test the SAML connection
 </TutorialHero>

--- a/docs/authentication/enterprise-connections/saml/azure.mdx
+++ b/docs/authentication/enterprise-connections/saml/azure.mdx
@@ -54,71 +54,70 @@ This process requires configuration changes in both the Clerk dashboard, and in 
   - [YOUR_CLERK_ENTITY_ID]
   - [YOUR_CLERK_REPLY_URL]
 
-  <CopyableMarkdown> {`
-  Here are the instructions for setting up SAML SSO with Microsoft Azure Entra ID:
+  <Copyable as="html">
+    Here are the instructions for setting up SAML SSO with Microsoft Azure Entra ID:
 
-  **Step 1: Create a new enterprise application in Microsoft**
+    **Step 1: Create a new enterprise application in Microsoft**
 
-  1. Navigate to the [Microsoft Azure portal](https://azure.microsoft.com/en-us/get-started/azure-portal) and sign in.
-  1. Under the **Azure Services** section, find and select **Enterprise applications**. You may have to go to the [**All services**](https://portal.azure.com/#allservices) page and then scroll down to the **Identity** section to find it.
-  1. Select **New application**. You'll be redirected to the **Browse Microsoft Entra Gallery** page.
-  1. Select **Create your own application**.
-  1. In the modal that opens:
-      - **Name** of your application (likely [YOUR_APPLICATION_NAME]).
-      - Select **Integrate any other application you don't find in the gallery (Non-gallery)**.
-      - Select **Create**.
+    1. Navigate to the [Microsoft Azure portal](https://azure.microsoft.com/en-us/get-started/azure-portal) and sign in.
+    1. Under the **Azure Services** section, find and select **Enterprise applications**. You may have to go to the [**All services**](https://portal.azure.com/#allservices) page and then scroll down to the **Identity** section to find it.
+    1. Select **New application**. You'll be redirected to the **Browse Microsoft Entra Gallery** page.
+    1. Select **Create your own application**.
+    1. In the modal that opens:
+        - **Name** of your application (likely [YOUR_APPLICATION_NAME]).
+        - Select **Integrate any other application you don't find in the gallery (Non-gallery)**.
+        - Select **Create**.
 
-  **Step 2: Assign your users or groups in Microsoft**
+    **Step 2: Assign your users or groups in Microsoft**
 
-  Now that you have created the enterprise app, you need to assign users or groups before they can use it to log in. Below are instructions for assigning an individual user, but for more options and instructions for groups, see Microsoft's docs [here](https://learn.microsoft.com/en-us/entra/identity/enterprise-apps/assign-user-or-group-access-portal?pivots=portal).
+    Now that you have created the enterprise app, you need to assign users or groups before they can use it to log in. Below are instructions for assigning an individual user, but for more options and instructions for groups, see Microsoft's docs [here](https://learn.microsoft.com/en-us/entra/identity/enterprise-apps/assign-user-or-group-access-portal?pivots=portal).
 
-  1. In the **Getting Started** section, select the **Assign users and groups** link.
-  1. Select **Add user/group**. You'll be redirected to the **Add Assignment** page.
-  1. Select the **None Selected** link.
-  1. To assign a user to the enterprise app, you can either use the search field to find a user or select the checkbox next to the user in the table.
-  1. Select **Select** at the bottom of the page. You'll be redirected to the **Add Assignment** page.
-  1. Select **Assign** at the bottom of the page.
+    1. In the **Getting Started** section, select the **Assign users and groups** link.
+    1. Select **Add user/group**. You'll be redirected to the **Add Assignment** page.
+    1. Select the **None Selected** link.
+    1. To assign a user to the enterprise app, you can either use the search field to find a user or select the checkbox next to the user in the table.
+    1. Select **Select** at the bottom of the page. You'll be redirected to the **Add Assignment** page.
+    1. Select **Assign** at the bottom of the page.
 
-  **Step 3: Set Basic SAML Configuration**
+    **Step 3: Set Basic SAML Configuration**
 
-  1. In the navigation sidenav, open the **Manage** dropdown and select **Single sign-on**.
-  1. In the **Select a single sign-on method** section, select **SAML**. You'll be redirected to the **Set up Single Sign-On with SAML** page.
-  1. Find the **Basic SAML Configuration** section.
-  1. Select **Edit**. The **Basic SAML Configuration** panel will open.
-  1. Add the following **Identifier (Entity ID)** and **Reply URL (Assertion Consumer Service URL)** values. These values will be saved automatically.
-     - **Identifier (Entity ID)**: \`[YOUR_CLERK_ENTITY_ID]\`
-      - **Reply URL (Assertion Consumer Service URL)**: \`[YOUR_CLERK_REPLY_URL]\`
-  1. Select **Save** at the top of the panel. Close the panel.
+    1. In the navigation sidenav, open the **Manage** dropdown and select **Single sign-on**.
+    1. In the **Select a single sign-on method** section, select **SAML**. You'll be redirected to the **Set up Single Sign-On with SAML** page.
+    1. Find the **Basic SAML Configuration** section.
+    1. Select **Edit**. The **Basic SAML Configuration** panel will open.
+    1. Add the following **Identifier (Entity ID)** and **Reply URL (Assertion Consumer Service URL)** values. These values will be saved automatically.
+       - **Identifier (Entity ID)**: `[YOUR_CLERK_ENTITY_ID]`
+        - **Reply URL (Assertion Consumer Service URL)**: `[YOUR_CLERK_REPLY_URL]`
+    1. Select **Save** at the top of the panel. Close the panel.
 
-  **Step 4: Verify correct configuration of attributes and claims**
+    **Step 4: Verify correct configuration of attributes and claims**
 
-  We expect your SAML responses to have the following specific attributes:
+    We expect your SAML responses to have the following specific attributes:
 
-  Email address (required). This is the email address that your users will use to authenticate into your app:
-    - Claim name: \`http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress\`
-    - Value: \`user.mail\`
+    Email address (required). This is the email address that your users will use to authenticate into your app:
+      - Claim name: `http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress`
+      - Value: `user.mail`
 
-  First name (optional):
-    - Claim name: \`http://schemas.xmlsoap.org/ws/2005/05/identity/claims/givenname\`
-    - Value: \`user.givenname\`
+    First name (optional):
+      - Claim name: `http://schemas.xmlsoap.org/ws/2005/05/identity/claims/givenname`
+      - Value: `user.givenname`
 
-  First name (optional):
-    - Claim name: \`http://schemas.xmlsoap.org/ws/2005/05/identity/claims/surname\`
-    - Value: \`user.surname\`
+    First name (optional):
+      - Claim name: `http://schemas.xmlsoap.org/ws/2005/05/identity/claims/surname`
+      - Value: `user.surname`
 
-  These are the defaults, and probably won't need you to change them. However, many SAML configuration errors are due to incorrect attribute mappings, so it's worth double-checking. Here's how:
+    These are the defaults, and probably won't need you to change them. However, many SAML configuration errors are due to incorrect attribute mappings, so it's worth double-checking. Here's how:
 
-  1. Still on the **Set up Single Sign-On with SAML** page, find the **Attributes & Claims** section.
-  1. Select **Edit**.
-  1  Verify that the above three attributes and values are present.
+    1. Still on the **Set up Single Sign-On with SAML** page, find the **Attributes & Claims** section.
+    1. Select **Edit**.
+    1  Verify that the above three attributes and values are present.
 
-  **Step 5: Share the application's metadata URL**
+    **Step 5: Share the application's metadata URL**
 
-  1. Still on the **Set up Single Sign-On with SAML** page, find the **SAML Certificates** section.
-  1. Copy the **App Federation Metadata Url**, and reply to this email with it. This is the final piece of information we need to enable SAML.
+    1. Still on the **Set up Single Sign-On with SAML** page, find the **SAML Certificates** section.
+    1. Copy the **App Federation Metadata Url**, and reply to this email with it. This is the final piece of information we need to enable SAML.
 
-`}
-  </CopyableMarkdown>
+  </Copyable>
 
   ## Add App Federation Metadata URL in the Dashboard
 

--- a/docs/authentication/enterprise-connections/saml/azure.mdx
+++ b/docs/authentication/enterprise-connections/saml/azure.mdx
@@ -18,11 +18,11 @@ description: Learn how to allow users to sign up and sign in to your Clerk app w
   ]}
 >
   - Create a SSO connection via Clerk Dashboard
-  - Give your customer instructions on how to connect Microsoft Azure Entra ID to your app
+  - Give your customer instructions on how to connect Microsoft Entra ID to your app
   - Enable and test the SAML connection
 </TutorialHero>
 
-Enabling SAML with Microsoft Azure Entra ID (formerly [Active Directory](https://learn.microsoft.com/en-us/entra/fundamentals/new-name)) allows your users to sign up and sign in to your Clerk application with their Microsoft account.
+Enabling SAML with Microsoft Entra ID (formerly [Azure Active Directory](https://learn.microsoft.com/en-us/entra/fundamentals/new-name)) allows your users to sign up and sign in to your Clerk application with their Microsoft account.
 
 This process requires configuration changes in both the Clerk Dashboard, and in your customer's Microsoft Entra ID settings in their Azure account.
 
@@ -35,17 +35,17 @@ This process requires configuration changes in both the Clerk Dashboard, and in 
   1. Enter the **Domain**. This is the email domain of the users you want to allow to sign in to your application. Optionally, select an **Organization**.
   1. Enter the **Name**. This will be displayed on the sign-in form.
   1. Select **Add connection**. You'll be redirected to the connection's configuration page. Note that the connection is disabled by default.
-  1. In the **Service Provider Configuration** section, note the **Reply URL (Assertion Consumer Service URL)** and **Identifier (Entity ID)**. These will need to be added to your customer's Microsoft Entra ID application.
+  1. In the **Service Provider Configuration** section, save the **Reply URL (Assertion Consumer Service URL)** and **Identifier (Entity ID)** values somewhere secure. You'll need to give these to the customer so they can configure their Microsoft Entra ID application.
 
   ## Configure SAML application
 
-  Now that the enterprise connection is configured in Clerk and the Reply URL and Identifier are known, the customer's Azure application needs to be configured. At a high level, the process is:
+  Now that the enterprise connection is configured in Clerk and the **Reply URL** and **Identifier** are known, the customer's Microsoft application needs to be configured. At a high level, the process is:
 
   - Create a new enterprise app in Microsoft Azure.
-  - Assign selected users or groups to that Azure application.
-  - Add the Entity ID and Reply URL from Clerk to the Azure application's SAML configuration.
-  - Verify that the attribute mappings are correct
-  - Obtain and share the Identity Provider's application's metadata URL
+  - Assign selected users or groups to that Microsoft application.
+  - Add the **Reply URL** and **Identifier** from Clerk to the Microsoft application's SAML configuration.
+  - Verify that the attribute mappings are correct.
+  - Obtain and share the application's metadata URL.
 
   You are welcome the use the below email template with detailed instructions. They contain the following
   template strings that you should replace with your actual values:
@@ -55,7 +55,7 @@ This process requires configuration changes in both the Clerk Dashboard, and in 
   - \[YOUR\_CLERK\_REPLY\_URL]
 
   <Copyable as="html">
-    Here are the instructions for setting up SAML SSO with Microsoft Azure Entra ID:
+    Here are the instructions for setting up SAML SSO with Microsoft Entra ID:
 
     **Step 1: Create a new enterprise application in Microsoft**
 
@@ -121,23 +121,23 @@ This process requires configuration changes in both the Clerk Dashboard, and in 
     1. Copy the **App Federation Metadata Url**, and reply to this email with it. This is the final piece of information we need to enable SAML.
   </Copyable>
 
-  ## Add App Federation Metadata URL in the Dashboard
+  ## Add App Federation Metadata URL in the Clerk Dashboard
 
   After following the instructions in the email, your customer should have sent you the Microsoft app's **App Federation Metadata URL**. Now, you're going to add it to the Clerk connection, completing the SAML connection configuration.
 
   1. Navigate to the [**SSO connections**](https://dashboard.clerk.com/last-active?path=user-authentication/sso-connections) page in the Clerk Dashboard.
   1. Select the SAML connection.
   1. In the **Identity Provider Configuration** section, under **App Federation Metadata Url**, paste the **App Federation Metadata URL**.
-  1. Select **Fetch & save**.
+  1. Select **Fetch & save**. Keep the page open for the next step.
 
   ## Enable the connection in Clerk
 
-  The SAML connection is ready to enable! Once enabled, all users with email addresses ending in the domain will be redirected to the IDP at sign-in and sign-up.
+  The SAML connection is ready to enable! Once enabled, all users with email addresses ending in the domain will be redirected to Microsoft at sign-up and sign-in.
 
   > [!WARNING]
   > If there are existing users with email domains that match the SAML connection, and there is an error in the SAML configuration in Clerk or Microsoft, those users will be **unable to sign in** when the connection is enabled. If this is a concern, we recommend coordinating with your counterpart to test the connection at an off-peak time.
 
-  To make the connection available for users of that IDP to authenticate with:
+  To make the connection available for users to authenticate with:
 
   1. Navigate back to the Clerk Dashboard where you should still have the connection's configuration page open. If not, navigate to the [**SSO connections**](https://dashboard.clerk.com/last-active?path=user-authentication/sso-connections) page and select the connection.
   1. At the top of the page, toggle on **Enable connection** and select **Save**.

--- a/docs/authentication/enterprise-connections/saml/azure.mdx
+++ b/docs/authentication/enterprise-connections/saml/azure.mdx
@@ -17,39 +17,60 @@ description: Learn how to allow users to sign up and sign in to your Clerk app w
     }
   ]}
 >
-  - Use Microsoft Azure Entra ID to enable SSO via SAML for your Clerk app
+  - Create a SAML SSO connection for your customer
+  - Give your customer instructions on how to connect Microsoft Azure Entra ID to your app
+  - Enable and test the SAML connection
 </TutorialHero>
 
 Enabling SAML with Microsoft Azure Entra ID (formerly [Active Directory](https://learn.microsoft.com/en-us/entra/fundamentals/new-name)) allows your users to sign up and sign in to your Clerk application with their Microsoft account.
 
-To make the setup process easier, it's recommended to keep two browser tabs open: one for the [Clerk Dashboard](https://dashboard.clerk.com/last-active?path=user-authentication/sso-connections) and one for your [Microsoft Azure portal](https://portal.azure.com).
+This process requires configuration changes in both the Clerk dashboard, and in your customer's Microsoft Entra ID settings in their Azure account.
 
 <Steps>
-  ## Enable Microsoft Entra ID as a SAML connection in Clerk
+  ## Create a Microsoft Entra ID SAML connection in Clerk
 
   1. In the Clerk Dashboard, navigate to the [**SSO connections**](https://dashboard.clerk.com/last-active?path=user-authentication/sso-connections) page.
   1. Select **Add connection** and select **For specific domains or organizations**.
   1. Under **SAML**, select **Microsoft Entra ID (Formerly AD)**.
   1. Enter the **Domain**. This is the email domain of the users you want to allow to sign in to your application. Optionally, select an **Organization**.
   1. Enter the **Name**. This will be displayed on the sign-in form.
-  1. Select **Add connection**. You'll be redirected to the connection's configuration page.
-  1. In the **Service Provider Configuration** section, save the **Reply URL (Assertion Consumer Service URL)** and **Identifier (Entity ID)** values somewhere secure. Keep this page open.
+  1. Select **Add connection**. You'll be redirected to the connection's configuration page. Note that the connection is disabled by default.
+  1. In the **Service Provider Configuration** section, note the **Reply URL (Assertion Consumer Service URL)** and **Identifier (Entity ID)**. These will need to be added to your customer's Microsoft Entra ID application.
 
-  ## Create a new enterprise app in Microsoft
+  ## Configure the third-party Identity Provider
 
-  1. In a separate page, navigate to the [Microsoft Azure portal](https://azure.microsoft.com/en-us/get-started/azure-portal) and sign in.
+  Now that the enterprise connection is configured in Clerk and the Reply URL and Identifier are known, the customer's Azure application needs to be configured. At a high level, the process is:
+
+  - Create a new enterprise app in Microsoft Azure.
+  - Assign selected users or groups to that Azure application.
+  - Add the Entity ID and Reply URL from Clerk to the Azure application's SAML configuration.
+  - Verify that the attribute mappings are correct
+  - Obtain and share the application's metadata URL
+
+  You are welcome the use the below email template with detailed instructions. They contain the following
+  template strings that you should replace with your actual values:
+
+  - [YOUR_APPLICATION_NAME]
+  - [YOUR_CLERK_ENTITY_ID]
+  - [YOUR_CLERK_REPLY_URL]
+
+  <CopyableMarkdown> {`
+  Here are the instructions for setting up SAML SSO with Microsoft Azure Entra ID:
+
+  **Step 1: Create a new enterprise application in Microsoft**
+
+  1. Navigate to the [Microsoft Azure portal](https://azure.microsoft.com/en-us/get-started/azure-portal) and sign in.
   1. Under the **Azure Services** section, find and select **Enterprise applications**. You may have to go to the [**All services**](https://portal.azure.com/#allservices) page and then scroll down to the **Identity** section to find it.
   1. Select **New application**. You'll be redirected to the **Browse Microsoft Entra Gallery** page.
   1. Select **Create your own application**.
   1. In the modal that opens:
+      - **Name** of your application (likely [YOUR_APPLICATION_NAME]).
+      - Select **Integrate any other application you don't find in the gallery (Non-gallery)**.
+      - Select **Create**.
 
-  - Enter the **Name** of your app.
-  - Select **Integrate any other application you don't find in the gallery (Non-gallery)**.
-  - Select **Create**.
+  **Step 2: Assign your users or groups in Microsoft**
 
-  ## Assign selected user or group in Microsoft
-
-  Now that you have created the enterprise app, you need to assign users or groups to the app. For example, if you were part of the Clerk organization, you would have access to users and groups within the Clerk organization. In this case, you could assign individual users or entire groups to the enterprise app you just created.
+  Now that you have created the enterprise app, you need to assign users or groups before they can use it to log in. Below are instructions for assigning an individual user, but for more options and instructions for groups, see Microsoft's docs [here](https://learn.microsoft.com/en-us/entra/identity/enterprise-apps/assign-user-or-group-access-portal?pivots=portal).
 
   1. In the **Getting Started** section, select the **Assign users and groups** link.
   1. Select **Add user/group**. You'll be redirected to the **Add Assignment** page.
@@ -58,43 +79,64 @@ To make the setup process easier, it's recommended to keep two browser tabs open
   1. Select **Select** at the bottom of the page. You'll be redirected to the **Add Assignment** page.
   1. Select **Assign** at the bottom of the page.
 
-  ## Configure Clerk as your Service Provider
-
-  After assigning the user or group to the enterprise app, you need to configure the SSO settings in Microsoft to enable SAML SSO.
+  **Step 3: Set Basic SAML Configuration**
 
   1. In the navigation sidenav, open the **Manage** dropdown and select **Single sign-on**.
   1. In the **Select a single sign-on method** section, select **SAML**. You'll be redirected to the **Set up Single Sign-On with SAML** page.
   1. Find the **Basic SAML Configuration** section.
   1. Select **Edit**. The **Basic SAML Configuration** panel will open.
-  1. Paste the **Identifier (Entity ID)** and **Reply URL (Assertion Consumer Service URL)** values you saved from the Clerk Dashboard into their respective fields. These values will be saved automatically.
+  1. Add the following **Identifier (Entity ID)** and **Reply URL (Assertion Consumer Service URL)** values. These values will be saved automatically.
+     - **Identifier (Entity ID)**: \`[YOUR_CLERK_ENTITY_ID]\`
+      - **Reply URL (Assertion Consumer Service URL)**: \`[YOUR_CLERK_REPLY_URL]\`
   1. Select **Save** at the top of the panel. Close the panel.
 
-  ## Configure Microsoft as your Identity Provider
+  **Step 4: Verify correct configuration of attributes and claims**
 
-  1. On the **Set up Single Sign-On with SAML** page, find the **SAML Certificates** section.
-  1. Copy the **App Federation Metadata Url**.
+  We expect your SAML responses to have the following specific attributes:
+
+  Email address (required). This is the email address that your users will use to authenticate into your app:
+    - Claim name: \`http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress\`
+    - Value: \`user.mail\`
+
+  First name (optional):
+    - Claim name: \`http://schemas.xmlsoap.org/ws/2005/05/identity/claims/givenname\`
+    - Value: \`user.givenname\`
+
+  First name (optional):
+    - Claim name: \`http://schemas.xmlsoap.org/ws/2005/05/identity/claims/surname\`
+    - Value: \`user.surname\`
+
+  These are the defaults, and probably won't need you to change them. However, many SAML configuration errors are due to incorrect attribute mappings, so it's worth double-checking. Here's how:
+
+  1. Still on the **Set up Single Sign-On with SAML** page, find the **Attributes & Claims** section.
+  1. Select **Edit**.
+  1  Verify that the above three attributes and values are present.
+
+  **Step 5: Share the application's metadata URL**
+
+  1. Still on the **Set up Single Sign-On with SAML** page, find the **SAML Certificates** section.
+  1. Copy the **App Federation Metadata Url**, and reply to this email with it. This is the final piece of information we need to enable SAML.
+
+`}
+  </CopyableMarkdown>
+
+  ## Add App Federation Metadata URL in the Dashboard
+
+  Now that you know the Microsoft app's **App Federation Metadata URL**, you can add it to the Clerk connection, completing the SAML connection configuration.
+
   1. Navigate back to the **Clerk Dashboard**. In the **Identity Provider Configuration** section, under **App Federation Metadata Url**, paste the **App Federation Metadata URL**.
   1. Select **Fetch & save**.
 
-  ## Map Microsoft claims to Clerk attributes
-
-  Mapping the claims in your IdP to the attributes in Clerk ensures that the data from your IdP is correctly mapped to the data in Clerk.
-
-  | Clerk attribute | Microsoft claim |
-  | - | - |
-  | `mail` | `user.userprincipalname` |
-  | `firstName` | `user.givenname` |
-  | `lastName` | `user.surname` |
-
-  The only Microsoft claim that is necessary to map is the email address claim. This is the email address that your users will use to authenticate into your app.
-
-  1. On the **Set up Single Sign-On with SAML** page, find the **Attributes & Claims** section.
-  1. Select **Edit**.
-  1. To edit the email claim, select the claim with the claim name ending with `/claims/emailaddress`. You'll be redirected to the **Manage claim** page.
-  1. Next to **Source attribute**, search for and select `user.userprincipalname` in the dropdown.
-  1. Select **Save** at the top of the page.
-
   ## Enable the connection in Clerk
 
-  <Include src="_partials/authentication/saml/enable-connection" />
+  The SAML connection is ready to enable! Once enabled, all users with email addresses ending in the domain will be redirected to the IDP at sign-in and sign-up.
+
+  > [!WARNING]
+  > If there are existing users with email domains that match the SAML connection, and there is an error in the SAML configuration in Clerk or Microsoft, those users will be **unable to sign in** when the connection is enabled. If this is a concern, we recommend coordinating with your counterpart to test the connection at an off-peak time.
+
+  To make the connection available for users of that IDP to authenticate with:
+
+  1. Navigate back to the Clerk Dashboard where you should still have the connection's configuration page open. If not, navigate to the SSO connections page and select the connection.
+  1. At the top of the page, toggle on Enable connection and select Save.
+
 </Steps>

--- a/docs/authentication/enterprise-connections/saml/azure.mdx
+++ b/docs/authentication/enterprise-connections/saml/azure.mdx
@@ -24,7 +24,7 @@ description: Learn how to allow users to sign up and sign in to your Clerk app w
 
 Enabling SAML with Microsoft Azure Entra ID (formerly [Active Directory](https://learn.microsoft.com/en-us/entra/fundamentals/new-name)) allows your users to sign up and sign in to your Clerk application with their Microsoft account.
 
-This process requires configuration changes in both the Clerk dashboard, and in your customer's Microsoft Entra ID settings in their Azure account.
+This process requires configuration changes in both the Clerk Dashboard, and in your customer's Microsoft Entra ID settings in their Azure account.
 
 <Steps>
   ## Create a Microsoft Entra ID SAML connection in Clerk
@@ -110,7 +110,7 @@ This process requires configuration changes in both the Clerk dashboard, and in 
 
     1. Still on the **Set up Single Sign-On with SAML** page, find the **Attributes & Claims** section.
     1. Select **Edit**.
-    1  Verify that the above three attributes and values are present.
+    1. Verify that the above three attributes and values are present.
 
     **Step 5: Share the application's metadata URL**
 
@@ -121,9 +121,11 @@ This process requires configuration changes in both the Clerk dashboard, and in 
 
   ## Add App Federation Metadata URL in the Dashboard
 
-  Now that you know the Microsoft app's **App Federation Metadata URL**, you can add it to the Clerk connection, completing the SAML connection configuration.
+  After following the instructions in the email, your customer should have sent you the Microsoft app's **App Federation Metadata URL**. Now, you're going to add it to the Clerk connection, completing the SAML connection configuration.
 
-  1. Navigate back to the **Clerk Dashboard**. In the **Identity Provider Configuration** section, under **App Federation Metadata Url**, paste the **App Federation Metadata URL**.
+  1. Navigate to the [**SSO connections**](https://dashboard.clerk.com/last-active?path=user-authentication/sso-connections) page in the Clerk Dashboard. 
+  1. Select the SAML connection.
+  1. In the **Identity Provider Configuration** section, under **App Federation Metadata Url**, paste the **App Federation Metadata URL**.
   1. Select **Fetch & save**.
 
   ## Enable the connection in Clerk
@@ -135,7 +137,7 @@ This process requires configuration changes in both the Clerk dashboard, and in 
 
   To make the connection available for users of that IDP to authenticate with:
 
-  1. Navigate back to the Clerk Dashboard where you should still have the connection's configuration page open. If not, navigate to the SSO connections page and select the connection.
-  1. At the top of the page, toggle on Enable connection and select Save.
+  1. Navigate back to the Clerk Dashboard where you should still have the connection's configuration page open. If not, navigate to the [**SSO connections**](https://dashboard.clerk.com/last-active?path=user-authentication/sso-connections) page and select the connection.
+  1. At the top of the page, toggle on **Enable connection** and select **Save**.
 
 </Steps>


### PR DESCRIPTION
Preview: https://clerk.com/docs/pr/2112

## What problem does this solve?

Here's how configuring SAML usually works:

1. An App Owner begins to onboard a new enterprise, and is put in touch with the enterprise's IT Admin
2. The App Owner creates the saml connection, and shares the Entity ID and Reply URL with the IT Admin via an email, along with more instructions
3. The IT admin follows those instructions, and responds via email with a metadata url
4. The App owner adds the metadata URL, and then coordinates on a time with the IT admin to enable and test the connection

Our docs today don't reflect that reality. They presume the the reader has simultaneous access to Clerk and the Microsoft IDP. As such, an application owner reading our docs needs to understand them deeply enough to re-write them into an email suitable for the IT-admin's consumption. This is time consuming and painful, because the App owner wants to avoid needing to internalize the nitty-gritty details of SAML - that's why they have Clerk!

## What changed?

This rewrites the docs with the two above personas in mind.

The Application Owner is the primary reader, with access to Clerk. The instructions for the IT Admin (with access to Azure) are encapsulated in an email template.

## Did any of the actual instructions change?

In running through the tutorial, I also made a few tweaks and fixes.

The biggest change is in the attribute mapping section. Right now, we're instructing the user to set the email attribute to contain the userprincipalname, which I think is flatly incorrect:

https://github.com/clerk/clerk-docs/blob/ae2b5a3b7017514438719aa5f0c97a7d6b51dc50/docs/authentication/enterprise-connections/saml/azure.mdx?plain=1#L93-L94

And we don't acknowledge that the default attribute mappings are likely the correct ones and don't need to be modified. 

## What needs to happen before merging?

You may have noticed: the email template looks terrible in the browser. I introduced a new component for the template in a separate PR to this repo's parent, which introduces a copy button. Try clicking that copy button and pasting into a new email - that should look great! 

I'm not sure why the markdown renders so badly on the browser. It probably needs to be fixed in the component definition on the parent repo. but fix it we must before merging this.

## Stretch goals

You'll notice that the email template contains placeholders. It would be very sweet if we could automatically fetch those values and fill them! I'm willing to build the APIs necessary to make that happen if you're willing to wire them into this page 😆 .