### PR TITLE
remove usage of the oauth prefix in getUserOauthAccessToken

### DIFF
--- a/docs/authentication/social-connections/overview.mdx
+++ b/docs/authentication/social-connections/overview.mdx
@@ -98,7 +98,7 @@ export async function GET() {
   }
 
   // Get the OAuth access token for the user
-  const provider = 'oauth_notion'
+  const provider = 'notion'
 
   const client = await clerkClient()
 

--- a/docs/references/backend/user/get-user-oauth-access-token.mdx
+++ b/docs/references/backend/user/get-user-oauth-access-token.mdx
@@ -10,7 +10,7 @@ Retrieve the corresponding OAuth access token for a user that has previously aut
 ```ts
 function getUserOauthAccessToken(
   userId: string,
-  provider: `oauth_${OAuthProvider}`,
+  provider: `${OAuthProvider}`,
 ): Promise<OauthAccessToken[]>
 ```
 
@@ -25,9 +25,9 @@ function getUserOauthAccessToken(
   ---
 
   - `provider`
-  - <code>oauth\_$\{[OAuthProvider](/docs/references/javascript/types/sso#o-auth-provider)}</code>
+  - <code>$\{[OAuthProvider](/docs/references/javascript/types/sso#o-auth-provider)}</code>
 
-  The OAuth provider to retrieve the access token for. If using a custom OAuth provider, prefix the provider name with `oauth_custom_` (e.g., `oauth_custom_foo`).
+  The OAuth provider to retrieve the access token for. If using a custom OAuth provider, prefix the provider name with `custom_` (e.g., `custom_foo`).
 </Properties>
 
 ## Example
@@ -37,7 +37,7 @@ function getUserOauthAccessToken(
 ```tsx
 const userId = 'user_123'
 
-const provider = 'oauth_google'
+const provider = 'google'
 
 const response = await clerkClient.users.getUserOauthAccessToken(userId, provider)
 ```


### PR DESCRIPTION
Reflects changes made in https://github.com/clerk/javascript/pull/5097
