### PR TITLE
(session-tokens) system perms arent included in session token

### DIFF
--- a/docs/backend-requests/resources/session-tokens.mdx
+++ b/docs/backend-requests/resources/session-tokens.mdx
@@ -35,7 +35,7 @@ The following claims are only included if the user is part of an [organization](
 | Claim | Abbreviation expanded | Description | Example |
 | - | - | - | - |
 | `org_id` | organization ID | The ID of the active organization that the user belongs to. | `org_123` |
-| `org_permissions` | organization permissions | The permissions of the user in the currently active organization. | `["org:sys_profile:manage", "org:sys_profile:delete"]` |
+| `org_permissions` | organization permissions | The permissions of the user in the currently active organization. System permissions are not included in the session token. | `["org:admin:example_permission", "org:member:example_permission"]` |
 | `org_slug` | organization slug | The slug of the currently active organization that the user belongs to. | `org-slug` |
 | `org_role` | organization role | The role of the user in the currently active organization. | `org:admin` |
 


### PR DESCRIPTION
Mery pointed out that system permissions aren't included in the session token's claims!
https://linear.app/clerk/issue/DOCS-10227/update-example-value-for-org-permissions-claim-in-documentation