### PR TITLE
Add validation for links inside typedoc files

### DIFF
--- a/scripts/build-docs.test.ts
+++ b/scripts/build-docs.test.ts
@@ -1647,4 +1647,94 @@ description: Generated API docs
     // Should warn about missing src attribute
     expect(output).toContain('warning <Typedoc /> component has no "src" attribute')
   })
+
+  test('Should fail it typedoc file links to a non-existent file', async () => {
+    const { tempDir } = await createTempFiles([
+      {
+        path: './docs/manifest.json',
+        content: JSON.stringify({
+          navigation: [[{ title: 'API Doc', href: '/docs/api-doc' }]],
+        }),
+      },
+      {
+        path: './typedoc/api/client.mdx',
+        content: `[Non-existent File](/docs/non-existent-file)`,
+      },
+      {
+        path: './docs/api-doc.mdx',
+        content: `---
+title: API Documentation
+description: Generated API docs
+---
+
+# API Documentation
+
+<Typedoc src="api/client" />
+`,
+      },
+    ])
+
+    const output = await build(
+      createConfig({
+        ...baseConfig,
+        basePath: tempDir,
+        validSdks: ['react'],
+      }),
+    )
+
+    expect(output).toContain('Doc /docs/non-existent-file not found')
+  })
+
+  test('Should fail if typedoc file links to non-existent hash', async () => {
+    const { tempDir } = await createTempFiles([
+      {
+        path: './docs/manifest.json',
+        content: JSON.stringify({
+          navigation: [
+            [
+              { title: 'API Doc', href: '/docs/api-doc' },
+              { title: 'Overview', href: '/docs/overview' },
+            ],
+          ],
+        }),
+      },
+      {
+        path: './docs/overview.mdx',
+        content: `---
+title: Overview
+description: Overview of the API
+---
+
+# Overview
+
+`,
+      },
+      {
+        path: './typedoc/api/client.mdx',
+        content: `[Non-existent Hash](/docs/overview#non-existent-hash)`,
+      },
+      {
+        path: './docs/api-doc.mdx',
+        content: `---
+title: API Documentation
+description: Generated API docs
+---
+
+# API Documentation
+
+<Typedoc src="api/client" />
+`,
+      },
+    ])
+
+    const output = await build(
+      createConfig({
+        ...baseConfig,
+        basePath: tempDir,
+        validSdks: ['react'],
+      }),
+    )
+
+    expect(output).toContain('Hash "non-existent-hash" not found in /docs/overview')
+  })
 })

--- a/scripts/build-docs.ts
+++ b/scripts/build-docs.ts
@@ -1297,6 +1297,10 @@ const main = async () => {
       '/docs/maintenance-mode.mdx': ['doc-not-in-manifest'],
       '/docs/deployments/staging-alternatives.mdx': ['doc-not-in-manifest'],
       '/docs/references/nextjs/usage-with-older-versions.mdx': ['doc-not-in-manifest'],
+
+      // Typedoc warnings
+      '../clerk-typedoc/types/active-session-resource.mdx': ['link-hash-not-found'],
+      '../clerk-typedoc/types/pending-session-resource.mdx': ['link-hash-not-found'],
     },
     validSdks: VALID_SDKS,
     manifestOptions: {

--- a/scripts/build-docs.ts
+++ b/scripts/build-docs.ts
@@ -741,12 +741,6 @@ const parseInMarkdownFile =
           return
         })
       })
-      .process({
-        path: `${href.substring(1)}.mdx`,
-        value: fileContent,
-      })
-
-    await markdownProcessor()
       // Validate the <Typedoc />
       .use(() => (tree, vfile) => {
         return mdastVisit(tree, (node) => {

--- a/scripts/build-docs.ts
+++ b/scripts/build-docs.ts
@@ -1077,6 +1077,46 @@ export const build = async (config: BuildConfig) => {
   )
   console.info(`✔️ Validated all partials`)
 
+  const typedocVFiles = await Promise.all(
+    typedocs.map(async (typedoc) => {
+      const filePath = path.join(config.typedocRelativePath, typedoc.path)
+
+      return await remark()
+        // validate links in partials to docs are valid
+        .use(() => (tree, vfile) => {
+          return mdastVisit(tree, (node) => {
+            if (node.type !== 'link') return
+            if (!('url' in node)) return
+            if (typeof node.url !== 'string') return
+            if (!node.url.startsWith('/docs/')) return
+            if (!('children' in node)) return
+
+            const [url, hash] = removeMdxSuffix(node.url).split('#')
+
+            const ignore = config.ignorePaths.some((ignoreItem) => url.startsWith(ignoreItem))
+            if (ignore === true) return
+
+            const doc = docsMap.get(url)
+
+            if (doc === undefined) {
+              safeMessage(config, vfile, filePath, 'link-doc-not-found', [url], node.position)
+              return
+            }
+
+            if (hash !== undefined) {
+              const hasHash = doc.headingsHashs.includes(hash)
+
+              if (hasHash === false) {
+                safeMessage(config, vfile, filePath, 'link-hash-not-found', [hash, url], node.position)
+              }
+            }
+          })
+        })
+        .process(typedoc.vfile)
+    }),
+  )
+  console.info(`✔️ Validated all typedocs`)
+
   const coreVFiles = await Promise.all(
     docsArray.map(async (doc) => {
       const filePath = `${doc.href}.mdx`
@@ -1175,7 +1215,7 @@ export const build = async (config: BuildConfig) => {
 
   console.info(`✔️ Validated all docs`)
 
-  return reporter([...coreVFiles, ...partialsVFiles], { quiet: true })
+  return reporter([...coreVFiles, ...partialsVFiles, ...typedocVFiles], { quiet: true })
 }
 
 type BuildConfigOptions = {


### PR DESCRIPTION
### What does this solve?

- When updating the validation script to validate typedoc files, I added to the script to pull out the headings / hashes, but failed to add validation to check the links inside the typedoc files.

### What changed?

- Added validation to ensure the links and hashes inside the typedoc markdown point to valid urls and headings

### Checklist

- [x] I have clicked on "Files changed" and performed a thorough self-review
- [ ] All existing checks pass
