### PR TITLE
docs(expo): Remove publishable key checks

### DIFF
--- a/docs/components/clerk-provider.mdx
+++ b/docs/components/clerk-provider.mdx
@@ -74,14 +74,8 @@ The recommended approach is to wrap your entire app with `<ClerkProvider>` at th
     import { Slot } from 'expo-router'
 
     export default function Layout() {
-      const publishableKey = process.env.EXPO_PUBLIC_CLERK_PUBLISHABLE_KEY
-
-      if (publishableKey === undefined) {
-        throw new Error('Add EXPO_PUBLIC_CLERK_PUBLISHABLE_KEY to your .env file')
-      }
-
       return (
-        <ClerkProvider publishableKey={publishableKey}>
+        <ClerkProvider>
           <Slot />
         </ClerkProvider>
       )

--- a/docs/quickstarts/expo.mdx
+++ b/docs/quickstarts/expo.mdx
@@ -89,7 +89,7 @@ description: Add authentication and user management to your Expo app with Clerk.
   import { Slot } from 'expo-router'
 
   export default function RootLayout() {
-    const publishableKey = process.env.EXPO_PUBLIC_CLERK_PUBLISHABLE_KEY!
+    const publishableKey = process.env.EXPO_PUBLIC_CLERK_PUBLISHABLE_KEY
 
     return (
       <ClerkProvider publishableKey={publishableKey}>
@@ -131,7 +131,7 @@ description: Add authentication and user management to your Expo app with Clerk.
      import { Slot } from 'expo-router'
 
      export default function RootLayout() {
-       const publishableKey = process.env.EXPO_PUBLIC_CLERK_PUBLISHABLE_KEY!
+       const publishableKey = process.env.EXPO_PUBLIC_CLERK_PUBLISHABLE_KEY
 
        return (
          <ClerkProvider tokenCache={tokenCache} publishableKey={publishableKey}>

--- a/docs/quickstarts/expo.mdx
+++ b/docs/quickstarts/expo.mdx
@@ -89,10 +89,8 @@ description: Add authentication and user management to your Expo app with Clerk.
   import { Slot } from 'expo-router'
 
   export default function RootLayout() {
-    const publishableKey = process.env.EXPO_PUBLIC_CLERK_PUBLISHABLE_KEY
-
     return (
-      <ClerkProvider publishableKey={publishableKey}>
+      <ClerkProvider>
         <Slot />
       </ClerkProvider>
     )
@@ -125,16 +123,14 @@ description: Add authentication and user management to your Expo app with Clerk.
        ```
      </CodeBlockTabs>
   1. Update your root layout to use the secure token cache:
-     ```tsx {{ filename: 'app/_layout.tsx', mark: [2, 9] }}
+     ```tsx {{ filename: 'app/_layout.tsx', mark: [2, 7] }}
      import { ClerkProvider } from '@clerk/clerk-expo'
      import { tokenCache } from '@clerk/clerk-expo/token-cache'
      import { Slot } from 'expo-router'
 
      export default function RootLayout() {
-       const publishableKey = process.env.EXPO_PUBLIC_CLERK_PUBLISHABLE_KEY
-
        return (
-         <ClerkProvider tokenCache={tokenCache} publishableKey={publishableKey}>
+         <ClerkProvider tokenCache={tokenCache}>
            <Slot />
          </ClerkProvider>
        )

--- a/docs/quickstarts/expo.mdx
+++ b/docs/quickstarts/expo.mdx
@@ -91,10 +91,6 @@ description: Add authentication and user management to your Expo app with Clerk.
   export default function RootLayout() {
     const publishableKey = process.env.EXPO_PUBLIC_CLERK_PUBLISHABLE_KEY!
 
-    if (!publishableKey) {
-      throw new Error('Add EXPO_PUBLIC_CLERK_PUBLISHABLE_KEY to your .env file')
-    }
-
     return (
       <ClerkProvider publishableKey={publishableKey}>
         <Slot />
@@ -129,17 +125,13 @@ description: Add authentication and user management to your Expo app with Clerk.
        ```
      </CodeBlockTabs>
   1. Update your root layout to use the secure token cache:
-     ```tsx {{ filename: 'app/_layout.tsx', mark: [2, 13] }}
+     ```tsx {{ filename: 'app/_layout.tsx', mark: [2, 9] }}
      import { ClerkProvider } from '@clerk/clerk-expo'
      import { tokenCache } from '@clerk/clerk-expo/token-cache'
      import { Slot } from 'expo-router'
 
      export default function RootLayout() {
        const publishableKey = process.env.EXPO_PUBLIC_CLERK_PUBLISHABLE_KEY!
-
-       if (!publishableKey) {
-         throw new Error('Add EXPO_PUBLIC_CLERK_PUBLISHABLE_KEY in your .env')
-       }
 
        return (
          <ClerkProvider tokenCache={tokenCache} publishableKey={publishableKey}>

--- a/docs/references/expo/offline-support.mdx
+++ b/docs/references/expo/offline-support.mdx
@@ -48,7 +48,7 @@ To enable offline support in your Expo app, follow these steps:
 
   On [`<ClerkProvider>`](/docs/components/clerk-provider), pass the `resourceCache` object to the `__experimental_resourceCache` property, as shown in the following example:
 
-  ```tsx {{ filename: 'app/_layout.tsx', mark: [4, 17] }}
+  ```tsx {{ filename: 'app/_layout.tsx', mark: [4, 13] }}
   import { ClerkProvider } from '@clerk/clerk-expo'
   import { Slot } from 'expo-router'
   import { tokenCache } from '@clerk/clerk-expo/token-cache'
@@ -56,10 +56,6 @@ To enable offline support in your Expo app, follow these steps:
 
   export default function RootLayout() {
     const publishableKey = process.env.EXPO_PUBLIC_CLERK_PUBLISHABLE_KEY!
-
-    if (!publishableKey) {
-      throw new Error('Add EXPO_PUBLIC_CLERK_PUBLISHABLE_KEY to your .env file')
-    }
 
     return (
       <ClerkProvider

--- a/docs/references/expo/offline-support.mdx
+++ b/docs/references/expo/offline-support.mdx
@@ -48,7 +48,7 @@ To enable offline support in your Expo app, follow these steps:
 
   On [`<ClerkProvider>`](/docs/components/clerk-provider), pass the `resourceCache` object to the `__experimental_resourceCache` property, as shown in the following example:
 
-  ```tsx {{ filename: 'app/_layout.tsx', mark: [4, 10] }}
+  ```tsx {{ filename: 'app/_layout.tsx', mark: [4, 8] }}
   import { ClerkProvider } from '@clerk/clerk-expo'
   import { Slot } from 'expo-router'
   import { tokenCache } from '@clerk/clerk-expo/token-cache'
@@ -56,10 +56,7 @@ To enable offline support in your Expo app, follow these steps:
 
   export default function RootLayout() {
     return (
-      <ClerkProvider
-        tokenCache={tokenCache}
-        __experimental_resourceCache={resourceCache}
-      >
+      <ClerkProvider tokenCache={tokenCache} __experimental_resourceCache={resourceCache}>
         <Slot />
       </ClerkProvider>
     )

--- a/docs/references/expo/offline-support.mdx
+++ b/docs/references/expo/offline-support.mdx
@@ -48,18 +48,15 @@ To enable offline support in your Expo app, follow these steps:
 
   On [`<ClerkProvider>`](/docs/components/clerk-provider), pass the `resourceCache` object to the `__experimental_resourceCache` property, as shown in the following example:
 
-  ```tsx {{ filename: 'app/_layout.tsx', mark: [4, 13] }}
+  ```tsx {{ filename: 'app/_layout.tsx', mark: [4, 10] }}
   import { ClerkProvider } from '@clerk/clerk-expo'
   import { Slot } from 'expo-router'
   import { tokenCache } from '@clerk/clerk-expo/token-cache'
   import { resourceCache } from '@clerk/clerk-expo/resource-cache'
 
   export default function RootLayout() {
-    const publishableKey = process.env.EXPO_PUBLIC_CLERK_PUBLISHABLE_KEY
-
     return (
       <ClerkProvider
-        publishableKey={publishableKey}
         tokenCache={tokenCache}
         __experimental_resourceCache={resourceCache}
       >

--- a/docs/references/expo/offline-support.mdx
+++ b/docs/references/expo/offline-support.mdx
@@ -55,7 +55,7 @@ To enable offline support in your Expo app, follow these steps:
   import { resourceCache } from '@clerk/clerk-expo/resource-cache'
 
   export default function RootLayout() {
-    const publishableKey = process.env.EXPO_PUBLIC_CLERK_PUBLISHABLE_KEY!
+    const publishableKey = process.env.EXPO_PUBLIC_CLERK_PUBLISHABLE_KEY
 
     return (
       <ClerkProvider

--- a/docs/references/expo/passkeys.mdx
+++ b/docs/references/expo/passkeys.mdx
@@ -185,7 +185,7 @@ description: Learn how to configure passkeys for your Expo application.
   import { passkeys } from '@clerk/clerk-expo/passkeys'
 
   export default function RootLayout() {
-    const publishableKey = process.env.EXPO_PUBLIC_CLERK_PUBLISHABLE_KEY!
+    const publishableKey = process.env.EXPO_PUBLIC_CLERK_PUBLISHABLE_KEY
 
     return (
       <ClerkProvider

--- a/docs/references/expo/passkeys.mdx
+++ b/docs/references/expo/passkeys.mdx
@@ -178,15 +178,13 @@ description: Learn how to configure passkeys for your Expo application.
 
   Pass the `passkeys` object to the `__experimental_passkeys` property of your `<ClerkProvider>` component, as shown in the following example:
 
-  ```tsx {{ filename: 'app/_layout.tsx', mark: [4, 13] }}
+  ```tsx {{ filename: 'app/_layout.tsx', mark: [4, 11] }}
   import { ClerkProvider } from '@clerk/clerk-expo'
   import { Slot } from 'expo-router'
   import { tokenCache } from '@clerk/clerk-expo/token-cache'
   import { passkeys } from '@clerk/clerk-expo/passkeys'
 
   export default function RootLayout() {
-    const publishableKey = process.env.EXPO_PUBLIC_CLERK_PUBLISHABLE_KEY
-
     return (
       <ClerkProvider
         tokenCache={tokenCache}

--- a/docs/references/expo/passkeys.mdx
+++ b/docs/references/expo/passkeys.mdx
@@ -178,7 +178,7 @@ description: Learn how to configure passkeys for your Expo application.
 
   Pass the `passkeys` object to the `__experimental_passkeys` property of your `<ClerkProvider>` component, as shown in the following example:
 
-  ```tsx {{ filename: 'app/_layout.tsx', mark: [4, 17] }}
+  ```tsx {{ filename: 'app/_layout.tsx', mark: [4, 13] }}
   import { ClerkProvider } from '@clerk/clerk-expo'
   import { Slot } from 'expo-router'
   import { tokenCache } from '@clerk/clerk-expo/token-cache'
@@ -186,10 +186,6 @@ description: Learn how to configure passkeys for your Expo application.
 
   export default function RootLayout() {
     const publishableKey = process.env.EXPO_PUBLIC_CLERK_PUBLISHABLE_KEY!
-
-    if (!publishableKey) {
-      throw new Error('Add EXPO_PUBLIC_CLERK_PUBLISHABLE_KEY in your .env')
-    }
 
     return (
       <ClerkProvider


### PR DESCRIPTION
### 🔎 Previews:

- https://clerk.com/docs/pr/2127/quickstarts/expo#add-clerk-provider-to-your-root-layout
- https://clerk.com/docs/pr/2127/quickstarts/expo#configure-the-token-cache
- https://clerk.com/docs/pr/2127/references/expo/passkeys#update-your-clerk-provider
- https://clerk.com/docs/pr/2127/references/expo/offline-support#use-the-experimental-resource-cache-property-on-clerk-provider
- https://clerk.com/docs/pr/2127/components/clerk-provider

### What does this solve?

- We already handle the `EXPO_PUBLIC_CLERK_PUBLISHABLE_KEY` environment variable check at runtime. See https://github.com/clerk/javascript/pull/5399.

### What changed?

- Removes the steps where we check for `EXPO_PUBLIC_CLERK_PUBLISHABLE_KEY` and pass it to the `<ClerkProvider>`. We do this at runtime already 👍🏼 

### Checklist

- [x] I have clicked on "Files changed" and performed a thorough self-review
- [x] I have added the "deploy-preview" label and added the preview link(s) to this PR description
- [x] All existing checks pass
