### PR TITLE
Mark Core 1 as unsupported, clarify browser support

### DIFF
--- a/docs/upgrade-guides/long-term-support.mdx
+++ b/docs/upgrade-guides/long-term-support.mdx
@@ -15,7 +15,7 @@ After the LTS period ends, there will be no further changes to the code for that
 | Version | Status | As Of | Until |
 | - | - | - | - |
 | Core 2 | Active | April 19, 2024 | TBD |
-| Core 1 | Long term support | April 19, 2024 | Q1 2025 |
+| Core 1 | Unsupported | - | - |
 | Legacy (v3) | Unsupported | - | - |
 
 ## Library compatibility
@@ -24,8 +24,8 @@ Clerk's SDKs run in the browser, in Node.js (+ other compatible runtimes), or in
 
 | Version | Node.js | Browsers |
 | - | - | - |
-| Core 2 | `>=18.17.0` | Evergreen, iOS 16 |
-| Core 1 | `>=14.0.0` | Evergreen, iOS 16 |
+| Core 2 | `>=18.17.0` | Browsers released in the last two years |
+| Core 1 | `>=14.0.0` | Chrome 114, Edge 115, Firefox 116, Safari 12.1 |
 
 ## Terminology
 


### PR DESCRIPTION
### 🔎 Previews:

- https://clerk.com/docs/pr/2190/upgrade-guides/long-term-support

### What does this solve?

Core 1 is now unsupported, so we want to call that out in our docs. Also, we want to clarify the actual supported browsers for Core 2, which targets "last 2 years". Finally, we want to specifically note that Core 1's browser support is frozen at the versions released for the final Core 1 release.

### What changed?

- This PR marks `Core 1` as unsupported on our Long Term Support page.
- Additionally, it clarifies the browser support for Core 1 and Core 2

### Checklist

- [x] I have clicked on "Files changed" and performed a thorough self-review
- [x] All existing checks pass
