### PR TITLE
docs(nuxt): Use `event.context.auth` as a function

### DIFF
--- a/docs/authentication/configuration/force-mfa.mdx
+++ b/docs/authentication/configuration/force-mfa.mdx
@@ -128,7 +128,7 @@ By default, Clerk does not enforce [multi-factor authentication (MFA)](/docs/aut
         const isMFARoute = event.path.startsWith('/account/manage-mfa/add')
         const isSignInRoute = event.path.startsWith('/sign-in')
 
-        const { userId, sessionClaims } = event.context.auth
+        const { userId, sessionClaims } = event.context.auth()
 
         // Redirect to homepage if the user is signed in and on the sign-in page
         if (userId !== null && isSignInRoute) {

--- a/docs/references/nuxt/clerk-middleware.mdx
+++ b/docs/references/nuxt/clerk-middleware.mdx
@@ -48,7 +48,7 @@ In the following example, the `clerkMiddleware()` helper checks if the user is s
 import { clerkMiddleware } from '@clerk/nuxt/server'
 
 export default clerkMiddleware((event) => {
-  const { userId } = event.context.auth
+  const { userId } = event.context.auth()
   const isAdminRoute = event.path.startsWith('/api/admin')
 
   if (!userId && isAdminRoute) {
@@ -72,7 +72,7 @@ In the following example, the `clerkMiddleware()` helper checks if the user is a
 import { clerkMiddleware } from '@clerk/nuxt/server'
 
 export default clerkMiddleware((event) => {
-  const { has } = event.context.auth
+  const { has } = event.context.auth()
   const isInvoicesRoute = event.path.startsWith('/api/invoices')
   const canCreateInvoices = has({
     permission: 'org:invoices:create',
@@ -102,7 +102,7 @@ In the following example, the `clerkMiddleware()` helper checks if the user is a
 import { clerkMiddleware } from '@clerk/nuxt/server'
 
 export default clerkMiddleware((event) => {
-  const { has } = event.context.auth
+  const { has } = event.context.auth()
   const isAdminRoute = event.path.startsWith('/api/admin')
   const isAdmin = has({
     role: 'org:admin',

--- a/docs/references/nuxt/overview.mdx
+++ b/docs/references/nuxt/overview.mdx
@@ -13,7 +13,7 @@ Because the Nuxt SDK is built on top of the Clerk Vue SDK, you can use the compo
 
 ## `Auth` object
 
-The `Auth` object is available at `event.context.auth` in your [event handlers](https://h3.unjs.io/guide/event-handler). This JavaScript object contains important information like session data, your user's ID, as well as their organization ID. [Learn more](/docs/references/backend/types/auth-object).
+The `Auth` object is available at `event.context.auth()` in your [event handlers](https://h3.unjs.io/guide/event-handler). This JavaScript object contains important information like session data, your user's ID, as well as their organization ID. [Learn more](/docs/references/backend/types/auth-object).
 
 ## `clerkMiddleware()`
 

--- a/docs/references/nuxt/read-session-data.mdx
+++ b/docs/references/nuxt/read-session-data.mdx
@@ -31,7 +31,7 @@ const { isLoaded, isSignedIn, user } = useUser()
 
 ## Server-side
 
-The `Auth` object is available at `event.context.auth` in your [event handlers](https://h3.unjs.io/guide/event-handler). This JavaScript object contains important information like the current user's session ID, user ID, and organization ID. The `userId` can be used to protect your API routes.
+The `Auth` object is available at `event.context.auth()` in your [event handlers](https://h3.unjs.io/guide/event-handler). This JavaScript object contains important information like the current user's session ID, user ID, and organization ID. The `userId` can be used to protect your API routes.
 
 In some cases, you may need the full [`Backend User`](/docs/references/backend/types/backend-user) object of the currently active user. This is helpful if you want to render information, like their first and last name, directly from the server. The `clerkClient()` helper returns an instance of the [JavaScript Backend SDK](/docs/references/backend/overview), which exposes Clerk's Backend API resources through methods such as the [`getUser()`](/docs/references/backend/user/get-user){{ target: '_blank' }} method. This method returns the full `Backend User` object.
 
@@ -42,7 +42,7 @@ import { clerkClient } from '@clerk/nuxt/server'
 
 export default defineEventHandler(async (event) => {
   // Use `auth` to get the user's ID
-  const { userId } = event.context.auth
+  const { userId } = event.context.auth()
 
   // Protect the API route by checking if the user is signed in
   if (!userId) {


### PR DESCRIPTION
### 🔎 Previews:

- https://clerk.com/docs/pr/2182/references/nuxt/overview#auth-object
- https://clerk.com/docs/pr/2182/references/nuxt/clerk-middleware#authentication-based-protection
- https://clerk.com/docs/pr/2182/references/nuxt/clerk-middleware#protecting-routes-using-custom-permissions
- https://clerk.com/docs/pr/2182/references/nuxt/clerk-middleware#protecting-routes-using-custom-permissions
- https://clerk.com/docs/pr/2182/references/nuxt/read-session-data#server-side

### What does this solve?

We deprecated `event.context.auth` in favor of `event.context.auth()` as a function [here](https://github.com/clerk/javascript/pull/5513). 

### What changed?

This PR updates all occurrences to use `event.context.auth()` as a function and not the deprecated one.

### Checklist

- [x] I have clicked on "Files changed" and performed a thorough self-review
- [x] All existing checks pass
