### PR TITLE
iOS: add state annotation to quick start clerk reference

### DIFF
--- a/docs/quickstarts/ios.mdx
+++ b/docs/quickstarts/ios.mdx
@@ -55,7 +55,7 @@ description: Add authentication and user management to your iOS app with Clerk.
 
   @main
   struct ClerkQuickstartApp: App {
-    private var clerk = Clerk.shared
+    @State private var clerk = Clerk.shared
 
     var body: some Scene {
       WindowGroup {


### PR DESCRIPTION
### 🔎 Previews:

- https://clerk.com/docs/pr/2115/quickstarts/ios

### What changed?

- Adding `@State` annotation to the clerk reference in the quick start for clarity.

### Checklist

- [x] I have clicked on "Files changed" and performed a thorough self-review
- [x] I have added the "deploy-preview" label and added the preview link(s) to this PR description
- [x] All existing checks pass
