### PR TITLE
Move proxyUrl parameter to the correct place

### DIFF
--- a/docs/advanced-usage/using-proxies.mdx
+++ b/docs/advanced-usage/using-proxies.mdx
@@ -275,11 +275,11 @@ When using a proxy, all requests to the Frontend API will be made through your d
       // Initialize Clerk with your Clerk Publishable Key
       const clerkPubKey = import.meta.env.VITE_CLERK_PUBLISHABLE_KEY
 
-      const clerk = new Clerk(clerkPubKey)
-
-      await clerk.load({
+      const clerk = new Clerk(clerkPubKey, {
         proxyUrl: 'https://app.dev/__clerk',
       })
+
+      await clerk.load()
       ```
     </Tab>
   </Tabs>


### PR DESCRIPTION
### 🔎 Previews:

-

### What does this solve?

- <!--- Describe your changes in detail. Why does this change need to happen? Include any links to Slack discussions, Linear comments, etc. --> it doesn't work when i set proxyUrl on .load: e.q. clerk.load({proxyUrl})

### What changed?

- <!--- How does this PR solve the problem? --> it works when i set proxyUrl on constructor: e.q. new Clerk(..., {proxyUrl})

### Checklist

- [x] I have clicked on "Files changed" and performed a thorough self-review
- [ ] All existing checks pass
