### PR TITLE
useAuth() now returns sessionClaims

### DIFF
--- a/docs/hooks/use-auth.mdx
+++ b/docs/hooks/use-auth.mdx
@@ -67,6 +67,13 @@ The `useAuth()` hook provides access to the current user's authentication state 
 
   ---
 
+  - `sessionClaims`
+  - `JwtPayload`
+
+  The current user's [session claims](/docs/backend-requests/resources/session-tokens).
+
+  ---
+
   - `getToken()`
   - `(options?: GetTokenOptions) => Promise<string | null>`
 


### PR DESCRIPTION
### What does this solve?

- We now return sessionClaims from useAuth(). The engineering PR is [here](https://github.com/clerk/javascript/pull/5565).

### What changed?

- Updates the reference doc's returns table

### Checklist

- [x] I have clicked on "Files changed" and performed a thorough self-review
- [x] All existing checks pass
