### PR TITLE
update ios email sms otp example code

### DIFF
--- a/docs/custom-flows/email-sms-otp.mdx
+++ b/docs/custom-flows/email-sms-otp.mdx
@@ -586,7 +586,7 @@ This guide will walk you through how to build a custom SMS OTP sign-up and sign-
             // Find the phoneNumberId from all the available first factors for the current sign-in
             guard
               let phoneNumberFactor = signIn.supportedFirstFactors?.first(where: { factor in
-                factor.strategy == "phone_code"
+                factor.strategy == "phone_code" && factor.safeIdentifier == signIn.identifier
               }),
               let phoneNumberId = phoneNumberFactor.phoneNumberId
             else {


### PR DESCRIPTION
### 🔎 Previews:

- https://clerk.com/docs/pr/2126/custom-flows/email-sms-otp#sign-in-flow

### What does this solve?

- If a user has more than one phone number, the docs would have just grabbed the first one. This makes sure it grabs the phone number used to initiate the sign in flow.

### What changed?

- Adds additional filter when pulling the phone code factor.

### Checklist

- [x] I have clicked on "Files changed" and performed a thorough self-review
- [x] I have added the "deploy-preview" label and added the preview link(s) to this PR description
- [x] All existing checks pass
