### PR TITLE
fix: rename checkout popup to checkout drawer

### DIFF
--- a/docs/components/pricing-table.mdx
+++ b/docs/components/pricing-table.mdx
@@ -18,7 +18,7 @@ The `<PricingTable />` component displays a table of Plans and Features that use
   - `checkoutProps`
   - `{ appearance: Appearance }`
 
-  Options for the checkout popup. Accepts the following properties:
+  Options for the checkout drawer. Accepts the following properties:
 
   - [`appearance`](/docs/customization/overview): an object used to style your components. Will only affect [Clerk components](/docs/components/overview) and not [Account Portal](/docs/account-portal/overview) pages.
 


### PR DESCRIPTION
### 🔎 Previews:

- https://clerk.com/docs/pr/2225/components/pricing-table#properties

### What does this solve?

- Renaming `popup` to `drawer`

### What changed?

- <!--- How does this PR solve the problem? -->

### Checklist

- [x] I have clicked on "Files changed" and performed a thorough self-review
- [x] All existing checks pass
