### PR TITLE
fix: use `role` in public metadata example (to be consistent)

### DIFF
--- a/docs/users/metadata.mdx
+++ b/docs/users/metadata.mdx
@@ -196,7 +196,7 @@ Public metadata is accessible by both the frontend and the backend, but can only
 
       await clerkClient.users.updateUserMetadata(userId, {
         publicMetadata: {
-          role
+          role,
         },
       })
 

--- a/docs/users/metadata.mdx
+++ b/docs/users/metadata.mdx
@@ -192,11 +192,11 @@ Public metadata is accessible by both the frontend and the backend, but can only
   <Tab>
     ```ts {{ filename: 'route.ts' }}
     export async function POST(req) {
-      const { stripeId, userId } = await req.json()
+      const { role, userId } = await req.json()
 
       await clerkClient.users.updateUserMetadata(userId, {
         publicMetadata: {
-          stripeId: stripeId,
+          role
         },
       })
 


### PR DESCRIPTION
I believe the intention here was to use `role` as an example of public metadata, and that using the `stripeId` was a copy/paste mistake from the private metadata example.
