### PR TITLE
docs: Add Rate Limiting Information For `getToken` With Template

### DIFF
--- a/docs/references/backend/types/auth-object.mdx
+++ b/docs/references/backend/types/auth-object.mdx
@@ -216,6 +216,8 @@ You can use `has()` to check if a user has verified their credentials within a c
 
 `getToken()` retrieves the current user's [session token](/docs/backend-requests/resources/session-tokens) or a [custom JWT template](/docs/backend-requests/jwt-templates).
 
+> Note that `getToken` invokations with a template provided will perform a network request and will count towards [Clerk backend rate limits](/docs/backend-requests/resources/rate-limits#backend-api-requests).
+
 ```typescript
 const getToken: ServerGetToken
 

--- a/docs/references/backend/types/auth-object.mdx
+++ b/docs/references/backend/types/auth-object.mdx
@@ -216,7 +216,8 @@ You can use `has()` to check if a user has verified their credentials within a c
 
 `getToken()` retrieves the current user's [session token](/docs/backend-requests/resources/session-tokens) or a [custom JWT template](/docs/backend-requests/jwt-templates).
 
-> Note that `getToken` invokations with a template provided will perform a network request and will count towards [Clerk backend rate limits](/docs/backend-requests/resources/rate-limits#backend-api-requests).
+> [!NOTE]
+> Providing a `template` will perform a network request and will count towards [rate limits](/docs/backend-requests/resources/rate-limits#backend-api-requests).
 
 ```typescript
 const getToken: ServerGetToken


### PR DESCRIPTION
### 🔎 Previews:

None yet.

### What does this solve?

We were seeing rate limiting issues while performing `getToken({ template: 'my-template' })`. This behavior was unclear from the documentation, especially since tokens are typically retrieved directly from request cookies without making an API request.

After cloning the Clerk codebase, we found the following:
```
export function signedInAuthObject(...): SignedInAuthObject {
  ...
  const apiClient = createBackendApiClient(authenticateContext);
  const getToken = createGetToken({
    sessionId,
    sessionToken,
    fetcher: async (...args) => (await apiClient.sessions.getToken(...args)).jwt,
  });
}

const createGetToken: CreateGetToken = params => {
  const { fetcher, sessionToken, sessionId } = params || {};

  return async (options: ServerGetTokenOptions = {}) => {
    if (!sessionId) {
      return null;
    }

    if (options.template) {
      return fetcher(sessionId, options.template);
    }

    return sessionToken;
  };
};
```

In other words, the function will perform a request _sometimes_, depending on if `template` was provided.

### What changed?

Added a note that providing a template string will perform a request and count towards rate limits.

### Checklist

- [x] I have clicked on "Files changed" and performed a thorough self-review
- [ ] All existing checks pass
