### PR TITLE
Added clarity on JWT console command for postman-or-insomnia.mdx

### DIFF
--- a/docs/testing/postman-or-insomnia.mdx
+++ b/docs/testing/postman-or-insomnia.mdx
@@ -22,6 +22,7 @@ Give your template a unique name, such as _'testing-template'_. Set the **Token 
 Visit your frontend that is using the same Clerk Application and instance that you want to test. Sign in as a user. The user that you sign in as will be the user you test with in Postman or Insomnia. You can create several tokens for several different users. Once you have signed in, open your Dev Tools and go to the **Console** tab. Enter the following command:
 
 ```js
+// Make sure that you are using the correct user credentials or organization in clerk.dashboard.com when using the command in console.
 await window.Clerk.session.getToken({ template: '<the template name you chose above>' })
 ```
 


### PR DESCRIPTION
### 🔎 Previews:

-

### What does this solve?

Added more information on how to run the command properly (prerequisite and clarity for running the code). 

### What changed?

In the js command, I added some text to clarify if a user would not be getting the JWT because they are using the wrong credentials and not in their respective account to pull the token to be used in Postman or Insomnia.

### Checklist

- [x] I have clicked on "Files changed" and performed a thorough self-review
- [x] All existing checks pass
