### PR TITLE
Fix preview revalidation workflow condition

### DIFF
--- a/.github/workflows/revalidate.yml
+++ b/.github/workflows/revalidate.yml
@@ -11,7 +11,7 @@ on:
 
 jobs:
   revalidate:
-    if: ${{ github.event.pull_request.head.repo.owner == 'clerk' }}
+    if: ${{ github.event.pull_request.head.repo.owner.login == 'clerk' }}
     runs-on: ubuntu-latest
     steps:
       - name: Trigger revalidate


### PR DESCRIPTION
Fixes the branch owner check in `.github/workflows/revalidate.yml` to ensure the preview revalidation runs on PR synchronise.