### PR TITLE
Validate links to headings inside of partials

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23,6 +23,7 @@
         "remark-mdx": "^3.0.1",
         "tsx": "^4.19.2",
         "typescript": "^5.7.3",
+        "unist-util-map": "^4.0.0",
         "unist-util-visit": "^5.0.0",
         "vfile": "^6.0.1",
         "vfile-reporter": "^8.0.0",
@@ -3900,6 +3901,20 @@
       "resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-6.0.0.tgz",
       "integrity": "sha512-2qCTHimwdxLfz+YzdGfkqNlH0tLi9xjTnHddPmJwtIG9MGsdbutfTc4P+haPD7l7Cjxf/WZj+we5qfVPvvxfYw==",
       "dev": true,
+      "dependencies": {
+        "@types/unist": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-map": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/unist-util-map/-/unist-util-map-4.0.0.tgz",
+      "integrity": "sha512-HJs1tpkSmRJUzj6fskQrS5oYhBYlmtcvy4SepdDEEsL04FjBrgF0Mgggvxc1/qGBGgW7hRh9+UBK1aqTEnBpIA==",
+      "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@types/unist": "^3.0.0"
       },

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "remark-mdx": "^3.0.1",
     "tsx": "^4.19.2",
     "typescript": "^5.7.3",
+    "unist-util-map": "^4.0.0",
     "unist-util-visit": "^5.0.0",
     "vfile": "^6.0.1",
     "vfile-reporter": "^8.0.0",

--- a/scripts/build-docs.test.ts
+++ b/scripts/build-docs.test.ts
@@ -388,6 +388,53 @@ title: Simple Test
 
     expect(output).toContain(`warning <Include /> prop "src" must start with "_partials/"`)
   })
+
+  test('Should validate heading within a partial', async () => {
+    const { tempDir } = await createTempFiles([
+      {
+        path: './docs/manifest.json',
+        content: JSON.stringify({
+          navigation: [
+            [{ title: 'Simple Test', href: '/docs/test-page-1' }],
+            [{ title: 'Test Page 2', href: '/docs/test-page-2' }],
+          ],
+        }),
+      },
+      {
+        path: './docs/_partials/test-partial.mdx',
+        content: `# Heading`,
+      },
+      {
+        path: './docs/test-page-1.mdx',
+        content: `---
+title: Test Page 1
+description: This is a test page
+---
+
+<Include src="_partials/test-partial" />`,
+      },
+      {
+        path: './docs/test-page-2.mdx',
+        content: `---
+title: Test Page 2
+description: This is a test page
+---
+
+[Test Page](/docs/test-page-1#heading)`,
+      },
+    ])
+
+    const output = await build(
+      createConfig({
+        ...baseConfig,
+        basePath: tempDir,
+        validSdks: ['react'],
+      }),
+    )
+
+    expect(output).not.toContain(`warning Hash "heading" not found in /docs/test-page-1`)
+    expect(output).toBe('')
+  })
 })
 
 describe('Link Validation and Processing', () => {


### PR DESCRIPTION
### What does this solve?

- Currently the script will fail if a heading is in a partial embedded in to a page, and another page attempts to link to that heading in the partial

### What changed?

- This change temporarily embeds the partials in to the page before extracting the headings to be accurate

### Checklist

- [x] I have clicked on "Files changed" and performed a thorough self-review
- [x] All existing checks pass
