### PR TITLE
Redeploy on redirects changes

### DIFF
--- a/.github/workflows/redeploy.yml
+++ b/.github/workflows/redeploy.yml
@@ -8,6 +8,7 @@ on:
       - core-1
     paths:
       - 'docs/**'
+      - 'redirects/**'
 
 jobs:
   redeploy:


### PR DESCRIPTION
### 🔎 Previews:

-

### What does this solve?

- Currently the redeploy github action only runs on changes to the `/docs/**` folder of this repo, but with the redirects getting moved over to this repo, this means changes to the redirects doesn't make clerk.com redeploy like it did before.

### What changed?

- Add the `redirects/**` folder to the paths config that the github action matches on

### Checklist

- [x] I have clicked on "Files changed" and performed a thorough self-review
- [x] All existing checks pass
