### PR TITLE
Remove curly brackets around includes for icons

### DIFF
--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -37,73 +37,73 @@ Find all the guides and resources you need to develop with Clerk.
 <Cards variant="plain" cols={3}>
   - [Next.js](/docs/quickstarts/nextjs)
   - Easily add secure, beautiful, and fast authentication to Next.js with Clerk.
-  - {<Include src="_partials/icons/nextjs" />}
+  - <Include src="_partials/icons/nextjs" />
 
   ---
 
   - [React](/docs/quickstarts/react)
   - Get started installing and initializing Clerk in a new React + Vite app.
-  - {<Include src="_partials/icons/react" />}
+  - <Include src="_partials/icons/react" />
 
   ---
 
   - [Astro](/docs/quickstarts/astro)
   - Easily add secure and SSR-friendly authentication to your Astro application with Clerk.
-  - {<Include src="_partials/icons/astro" />}
+  - <Include src="_partials/icons/astro" />
 
   ---
 
   - [Chrome Extension](/docs/quickstarts/chrome-extension)
   - Use the Chrome Extension SDK to authenticate users in your Chrome extension.
-  - {<Include src="_partials/icons/chrome-extension" />}
+  - <Include src="_partials/icons/chrome-extension" />
 
   ---
 
   - [Expo](/docs/quickstarts/expo)
   - Use Clerk with Expo to authenticate users in your React Native application.
-  - {<Include src="_partials/icons/expo" />}
+  - <Include src="_partials/icons/expo" />
 
   ---
 
   - [iOS](/docs/quickstarts/ios)
   - Use the Clerk iOS SDK to authenticate users in your native Apple applications.
-  - {<Include src="_partials/icons/ios" />}
+  - <Include src="_partials/icons/ios" />
 
   ---
 
   - [JavaScript](/docs/quickstarts/javascript)
   - The Clerk JavaScript SDK gives you access to prebuilt components and helpers to make user authentication easier.
-  - {<Include src="_partials/icons/javascript" />}
+  - <Include src="_partials/icons/javascript" />
 
   ---
 
   - [Nuxt](/docs/quickstarts/nuxt)
   - Easily add secure, beautiful, and fast authentication to Nuxt with Clerk.
-  - {<Include src="_partials/icons/nuxt" />}
+  - <Include src="_partials/icons/nuxt" />
 
   ---
 
   - [React Router](/docs/quickstarts/react-router)
   - Easily add secure, edge- and SSR-friendly authentication to React Router with Clerk.
-  - {<Include src="_partials/icons/react-router" />}
+  - <Include src="_partials/icons/react-router" />
 
   ---
 
   - [Remix](/docs/quickstarts/remix)
   - Easily add secure, edge- and SSR-friendly authentication to Remix with Clerk.
-  - {<Include src="_partials/icons/remix" />}
+  - <Include src="_partials/icons/remix" />
 
   ---
 
   - [TanStack React Start (beta)](/docs/quickstarts/tanstack-react-start)
   - Easily add secure and SSR-friendly authentication to your TanStack React Start application with Clerk.
-  - {<Include src="_partials/icons/tanstack-start" />}
+  - <Include src="_partials/icons/tanstack-start" />
 
   ---
 
   - [Vue](/docs/quickstarts/vue)
   - Get started installing and initializing Clerk in a new Vue + Vite app.
-  - {<Include src="_partials/icons/vue" />}
+  - <Include src="_partials/icons/vue" />
 </Cards>
 
 ## Explore by backend framework
@@ -113,43 +113,43 @@ Find all the guides and resources you need to develop with Clerk.
 <Cards variant="plain" cols={3}>
   - [JS Backend SDK](/docs/references/backend/overview)
   - The Clerk Backend SDK exposes our Backend API resources and low-level authentication utilities for JavaScript environments.
-  - {<Include src="_partials/icons/backend-sdk" />}
+  - <Include src="_partials/icons/backend-sdk" />
 
   ---
 
   - [C#](https://github.com/clerk/clerk-sdk-csharp/blob/main/README.md)
   - The Clerk C# SDK is a wrapper around our Backend API to make it easier to integrate Clerk into your backend.
-  - {<Include src="_partials/icons/c-sharp" />}
+  - <Include src="_partials/icons/c-sharp" />
 
   ---
 
   - [Express](/docs/quickstarts/express)
   - Quickly add authentication and user management to your Express application.
-  - {<Include src="_partials/icons/express" />}
+  - <Include src="_partials/icons/express" />
 
   ---
 
   - [Go](/docs/references/go/overview)
   - The Clerk Go SDK is a wrapper around the Backend API written in Golang to make it easier to integrate Clerk into your backend.
-  - {<Include src="_partials/icons/go" />}
+  - <Include src="_partials/icons/go" />
 
   ---
 
   - [Fastify](/docs/quickstarts/fastify)
   - Build secure authentication and user management flows for your Fastify server.
-  - {<Include src="_partials/icons/fastify" />}
+  - <Include src="_partials/icons/fastify" />
 
   ---
 
   - [Python](https://github.com/clerk/clerk-sdk-python/blob/main/README.md)
   - The Clerk Python SDK is a wrapper around the Backend API written in Python to make it easier to integrate Clerk into your backend.
-  - {<Include src="_partials/icons/python" />}
+  - <Include src="_partials/icons/python" />
 
   ---
 
   - [Ruby on Rails](/docs/quickstarts/ruby)
   - Integrate authentication and user management into your Ruby application.
-  - {<Include src="_partials/icons/ruby.mdx" />}
+  - <Include src="_partials/icons/ruby.mdx" />
 </Cards>
 
 ## Explore by feature

--- a/docs/quickstarts/overview.mdx
+++ b/docs/quickstarts/overview.mdx
@@ -8,37 +8,37 @@ description: See the getting started guides and tutorials.
 <Cards>
   - [Next.js](/docs/quickstarts/nextjs)
   - Easily add secure, beautiful, and fast authentication to your Next.js application with Clerk.
-  - {<Include src="_partials/icons/nextjs" />}
+  - <Include src="_partials/icons/nextjs" />
 
   ---
 
   - [Astro](/docs/quickstarts/astro)
   - Easily add secure and SSR-friendly authentication to your Astro application with Clerk.
-  - {<Include src="_partials/icons/astro" />}
+  - <Include src="_partials/icons/astro" />
 
   ---
 
   - [Nuxt](/docs/quickstarts/nuxt)
   - Easily add secure, beautiful, and fast authentication to Nuxt with Clerk.
-  - {<Include src="_partials/icons/nuxt" />}
+  - <Include src="_partials/icons/nuxt" />
 
   ---
 
   - [React Router (Beta)](/docs/quickstarts/react-router)
   - The Clerk React Router SDK provides prebuilt components, hooks, and stores to make it easy to integrate authentication and user management in your React Router app.
-  - {<Include src="_partials/icons/react-router" />}
+  - <Include src="_partials/icons/react-router" />
 
   ---
 
   - [Remix](/docs/quickstarts/remix)
   - Easily add secure, edge- and SSR-friendly authentication to your Remix application with Clerk.
-  - {<Include src="_partials/icons/remix" />}
+  - <Include src="_partials/icons/remix" />
 
   ---
 
   - [TanStack React Start (beta)](/docs/quickstarts/tanstack-react-start)
   - Easily add secure and SSR-friendly authentication to your TanStack React Start application with Clerk.
-  - {<Include src="_partials/icons/tanstack-start" />}
+  - <Include src="_partials/icons/tanstack-start" />
 </Cards>
 
 ## Frontend
@@ -46,37 +46,37 @@ description: See the getting started guides and tutorials.
 <Cards>
   - [React](/docs/quickstarts/react)
   - Easily add secure, beautiful, and fast authentication to your React application with Clerk.
-  - {<Include src="_partials/icons/react" />}
+  - <Include src="_partials/icons/react" />
 
   ---
 
   - [Chrome Extension](/docs/quickstarts/chrome-extension)
   - Use the Chrome Extension SDK to authenticate users in your Chrome extension.
-  - {<Include src="_partials/icons/chrome-extension" />}
+  - <Include src="_partials/icons/chrome-extension" />
 
   ---
 
   - [Expo](/docs/quickstarts/expo)
   - Use Clerk with Expo to authenticate users in your React Native application.
-  - {<Include src="_partials/icons/expo" />}
+  - <Include src="_partials/icons/expo" />
 
   ---
 
   - [iOS](/docs/quickstarts/ios)
   - Use the Clerk iOS SDK to authenticate users in your native Apple applications.
-  - {<Include src="_partials/icons/ios" />}
+  - <Include src="_partials/icons/ios" />
 
   ---
 
   - [JavaScript](/docs/quickstarts/javascript)
   - Easily add secure, beautiful, and fast authentication to your JavaScript application with Clerk.
-  - {<Include src="_partials/icons/javascript" />}
+  - <Include src="_partials/icons/javascript" />
 
   ---
 
   - [Vue](/docs/quickstarts/vue)
   - Easily add secure, beautiful, and fast authentication to your Vue application with Clerk.
-  - {<Include src="_partials/icons/vue" />}
+  - <Include src="_partials/icons/vue" />
 </Cards>
 
 ## Backend
@@ -84,13 +84,13 @@ description: See the getting started guides and tutorials.
 <Cards>
   - [Express](/docs/quickstarts/express)
   - Easily add secure, beautiful, and fast authentication to your Express application with Clerk.
-  - {<Include src="_partials/icons/express" />}
+  - <Include src="_partials/icons/express" />
 
   ---
 
   - [Fastify](/docs/quickstarts/fastify)
   - Easily add secure, beautiful, and fast authentication to your Fastify application with Clerk.
-  - {<Include src="_partials/icons/fastify" />}
+  - <Include src="_partials/icons/fastify" />
 </Cards>
 
 <Include src="_partials/help" />

--- a/docs/references/overview.mdx
+++ b/docs/references/overview.mdx
@@ -10,73 +10,73 @@ description: Learn about the Clerk and community SDK's available for integrating
 <Cards>
   - [Next.js](/docs/references/nextjs/overview)
   - Easily add secure, beautiful, and fast authentication to Next.js with Clerk.
-  - {<Include src="_partials/icons/nextjs" />}
+  - <Include src="_partials/icons/nextjs" />
 
   ---
 
   - [React](/docs/references/react/overview)
   - Get started installing and initializing Clerk in a new React + Vite app.
-  - {<Include src="_partials/icons/react" />}
+  - <Include src="_partials/icons/react" />
 
   ---
 
   - [Astro](/docs/references/astro/overview)
   - Easily add secure and SSR-friendly authentication to your Astro application with Clerk.
-  - {<Include src="_partials/icons/astro" />}
+  - <Include src="_partials/icons/astro" />
 
   ---
 
   - [Chrome Extension](/docs/references/chrome-extension/overview)
   - Use the Chrome Extension SDK to authenticate users in your Chrome extension.
-  - {<Include src="_partials/icons/chrome-extension" />}
+  - <Include src="_partials/icons/chrome-extension" />
 
   ---
 
   - [Expo](/docs/references/expo/overview)
   - Use Clerk with Expo to authenticate users in your React Native application.
-  - {<Include src="_partials/icons/expo" />}
+  - <Include src="_partials/icons/expo" />
 
   ---
 
   - [iOS](/docs/references/ios/overview)
   - Use the Clerk iOS SDK to authenticate users in your native Apple applications.
-  - {<Include src="_partials/icons/ios" />}
+  - <Include src="_partials/icons/ios" />
 
   ---
 
   - [JavaScript](/docs/references/javascript/overview)
   - The Clerk JavaScript SDK gives you access to prebuilt components and helpers to make user authentication easier.
-  - {<Include src="_partials/icons/javascript" />}
+  - <Include src="_partials/icons/javascript" />
 
   ---
 
   - [Nuxt](/docs/references/nuxt/overview)
   - Easily add secure, beautiful, and fast authentication to Nuxt with Clerk.
-  - {<Include src="_partials/icons/nuxt" />}
+  - <Include src="_partials/icons/nuxt" />
 
   ---
 
   - [React Router](/docs/references/react-router/overview)
   - Easily add secure, edge- and SSR-friendly authentication to React Router with Clerk.
-  - {<Include src="_partials/icons/react-router" />}
+  - <Include src="_partials/icons/react-router" />
 
   ---
 
   - [Remix](/docs/references/remix/overview)
   - Easily add secure, edge- and SSR-friendly authentication to Remix with Clerk.
-  - {<Include src="_partials/icons/remix" />}
+  - <Include src="_partials/icons/remix" />
 
   ---
 
   - [TanStack React Start (beta)](/docs/references/tanstack-react-start/overview)
   - Easily add secure and SSR-friendly authentication to your TanStack React Start application with Clerk.
-  - {<Include src="_partials/icons/tanstack-start" />}
+  - <Include src="_partials/icons/tanstack-start" />
 
   ---
 
   - [Vue](/docs/references/vue/overview)
   - Get started installing and initializing Clerk in a new Vue + Vite app.
-  - {<Include src="_partials/icons/vue" />}
+  - <Include src="_partials/icons/vue" />
 </Cards>
 
 ## Backend SDKs
@@ -84,43 +84,43 @@ description: Learn about the Clerk and community SDK's available for integrating
 <Cards>
   - [JS Backend SDK](/docs/references/backend/overview)
   - The Clerk Backend SDK exposes our Backend API resources and low-level authentication utilities for JavaScript environments.
-  - {<Include src="_partials/icons/backend-sdk" />}
+  - <Include src="_partials/icons/backend-sdk" />
 
   ---
 
   - [C#](https://github.com/clerk/clerk-sdk-csharp/blob/main/README.md)
   - The Clerk C# SDK is a wrapper around our Backend API to make it easier to integrate Clerk into your backend.
-  - {<Include src="_partials/icons/c-sharp" />}
+  - <Include src="_partials/icons/c-sharp" />
 
   ---
 
   - [Express](/docs/references/express/overview)
   - Quickly add authentication and user management to your Express application.
-  - {<Include src="_partials/icons/express" />}
+  - <Include src="_partials/icons/express" />
 
   ---
 
   - [Go](/docs/references/go/overview)
   - The Clerk Go SDK is a wrapper around the Backend API written in Golang to make it easier to integrate Clerk into your backend.
-  - {<Include src="_partials/icons/go" />}
+  - <Include src="_partials/icons/go" />
 
   ---
 
   - [Fastify](/docs/references/fastify/overview)
   - Build secure authentication and user management flows for your Fastify server.
-  - {<Include src="_partials/icons/fastify" />}
+  - <Include src="_partials/icons/fastify" />
 
   ---
 
   - [Python](https://github.com/clerk/clerk-sdk-python/blob/main/README.md)
   - The Clerk Python SDK is a wrapper around the Backend API written in Python to make it easier to integrate Clerk into your backend.
-  - {<Include src="_partials/icons/python" />}
+  - <Include src="_partials/icons/python" />
 
   ---
 
   - [Ruby on Rails](/docs/references/ruby/overview)
   - Integrate authentication and user management into your Ruby application.
-  - {<Include src="_partials/icons/ruby.mdx" />}
+  - <Include src="_partials/icons/ruby.mdx" />
 </Cards>
 
 ## Build with community-maintained SDKs


### PR DESCRIPTION
### 🔎 Previews:

- https://clerk.com/docs/pr/2214
- https://clerk.com/docs/pr/2214/quickstarts/overview
- https://clerk.com/docs/pr/2214/references/overview

### What does this solve?

- The build script I'm working on (https://github.com/clerk/clerk-docs/pull/2041) had issues parsing the `<Include />` component when inside the curly braces, easiest fix was to just take them out of the the brackets.

### What changed?

- Updated from `{<Include src="_partials/icons/nextjs" />}` to `<Include src="_partials/icons/nextjs" />`

### Checklist

- [x] I have clicked on "Files changed" and performed a thorough self-review
- [x] All existing checks pass
