### PR TITLE
Adjust the SignUp flow template to include CAPTCHA div

### DIFF
--- a/docs/custom-flows/application-invitations.mdx
+++ b/docs/custom-flows/application-invitations.mdx
@@ -120,6 +120,7 @@ To create a sign-up flow using the invitation token, you need to extract the tok
                 onChange={(e) => setPassword(e.target.value)}
               />
             </div>
+            <div id="clerk-captcha" />
             <div>
               <button type="submit">Next</button>
             </div>


### PR DESCRIPTION
### 🔎 Previews:

- Adjusting the sign up flow template to include the CAPTCHA div, to save one other error a user may run into as part of trying to utilize the template

### What does this solve?

- When attempting to copy/paste the example code, users may run into an issue with getting it to work. First, if the first name and last name are not enabled, it will error. Second, if a CAPTCHA is not included (in the cases where it is enabled for the sign up flow, which I believe it is by default), it will error. 

### What changed?

- The template has been modified to include the minor fix for CAPTCHA users. 

### Checklist

- [x] I have clicked on "Files changed" and performed a thorough self-review
- [x] All existing checks pass
