### PR TITLE
v2 session token followup: update session token examples

### DIFF
--- a/docs/_partials/has-warning.mdx
+++ b/docs/_partials/has-warning.mdx
@@ -1,2 +1,2 @@
 > [!WARNING]
-> Using `has()` **on the server-side** to check permissions works only with **custom permissions**, as [system permissions](/docs/organizations/roles-permissions#system-permissions) aren't included in `auth.sessionClaims.orgs_permissions`. To check system permissions, verify the user's role instead.
+> Using `has()` **on the server-side** to check permissions works only with **custom permissions**, as [system permissions](/docs/organizations/roles-permissions#system-permissions) aren't included in the session token claims. To check system permissions, verify the user's role instead.

--- a/docs/references/backend/types/auth-object.mdx
+++ b/docs/references/backend/types/auth-object.mdx
@@ -344,100 +344,224 @@ The `Auth` object is not available in the frontend. To use the `getToken()` meth
 
 The following is an example of the `Auth` object without an active organization:
 
-```js {{ prettier: false }}
-{
-  sessionId: 'sess_123',
-  userId: 'user_123',
-  orgId: null,
-  orgRole: null,
-  orgSlug: null,
-  orgPermissions: null,
-  has: [Function (anonymous)],
-  getToken: [AsyncFunction (anonymous)],
-  claims: {
-    azp: 'http://localhost:3000',
-    exp: 1666622607,
-    iat: 1666622547,
-    iss: 'https://clerk.quiet.muskox-85.lcl.dev',
-    nbf: 1666622537,
-    sid: 'sess_123',
-    sub: 'user_123',
-  },
-}
-```
+<Tabs items={["Version 2", "Version 1"]}>
+  <Tab>
+    > [!IMPORTANT]
+    > This example is for version 2 of Clerk's session token. To see an example of version 1, select the respective tab above.
+
+    ```js {{ prettier: false }}
+    {
+      azp: 'http://localhost:3000',
+      email: 'email@example.com',
+      exp: 1744735488,
+      fva: [ 9, -1 ],
+      iat: 1744735428,
+      iss: 'https://renewing-bobcat-00.clerk.accounts.dev',
+      jti: 'aee4d4a5071bdd66e21b',
+      nbf: 1744735418,
+      role: 'authenticated',
+      sid: 'sess_123',
+      sub: 'user_123',
+      v: 2
+    }
+    ```
+  </Tab>
+
+  <Tab>
+    > [!IMPORTANT]
+    > Version 1 of Clerk's session token was deprecated on April 14, 2025. To upgrade to version 2, go to the [**Updates**](https://dashboard.clerk.com/last-active?path=updates) page in the Clerk Dashboard.
+
+    ```js {{ prettier: false }}
+    {
+      sessionId: 'sess_123',
+      userId: 'user_123',
+      orgId: null,
+      orgRole: null,
+      orgSlug: null,
+      orgPermissions: null,
+      has: [Function (anonymous)],
+      getToken: [AsyncFunction (anonymous)],
+      claims: {
+        azp: 'http://localhost:3000',
+        exp: 1666622607,
+        iat: 1666622547,
+        iss: 'https://renewing-bobcat-00.clerk.accounts.dev',
+        nbf: 1666622537,
+        sid: 'sess_123',
+        sub: 'user_123',
+      },
+    }
+    ```
+  </Tab>
+</Tabs>
 
 ## `Auth` object example with active organization
 
 The following is an example of the `Auth` object with an active organization:
 
-```js {{ prettier: false }}
-{
-  sessionId: 'sess_123',
-  userId: 'user_123',
-  orgId: 'org_123',
-  orgRole: 'org:admin',
-  orgSlug: undefined,
-  orgPermissions: ['org:team_settings:manage'], // Custom permissions
-  has: [Function (anonymous)],
-  getToken: [AsyncFunction (anonymous)],
-  claims: {
-    azp: 'http://localhost:3000',
-    exp: 1666622607,
-    iat: 1666622547,
-    iss: 'https://clerk.quiet.muskox-85.lcl.dev',
-    nbf: 1666622537,
-    sid: 'sess_123',
-    sub: 'user_123',
-  },
-}
-```
+<Tabs items={["Version 2", "Version 1"]}>
+  <Tab>
+    > [!IMPORTANT]
+    > This example is for version 2 of Clerk's session token. To see an example of version 1, select the respective tab above.
+
+    ```js {{ prettier: false }}
+    {
+      azp: 'http://localhost:3000',
+      email: 'email@example.com',
+      exp: 1744734948,
+      fea: 'o:example-feature',
+      fva: [ 0, -1 ],
+      iat: 1744734888,
+      iss: 'https://renewing-bobcat-00.clerk.accounts.dev',
+      jti: '004f0096e5cd44911924',
+      nbf: 1744734878,
+      o: {
+        fpm: '1',
+        id: 'org_123',
+        per: 'example-perm',
+        rol: 'admin',
+        slg: 'example-org'
+      },
+      role: 'authenticated',
+      sid: 'sess_123',
+      sub: 'user_123',
+      v: 2
+    }
+    ```
+  </Tab>
+
+  <Tab>
+    > [!IMPORTANT]
+    > Version 1 of Clerk's session token was deprecated on April 14, 2025. To upgrade to version 2, go to the [**Updates**](https://dashboard.clerk.com/last-active?path=updates) page in the Clerk Dashboard.
+
+    ```js {{ prettier: false }}
+    {
+      sessionId: 'sess_123',
+      userId: 'user_123',
+      orgId: 'org_123',
+      orgRole: 'org:admin',
+      orgSlug: undefined,
+      orgPermissions: ['org:example-feature:example-perm'], // Custom permissions
+      has: [Function (anonymous)],
+      getToken: [AsyncFunction (anonymous)],
+      claims: {
+        azp: 'http://localhost:3000',
+        exp: 1666622607,
+        iat: 1666622547,
+        iss: 'https://renewing-bobcat-00.clerk.accounts.dev',
+        nbf: 1666622537,
+        sid: 'sess_123',
+        sub: 'user_123',
+      },
+    }
+    ```
+  </Tab>
+</Tabs>
 
 ## `Auth` object example with valid factor age
 
-```js {{ mark: [8], prettier: false }}
-{
-  sessionId: 'sess_123',
-  userId: 'user_123',
-  orgId: null,
-  orgRole: null,
-  orgSlug: null,
-  orgPermissions: null,
-  factorVerificationAge: [0,0],
-  has: [Function (anonymous)],
-  getToken: [AsyncFunction (anonymous)],
-  claims: {
-    azp: 'http://localhost:3000',
-    exp: 1666622607,
-    iat: 1666622547,
-    iss: 'https://clerk.quiet.muskox-85.lcl.dev',
-    nbf: 1666622537,
-    sid: 'sess_123',
-    sub: 'user_123',
-  },
-}
-```
+<Tabs items={["Version 2", "Version 1"]}>
+  <Tab>
+    > [!IMPORTANT]
+    > This example is for version 2 of Clerk's session token. To see an example of version 1, select the respective tab above.
+
+    ```js {{ mark: [5], prettier: false }}
+    {
+      azp: 'http://localhost:3000',
+      email: 'email@example.com',
+      exp: 1744735488,
+      fva: [ 0,0 ],
+      iat: 1744735428,
+      iss: 'https://renewing-bobcat-00.clerk.accounts.dev',
+      jti: 'aee4d4a5071bdd66e21b',
+      nbf: 1744735418,
+      role: 'authenticated',
+      sid: 'sess_123',
+      sub: 'user_123',
+      v: 2
+    }
+    ```
+  </Tab>
+
+  <Tab>
+    > [!IMPORTANT]
+    > Version 1 of Clerk's session token was deprecated on April 14, 2025. To upgrade to version 2, go to the [**Updates**](https://dashboard.clerk.com/last-active?path=updates) page in the Clerk Dashboard.
+
+    ```js {{ mark: [8], prettier: false }}
+    {
+      sessionId: 'sess_123',
+      userId: 'user_123',
+      orgId: null,
+      orgRole: null,
+      orgSlug: null,
+      orgPermissions: null,
+      factorVerificationAge: [0,0],
+      has: [Function (anonymous)],
+      getToken: [AsyncFunction (anonymous)],
+      claims: {
+        azp: 'http://localhost:3000',
+        exp: 1666622607,
+        iat: 1666622547,
+        iss: 'https://renewing-bobcat-00.clerk.accounts.dev',
+        nbf: 1666622537,
+        sid: 'sess_123',
+        sub: 'user_123',
+      },
+    }
+    ```
+  </Tab>
+</Tabs>
 
 ## `Auth` object example of a user without an MFA method registered
 
-```js {{ mark: [8], prettier: false }}
-{
-  sessionId: 'sess_123',
-  userId: 'user_123',
-  orgId: null,
-  orgRole: null,
-  orgSlug: null,
-  orgPermissions: null,
-  factorVerificationAge: [0, -1],
-  has: [Function (anonymous)],
-  getToken: [AsyncFunction (anonymous)],
-  claims: {
-    azp: 'http://localhost:3000',
-    exp: 1666622607,
-    iat: 1666622547,
-    iss: 'https://clerk.quiet.muskox-85.lcl.dev',
-    nbf: 1666622537,
-    sid: 'sess_123',
-    sub: 'user_123',
-  },
-}
-```
+<Tabs items={["Version 2", "Version 1"]}>
+  <Tab>
+    > [!IMPORTANT]
+    > This example is for version 2 of Clerk's session token. To see an example of version 1, select the respective tab above.
+
+    ```js {{ mark: [5], prettier: false }}
+    {
+      azp: 'http://localhost:3000',
+      email: 'email@example.com',
+      exp: 1744735488,
+      fva: [ 0,-1 ],
+      iat: 1744735428,
+      iss: 'https://renewing-bobcat-00.clerk.accounts.dev',
+      jti: 'aee4d4a5071bdd66e21b',
+      nbf: 1744735418,
+      role: 'authenticated',
+      sid: 'sess_123',
+      sub: 'user_123',
+      v: 2
+    }
+    ```
+  </Tab>
+
+  <Tab>
+    > [!IMPORTANT]
+    > Version 1 of Clerk's session token was deprecated on April 14, 2025. To upgrade to version 2, go to the [**Updates**](https://dashboard.clerk.com/last-active?path=updates) page in the Clerk Dashboard.
+
+    ```js {{ mark: [8], prettier: false }}
+    {
+      sessionId: 'sess_123',
+      userId: 'user_123',
+      orgId: null,
+      orgRole: null,
+      orgSlug: null,
+      orgPermissions: null,
+      factorVerificationAge: [0, -1],
+      has: [Function (anonymous)],
+      getToken: [AsyncFunction (anonymous)],
+      claims: {
+        azp: 'http://localhost:3000',
+        exp: 1666622607,
+        iat: 1666622547,
+        iss: 'https://renewing-bobcat-00.clerk.accounts.dev',
+        nbf: 1666622537,
+        sid: 'sess_123',
+        sub: 'user_123',
+        },
+      }
+    ```
+  </Tab>
+</Tabs>

--- a/docs/references/backend/types/auth-object.mdx
+++ b/docs/references/backend/types/auth-object.mdx
@@ -342,7 +342,7 @@ The `Auth` object is not available in the frontend. To use the `getToken()` meth
 
 ## `Auth` object example without active organization
 
-The following is an example of the `Auth` object without an active organization:
+The following is an example of the `Auth` object without an active organization. Notice that there is no `o` claim. Read more about token claims in the [guide on session tokens](/docs/backend-requests/resources/session-tokens).
 
 <Tabs items={["Version 2", "Version 1"]}>
   <Tab>
@@ -397,7 +397,7 @@ The following is an example of the `Auth` object without an active organization:
 
 ## `Auth` object example with active organization
 
-The following is an example of the `Auth` object with an active organization:
+The following is an example of the `Auth` object with an active organization. Notice the addition of the `o` claim. Read more about token claims in the [guide on session tokens](/docs/backend-requests/resources/session-tokens).
 
 <Tabs items={["Version 2", "Version 1"]}>
   <Tab>
@@ -460,6 +460,8 @@ The following is an example of the `Auth` object with an active organization:
 
 ## `Auth` object example with valid factor age
 
+The following is an example of the `Auth` object with a valid factor age. Notice the addition of the `fva` claim with a value of `[0, 0]`, indicating that the first and second factors have been verified within the past minute. Read more about token claims in the [guide on session tokens](/docs/backend-requests/resources/session-tokens).
+
 <Tabs items={["Version 2", "Version 1"]}>
   <Tab>
     > [!IMPORTANT]
@@ -513,6 +515,8 @@ The following is an example of the `Auth` object with an active organization:
 </Tabs>
 
 ## `Auth` object example of a user without an MFA method registered
+
+The following is an example of the `Auth` object of a user without an MFA method registered. Notice the addition of the `fva` claim, but the value is `[0, -1]`. `0` indicates that the first factor has been verified within the past minute, and `-1` indicates that there is no second factor registered for the user. Read more about token claims in the [guide on session tokens](/docs/backend-requests/resources/session-tokens).
 
 <Tabs items={["Version 2", "Version 1"]}>
   <Tab>


### PR DESCRIPTION
### What does this solve?

- Clerk released v2 of session tokens, which means the structure of the jwt has changed.

### What changed?

Updates all the examples with session tokens to include tabs for version 2 vs version 1:
<img width="773" alt="Screenshot 2025-04-15 at 12 57 36" src="https://github.com/user-attachments/assets/9570dde0-7699-432b-a454-737fdf8510b5" />


### Checklist

- [ ] I have clicked on "Files changed" and performed a thorough self-review
- [ ] All existing checks pass
