### PR TITLE
chore: remove requirement to enable native API during development

### DIFF
--- a/docs/quickstarts/chrome-extension.mdx
+++ b/docs/quickstarts/chrome-extension.mdx
@@ -26,16 +26,10 @@ description: Add authentication and user management to your Chrome Extension wit
   - Build, load, and test your Chrome Extension
 </TutorialHero>
 
+> [!NOTE]
+> Ensure that the Native API is enabled to integrate Clerk in your native application. In the Clerk Dashboard, navigate to the [**Native Applications**](https://dashboard.clerk.com/last-active?path=/native-applications) page.
+
 <Steps>
-  ## Enable the Native API
-
-  The Native API is disabled by default for all Clerk instances.
-
-  To enable the Native API:
-
-  1. In the Clerk Dashboard, navigate to the [**Native Applications**](https://dashboard.clerk.com/last-active?path=/native-applications) page.
-  1. Enable the **Native API**.
-
   ## Configure your authentication options
 
   When creating your Clerk application in the Clerk Dashboard, your authentication options will depend on how you configure your Chrome Extension. Chrome Extensions can be used as a popup, a side panel, or in conjunction with a web app. Popups and side panels have limited authentication options. [Learn more about what options are available.](/docs/references/chrome-extension/overview#authenication-options)

--- a/docs/quickstarts/expo.mdx
+++ b/docs/quickstarts/expo.mdx
@@ -30,16 +30,10 @@ description: Add authentication and user management to your Expo app with Clerk.
   - Use Clerk hooks to enable users to sign in and out
 </TutorialHero>
 
+> [!NOTE]
+> Ensure that the Native API is enabled to integrate Clerk in your native application. In the Clerk Dashboard, navigate to the [**Native Applications**](https://dashboard.clerk.com/last-active?path=/native-applications) page.
+
 <Steps>
-  ## Enable the Native API
-
-  The Native API is disabled by default for all Clerk instances.
-
-  To enable the Native API:
-
-  1. In the Clerk Dashboard, navigate to the [**Native Applications**](https://dashboard.clerk.com/last-active?path=/native-applications) page.
-  1. Enable the **Native API**.
-
   ## Install `@clerk/clerk-expo`
 
   The [Clerk Expo SDK](/docs/references/expo/overview) gives you access to prebuilt components, hooks, and helpers to make user authentication easier.

--- a/docs/quickstarts/ios.mdx
+++ b/docs/quickstarts/ios.mdx
@@ -18,16 +18,10 @@ description: Add authentication and user management to your iOS app with Clerk.
   - Use Clerk to enable users to sign in and out of your application
 </TutorialHero>
 
+> [!NOTE]
+> Ensure that the Native API is enabled to integrate Clerk in your native application. In the Clerk Dashboard, navigate to the [**Native Applications**](https://dashboard.clerk.com/last-active?path=/native-applications) page.
+
 <Steps>
-  ## Enable the Native API
-
-  The Native API is disabled by default for all Clerk instances.
-
-  To enable the Native API:
-
-  1. In the Clerk Dashboard, navigate to the [**Native Applications**](https://dashboard.clerk.com/last-active?path=/native-applications) page.
-  1. Enable the **Native API**.
-
   ## Create an iOS Project
 
   To get started using Clerk with iOS, create a new project in Xcode. Select SwiftUI as your interface and Swift as your language.


### PR DESCRIPTION
### What does this solve?

- Previously customers had to enable the native API before they could integrate with their native application. This is no longer necessary as it is enabled by default for development instances.

### What changed?

- Remove the step in favor of a callout to enable the Native API

### Checklist

- [X] I have clicked on "Files changed" and performed a thorough self-review
- [X] I have added the "deploy-preview" label and added the preview link(s) to this PR description
- [X] All existing checks pass
