### PR TITLE
(clerkloaded, clerkloading) do not wrap app

### DIFF
--- a/docs/components/control/clerk-loaded.mdx
+++ b/docs/components/control/clerk-loaded.mdx
@@ -7,6 +7,8 @@ The `<ClerkLoaded>` component guarantees that the Clerk object has loaded and wi
 
 ## Usage
 
+It's not recommended to wrap the entire app in the `<ClerkLoaded>` component; instead, only wrap the components that need access to the `Clerk` object.
+
 <Tabs items={["Next.js", "React", "Remix", "Expo"]}>
   <Tab>
     <Tabs items={["App Router", "Pages Router"]}>

--- a/docs/components/control/clerk-loaded.mdx
+++ b/docs/components/control/clerk-loaded.mdx
@@ -11,68 +11,33 @@ The `<ClerkLoaded>` component guarantees that the Clerk object has loaded and wi
   <Tab>
     <Tabs items={["App Router", "Pages Router"]}>
       <Tab>
-        ```tsx {{ filename: 'app/layout.tsx' }}
-        import { ClerkProvider, ClerkLoaded, ClerkLoading } from '@clerk/nextjs'
-        import './globals.css'
-
-        export default function RootLayout({ children }: { children: React.ReactNode }) {
-          return (
-            <ClerkProvider>
-              <html lang="en">
-                <body>
-                  <ClerkLoaded>{children}</ClerkLoaded>
-                </body>
-              </html>
-            </ClerkProvider>
-          )
-        }
-        ```
-
-        Once you have wrapped your app with `<ClerkLoaded>`, you can access the `Clerk` object without the need to check if it exists.
-
         ```tsx {{ filename: 'app/page.tsx' }}
-        declare global {
-          interface Window {
-            Clerk: any
-          }
-        }
+        import { ClerkLoaded } from '@clerk/nextjs'
 
-        export default function Home() {
-          return <div>This page uses Clerk {window.Clerk.version}; </div>
+        export default function Page() {
+          return (
+            <ClerkLoaded>
+              <div>Clerk has loaded and is available under window.Clerk</div>
+              <p>Clerk version: {window.Clerk.version}</p>
+              <MyCustomSignInFlow />
+            </ClerkLoaded>
+          )
         }
         ```
       </Tab>
 
       <Tab>
-        ```tsx {{ filename: 'pages/_app.tsx' }}
-        import '@/styles/globals.css'
-        import { ClerkLoaded, ClerkProvider } from '@clerk/nextjs'
-        import { AppProps } from 'next/app'
-
-        function MyApp({ Component, pageProps }: AppProps) {
-          return (
-            <ClerkProvider {...pageProps}>
-              <ClerkLoaded>
-                <Component {...pageProps} />
-              </ClerkLoaded>
-            </ClerkProvider>
-          )
-        }
-
-        export default MyApp
-        ```
-
-        Once you have wrapped your app with `<ClerkLoaded>`, you can access the `Clerk` object without the need to check if it exists.
-
         ```tsx {{ filename: 'pages/index.tsx' }}
-        declare global {
-          interface Window {
-            Clerk: any
-          }
-        }
+        import { ClerkLoaded } from '@clerk/nextjs'
 
-        export default function Home() {
-          return <div>This page uses Clerk {window.Clerk.version}; </div>
+        export default function Page() {
+          return (
+            <ClerkLoaded>
+              <div>Clerk has loaded and is available under window.Clerk</div>
+              <p>Clerk version: {window.Clerk.version}</p>
+              <MyCustomSignInFlow />
+            </ClerkLoaded>
+          )
         }
         ```
       </Tab>
@@ -80,9 +45,8 @@ The `<ClerkLoaded>` component guarantees that the Clerk object has loaded and wi
   </Tab>
 
   <Tab>
-    ```tsx {{ filename: 'app.tsx' }}
-    import { useEffect } from 'react'
-    import { ClerkLoaded, ClerkProvider } from '@clerk/clerk-react'
+    ```tsx {{ filename: 'example.tsx' }}
+    import { ClerkLoaded } from '@clerk/clerk-react'
 
     declare global {
       interface Window {
@@ -90,26 +54,14 @@ The `<ClerkLoaded>` component guarantees that the Clerk object has loaded and wi
       }
     }
 
-    function App() {
+    export default function Example() {
       return (
-        <ClerkProvider publishableKey={`{{pub_key}}`}>
-          <ClerkLoaded>
-            <Page />
-          </ClerkLoaded>
-        </ClerkProvider>
+        <ClerkLoaded>
+          <div>Clerk has loaded and is available under window.Clerk</div>
+          <p>Clerk version: {window.Clerk.version}</p>
+        </ClerkLoaded>
       )
     }
-
-    function Page() {
-      useEffect(() => {
-        // no need to check if window.Clerk exists
-        document.title = 'This page uses Clerk ' + window.Clerk.version
-      }, [])
-
-      return <div>The content </div>
-    }
-
-    export default App
     ```
   </Tab>
 
@@ -117,12 +69,18 @@ The `<ClerkLoaded>` component guarantees that the Clerk object has loaded and wi
     ```tsx {{ filename: 'routes/index.tsx' }}
     import { ClerkLoaded } from '@clerk/remix'
 
+    declare global {
+      interface Window {
+        Clerk: any
+      }
+    }
+
     export default function Index() {
       return (
         <div>
           <ClerkLoaded>
-            <div>Clerk is loaded</div>
-            <p>{window.Clerk.version}</p>
+            <div>Clerk has loaded and is available under window.Clerk</div>
+            <p>Clerk version: {window.Clerk.version}</p>
           </ClerkLoaded>
         </div>
       )
@@ -139,8 +97,8 @@ The `<ClerkLoaded>` component guarantees that the Clerk object has loaded and wi
       return (
         <View>
           <ClerkLoaded>
-            <Text>Clerk is loaded</Text>
-            <Text>{window.Clerk?.version}</Text>
+            <Text>Clerk has loaded and is available under window.Clerk</Text>
+            <Text>Clerk version: {window.Clerk?.version}</Text>
           </ClerkLoaded>
         </View>
       )

--- a/docs/components/control/clerk-loaded.mdx
+++ b/docs/components/control/clerk-loaded.mdx
@@ -19,8 +19,7 @@ It's not recommended to wrap the entire app in the `<ClerkLoaded>` component; in
         export default function Page() {
           return (
             <ClerkLoaded>
-              <div>Clerk has loaded and is available under window.Clerk</div>
-              <p>Clerk version: {window.Clerk.version}</p>
+              <p>Clerk has loaded</p>
               <MyCustomSignInFlow />
             </ClerkLoaded>
           )
@@ -35,8 +34,7 @@ It's not recommended to wrap the entire app in the `<ClerkLoaded>` component; in
         export default function Page() {
           return (
             <ClerkLoaded>
-              <div>Clerk has loaded and is available under window.Clerk</div>
-              <p>Clerk version: {window.Clerk.version}</p>
+              <p>Clerk has loaded</p>
               <MyCustomSignInFlow />
             </ClerkLoaded>
           )
@@ -59,8 +57,7 @@ It's not recommended to wrap the entire app in the `<ClerkLoaded>` component; in
     export default function Example() {
       return (
         <ClerkLoaded>
-          <div>Clerk has loaded and is available under window.Clerk</div>
-          <p>Clerk version: {window.Clerk.version}</p>
+          <p>Clerk has loaded</p>
         </ClerkLoaded>
       )
     }
@@ -81,8 +78,7 @@ It's not recommended to wrap the entire app in the `<ClerkLoaded>` component; in
       return (
         <div>
           <ClerkLoaded>
-            <div>Clerk has loaded and is available under window.Clerk</div>
-            <p>Clerk version: {window.Clerk.version}</p>
+            <p>Clerk has loaded</p>
           </ClerkLoaded>
         </div>
       )
@@ -99,8 +95,7 @@ It's not recommended to wrap the entire app in the `<ClerkLoaded>` component; in
       return (
         <View>
           <ClerkLoaded>
-            <Text>Clerk has loaded and is available under window.Clerk</Text>
-            <Text>Clerk version: {window.Clerk?.version}</Text>
+            <Text>Clerk has loaded</Text>
           </ClerkLoaded>
         </View>
       )

--- a/docs/components/control/clerk-loading.mdx
+++ b/docs/components/control/clerk-loading.mdx
@@ -7,6 +7,8 @@ The `<ClerkLoading>` renders its children while Clerk is loading, and is helpful
 
 ## Usage
 
+It's not recommended to wrap the entire app in the `<ClerkLoading>` component; instead, only wrap the components that need access to the `Clerk` object.
+
 <Tabs items={["Next.js", "React", "Remix", "Expo"]}>
   <Tab>
     <CodeBlockTabs options={["App Router", "Pages Router"]}>

--- a/docs/components/control/clerk-loading.mdx
+++ b/docs/components/control/clerk-loading.mdx
@@ -25,11 +25,10 @@ It's not recommended to wrap the entire app in the `<ClerkLoading>` component; i
         return (
           <>
             <ClerkLoading>
-              <div>Clerk is loading...</div>
+              <p>Clerk is loading...</p>
             </ClerkLoading>
             <ClerkLoaded>
-              <div>Clerk has loaded and is available under window.Clerk</div>
-              <p>Clerk version: {window.Clerk.version}</p>
+              <p>Clerk has loaded</p>
             </ClerkLoaded>
           </>
         )
@@ -49,11 +48,10 @@ It's not recommended to wrap the entire app in the `<ClerkLoading>` component; i
         return (
           <>
             <ClerkLoading>
-              <div>Clerk is loading</div>
+              <p>Clerk is loading</p>
             </ClerkLoading>
             <ClerkLoaded>
-              <div>Clerk has loaded and is available under window.Clerk</div>
-              <p>Clerk version: {window.Clerk.version}</p>
+              <p>Clerk has loaded</p>
             </ClerkLoaded>
           </>
         )
@@ -76,11 +74,10 @@ It's not recommended to wrap the entire app in the `<ClerkLoading>` component; i
       return (
         <>
           <ClerkLoading>
-            <div>Clerk is loading</div>
+            <p>Clerk is loading</p>
           </ClerkLoading>
           <ClerkLoaded>
-            <div>Clerk has loaded and is available under window.Clerk</div>
-            <p>Clerk version: {window.Clerk.version}</p>
+            <p>Clerk has loaded</p>
           </ClerkLoaded>
         </>
       )
@@ -102,11 +99,10 @@ It's not recommended to wrap the entire app in the `<ClerkLoading>` component; i
       return (
         <>
           <ClerkLoading>
-            <div>Clerk is loading</div>
+            <p>Clerk is loading</p>
           </ClerkLoading>
           <ClerkLoaded>
-            <div>Clerk has loaded and is available under window.Clerk</div>
-            <p>Clerk version: {window.Clerk.version}</p>
+            <p>Clerk has loaded</p>
           </ClerkLoaded>
         </>
       )
@@ -132,8 +128,7 @@ It's not recommended to wrap the entire app in the `<ClerkLoading>` component; i
             <Text>Clerk is loading</Text>
           </ClerkLoading>
           <ClerkLoaded>
-            <Text>Clerk has loaded and is available under window.Clerk</Text>
-            <Text>Clerk version: {window.Clerk.version}</Text>
+            <Text>Clerk has loaded</Text>
           </ClerkLoaded>
         </View>
       )

--- a/docs/components/control/clerk-loading.mdx
+++ b/docs/components/control/clerk-loading.mdx
@@ -10,86 +10,103 @@ The `<ClerkLoading>` renders its children while Clerk is loading, and is helpful
 <Tabs items={["Next.js", "React", "Remix", "Expo"]}>
   <Tab>
     <CodeBlockTabs options={["App Router", "Pages Router"]}>
-      ```tsx {{ filename: 'app/layout.tsx' }}
-      import { ClerkProvider, ClerkLoaded, ClerkLoading } from '@clerk/nextjs'
-      import './globals.css'
+      ```tsx {{ filename: 'app/page.tsx' }}
+      import { ClerkLoaded, ClerkLoading } from '@clerk/nextjs'
 
-      export default function RootLayout({ children }: { children: React.ReactNode }) {
+      declare global {
+        interface Window {
+          Clerk: any
+        }
+      }
+
+      export default function Page() {
         return (
-          <ClerkProvider>
-            <html lang="en">
-              <body>
-                <ClerkLoading>
-                  <div>Clerk is loading...</div>
-                </ClerkLoading>
-                <ClerkLoaded>{children}</ClerkLoaded>
-              </body>
-            </html>
-          </ClerkProvider>
+          <>
+            <ClerkLoading>
+              <div>Clerk is loading...</div>
+            </ClerkLoading>
+            <ClerkLoaded>
+              <div>Clerk has loaded and is available under window.Clerk</div>
+              <p>Clerk version: {window.Clerk.version}</p>
+            </ClerkLoaded>
+          </>
         )
       }
       ```
 
-      ```tsx {{ filename: 'pages/_app.tsx' }}
-      import '@/styles/globals.css'
-      import { ClerkLoaded, ClerkLoading, ClerkProvider } from '@clerk/nextjs'
-      import { AppProps } from 'next/app'
+      ```tsx {{ filename: 'pages/index.tsx' }}
+      import { ClerkLoaded, ClerkLoading } from '@clerk/nextjs'
 
-      function MyApp({ Component, pageProps }: AppProps) {
+      declare global {
+        interface Window {
+          Clerk: any
+        }
+      }
+
+      export default function Page() {
         return (
-          <ClerkProvider {...pageProps}>
+          <>
             <ClerkLoading>
               <div>Clerk is loading</div>
             </ClerkLoading>
             <ClerkLoaded>
-              <Component {...pageProps} />
+              <div>Clerk has loaded and is available under window.Clerk</div>
+              <p>Clerk version: {window.Clerk.version}</p>
             </ClerkLoaded>
-          </ClerkProvider>
+          </>
         )
       }
-
-      export default MyApp
       ```
     </CodeBlockTabs>
   </Tab>
 
   <Tab>
-    ```tsx {{ filename: 'app.tsx' }}
-    import { ClerkLoaded, ClerkLoading, ClerkProvider } from '@clerk/clerk-react'
+    ```tsx {{ filename: 'example.tsx' }}
+    import { ClerkLoaded, ClerkLoading } from '@clerk/clerk-react'
 
-    function App() {
+    declare global {
+      interface Window {
+        Clerk: any
+      }
+    }
+
+    export default function Example() {
       return (
-        <ClerkProvider publishableKey={`{{pub_key}}`}>
+        <>
           <ClerkLoading>
             <div>Clerk is loading</div>
           </ClerkLoading>
           <ClerkLoaded>
-            <Page />
+            <div>Clerk has loaded and is available under window.Clerk</div>
+            <p>Clerk version: {window.Clerk.version}</p>
           </ClerkLoaded>
-          <div>This div is always visible</div>
-        </ClerkProvider>
+        </>
       )
     }
-
-    function Page() {
-      return <div>The content</div>
-    }
-
-    export default App
     ```
   </Tab>
 
   <Tab>
     ```tsx {{ filename: 'routes/index.tsx' }}
-    import { ClerkLoading } from '@clerk/remix'
+    import { ClerkLoading, ClerkLoaded } from '@clerk/remix'
+
+    declare global {
+      interface Window {
+        Clerk: any
+      }
+    }
 
     export default function Index() {
       return (
-        <div>
+        <>
           <ClerkLoading>
             <div>Clerk is loading</div>
           </ClerkLoading>
-        </div>
+          <ClerkLoaded>
+            <div>Clerk has loaded and is available under window.Clerk</div>
+            <p>Clerk version: {window.Clerk.version}</p>
+          </ClerkLoaded>
+        </>
       )
     }
     ```
@@ -97,8 +114,14 @@ The `<ClerkLoading>` renders its children while Clerk is loading, and is helpful
 
   <Tab>
     ```tsx {{ filename: 'app/index.tsx' }}
-    import { ClerkLoading } from '@clerk/clerk-expo'
+    import { ClerkLoading, ClerkLoaded } from '@clerk/clerk-expo'
     import { Text, View } from 'react-native'
+
+    declare global {
+      interface Window {
+        Clerk: any
+      }
+    }
 
     export default function Screen() {
       return (
@@ -106,6 +129,10 @@ The `<ClerkLoading>` renders its children while Clerk is loading, and is helpful
           <ClerkLoading>
             <Text>Clerk is loading</Text>
           </ClerkLoading>
+          <ClerkLoaded>
+            <Text>Clerk has loaded and is available under window.Clerk</Text>
+            <Text>Clerk version: {window.Clerk.version}</Text>
+          </ClerkLoaded>
         </View>
       )
     }


### PR DESCRIPTION
### 🔎 Previews

- https://clerk.com/docs/pr/2156/components/control/clerk-loaded
- https://clerk.com/docs/pr/2156/components/control/clerk-loading

### What does this solve?

- Wrapping your app in either of these components can lead to your entire app not rendering if Clerk is down

### What changed?

- Only wrap Clerk-related components with these components

### Checklist

- [ ] I have clicked on "Files changed" and performed a thorough self-review
- [ ] All existing checks pass
