### PR TITLE
docs(nextjs): removed unused/non-existing imported function

### DIFF
--- a/docs/references/nextjs/clerk-middleware.mdx
+++ b/docs/references/nextjs/clerk-middleware.mdx
@@ -262,7 +262,7 @@ If you would like to set up debugging for your development environment only, you
 You can combine other Middleware with Clerk's Middleware by returning the second Middleware from `clerkMiddleware()`.
 
 ```js {{ filename: 'middleware.ts' }}
-import { clerkMiddleware, createRouteMatcher, redirectToSignIn } from '@clerk/nextjs/server'
+import { clerkMiddleware, createRouteMatcher } from '@clerk/nextjs/server'
 import createMiddleware from 'next-intl/middleware'
 
 import { AppConfig } from './utils/AppConfig'


### PR DESCRIPTION
### 🔎 Previews:

-

### What does this solve?
### What changed?

- Removes an unused and non-existent import (redirectToSignIn), reducing confusion, from the "Combine Middleware" example for Next.js.

### Checklist

- [ ] I have clicked on "Files changed" and performed a thorough self-review
- [ ] All existing checks pass
