### PR TITLE
docs(expo): Remove remaining `<ClerkLoaded>` usage from Expo docs

### DIFF
--- a/docs/references/expo/offline-support.mdx
+++ b/docs/references/expo/offline-support.mdx
@@ -49,7 +49,7 @@ To enable offline support in your Expo app, follow these steps:
   On [`<ClerkProvider>`](/docs/components/clerk-provider), pass the `secureStore` object to the `__experimental_resourceCache` property, as shown in the following example:
 
   ```tsx {{ filename: 'app/_layout.tsx', mark: [4, [14, 18]] }}
-  import { ClerkProvider, ClerkLoaded } from '@clerk/clerk-expo'
+  import { ClerkProvider } from '@clerk/clerk-expo'
   import { Slot } from 'expo-router'
   import { tokenCache } from '../token-cache'
   import { secureStore } from '@clerk/clerk-expo/secure-store'
@@ -67,9 +67,7 @@ To enable offline support in your Expo app, follow these steps:
         tokenCache={tokenCache}
         __experimental_resourceCache={secureStore}
       >
-        <ClerkLoaded>
-          <Slot />
-        </ClerkLoaded>
+        <Slot />
       </ClerkProvider>
     )
   }

--- a/docs/references/expo/passkeys.mdx
+++ b/docs/references/expo/passkeys.mdx
@@ -180,7 +180,7 @@ description: Learn how to configure passkeys for your Expo application.
 
   ```tsx {{ filename: 'app/_layout.tsx', mark: [3, 17] }}
   import { tokenCache } from '@/cache'
-  import { ClerkProvider, ClerkLoaded } from '@clerk/clerk-expo'
+  import { ClerkProvider } from '@clerk/clerk-expo'
   import { passkeys } from '@clerk/clerk-expo/passkeys'
   import { Slot } from 'expo-router'
 
@@ -197,9 +197,7 @@ description: Learn how to configure passkeys for your Expo application.
         publishableKey={publishableKey}
         __experimental_passkeys={passkeys}
       >
-        <ClerkLoaded>
-          <Slot />
-        </ClerkLoaded>
+        <Slot />
       </ClerkProvider>
     )
   }


### PR DESCRIPTION
### 🔎 Previews:

- https://clerk.com/docs/pr/2114/references/expo/passkeys#update-your-clerk-provider
- https://clerk.com/docs/pr/2114/references/expo/offline-support#use-the-experimental-resource-cache-property-on-clerk-provider

### What does this solve?

- We removed the usage of `<ClerkLoaded>` in the quickstart in #2103. We left some in the Expo guides 😆 

### What changed?

- Removed `<ClerkLoaded>` usage in the offline support and passkey guides of Expo docs

### Checklist

- [x] I have clicked on "Files changed" and performed a thorough self-review
- [x] I have added the "deploy-preview" label and added the preview link(s) to this PR description
- [x] All existing checks pass
