### PR TITLE
Changed Request to NextRequest to solve the error

### DIFF
--- a/docs/webhooks/sync-data.mdx
+++ b/docs/webhooks/sync-data.mdx
@@ -105,8 +105,10 @@ These steps apply to any Clerk event. To make the setup process easier, it's rec
     <Tab>
       ```ts {{ filename: 'app/api/webhooks/route.ts' }}
       import { verifyWebhook } from '@clerk/nextjs/webhooks'
+      import { NextRequest } from 'next/server'
 
-      export async function POST(req: Request) {
+
+      export async function POST(req: NextRequest) {
         try {
           const evt = await verifyWebhook(req)
 


### PR DESCRIPTION
error:  Argument of type 'Request' is not assignable to parameter of type 'RequestLike'

### 🔎 Previews:

-

### What does this solve?

This PR fixes a type error caused when passing a `Request` object to a function expecting a `RequestLike` type. Specifically, using the native `Request` object was leading to the following error:

```
EditArgument of type 'Request' is not assignable to parameter of type 'RequestLike'

```

This change ensures compatibility with Next.js middleware expectations. More context: this error typically appears when working with Next.js middleware or API routes, which expect a `NextRequest` instead of a standard `Request`.

### What changed?

* Replaced instances of the standard `Request` object with `NextRequest` to match the expected `RequestLike` interface.
* This resolves the type mismatch and aligns the implementation with Next.js middleware type expectations.

### Checklist

* [x] I have clicked on "Files changed" and performed a thorough self-review
* [x] All existing checks pass
