### PR TITLE
(changing-domains) change callout from note to warning

### DIFF
--- a/docs/deployments/changing-domains.mdx
+++ b/docs/deployments/changing-domains.mdx
@@ -5,7 +5,7 @@ description: Learn how to change your Clerk production instance's domain or subd
 
 Learn how to change your Clerk production instance's domain or subdomain.
 
-> [!NOTE]
+> [!WARNING]
 > You cannot change the domain of the [development instance](/docs/deployments/environments#development-instance) of your Clerk application.
 
 ## Change domain
@@ -22,7 +22,7 @@ Learn how to change your Clerk production instance's domain or subdomain.
 
 ### Update your domain via Clerk Dashboard
 
-To update your production domain in the Clerk Dashboard:
+To update your **production** domain in the Clerk Dashboard:
 
 1. In the navigation sidenav, select **[Domains](https://dashboard.clerk.com/last-active?path=domains)**.
 1. Select the **Danger** tab.


### PR DESCRIPTION
A user is confused on why they can't see the "Danger" tab in the Domains section of the Dash.
It's because they're trying to change their Clerk provisioned domain (dev instance), which is not allowed.

### Checklist

- [x] I have clicked on "Files changed" and performed a thorough self-review
- [x] All existing checks pass
