### PR TITLE
[typo] Update Azure SAML mislabeled claim

### DIFF
--- a/docs/authentication/enterprise-connections/saml/azure.mdx
+++ b/docs/authentication/enterprise-connections/saml/azure.mdx
@@ -104,7 +104,7 @@ This process requires configuration changes in both the Clerk Dashboard, and in 
     - Claim name: `http://schemas.xmlsoap.org/ws/2005/05/identity/claims/givenname`
     - Value: `user.givenname`
 
-    First name (optional):
+    Last name (optional):
 
     - Claim name: `http://schemas.xmlsoap.org/ws/2005/05/identity/claims/surname`
     - Value: `user.surname`


### PR DESCRIPTION
fix typo -- `First name` is written twice, including for the claim surname.

Could also consider renaming attribute fields to Given Name / Surname.


### 🔎 Previews:

- TBD

### What does this solve?

- Fixes typo with Azure SAML mislabeled claim.

### What changed?

- Fixes typo with Azure SAML mislabeled claim.

### Checklist

- [x] I have clicked on "Files changed" and performed a thorough self-review
- [ ] All existing checks pass
