### PR TITLE
Update`useClerk()` warning message

### DIFF
--- a/docs/hooks/use-clerk.mdx
+++ b/docs/hooks/use-clerk.mdx
@@ -4,7 +4,7 @@ description: Access and manage the Clerk object in your React application with C
 ---
 
 > [!WARNING]
-> This composable should only be used for advanced use cases, such as building a completely custom OAuth flow or as an escape hatch to access to the `Clerk` object.
+> This hook should only be used for advanced use cases, such as building a completely custom OAuth flow or as an escape hatch to access to the `Clerk` object.
 
 The `useClerk()` hook provides access to the [`Clerk`](/docs/references/javascript/clerk) object, allowing you to build alternatives to any Clerk Component.
 


### PR DESCRIPTION
### 🔎 Previews:

-

### What does this solve?

- The warning was probably copy pasted, but wasn't updated to reflect this hook is used in a react environment instead of vue

### What changed?

- changed `composable` to `hook`

### Checklist

- [x] I have clicked on "Files changed" and performed a thorough self-review
- [ ] All existing checks pass
