### PR TITLE
fix(docs): Clarify 'signUp' object usage as per useSignUp() documentation

### DIFF
--- a/docs/custom-flows/overview.mdx
+++ b/docs/custom-flows/overview.mdx
@@ -14,11 +14,11 @@ Before building custom authentication flows, read the following sections to get 
 
 ### Sign-up flow
 
-The [`SignUp`](/docs/references/javascript/sign-up) object is the pivotal concept in the sign-up process. It is used to gather the user's information, verify their email address or phone number, add OAuth accounts, and finally, convert them into a [`User`](/docs/references/javascript/user).
+The [`signUp`](/docs/references/javascript/sign-up) object (returned by the [`useSignUp`] hook) is the pivotal concept in the sign-up process. It is used to gather the user's information, verify their email address or phone number, add OAuth accounts, and finally, convert them into a [`User`](/docs/references/javascript/user).
 
-Every `SignUp` must meet specific requirements before being converted into a `User`. These requirements are defined by the instance settings you selected in the [Clerk Dashboard](https://dashboard.clerk.com/). For example, on the [**Email, phone, username**](https://dashboard.clerk.com/last-active?path=user-authentication/email-phone-username) page, you can configure passwords, email links, or both as [authentication strategies](/docs/authentication/configuration/sign-up-sign-in-options#authentication-strategies).
+Every `signUp` must meet specific requirements before being converted into a `User`. These requirements are defined by the instance settings you selected in the [Clerk Dashboard](https://dashboard.clerk.com/). For example, on the [**Email, phone, username**](https://dashboard.clerk.com/last-active?path=user-authentication/email-phone-username) page, you can configure passwords, email links, or both as [authentication strategies](/docs/authentication/configuration/sign-up-sign-in-options#authentication-strategies).
 
-Once all requirements are met, the `SignUp` will turn into a new `User`, and an active session for that `User` will be created on the current [`Client`](/docs/references/javascript/client).
+Once all requirements are met, the `signUp` will turn into a new `User`, and an active session for that `User` will be created on the current [`Client`](/docs/references/javascript/client).
 
 Don't worry about collecting all the required fields at once and passing them to a single request. The API is designed to accommodate progressive multi-step sign-up forms.
 
@@ -31,33 +31,33 @@ The following steps outline the sign-up process:
 
 #### The state of a `SignUp`
 
-The `SignUp` object will show **the state of the current sign-up** in the `status` property.
+The `signUp` object will show **the state of the current sign-up** in the `status` property.
 
 If you need further help on where things are and what you need to do next, you can also consult the `required_fields`, `optional_fields`, and `missingFields` properties.
 
 <Properties>
   - `requiredFields`
 
-  All fields that must be collected before the `SignUp` converts into a `User`.
+  All fields that must be collected before the `signUp` converts into a `User`.
 
   ---
 
   - `optionalFields`
 
-  All fields that can be collected, but are not necessary to convert the `SignUp` into a `User`.
+  All fields that can be collected, but are not necessary to convert the `signUp` into a `User`.
 
   ---
 
   - `missingFields`
 
-  A subset of `requiredFields`. It contains all fields that still need to be collected before a `SignUp` can be converted into a `User`. Note that this property will be updated dynamically. As you add more fields to the `SignUp`, they will be removed. Once this property is empty, your `SignUp` will automatically convert into a `User`.
+  A subset of `requiredFields`. It contains all fields that still need to be collected before a `signUp` can be converted into a `User`. Note that this property will be updated dynamically. As you add more fields to the `signUp`, they will be removed. Once this property is empty, your `signUp` will automatically convert into a `User`.
 </Properties>
 
 #### Verified fields
 
-Some properties of the `SignUp`, such as `emailAddress` and `phoneNumber`, must be **verified** before they are **fully** added to the `SignUp` object.
+Some properties of the `signUp`, such as `emailAddress` and `phoneNumber`, must be **verified** before they are **fully** added to the `signUp` object.
 
-The `SignUp` object will show **the state of verification** in the following properties:
+The `signUp` object will show **the state of verification** in the following properties:
 
 <Properties>
   - `unverifiedFields`
@@ -68,7 +68,7 @@ The `SignUp` object will show **the state of verification** in the following pro
 
   - `verifications`
 
-  An object that describes the current state of verification for the [`SignUp`](/docs/references/javascript/sign-in). There are currently three different keys: `email_address`, `phone_number`, and `external_account`.
+  An object that describes the current state of verification for the [`signUp`](/docs/references/javascript/sign-in). There are currently three different keys: `email_address`, `phone_number`, and `external_account`.
 </Properties>
 
 ### Sign-in flow


### PR DESCRIPTION

### What does this solve?

- This small update clarifies the terminology from SignUp to signUp to match the actual object returned by the useSignUp hook.
- This aims to reduce confusion for developers following the documentation by using the correct casing and referring to the exact object returned.
- Related to [this documentation page](https://clerk.com/docs/custom-flows/overview).

### What changed
- SignUp object changed to signUp object

