### PR TITLE
Add 'external_account.phoneNumber' property on type references

### DIFF
--- a/docs/references/javascript/types/external-account.mdx
+++ b/docs/references/javascript/types/external-account.mdx
@@ -80,6 +80,13 @@ External account must be verified, so that you can make sure they can be assigne
 
   ---
 
+  - `phoneNumber`
+  - `string | null`
+
+  The phone number related to this specific external account.
+
+  ---
+
   - `publicMetadata`
   - `Record<string, unknown>`
 


### PR DESCRIPTION
### 🔎 Previews:

- https://clerk.com/docs/pr/2168

### What does this solve?

- We make sure to keep our docs types up to date with our actual FE types

### What changed?

- We introduced a new property 'phoneNumber' as part of the external account type and response

### Checklist

- [ ] I have clicked on "Files changed" and performed a thorough self-review
- [ ] All existing checks pass
