### PR TITLE
Update SEO title and meta description for all 14 docs pages related to Orgs

### DIFF
--- a/docs/organizations/create-orgs-for-users.mdx
+++ b/docs/organizations/create-orgs-for-users.mdx
@@ -1,6 +1,8 @@
 ---
-title: Create organizations programmatically on behalf of users
+title: Create organizations on behalf of users
 description: Step-by-step guide on how to programmatically create organizations on your users' behalf in order to automate user onboarding, without running into rate limits and billing issues.
+metadata:
+  title: Create organizations programmatically on behalf of users
 ---
 
 In some cases, you may want the onboarding process for your app to include creating an organization on the user's behalf. This could be beneficial for several reasons, such as:

--- a/docs/organizations/create-orgs-for-users.mdx
+++ b/docs/organizations/create-orgs-for-users.mdx
@@ -1,6 +1,6 @@
 ---
-title: Create organizations on behalf of users
-description: Learn how to architect your application to create organizations on users' behalf without running into rate limits and billing issues.
+title: Create organizations programmatically on behalf of users
+description: Step-by-step guide on how to programmatically create organizations on your users' behalf in order to automate user onboarding, without running into rate limits and billing issues.
 ---
 
 In some cases, you may want the onboarding process for your app to include creating an organization on the user's behalf. This could be beneficial for several reasons, such as:

--- a/docs/organizations/create-roles-permissions.mdx
+++ b/docs/organizations/create-roles-permissions.mdx
@@ -1,6 +1,6 @@
 ---
-title: Create roles and permissions
-description: Use the Clerk Dashboard to create and assign roles and permissions to users in your organization.
+title: Create custom user roles and permissions in Clerk
+description: How to build custom roles and granular permissions into your B2B multitenant SaaS in 4 steps, using Clerk Orgs.
 ---
 
 In the Clerk Dashboard, you can create roles, assign permissions to them, and change users' roles.

--- a/docs/organizations/create-roles-permissions.mdx
+++ b/docs/organizations/create-roles-permissions.mdx
@@ -1,6 +1,8 @@
 ---
-title: Create custom user roles and permissions in Clerk
+title: Create user roles and permissions
 description: How to build custom roles and granular permissions into your B2B multitenant SaaS in 4 steps, using Clerk Orgs.
+metadata:
+  title: Create custom user roles and permissions in Clerk
 ---
 
 In the Clerk Dashboard, you can create roles, assign permissions to them, and change users' roles.

--- a/docs/organizations/create-roles-permissions.mdx
+++ b/docs/organizations/create-roles-permissions.mdx
@@ -1,5 +1,5 @@
 ---
-title: Create user roles and permissions
+title: Create custom roles and permissions
 description: How to build custom roles and granular permissions into your B2B multitenant SaaS in 4 steps, using Clerk Orgs.
 metadata:
   title: Create custom user roles and permissions in Clerk

--- a/docs/organizations/create-roles-permissions.mdx
+++ b/docs/organizations/create-roles-permissions.mdx
@@ -1,6 +1,6 @@
 ---
 title: Create custom roles and permissions
-description: How to build custom roles and granular permissions into your B2B multitenant SaaS in 4 steps, using Clerk Orgs.
+description: How to build custom roles and granular permissions into your B2B multitenant SaaS in 4 steps, using Clerk Organizations.
 metadata:
   title: Create custom user roles and permissions in Clerk
 ---

--- a/docs/organizations/creator-role.mdx
+++ b/docs/organizations/creator-role.mdx
@@ -1,6 +1,8 @@
 ---
-title: Assigning Creator roles in Clerk
+title: Reassign the Creator role
 description: Learn how to assign Creator Roles to other roles/members within your organization. You can grant admin privileges, manage resources, and customize user permissions.
+metadata:
+  title: Assigning Creator roles in Clerk
 content-type: guide
 ---
 

--- a/docs/organizations/creator-role.mdx
+++ b/docs/organizations/creator-role.mdx
@@ -1,6 +1,6 @@
 ---
-title: Reassign the Creator role
-description: Learn how to assign Clerk's Creator role to any other role in an organization.
+title: Assigning Creator roles in Clerk
+description: Learn how to assign Creator Roles to other roles/members within your organization. You can grant admin privileges, manage resources, and customize user permissions.
 content-type: guide
 ---
 

--- a/docs/organizations/default-role.mdx
+++ b/docs/organizations/default-role.mdx
@@ -1,6 +1,6 @@
 ---
-title: Reassign the Default role for members
-description: Learn how to assign Clerk's Default role to any other role in an organization.
+title: Reassign Default roles for organization members
+description: Learn how to assign default roles to other user roles/members in any B2C/B2B SaaS that’s powered by Clerk.
 content-type: guide
 ---
 

--- a/docs/organizations/default-role.mdx
+++ b/docs/organizations/default-role.mdx
@@ -1,6 +1,8 @@
 ---
-title: Reassign Default roles for organization members
+title: Reassign the Default role for members
 description: Learn how to assign default roles to other user roles/members in any B2C/B2B SaaS that’s powered by Clerk.
+metadata:
+  title: Reassigning Default roles for organization members
 content-type: guide
 ---
 

--- a/docs/organizations/force-organizations.mdx
+++ b/docs/organizations/force-organizations.mdx
@@ -1,6 +1,6 @@
 ---
-title: Hide personal accounts and force organizations
-description: Learn how to hide personal accounts and force organizations in your Clerk application.
+title: Enforce organization membership in Clerk (B2B Setup)
+description: Learn how to hide personal accounts and enforce organization membership requirements within your Clerk app to ensure structured user access and permissions in multitenant use cases.
 ---
 
 <TutorialHero

--- a/docs/organizations/force-organizations.mdx
+++ b/docs/organizations/force-organizations.mdx
@@ -1,6 +1,8 @@
 ---
-title: Enforce organization membership in Clerk (B2B Setup)
+title: Hide personal accounts and force organizations
 description: Learn how to hide personal accounts and enforce organization membership requirements within your Clerk app to ensure structured user access and permissions in multitenant use cases.
+metadata:
+  title: Enforce organization membership in Clerk (B2B Setup)
 ---
 
 <TutorialHero

--- a/docs/organizations/invitations.mdx
+++ b/docs/organizations/invitations.mdx
@@ -1,6 +1,8 @@
 ---
-title: Send and manage B2C/B2B organization invitations via Clerk
+title: Invite users to your organization
 description: Step-by-step guide on how to send, manage, and track user invitations within your multitenant SaaS, all using Clerk Organizations.
+metadata:
+  title: Send and manage B2C/B2B organization invitations via Clerk
 ---
 
 Organization invitations allow you to add new members to your organization. When you send an invitation, Clerk sends an email to the invited user with a unique invitation link. When the user visits the organization invitation link, they will be redirected to the [Account Portal sign-in page](/docs/account-portal/overview#sign-in). If the user is already signed in, they will be redirected to your application's homepage (`/`). If you want to redirect the user to a specific page in your application, you can [specify a redirect URL when creating the invitation](#redirect-url).

--- a/docs/organizations/invitations.mdx
+++ b/docs/organizations/invitations.mdx
@@ -1,6 +1,6 @@
 ---
-title: Invite users to your organization
-description: Learn how to invite users to your organization.
+title: Send and manage B2C/B2B organization invitations via Clerk
+description: Step-by-step guide on how to send, manage, and track user invitations within your multitenant SaaS, all using Clerk Organizations.
 ---
 
 Organization invitations allow you to add new members to your organization. When you send an invitation, Clerk sends an email to the invited user with a unique invitation link. When the user visits the organization invitation link, they will be redirected to the [Account Portal sign-in page](/docs/account-portal/overview#sign-in). If the user is already signed in, they will be redirected to your application's homepage (`/`). If you want to redirect the user to a specific page in your application, you can [specify a redirect URL when creating the invitation](#redirect-url).

--- a/docs/organizations/manage-sso.mdx
+++ b/docs/organizations/manage-sso.mdx
@@ -2,7 +2,7 @@
 title: Organization-level enterprise SSO
 description: Integrate as many enterprise SSO methods within Clerk Organizations. Enable SAML SSO, OAuth/OIDC, and other secure MFA/single sign-on options for B2B SaaS apps.
 metadata:
-  title: Organization-level SSO setup for B2B/B2C - SAML and OIDC guide
+  title: Set up organization-level SAML and OIDC for B2B/B2C apps
 ---
 
 Clerk supports enabling enterprise SSO connections for specific organizations. When users sign up or sign in using an organization's enterprise connection, they're automatically added as members of that organization and assigned the [default role](/docs/organizations/roles-permissions#default-roles), which can be either `member` or `admin`.

--- a/docs/organizations/manage-sso.mdx
+++ b/docs/organizations/manage-sso.mdx
@@ -1,6 +1,6 @@
 ---
-title: Organization-level enterprise SSO
-description: Learn how to set up and manage enterprise SSO for organizations.
+title: Organization-level SSO setup for B2B/B2C: SAML and OIDC guide
+description: Integrate as many enterprise SSO methods within Clerk Organizations. Enable SAML SSO, OAuth/OIDC, and other secure MFA/single sign-on options for B2B SaaS apps.
 ---
 
 Clerk supports enabling enterprise SSO connections for specific organizations. When users sign up or sign in using an organization's enterprise connection, they're automatically added as members of that organization and assigned the [default role](/docs/organizations/roles-permissions#default-roles), which can be either `member` or `admin`.

--- a/docs/organizations/manage-sso.mdx
+++ b/docs/organizations/manage-sso.mdx
@@ -1,6 +1,8 @@
 ---
-title: Organization-level SSO setup for B2B/B2C: SAML and OIDC guide
+title: Organization-level enterprise SSO
 description: Integrate as many enterprise SSO methods within Clerk Organizations. Enable SAML SSO, OAuth/OIDC, and other secure MFA/single sign-on options for B2B SaaS apps.
+metadata:
+  title: Organization-level SSO setup for B2B/B2C - SAML and OIDC guide
 ---
 
 Clerk supports enabling enterprise SSO connections for specific organizations. When users sign up or sign in using an organization's enterprise connection, they're automatically added as members of that organization and assigned the [default role](/docs/organizations/roles-permissions#default-roles), which can be either `member` or `admin`.

--- a/docs/organizations/metadata.mdx
+++ b/docs/organizations/metadata.mdx
@@ -1,6 +1,6 @@
 ---
-title: Organization metadata
-description: Organization objects hold a set of metadata that can be used internally to store arbitrary information.
+title: Custom metadata for B2B authentication flows
+description: Learn how to add custom metadata to your B2B authentication flows to store additional information in the org object for advanced user segmentation, analytics, and B2B workflows.
 ---
 
 Organization metadata allows you to store information about an organization that is not part of the standard fields, such as custom attributes that are specific to your application.

--- a/docs/organizations/metadata.mdx
+++ b/docs/organizations/metadata.mdx
@@ -1,6 +1,8 @@
 ---
-title: Custom metadata for B2B authentication flows
+title: Organization metadata
 description: Learn how to add custom metadata to your B2B authentication flows to store additional information in the org object for advanced user segmentation, analytics, and B2B workflows.
+metadata:
+  title: Custom metadata for B2B authentication flows
 ---
 
 Organization metadata allows you to store information about an organization that is not part of the standard fields, such as custom attributes that are specific to your application.

--- a/docs/organizations/org-slugs-in-urls.mdx
+++ b/docs/organizations/org-slugs-in-urls.mdx
@@ -1,6 +1,6 @@
 ---
-title: Use organization slugs in URLs
-description: Learn how to use organization slugs in your application URLs to manage and switch between active Clerk organizations.
+title: Use organization slugs in URLs for tenant-specific auth flows
+description: Learn how to use organization slugs in your application URLs to build tenant-specific authentication flows. Enable seamless switching between active orgs (one-to-many or many-to-many) with Clerk's secure and scalable multi-tenant authentication suite.
 ---
 
 <TutorialHero

--- a/docs/organizations/org-slugs-in-urls.mdx
+++ b/docs/organizations/org-slugs-in-urls.mdx
@@ -1,6 +1,8 @@
 ---
-title: Use organization slugs in URLs for tenant-specific auth flows
+title: Use organization slugs in URLs
 description: Learn how to use organization slugs in your application URLs to build tenant-specific authentication flows. Enable seamless switching between active orgs (one-to-many or many-to-many) with Clerk's secure and scalable multi-tenant authentication suite.
+metadata:
+  title: Use organization slugs in URLs for tenant-specific auth flows
 ---
 
 <TutorialHero

--- a/docs/organizations/organization-workspaces.mdx
+++ b/docs/organizations/organization-workspaces.mdx
@@ -2,7 +2,7 @@
 title: Organization workspaces in the Clerk Dashboard
 description: Discover how to create and manage teams, projects, workspaces, and resources within the Clerk Dashboard in order to design a scalable multitenant architecture. You can invite collaborators to an org workspace, and also transfer your apps between workspaces.
 metadata:
-  title: Create and manage B2C/B2B workspaces from your Clerk Dashboard
+  title: Create and manage B2C/B2B workspaces for your Clerk Dashboard
 ---
 
 In the Clerk Dashboard, there are two types of workspaces:

--- a/docs/organizations/organization-workspaces.mdx
+++ b/docs/organizations/organization-workspaces.mdx
@@ -1,6 +1,8 @@
 ---
-title: Create and manage B2C/B2B workspaces from your Clerk Dashboard
+title: Organization workspaces in the Clerk Dashboard
 description: Discover how to create and manage teams, projects, workspaces, and resources within the Clerk Dashboard in order to design a scalable multitenant architecture. You can invite collaborators to an org workspace, and also transfer your apps between workspaces.
+metadata:
+  title: Create and manage B2C/B2B workspaces from your Clerk Dashboard
 ---
 
 In the Clerk Dashboard, there are two types of workspaces:

--- a/docs/organizations/organization-workspaces.mdx
+++ b/docs/organizations/organization-workspaces.mdx
@@ -1,6 +1,6 @@
 ---
-title: Organization workspaces in the Clerk Dashboard
-description: Use the Clerk Dashboard to create and invite collaborators to an organization workspace, and to transfer your apps between workspaces.
+title: Create and manage B2C/B2B workspaces from your Clerk Dashboard
+description: Discover how to create and manage teams, projects, workspaces, and resources within the Clerk Dashboard in order to design a scalable multitenant architecture. You can invite collaborators to an org workspace, and also transfer your apps between workspaces.
 ---
 
 In the Clerk Dashboard, there are two types of workspaces:

--- a/docs/organizations/overview.mdx
+++ b/docs/organizations/overview.mdx
@@ -1,6 +1,8 @@
 ---
-title: Overview - Build a B2B/B2C multi-tenant SaaS with Clerk Organizations
+title: Organizations
 description: Learn how to use Clerk Orgs to build scalable B2B auth features, user management, role based access control (RBAC), and per-organization invitation flows into your B2B SaaS.
+metadata:
+  title: Overview - Build a B2B/B2C multi-tenant SaaS with Clerk Organizations
 ---
 
 Organizations are a flexible and scalable way to manage users and their access to resources within your Clerk application. With organizations, you can assign specific roles and permissions to users, making them useful for managing projects, coordinating teams, or facilitating partnerships.

--- a/docs/organizations/overview.mdx
+++ b/docs/organizations/overview.mdx
@@ -1,6 +1,6 @@
 ---
-title: Organizations
-description: Learn about how to create and manage Clerk organizations and their members.
+title: Overview - Build a B2B/B2C multi-tenant SaaS with Clerk Organizations
+description: Learn how to use Clerk Orgs to build scalable B2B auth features, user management, role based access control (RBAC), and per-organization invitation flows into your B2B SaaS.
 ---
 
 Organizations are a flexible and scalable way to manage users and their access to resources within your Clerk application. With organizations, you can assign specific roles and permissions to users, making them useful for managing projects, coordinating teams, or facilitating partnerships.

--- a/docs/organizations/overview.mdx
+++ b/docs/organizations/overview.mdx
@@ -1,6 +1,6 @@
 ---
 title: Organizations
-description: Learn how to use Clerk Orgs to build scalable B2B auth features, user management, role based access control (RBAC), and per-organization invitation flows into your B2B SaaS.
+description: Learn how to use Clerk Organizations to build scalable B2B auth features, user management, role based access control (RBAC), and per-organization invitation flows into your B2B SaaS.
 metadata:
   title: Overview - Build a B2B/B2C multi-tenant SaaS with Clerk Organizations
 ---

--- a/docs/organizations/roles-permissions.mdx
+++ b/docs/organizations/roles-permissions.mdx
@@ -1,6 +1,6 @@
 ---
-title: Roles and permissions
-description: Learn about how to create and manage roles and permissions for Clerk organizations and their members.
+title: Manage B2B roles and permissions with Clerk Organizations
+description: Step-by-step guide on how to implement role based access control (RBAC) in B2B SaaS apps. You can set as many custom roles, assign privileges and access permissions, all using Clerk Organizations.
 ---
 
 Clerk supports modeling your own custom role and permissions to control access to resources within your application when you use [organizations](/docs/organizations/overview).

--- a/docs/organizations/roles-permissions.mdx
+++ b/docs/organizations/roles-permissions.mdx
@@ -2,7 +2,7 @@
 title: Roles and permissions
 description: Step-by-step guide on how to implement role based access control (RBAC) in B2C/B2B SaaS apps. You can set as many custom roles, assign privileges and access permissions, all using Clerk Organizations.
 metadata:
-  title: Manage B2B/B2C roles and permissions with Clerk Organizations
+  title: B2B/B2C roles and permissions with Clerk Organizations
 ---
 
 Clerk supports modeling your own custom role and permissions to control access to resources within your application when you use [organizations](/docs/organizations/overview).

--- a/docs/organizations/roles-permissions.mdx
+++ b/docs/organizations/roles-permissions.mdx
@@ -1,6 +1,8 @@
 ---
-title: Manage B2B roles and permissions with Clerk Organizations
-description: Step-by-step guide on how to implement role based access control (RBAC) in B2B SaaS apps. You can set as many custom roles, assign privileges and access permissions, all using Clerk Organizations.
+title: Roles and permissions
+description: Step-by-step guide on how to implement role based access control (RBAC) in B2C/B2B SaaS apps. You can set as many custom roles, assign privileges and access permissions, all using Clerk Organizations.
+metadata:
+  title: Manage B2B/B2C roles and permissions with Clerk Organizations
 ---
 
 Clerk supports modeling your own custom role and permissions to control access to resources within your application when you use [organizations](/docs/organizations/overview).

--- a/docs/organizations/verified-domains.mdx
+++ b/docs/organizations/verified-domains.mdx
@@ -1,6 +1,6 @@
 ---
-title: Verified domains
-description: Learn about how to use verified domains for organizations.
+title: Verified Domains within Clerk Organizations (Step-by-Step)
+description: Build organization-specific or tenant-isolated authentication flows that only authorized users with matching domains can join, using Verified Domains within Clerk Organizations.
 ---
 
 Verified domains can be used to streamline enrollment into an organization. For example, if the domain `@clerk.com` is verified, any user with an email address ending in `@clerk.com` can be automatically invited or be suggested to join an organization with that domain. The role assigned to this user will be the role set as the [**Default** role](/docs/organizations/roles-permissions#the-default-role-for-members) in the organization settings page. The verified domains feature is useful for organizations that want to restrict membership to users with specific email domains.

--- a/docs/organizations/verified-domains.mdx
+++ b/docs/organizations/verified-domains.mdx
@@ -1,6 +1,8 @@
 ---
-title: Verified Domains within Clerk Organizations (Step-by-Step)
+title: Verified domains
 description: Build organization-specific or tenant-isolated authentication flows that only authorized users with matching domains can join, using Verified Domains within Clerk Organizations.
+metadata:
+  title: Verified domains within Clerk Organizations (Step-by-Step)
 ---
 
 Verified domains can be used to streamline enrollment into an organization. For example, if the domain `@clerk.com` is verified, any user with an email address ending in `@clerk.com` can be automatically invited or be suggested to join an organization with that domain. The role assigned to this user will be the role set as the [**Default** role](/docs/organizations/roles-permissions#the-default-role-for-members) in the organization settings page. The verified domains feature is useful for organizations that want to restrict membership to users with specific email domains.

--- a/docs/organizations/verify-user-permissions.mdx
+++ b/docs/organizations/verify-user-permissions.mdx
@@ -1,6 +1,6 @@
 ---
-title: Verify the active user's permissions in an organization
-description: A collection of utility functions and components in order to allow developers to perform authorization checks.
+title: Verifying user permissions in Clerk Organizations
+description: Learn how to verify and validate user roles and permissions within Clerk to maintain secure access control. We provide a collection of utility functions and components that allow developers to perform authorization checks.
 ---
 
 > [!IMPORTANT]

--- a/docs/organizations/verify-user-permissions.mdx
+++ b/docs/organizations/verify-user-permissions.mdx
@@ -1,6 +1,8 @@
 ---
-title: Verifying user permissions in Clerk Organizations
+title: Verify the active user's permissions in an organization
 description: Learn how to verify and validate user roles and permissions within Clerk to maintain secure access control. We provide a collection of utility functions and components that allow developers to perform authorization checks.
+metadata:
+  title: Verifying user permissions with Clerk Organizations
 ---
 
 > [!IMPORTANT]


### PR DESCRIPTION
### Previews:
https://clerk.com/docs/pr/2230

### What does this solve?
- We on the Growth Marketing front have been exploring ways to grow our LLM and Search Engine traffic, starting with Organizations as our guinea pig.  To be more specific, we noticed some opportunities to improve the seo`title` and `description` frontmatter across the `/docs/organizations/` section.

- CONTEXT: Our current docs pages for Organizations have limited visibility in search results. They don’t rank well for popular SEO terms that developers or decision-makers might use when looking for a B2B Organizations product (e.g., “multi-tenant auth,” “teams in SaaS apps,” “organization-level access control,” etc.). You can read the [experiment doc on Notion](https://www.notion.so/clerkdev/Content-Experiment-Orgs-1e02b9ab44fe809fb90dc460a284fa24?pvs=4).

### What changed?
- This PR updates the title` and `description` fields across all the 14 docs pages for Orgs to provide clearer, more concise summaries that better reflect each page’s purpose. These improvements aim to enhance readability, consistency, and discoverability (SEO and LLM-wise).

- Let me know if anything should be revised or reverted. Happy to adjust. I have clicked on "Files changed" and performed a thorough self-review. All existing checks pass

### Quick question
- From what I can see in my preview, it seems the title for each page (H1) and the SEO title that should show up in SERPs (Search Engine Result Pages) are the same. Is there a way for us to make this separate? The intent for us is not to change the page titles that appear on the page, but the SEO title and meta description that appears on SERPs.
- E.g: ![image](https://github.com/user-attachments/assets/c51052f9-af01-42e7-bc8d-455342165c94)

