### PR TITLE
Remove infinite redirect

### DIFF
--- a/redirects/static/docs.json
+++ b/redirects/static/docs.json
@@ -2278,15 +2278,5 @@
     "source": "/docs/quickstarts/tanstack-start",
     "destination": "/docs/quickstarts/tanstack-react-start",
     "permanent": true
-  },
-  {
-    "source": "/docs/references/nextjs/overview",
-    "destination": "/docs/references/nextjs/overview",
-    "permanent": true
-  },
-  {
-    "source": "/docs/references/nextjs/overview2",
-    "destination": "/docs/references/nextjs/overview",
-    "permanent": true
   }
 ]


### PR DESCRIPTION
### 🔎 Previews:

-

### What does this solve?

- Currently `/docs/references/nextjs/overview` redirects to itself which crashes the page

### What changed?

- removed redirect

### Checklist

- [x] I have clicked on "Files changed" and performed a thorough self-review
- [ ] All existing checks pass
