### PR TITLE
Remove typedoc submodule, replace with just fetching the typedoc repo contents

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,6 +1,0 @@
-version: 2
-updates:
-  - package-ecosystem: 'gitsubmodule'
-    directory: '/'
-    schedule:
-      interval: 'daily'

--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,5 @@ yarn.lock
 
 /docs/docs
 /docs/docs/
+
+/clerk-typedoc

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,0 @@
-[submodule "clerk-typedoc"]
-	path = clerk-typedoc
-	url = https://github.com/clerk/generated-typedoc.git
-	branch = main

--- a/package.json
+++ b/package.json
@@ -12,8 +12,6 @@
     "lint:validation": "npm run build",
     "build": "tsx ./scripts/build-docs.ts",
     "test": "vitest --silent",
-    "typedoc:download": "git submodule update --init",
-    "typedoc:update": "git submodule update --remote",
     "move-doc": "node scripts/move-doc.mjs"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -12,7 +12,9 @@
     "lint:validation": "npm run build",
     "build": "tsx ./scripts/build-docs.ts",
     "test": "vitest --silent",
-    "move-doc": "node scripts/move-doc.mjs"
+    "move-doc": "node scripts/move-doc.mjs",
+    "typedoc:download": "git clone https://github.com/clerk/generated-typedoc.git --single-branch --depth 1 clerk-typedoc && rm -rf clerk-typedoc/.git",
+    "typedoc:update": "rm -rf clerk-typedoc && npm run typedoc:download"
   },
   "devDependencies": {
     "@sindresorhus/slugify": "^2.2.1",

--- a/package.json
+++ b/package.json
@@ -12,9 +12,9 @@
     "lint:validation": "npm run build",
     "build": "tsx ./scripts/build-docs.ts",
     "test": "vitest --silent",
-    "move-doc": "node scripts/move-doc.mjs",
     "typedoc:download": "git clone https://github.com/clerk/generated-typedoc.git --single-branch --depth 1 clerk-typedoc && rm -rf clerk-typedoc/.git",
-    "typedoc:update": "rm -rf clerk-typedoc && npm run typedoc:download"
+    "typedoc:update": "rm -rf clerk-typedoc && npm run typedoc:download",
+    "move-doc": "node scripts/move-doc.mjs"
   },
   "devDependencies": {
     "@sindresorhus/slugify": "^2.2.1",


### PR DESCRIPTION
Continuation of https://github.com/clerk/clerk-docs/pull/2194

### What does this solve?

- We didn't like the author experience of using submodule, files showing up in search and the dual repo in vscode confusion

### What changed?

- Instead of using submodule (either implied or explicit) we will just clone in the latest files, then remove the .git folder to make it a standard dumb folder

- authors will need to remember to run `npm run typedoc:update` to pull in the latest version of the typedoc generated files if they need them

### Checklist

- [ ] I have clicked on "Files changed" and performed a thorough self-review
- [ ] All existing checks pass
