### PR TITLE
(themes) fix order of code example tabs

### DIFF
--- a/docs/customization/themes.mdx
+++ b/docs/customization/themes.mdx
@@ -139,6 +139,23 @@ In the following example, the "Dark" theme is applied to all Clerk components.
   </Tab>
 
   <Tab>
+    ```js {{ filename: 'astro.config.mjs', mark: [2, [7, 9]] }}
+    import clerk from '@clerk/astro'
+    import { dark } from '@clerk/themes'
+
+    export default defineConfig({
+      integrations: [
+        clerk({
+          appearance: {
+            baseTheme: dark,
+          },
+        }),
+      ],
+    })
+    ```
+  </Tab>
+
+  <Tab>
     ```tsx {{ filename: 'app/root.tsx', mark: [3, [36, 38]] }}
     // Import ClerkApp
     import { ClerkApp } from '@clerk/remix'
@@ -183,23 +200,6 @@ In the following example, the "Dark" theme is applied to all Clerk components.
   </Tab>
 
   <Tab>
-    ```js {{ filename: 'astro.config.mjs', mark: [2, [7, 9]] }}
-    import clerk from '@clerk/astro'
-    import { dark } from '@clerk/themes'
-
-    export default defineConfig({
-      integrations: [
-        clerk({
-          appearance: {
-            baseTheme: dark,
-          },
-        }),
-      ],
-    })
-    ```
-  </Tab>
-
-  <Tab>
     ```ts {{ filename: 'src/main.ts', mark: [4, [8, 10]] }}
     import { createApp } from 'vue'
     import App from './App.vue'
@@ -238,7 +238,7 @@ You can also stack themes by passing an array of themes to the `baseTheme` prope
 
 In the following example, the "Dark" theme is applied first, then the "Neobrutalism" theme is applied on top of it.
 
-<Tabs items={["Next.js", "React", "Remix", "Astro", "Vue", "Nuxt"]}>
+<Tabs items={["Next.js", "React", "Astro", "Remix", "Vue", "Nuxt"]}>
   <Tab>
     <CodeBlockTabs options={["App Router", "Pages Router"]}>
       ```tsx {{ filename: '/src/app/layout.tsx', mark: [2, [7, 9]] }}
@@ -312,6 +312,23 @@ In the following example, the "Dark" theme is applied first, then the "Neobrutal
   </Tab>
 
   <Tab>
+    ```js {{ filename: 'astro.config.mjs', mark: [2, [7, 9]] }}
+    import clerk from '@clerk/astro'
+    import { dark, neobrutalism } from '@clerk/themes'
+
+    export default defineConfig({
+      integrations: [
+        clerk({
+          appearance: {
+            baseTheme: [dark, neobrutalism],
+          },
+        }),
+      ],
+    })
+    ```
+  </Tab>
+
+  <Tab>
     ```tsx {{ filename: 'app/root.tsx', mark: [3, [36, 38]] }}
     // Import ClerkApp
     import { ClerkApp } from '@clerk/remix'
@@ -356,23 +373,6 @@ In the following example, the "Dark" theme is applied first, then the "Neobrutal
   </Tab>
 
   <Tab>
-    ```js {{ filename: 'astro.config.mjs', mark: [2, [7, 9]] }}
-    import clerk from '@clerk/astro'
-    import { dark, neobrutalism } from '@clerk/themes'
-
-    export default defineConfig({
-      integrations: [
-        clerk({
-          appearance: {
-            baseTheme: [dark, neobrutalism],
-          },
-        }),
-      ],
-    })
-    ```
-  </Tab>
-
-  <Tab>
     ```ts {{ filename: 'src/main.ts', mark: [4, [8, 10]] }}
     import { createApp } from 'vue'
     import App from './App.vue'
@@ -411,7 +411,7 @@ You can apply a theme to all instances of a Clerk component by passing the compo
 
 In the following example, the "Neobrutalism" theme is applied to all instances of the [`<SignIn />`](/docs/components/authentication/sign-in) component.
 
-<Tabs items={["Next.js", "React", "Remix", "Astro", "Vue", "Nuxt"]}>
+<Tabs items={["Next.js", "React", "Astro", "Remix", "Vue", "Nuxt"]}>
   <Tab>
     <CodeBlockTabs options={["App Router", "Pages Router"]}>
       ```tsx {{ filename: '/src/app/layout.tsx', mark: [2, [7, 10]] }}
@@ -488,6 +488,24 @@ In the following example, the "Neobrutalism" theme is applied to all instances o
   </Tab>
 
   <Tab>
+    ```js {{ filename: 'astro.config.mjs', mark: [2, [7, 10]] }}
+    import clerk from '@clerk/astro'
+    import { dark } from '@clerk/themes'
+
+    export default defineConfig({
+      integrations: [
+        clerk({
+          appearance: {
+            baseTheme: dark,
+            signIn: { baseTheme: neobrutalism },
+          },
+        }),
+      ],
+    })
+    ```
+  </Tab>
+
+  <Tab>
     ```tsx {{ filename: 'app/root.tsx', mark: [3, [36, 39]] }}
     // Import ClerkApp
     import { ClerkApp } from '@clerk/remix'
@@ -533,24 +551,6 @@ In the following example, the "Neobrutalism" theme is applied to all instances o
   </Tab>
 
   <Tab>
-    ```js {{ filename: 'astro.config.mjs', mark: [2, [7, 10]] }}
-    import clerk from '@clerk/astro'
-    import { dark } from '@clerk/themes'
-
-    export default defineConfig({
-      integrations: [
-        clerk({
-          appearance: {
-            baseTheme: dark,
-            signIn: { baseTheme: neobrutalism },
-          },
-        }),
-      ],
-    })
-    ```
-  </Tab>
-
-  <Tab>
     ```ts {{ filename: 'src/main.ts', mark: [4, [8, 11]] }}
     import { createApp } from 'vue'
     import App from './App.vue'
@@ -589,7 +589,7 @@ In the following example, the "Neobrutalism" theme is applied to all instances o
 
 To apply a theme to a single Clerk component, pass the `appearance` prop to the component. The `appearance` prop accepts the property `baseTheme`, which can be set to a theme.
 
-<Tabs items={["Next.js", "React", "Remix", "Astro", "Vue", "Nuxt"]}>
+<Tabs items={["Next.js", "React", "Astro", "Remix",  "Vue", "Nuxt"]}>
   <Tab>
     <CodeBlockTabs options={["App Router", "Pages Router"]}>
       ```tsx {{ filename: 'app/sign-in/[[...sign-in]]/page.tsx', mark: [2, [7, 9]] }}
@@ -642,6 +642,21 @@ To apply a theme to a single Clerk component, pass the `appearance` prop to the 
   </Tab>
 
   <Tab>
+    ```astro {{ filename: 'pages/sign-in.astro', mark: [3, [9, 11]] }}
+    ---
+    import { SignIn } from '@clerk/astro/components'
+    import { dark } from '@clerk/themes'
+    ---
+
+    <SignIn
+      appearance={{
+        baseTheme: dark,
+      }}
+    />
+    ```
+  </Tab>
+
+  <Tab>
     ```tsx {{ filename: 'app/routes/sign-in/$.tsx', mark: [2, [9, 11]] }}
     import { SignIn } from '@clerk/remix'
     import { dark } from '@clerk/themes'
@@ -658,21 +673,6 @@ To apply a theme to a single Clerk component, pass the `appearance` prop to the 
         </div>
       )
     }
-    ```
-  </Tab>
-
-  <Tab>
-    ```astro {{ filename: 'pages/sign-in.astro', mark: [3, [9, 11]] }}
-    ---
-    import { SignIn } from '@clerk/astro/components'
-    import { dark } from '@clerk/themes'
-    ---
-
-    <SignIn
-      appearance={{
-        baseTheme: dark,
-      }}
-    />
     ```
   </Tab>
 
@@ -712,7 +712,7 @@ In the following example, the primary color of the themes are customized.
 > [!IMPORTANT]
 > For a list of all of the variables you can customize, and for more examples on how to use the `variables` property, see the [Variables](/docs/customization/variables) docs.
 
-<Tabs items={["Next.js", "React", "Remix", "Astro", "Vue", "Nuxt"]}>
+<Tabs items={["Next.js", "React", "Astro", "Remix", "Vue", "Nuxt"]}>
   <Tab>
     <CodeBlockTabs options={["App Router", "Pages Router"]}>
       ```tsx {{ filename: '/src/app/layout.tsx', mark: [2, [7, 14]] }}
@@ -801,6 +801,28 @@ In the following example, the primary color of the themes are customized.
   </Tab>
 
   <Tab>
+    ```js {{ filename: 'astro.config.mjs', mark: [2, [7, 14]] }}
+    import clerk from '@clerk/astro'
+    import { dark, neobrutalism, shadesOfPurple } from '@clerk/themes'
+
+    export default defineConfig({
+      integrations: [
+        clerk({
+          appearance: {
+            baseTheme: [dark, neobrutalism],
+            variables: { colorPrimary: 'blue' },
+            signIn: {
+              baseTheme: [shadesOfPurple],
+              variables: { colorPrimary: 'blue' },
+            },
+          },
+        }),
+      ],
+    })
+    ```
+  </Tab>
+
+  <Tab>
     ```tsx {{ filename: 'app/root.tsx', mark: [3, [36, 43]] }}
     // Import ClerkApp
     import { ClerkApp } from '@clerk/remix'
@@ -845,28 +867,6 @@ In the following example, the primary color of the themes are customized.
           variables: { colorPrimary: 'blue' },
         },
       },
-    })
-    ```
-  </Tab>
-
-  <Tab>
-    ```js {{ filename: 'astro.config.mjs', mark: [2, [7, 14]] }}
-    import clerk from '@clerk/astro'
-    import { dark, neobrutalism, shadesOfPurple } from '@clerk/themes'
-
-    export default defineConfig({
-      integrations: [
-        clerk({
-          appearance: {
-            baseTheme: [dark, neobrutalism],
-            variables: { colorPrimary: 'blue' },
-            signIn: {
-              baseTheme: [shadesOfPurple],
-              variables: { colorPrimary: 'blue' },
-            },
-          },
-        }),
-      ],
     })
     ```
   </Tab>


### PR DESCRIPTION
https://linear.app/clerk/issue/DOCS-10320/fix-documentation-error-in-clerk-themes-section