### PR TITLE
Add security warning for Protect and SignedIn components

### DIFF
--- a/docs/components/control/signed-in.mdx
+++ b/docs/components/control/signed-in.mdx
@@ -8,7 +8,7 @@ description: Conditionally render content only when a user is signed in.
 The `<SignedIn>` component offers authentication checks as a cross-cutting concern. Any children components wrapped by a `<SignedIn>` component will be rendered only if there's a User with an active Session signed in your application.
 
 > [!CAUTION]
-> This component only **visually hides** its children when the current user is not authenticated. The contents of its children remain accessible via the browser's source code even if the user fails the authentication check. Do not use this component to hide sensitive information that should be completely inaccessible to unauthorized users. For truly sensitive data, perform authentication checks on the server before sending the data to the client.
+> This component only **visually hides** its children when the current user is not authenticated. The contents of its children remain accessible via the browser's source code even if the user fails the authentication check. Do not use this component to hide sensitive information that should be completely inaccessible to unauthorized users. For truly sensitive data, perform [authentication checks](/docs/organizations/verify-user-permissions) on the server before sending the data to the client.
 
 ## Usage
 

--- a/docs/components/control/signed-in.mdx
+++ b/docs/components/control/signed-in.mdx
@@ -7,6 +7,9 @@ description: Conditionally render content only when a user is signed in.
 
 The `<SignedIn>` component offers authentication checks as a cross-cutting concern. Any children components wrapped by a `<SignedIn>` component will be rendered only if there's a User with an active Session signed in your application.
 
+> [!CAUTION]
+> This component only **visually hides** its children when the current user is not authenticated. The contents of its children remain accessible via the browser's source code even if the user fails the authentication check. Do not use this component to hide sensitive information that should be completely inaccessible to unauthorized users. For truly sensitive data, perform authentication checks on the server before sending the data to the client.
+
 ## Usage
 
 <Tabs items={["Next.js", "React", "Astro", "Expo", "Remix", "Tanstack React Start", "Vue"]}>

--- a/docs/components/protect.mdx
+++ b/docs/components/protect.mdx
@@ -6,7 +6,7 @@ description: The Protect component is used for authorization. It only renders it
 The `<Protect>` component is used for authorization. It only renders its children when the current user has the specified [permission or role](/docs/organizations/roles-permissions) in the organization.
 
 > [!CAUTION]
-> This component only **visually hides** its children when the current user is not authorized. The contents of its children remain accessible via the browser's source code even if the user fails the authorization check. Do not use this component to hide sensitive information that should be completely inaccessible to unauthorized users. For truly sensitive data, perform authorization checks on the server before sending the data to the client.
+> This component only **visually hides** its children when the current user is not authorized. The contents of its children remain accessible via the browser's source code even if the user fails the authorization check. Do not use this component to hide sensitive information that should be completely inaccessible to unauthorized users. For truly sensitive data, perform [authentication checks](/docs/organizations/verify-user-permissions) on the server before sending the data to the client.
 
 ## Properties
 

--- a/docs/components/protect.mdx
+++ b/docs/components/protect.mdx
@@ -5,6 +5,9 @@ description: The Protect component is used for authorization. It only renders it
 
 The `<Protect>` component is used for authorization. It only renders its children when the current user has the specified [permission or role](/docs/organizations/roles-permissions) in the organization.
 
+> [!CAUTION]
+> This component only **visually hides** its children when the current user is not authorized. The contents of its children remain accessible via the browser's source code even if the user fails the authorization check. Do not use this component to hide sensitive information that should be completely inaccessible to unauthorized users. For truly sensitive data, perform authorization checks on the server before sending the data to the client.
+
 ## Properties
 
 <Properties>


### PR DESCRIPTION
### 🔎 Previews:

- https://clerk.com/docs/pr/2196/components/protect#usage
- https://clerk.com/docs/pr/2196/components/control/signed-in

### What does this solve?

These two components return their children via source code due to the way that React hydration works. This change adds a note to the docs to clarify that if there is sensitive information that should be entirely inaccessible to the current user, these components are not enough to secure it.

### Checklist

- [x] I have clicked on "Files changed" and performed a thorough self-review
- [x] All existing checks pass
