### PR TITLE
Update workflows to remove `deploy-preview` label

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -13,5 +13,4 @@
 ### Checklist
 
 - [ ] I have clicked on "Files changed" and performed a thorough self-review
-- [ ] I have added the "deploy-preview" label and added the preview link(s) to this PR description
 - [ ] All existing checks pass

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -6,24 +6,16 @@ env:
 
 on:
   pull_request:
-    types: [labeled, unlabeled]
+    types: [opened]
 
 jobs:
   pr_preview:
-    if: ${{ github.event.label.name == 'deploy-preview' }}
+    if: ${{ github.event.pull_request.head.repo.owner.login == 'clerk' }}
     runs-on: ubuntu-latest
     permissions:
       pull-requests: write
     steps:
-      - name: Revalidate PR preview
-        run: |
-          curl -X POST ${{ env.API_BASE_URL }}/docs/revalidate \
-            -H "Content-Type: application/json" \
-            -H "Authorization: Bearer ${{ secrets.REVALIDATE_DOCS_SECRET }}" \
-            -d "{\"tags\": [\"docs:pr:${{ github.event.pull_request.number }}\"]}"
-
       - name: Share PR preview URL
-        if: ${{ github.event.action == 'labeled' }}
         uses: actions/github-script@v7
         with:
           script: |

--- a/.github/workflows/revalidate.yml
+++ b/.github/workflows/revalidate.yml
@@ -11,8 +11,7 @@ on:
 
 jobs:
   revalidate:
-    # skip if `deploy-preview` label has not been added
-    if: ${{ contains(github.event.pull_request.labels.*.name, 'deploy-preview') }}
+    if: ${{ github.event.pull_request.head.repo.owner == 'clerk' }}
     runs-on: ubuntu-latest
     steps:
       - name: Trigger revalidate


### PR DESCRIPTION
This PR updates the preview workflows to account for https://github.com/clerk/clerk/pull/1087 – please check out that PR for more info

- Share the preview URL when a first-party PR is _opened_ (replaces "_(un)labeled_")
- Revalidate the preview when a first-party PR is updated (via `synchronize` event)
- Remove `deploy-preview` label reference in pull request template

> [!IMPORTANT]
> ~We should merge https://github.com/clerk/clerk/pull/1087 first~ ✅ 