### PR TITLE
Include docs redirects in the generated docs artifact

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "@types/node": "^22.13.2",
         "concurrently": "^8.2.2",
         "glob": "^11.0.1",
+        "jsonc-parser": "^3.3.1",
         "prettier": "^3.2.5",
         "prettier-plugin-astro": "^0.14.0",
         "prettier-plugin-nginx": "^1.0.3",
@@ -2254,6 +2255,13 @@
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
       }
+    },
+    "node_modules/jsonc-parser": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-3.3.1.tgz",
+      "integrity": "sha512-HUgH65KyejrUFPvHFPbqOY0rsFip3Bo5wb4ngvdi1EpCYWUQDC5V+Y7mZws+DLkr4M//zQJoanu1SP+87Dv1oQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/locate-character": {
       "version": "3.0.0",

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "@types/node": "^22.13.2",
     "concurrently": "^8.2.2",
     "glob": "^11.0.1",
+    "jsonc-parser": "^3.3.1",
     "prettier": "^3.2.5",
     "prettier-plugin-astro": "^0.14.0",
     "prettier-plugin-nginx": "^1.0.3",

--- a/scripts/build-docs.ts
+++ b/scripts/build-docs.ts
@@ -96,11 +96,11 @@ async function main() {
     redirects: {
       static: {
         inputPath: '../redirects/static/docs.json',
-        outputPath: '../dist/_redirects/static.json',
+        outputPath: '_redirects/static.json',
       },
       dynamic: {
         inputPath: '../redirects/dynamic/docs.jsonc',
-        outputPath: '../dist/_redirects/dynamic.jsonc',
+        outputPath: '_redirects/dynamic.jsonc',
       },
     },
     ignoreLinks: [

--- a/scripts/build-docs.ts
+++ b/scripts/build-docs.ts
@@ -70,6 +70,12 @@ import { insertFrontmatter } from './lib/plugins/insertFrontmatter'
 import { validateAndEmbedLinks } from './lib/plugins/validateAndEmbedLinks'
 import { validateIfComponents } from './lib/plugins/validateIfComponents'
 import { validateUniqueHeadings } from './lib/plugins/validateUniqueHeadings'
+import {
+  analyzeAndFixRedirects as optimizeRedirects,
+  readRedirects,
+  transformRedirectsToObject,
+  writeRedirects,
+} from './lib/redirects'
 
 // Only invokes the main function if we run the script directly eg npm run build, bun run ./scripts/build-docs.ts
 if (require.main === module) {
@@ -87,6 +93,16 @@ async function main() {
     partialsPath: '../docs/_partials',
     distPath: '../dist',
     typedocPath: '../clerk-typedoc',
+    redirects: {
+      static: {
+        inputPath: '../redirects/static/docs.json',
+        outputPath: '../dist/_redirects/static.json',
+      },
+      dynamic: {
+        inputPath: '../redirects/dynamic/docs.jsonc',
+        outputPath: '../dist/_redirects/dynamic.jsonc',
+      },
+    },
     ignoreLinks: [
       '/docs/core-1',
       '/docs/reference/backend-api',
@@ -165,6 +181,16 @@ export async function build(config: BuildConfig, store: Store = createBlankStore
   const markdownCache = getMarkdownCache(store)
 
   await ensureDir(config.distPath)
+
+  if (config.redirects) {
+    const { staticRedirects, dynamicRedirects } = await readRedirects(config)
+
+    const optimizedStaticRedirects = optimizeRedirects(staticRedirects)
+    const transformedStaticRedirects = transformRedirectsToObject(optimizedStaticRedirects)
+
+    await writeRedirects(config, transformedStaticRedirects, dynamicRedirects)
+    console.info('✓ Wrote redirects to disk')
+  }
 
   const userManifest = await getManifest()
   console.info('✓ Read Manifest')

--- a/scripts/lib/config.ts
+++ b/scripts/lib/config.ts
@@ -24,6 +24,16 @@ type BuildConfigOptions = {
     collapseDefault: boolean
     hideTitleDefault: boolean
   }
+  redirects?: {
+    static: {
+      inputPath: string
+      outputPath: string
+    }
+    dynamic: {
+      inputPath: string
+      outputPath: string
+    }
+  }
   cleanDist: boolean
   flags?: {
     watch?: boolean
@@ -71,6 +81,19 @@ export function createConfig(config: BuildConfigOptions) {
       collapseDefault: false,
       hideTitleDefault: false,
     },
+
+    redirects: config.redirects
+      ? {
+          static: {
+            inputPath: resolve(config.redirects.static.inputPath),
+            outputPath: resolve(config.redirects.static.outputPath),
+          },
+          dynamic: {
+            inputPath: resolve(config.redirects.dynamic.inputPath),
+            outputPath: resolve(config.redirects.dynamic.outputPath),
+          },
+        }
+      : null,
 
     cleanDist: config.cleanDist,
 

--- a/scripts/lib/config.ts
+++ b/scripts/lib/config.ts
@@ -85,12 +85,12 @@ export function createConfig(config: BuildConfigOptions) {
     redirects: config.redirects
       ? {
           static: {
-            inputPath: resolve(config.redirects.static.inputPath),
-            outputPath: resolve(config.redirects.static.outputPath),
+            inputPath: resolve(path.join(config.distPath, config.redirects.static.inputPath)),
+            outputPath: resolve(path.join(config.distPath, config.redirects.static.outputPath)),
           },
           dynamic: {
-            inputPath: resolve(config.redirects.dynamic.inputPath),
-            outputPath: resolve(config.redirects.dynamic.outputPath),
+            inputPath: resolve(path.join(config.distPath, config.redirects.dynamic.inputPath)),
+            outputPath: resolve(path.join(config.distPath, config.redirects.dynamic.outputPath)),
           },
         }
       : null,

--- a/scripts/lib/redirects.ts
+++ b/scripts/lib/redirects.ts
@@ -1,0 +1,74 @@
+import type { BuildConfig } from './config'
+import fs from 'node:fs/promises'
+import path from 'node:path'
+import { parse as parseJSONC } from 'jsonc-parser'
+
+interface Redirect {
+  source: string
+  destination: string
+  permanent: boolean
+}
+
+export function transformRedirectsToObject(redirects: Redirect[]) {
+  return Object.fromEntries(redirects.map((item) => [item.source, item]))
+}
+
+export async function readRedirects(config: BuildConfig) {
+  const { static: staticConfig, dynamic: dynamicConfig } = config.redirects ?? {}
+  if (!staticConfig?.inputPath || !dynamicConfig?.inputPath) {
+    throw new Error('Redirect paths not configured')
+  }
+
+  const [staticContent, dynamicContent] = await Promise.all([
+    fs.readFile(staticConfig.inputPath, 'utf-8'),
+    fs.readFile(dynamicConfig.inputPath, 'utf-8'),
+  ])
+
+  return {
+    staticRedirects: JSON.parse(staticContent) as Redirect[],
+    dynamicRedirects: parseJSONC(dynamicContent) as Redirect[],
+  }
+}
+
+export function analyzeAndFixRedirects(redirects: Redirect[]): Redirect[] {
+  const redirectMap = new Map(redirects.map((r) => [r.source, r.destination]))
+  const finalDestinations = new Map<string, string>()
+
+  // Find final destinations for each redirect
+  for (const { source, destination, permanent } of redirects) {
+    let current = destination
+    const visited = new Set([source])
+
+    while (redirectMap.has(current) && !visited.has(current)) {
+      visited.add(current)
+      current = redirectMap.get(current)!
+    }
+
+    finalDestinations.set(source, current)
+  }
+
+  // Create new redirects pointing to final destinations
+  return redirects.map(({ source, permanent }) => ({
+    source,
+    destination: finalDestinations.get(source)!,
+    permanent,
+  }))
+}
+
+export async function writeRedirects(
+  config: BuildConfig,
+  staticRedirects: Record<string, Redirect>,
+  dynamicRedirects: Redirect[],
+) {
+  const { static: staticConfig, dynamic: dynamicConfig } = config.redirects ?? {}
+  if (!staticConfig?.outputPath || !dynamicConfig?.outputPath) {
+    throw new Error('Redirect output paths not configured')
+  }
+
+  await fs.mkdir(path.dirname(staticConfig.outputPath), { recursive: true })
+
+  await Promise.all([
+    fs.writeFile(staticConfig.outputPath, JSON.stringify(staticRedirects)),
+    fs.writeFile(dynamicConfig.outputPath, JSON.stringify(dynamicRedirects)),
+  ])
+}


### PR DESCRIPTION
### What does this solve?

- We need the redirects data to properly redirect requests

### What changed?

- This parses in the files (checking they are valid json / jsonc)
- It optimizes the static redirects so users aren't making multiple hops
- It writes out the redirects in to the dist folder

### Checklist

- [x] I have clicked on "Files changed" and performed a thorough self-review
- [x] All existing checks pass
