### PR TITLE
docs: Add `<PricingTable />` JavaScript usage

### DIFF
--- a/docs/components/pricing-table.mdx
+++ b/docs/components/pricing-table.mdx
@@ -123,3 +123,95 @@ The following example includes a basic implementation of the `<PricingTable />` 
     ```
   </Tab>
 </Tabs>
+
+<If sdk="js-frontend">
+  ## Usage with JavaScript
+
+  The following methods available on an instance of the [`Clerk`](/docs/references/javascript/clerk) class are used to render and control the `<PricingTable />` component:
+
+  - [`mountPricingTable()`](#mount-pricing-table)
+  - [`unmountPricingTable()`](#unmount-pricing-table)
+
+  The following examples assume that you followed the [quickstart](/docs/quickstarts/javascript) to add Clerk to your JavaScript app.
+
+  ### `mountPricingTable()`
+
+  ```typescript
+  function mountPricingTable(node: HTMLDivElement, props?: PricingTableProps): void
+  ```
+
+  #### `mountPricingTable()` params
+
+  <Properties>
+    - `node`
+    - [`HTMLDivElement`](https://developer.mozilla.org/en-US/docs/Web/API/HTMLDivElement)
+
+    The container `<div>` element used to render in the `<PricingTable />` component
+
+    ---
+
+    - `props?`
+    - [`PricingTableProps`](#properties)
+
+    The properties to pass to the `<PricingTable />` component
+  </Properties>
+
+  #### `mountPricingTable()` usage
+
+  ```js {{ filename: 'main.js', mark: [15] }}
+  import { Clerk } from '@clerk/clerk-js'
+
+  // Initialize Clerk with your Clerk Publishable Key
+  const clerkPubKey = import.meta.env.VITE_CLERK_PUBLISHABLE_KEY
+
+  const clerk = new Clerk(clerkPubKey)
+  await clerk.load()
+
+  document.getElementById('app').innerHTML = `
+    <div id="pricing-table"></div>
+  `
+
+  const pricingTableDiv = document.getElementById('pricing-table')
+
+  clerk.mountPricingTable(pricingTableDiv)
+  ```
+
+  ### `unmountPricingTable()`
+
+  ```typescript
+  function unmountPricingTable(node: HTMLDivElement): void
+  ```
+
+  #### `unmountPricingTable()` params
+
+  <Properties>
+    - `node`
+    - [`HTMLDivElement`](https://developer.mozilla.org/en-US/docs/Web/API/HTMLDivElement)
+
+    The container `<div>` element with a rendered `<PricingTable />` component instance
+  </Properties>
+
+  #### `unmountPricingTable()` usage
+
+  ```js {{ filename: 'main.js', mark: [19] }}
+  import { Clerk } from '@clerk/clerk-js'
+
+  // Initialize Clerk with your Clerk Publishable Key
+  const clerkPubKey = import.meta.env.VITE_CLERK_PUBLISHABLE_KEY
+
+  const clerk = new Clerk(clerkPubKey)
+  await clerk.load()
+
+  document.getElementById('app').innerHTML = `
+    <div id="pricing-table"></div>
+  `
+
+  const pricingTableDiv = document.getElementById('pricing-table')
+
+  clerk.mountPricingTable(pricingTableDiv)
+
+  // ...
+
+  clerk.unmountPricingTable(pricingTableDiv)
+  ```
+</If>


### PR DESCRIPTION
### 🔎 Previews:

- https://clerk.com/docs/pr/2222/components/pricing-table#usage-with-java-script

### What does this solve?

- [A user](https://x.com/volkandkaya/status/1919977618578755995) is looking to use the new billing component without React

### What changed?

- Added a "Usage with JavaScript" section for `<PricingTable />`, similar to other components

### Checklist

- [x] I have clicked on "Files changed" and performed a thorough self-review
- [x] All existing checks pass
