### PR TITLE
Treat typedoc repo as a full git submodule

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: 'gitsubmodule'
+    directory: '/'
+    schedule:
+      interval: 'daily'

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,4 @@
+[submodule "clerk-typedoc"]
+	path = clerk-typedoc
+	url = https://github.com/clerk/generated-typedoc.git
+	branch = main

--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
     "lint:validation": "npm run build",
     "build": "tsx ./scripts/build-docs.ts",
     "test": "vitest --silent",
-    "typedoc:download": "git clone https://github.com/clerk/generated-typedoc.git --single-branch --depth 1 clerk-typedoc"
+    "typedoc:download": "git submodule init",
+    "typedoc:update": "git submodule update"
   },
   "devDependencies": {
     "@sindresorhus/slugify": "^2.2.1",

--- a/package.json
+++ b/package.json
@@ -12,8 +12,8 @@
     "lint:validation": "npm run build",
     "build": "tsx ./scripts/build-docs.ts",
     "test": "vitest --silent",
-    "typedoc:download": "git submodule init",
-    "typedoc:update": "git submodule update"
+    "typedoc:download": "git submodule update --init",
+    "typedoc:update": "git submodule update --remote"
   },
   "devDependencies": {
     "@sindresorhus/slugify": "^2.2.1",


### PR DESCRIPTION
### What does this solve?

- Currently we download the typedoc generated repo in to this repo when we need it, cloning inside of this repo, git treats this as a implicit submodule, but vscode doesn't fully know how to handle this, and we don't get the full control over it.

### What changed?

- Setup clerk-typedoc ([typedoc-generated](https://github.com/clerk/generated-typedoc)) as an official git submodule, update the package.json scripts, and setup dependabot to check daily for changes to the typedoc repo.
- This is a more manual approach, but that does also give us more control, and a pr preview when changes have been pushed to the typedoc repo before we update to it.

### Checklist

- [x] I have clicked on "Files changed" and performed a thorough self-review
- [x] All existing checks pass
