### PR TITLE
Copy over the public folder (images) in to the generated out build artifact

### DIFF
--- a/scripts/build-docs.test.ts
+++ b/scripts/build-docs.test.ts
@@ -162,7 +162,7 @@ Testing with a simple page.`,
     ])
 
     const output = await build(
-      createConfig({
+      await createConfig({
         ...baseConfig,
         basePath: tempDir,
         validSdks: ['nextjs', 'react'],
@@ -209,7 +209,7 @@ Testing with a simple page.`,
     ])
 
     const output = await build(
-      createConfig({
+      await createConfig({
         ...baseConfig,
         basePath: tempDir,
         validSdks: ['nextjs', 'react'],
@@ -246,7 +246,7 @@ title: MDX Doc
     ])
 
     await build(
-      createConfig({
+      await createConfig({
         ...baseConfig,
         basePath: tempDir,
         validSdks: ['react'],
@@ -295,7 +295,7 @@ title: MDX Doc
     ])
 
     await build(
-      createConfig({
+      await createConfig({
         ...baseConfig,
         basePath: tempDir,
         validSdks: ['react'],
@@ -352,7 +352,7 @@ title: Simple Test
     ])
 
     const promise = build(
-      createConfig({
+      await createConfig({
         ...baseConfig,
         basePath: tempDir,
         validSdks: ['react'],
@@ -408,7 +408,7 @@ title: Simple Test
     ])
 
     await build(
-      createConfig({
+      await createConfig({
         ...baseConfig,
         basePath: tempDir,
         validSdks: ['nextjs'],
@@ -510,7 +510,7 @@ title: Simple Test
     ])
 
     await build(
-      createConfig({
+      await createConfig({
         ...baseConfig,
         basePath: tempDir,
         validSdks: ['nextjs', 'react', 'vue'],
@@ -614,7 +614,7 @@ title: Item 2
     ])
 
     await build(
-      createConfig({
+      await createConfig({
         ...baseConfig,
         basePath: tempDir,
         validSdks: ['expressjs', 'fastify', 'nextjs', 'react'],
@@ -673,7 +673,7 @@ title: Item 1
     ])
 
     await build(
-      createConfig({
+      await createConfig({
         ...baseConfig,
         basePath: tempDir,
         validSdks: ['expressjs', 'react'],
@@ -769,7 +769,7 @@ title: Item 1
     ])
 
     await build(
-      createConfig({
+      await createConfig({
         ...baseConfig,
         basePath: tempDir,
         validSdks: ['nextjs', 'react', 'vue'],
@@ -870,7 +870,7 @@ test`,
     ])
 
     const output = await build(
-      createConfig({
+      await createConfig({
         ...baseConfig,
         basePath: tempDir,
         validSdks: ['react'],
@@ -907,7 +907,7 @@ This is a normal document.`,
     ])
 
     await build(
-      createConfig({
+      await createConfig({
         ...baseConfig,
         basePath: tempDir,
         validSdks: ['react'],
@@ -969,7 +969,7 @@ title: Quickstart
     ])
 
     await build(
-      createConfig({
+      await createConfig({
         ...baseConfig,
         basePath: tempDir,
         validSdks: ['react', 'vue'],
@@ -1030,7 +1030,7 @@ Testing with a simple page.`,
     ])
 
     await build(
-      createConfig({
+      await createConfig({
         ...baseConfig,
         basePath: tempDir,
         validSdks: ['react'],
@@ -1091,7 +1091,7 @@ Testing with a simple page.`,
     ])
 
     await build(
-      createConfig({
+      await createConfig({
         ...baseConfig,
         basePath: tempDir,
         validSdks: ['react', 'vue', 'astro'],
@@ -1146,7 +1146,7 @@ Testing with a simple page.`,
     ])
 
     await build(
-      createConfig({
+      await createConfig({
         ...baseConfig,
         basePath: tempDir,
         validSdks: ['react', 'expo'],
@@ -1180,7 +1180,7 @@ Testing with a simple page.`,
     ])
 
     const promise = build(
-      createConfig({
+      await createConfig({
         ...baseConfig,
         basePath: tempDir,
         validSdks: ['react', 'expo'],
@@ -1216,7 +1216,7 @@ Testing with a simple page.`,
     ])
 
     const output = await build(
-      createConfig({
+      await createConfig({
         ...baseConfig,
         basePath: tempDir,
         validSdks: ['react', 'expo'],
@@ -1264,7 +1264,7 @@ Authentication login documentation.`,
     ])
 
     const promise = build(
-      createConfig({
+      await createConfig({
         ...baseConfig,
         basePath: tempDir,
         validSdks: ['react', 'python', 'nextjs'],
@@ -1299,7 +1299,7 @@ This document is available for React and Next.js.`,
     ])
 
     await build(
-      createConfig({
+      await createConfig({
         ...baseConfig,
         basePath: tempDir,
         validSdks: ['react', 'nextjs'],
@@ -1377,7 +1377,7 @@ Content for React users.`,
     ])
 
     await build(
-      createConfig({
+      await createConfig({
         ...baseConfig,
         basePath: tempDir,
         validSdks: ['react', 'nextjs', 'js-frontend'],
@@ -1491,7 +1491,7 @@ Common content for all SDKs.`,
     ])
 
     await build(
-      createConfig({
+      await createConfig({
         ...baseConfig,
         basePath: tempDir,
         validSdks: ['react', 'nextjs', 'js-frontend'],
@@ -1561,7 +1561,7 @@ Common content for all SDKs.`,
     ])
 
     await build(
-      createConfig({
+      await createConfig({
         ...baseConfig,
         basePath: tempDir,
         validSdks: ['react', 'nextjs'],
@@ -1616,7 +1616,7 @@ Common content for all SDKs.`,
     ])
 
     await build(
-      createConfig({
+      await createConfig({
         ...baseConfig,
         basePath: tempDir,
         validSdks: ['react', 'nextjs', 'js-frontend'],
@@ -1666,7 +1666,7 @@ sdk: fastify, expressjs
     ])
 
     await build(
-      createConfig({
+      await createConfig({
         ...baseConfig,
         basePath: tempDir,
         validSdks: ['fastify', 'expressjs'],
@@ -1702,7 +1702,7 @@ title: Duplicate Headings
     ])
 
     const promise = build(
-      createConfig({
+      await createConfig({
         ...baseConfig,
         basePath: tempDir,
         validSdks: ['react'],
@@ -1741,7 +1741,7 @@ sdk: react, nextjs
     ])
 
     const output = await build(
-      createConfig({
+      await createConfig({
         ...baseConfig,
         basePath: tempDir,
         validSdks: ['react', 'nextjs'],
@@ -1778,7 +1778,7 @@ sdk: react, nextjs
     ])
 
     const promise = build(
-      createConfig({
+      await createConfig({
         ...baseConfig,
         basePath: tempDir,
         validSdks: ['react', 'nextjs'],
@@ -1816,7 +1816,7 @@ description: Quickstart page
     ])
 
     const promise = build(
-      createConfig({
+      await createConfig({
         ...baseConfig,
         basePath: tempDir,
         validSdks: ['react'],
@@ -1855,7 +1855,7 @@ title: Simple Test
     ])
 
     await build(
-      createConfig({
+      await createConfig({
         ...baseConfig,
         basePath: tempDir,
         validSdks: ['react'],
@@ -1891,7 +1891,7 @@ sdk: react, nextjs
     ])
 
     await build(
-      createConfig({
+      await createConfig({
         ...baseConfig,
         basePath: tempDir,
         validSdks: ['react', 'nextjs'],
@@ -1929,7 +1929,7 @@ title: Simple Test
     ])
 
     const output = await build(
-      createConfig({
+      await createConfig({
         ...baseConfig,
         basePath: tempDir,
         validSdks: ['react'],
@@ -1968,7 +1968,7 @@ title: Simple Test
     ])
 
     const promise = build(
-      createConfig({
+      await createConfig({
         ...baseConfig,
         basePath: tempDir,
         validSdks: ['react'],
@@ -1999,7 +1999,7 @@ title: Simple Test
     ])
 
     const output = await build(
-      createConfig({
+      await createConfig({
         ...baseConfig,
         basePath: tempDir,
         validSdks: ['react'],
@@ -2045,7 +2045,7 @@ description: This is a test page
     ])
 
     const output = await build(
-      createConfig({
+      await createConfig({
         ...baseConfig,
         basePath: tempDir,
         validSdks: ['react'],
@@ -2079,7 +2079,7 @@ title: Simple Test
     ])
 
     const output = await build(
-      createConfig({
+      await createConfig({
         ...baseConfig,
         basePath: tempDir,
         validSdks: ['react'],
@@ -2118,7 +2118,7 @@ title: Core Page
     ])
 
     const output = await build(
-      createConfig({
+      await createConfig({
         ...baseConfig,
         basePath: tempDir,
         validSdks: ['react'],
@@ -2149,7 +2149,7 @@ title: Simple Test
     ])
 
     const output = await build(
-      createConfig({
+      await createConfig({
         ...baseConfig,
         basePath: tempDir,
         validSdks: ['react'],
@@ -2191,7 +2191,7 @@ title: Simple Test
     ])
 
     const output = await build(
-      createConfig({
+      await createConfig({
         ...baseConfig,
         basePath: tempDir,
         validSdks: ['react'],
@@ -2237,7 +2237,7 @@ title: Core Page
     ])
 
     await build(
-      createConfig({
+      await createConfig({
         ...baseConfig,
         basePath: tempDir,
         validSdks: ['react', 'nextjs'],
@@ -2289,7 +2289,7 @@ title: Core Page
     ])
 
     await build(
-      createConfig({
+      await createConfig({
         ...baseConfig,
         basePath: tempDir,
         validSdks: ['react', 'nextjs'],
@@ -2342,7 +2342,7 @@ title: Core Page
     ])
 
     await build(
-      createConfig({
+      await createConfig({
         ...baseConfig,
         basePath: tempDir,
         validSdks: ['react', 'nextjs'],
@@ -2398,7 +2398,7 @@ Content for section 2.`,
     ])
 
     const output = await build(
-      createConfig({
+      await createConfig({
         ...baseConfig,
         basePath: tempDir,
         validSdks: ['react'],
@@ -2451,7 +2451,7 @@ description: Link with code
     ])
 
     const output = await build(
-      createConfig({
+      await createConfig({
         ...baseConfig,
         basePath: tempDir,
         validSdks: ['react', 'nextjs'],
@@ -2507,7 +2507,7 @@ description: Link with code
     ])
 
     const output = await build(
-      createConfig({
+      await createConfig({
         ...baseConfig,
         basePath: tempDir,
         validSdks: ['react', 'nextjs'],
@@ -2543,7 +2543,7 @@ description: This is a test page
     ])
 
     const output = await build(
-      createConfig({
+      await createConfig({
         ...baseConfig,
         basePath: tempDir,
         validSdks: ['react'],
@@ -2573,7 +2573,7 @@ description: This is a test page
     ])
 
     const output = await build(
-      createConfig({
+      await createConfig({
         ...baseConfig,
         basePath: tempDir,
         validSdks: ['react'],
@@ -2636,7 +2636,7 @@ description: A page that contains cards
     ])
 
     const output = await build(
-      createConfig({
+      await createConfig({
         ...baseConfig,
         basePath: tempDir,
         validSdks: ['react'],
@@ -2673,7 +2673,7 @@ sdk: react
     ])
 
     const output = await build(
-      createConfig({
+      await createConfig({
         ...baseConfig,
         basePath: tempDir,
         validSdks: ['react'],
@@ -2728,7 +2728,7 @@ sdk: react
     ])
 
     const output = await build(
-      createConfig({
+      await createConfig({
         ...baseConfig,
         basePath: tempDir,
         validSdks: ['react'],
@@ -2759,7 +2759,7 @@ title: React Doc
 
     // This should throw an error because the file path starts with an SDK name
     const promise = build(
-      createConfig({
+      await createConfig({
         ...baseConfig,
         basePath: tempDir,
         validSdks: ['react'],
@@ -2808,7 +2808,7 @@ title: Standard Page
     ])
 
     await build(
-      createConfig({
+      await createConfig({
         ...baseConfig,
         basePath: tempDir,
         validSdks: ['react'],
@@ -2863,7 +2863,7 @@ title: Partials Page
     ])
 
     await build(
-      createConfig({
+      await createConfig({
         ...baseConfig,
         basePath: tempDir,
         validSdks: ['react'],
@@ -2919,7 +2919,7 @@ sdk: expo
     ])
 
     await build(
-      createConfig({
+      await createConfig({
         ...baseConfig,
         basePath: tempDir,
         validSdks: ['expo'],
@@ -2958,7 +2958,7 @@ description: \`This frontmatter has an unbalanced quote
 
     // This should throw a parsing error
     const promise = build(
-      createConfig({
+      await createConfig({
         ...baseConfig,
         basePath: tempDir,
         validSdks: ['react'],
@@ -2988,7 +2988,7 @@ description: This frontmatter is missing the required title field
 
     // This should throw an error about missing title
     const promise = build(
-      createConfig({
+      await createConfig({
         ...baseConfig,
         basePath: tempDir,
         validSdks: ['react'],
@@ -3013,7 +3013,7 @@ description: This frontmatter is missing the required title field
     ])
 
     const promise = build(
-      createConfig({
+      await createConfig({
         ...baseConfig,
         basePath: tempDir,
         validSdks: ['react'],
@@ -3050,7 +3050,7 @@ This page has an invalid SDK in frontmatter.`,
 
     // This should throw an error with specific message about invalid SDK
     const promise = build(
-      createConfig({
+      await createConfig({
         ...baseConfig,
         basePath: tempDir,
         validSdks: ['react'],
@@ -3097,7 +3097,7 @@ This document doesn't have the referenced header.`,
 
     // Should complete with warnings
     const output = await build(
-      createConfig({
+      await createConfig({
         ...baseConfig,
         basePath: tempDir,
         validSdks: ['react'],
@@ -3149,7 +3149,7 @@ title: Document with Warnings
 
     // Should complete with warnings
     const output = await build(
-      createConfig({
+      await createConfig({
         ...baseConfig,
         basePath: tempDir,
         validSdks: ['react'],
@@ -3187,7 +3187,7 @@ title: Original Title
 
     // Create store to maintain cache across builds
     const store = createBlankStore()
-    const config = createConfig({
+    const config = await createConfig({
       ...baseConfig,
       basePath: tempDir,
       validSdks: ['react'],
@@ -3249,7 +3249,7 @@ sdk: react
 
     // Create store to maintain cache across builds
     const store = createBlankStore()
-    const config = createConfig({
+    const config = await createConfig({
       ...baseConfig,
       basePath: tempDir,
       validSdks: ['react'],
@@ -3301,7 +3301,7 @@ sdk: react
 
     // Create store to maintain cache across builds
     const store = createBlankStore()
-    const config = createConfig({
+    const config = await createConfig({
       ...baseConfig,
       basePath: tempDir,
       validSdks: ['react'],
@@ -3351,7 +3351,7 @@ description: This page has a description
       ])
 
       const output = await build(
-        createConfig({
+        await createConfig({
           ...baseConfig,
           basePath: tempDir,
           validSdks: ['react'],
@@ -3398,7 +3398,7 @@ description: This page has a description
       ])
 
       const output = await build(
-        createConfig({
+        await createConfig({
           ...baseConfig,
           basePath: tempDir,
           validSdks: ['react'],
@@ -3448,7 +3448,7 @@ description: This page has a description
 
       // Should complete without the ignored warnings
       const output = await build(
-        createConfig({
+        await createConfig({
           ...baseConfig,
           basePath: tempDir,
           validSdks: ['react'],
@@ -3502,7 +3502,7 @@ description: This page has a description
 
       // Only ignore the link warning, but leave SDK warning
       const output = await build(
-        createConfig({
+        await createConfig({
           ...baseConfig,
           basePath: tempDir,
           validSdks: ['react'],
@@ -3550,7 +3550,7 @@ description: This page has a description
 
       // Ignore component attribute warnings
       const output = await build(
-        createConfig({
+        await createConfig({
           ...baseConfig,
           basePath: tempDir,
           validSdks: ['react'],
@@ -3594,7 +3594,7 @@ title: Missing Description
       ])
 
       const output = await build(
-        createConfig({
+        await createConfig({
           ...baseConfig,
           basePath: tempDir,
           validSdks: ['react'],
@@ -3649,7 +3649,7 @@ description: The page being linked to
 
       // Ignore hash warnings
       const output = await build(
-        createConfig({
+        await createConfig({
           ...baseConfig,
           basePath: tempDir,
           validSdks: ['react'],
@@ -3706,7 +3706,7 @@ description: This page has a description
       ])
 
       const output = await build(
-        createConfig({
+        await createConfig({
           ...baseConfig,
           basePath: tempDir,
           validSdks: ['react', 'nodejs'],
@@ -3750,7 +3750,7 @@ description: Test page with partial
 
       // Ignore link warnings in partials
       const output = await build(
-        createConfig({
+        await createConfig({
           ...baseConfig,
           basePath: tempDir,
           validSdks: ['react'],
@@ -3807,7 +3807,7 @@ interface Client {
     ])
 
     const output = await build(
-      createConfig({
+      await createConfig({
         ...baseConfig,
         basePath: tempDir,
         validSdks: ['react'],
@@ -3853,7 +3853,7 @@ interface Client {
     ])
 
     const output = await build(
-      createConfig({
+      await createConfig({
         ...baseConfig,
         basePath: tempDir,
         validSdks: ['react'],
@@ -3888,7 +3888,7 @@ description: Generated API docs
     ])
 
     // Create a config with a non-existent typedoc path
-    const configWithMissingFolder = createConfig({
+    const configWithMissingFolder = await createConfig({
       ...baseConfig,
       basePath: tempDir,
       typedocPath: '../non-existent-typedoc-folder',
@@ -3935,7 +3935,7 @@ interface Client {
     ])
 
     const output = await build(
-      createConfig({
+      await createConfig({
         ...baseConfig,
         basePath: tempDir,
         validSdks: ['react'],
@@ -4009,7 +4009,7 @@ interface Client {
     ])
 
     const output = await build(
-      createConfig({
+      await createConfig({
         ...baseConfig,
         basePath: tempDir,
         validSdks: ['react'],
@@ -4050,7 +4050,7 @@ description: Generated API docs
     ])
 
     const output = await build(
-      createConfig({
+      await createConfig({
         ...baseConfig,
         basePath: tempDir,
         validSdks: ['react'],
@@ -4088,7 +4088,7 @@ description: Generated API docs
     ])
 
     const output = await build(
-      createConfig({
+      await createConfig({
         ...baseConfig,
         basePath: tempDir,
         validSdks: ['react'],
@@ -4141,7 +4141,7 @@ description: Generated API docs
     ])
 
     const output = await build(
-      createConfig({
+      await createConfig({
         ...baseConfig,
         basePath: tempDir,
         validSdks: ['react'],
@@ -4178,7 +4178,7 @@ description: Generated API docs
     ])
 
     const output = await build(
-      createConfig({
+      await createConfig({
         ...baseConfig,
         basePath: tempDir,
         validSdks: ['react'],
@@ -4218,7 +4218,7 @@ sdk: react, nextjs
     ])
 
     const output = await build(
-      createConfig({
+      await createConfig({
         ...baseConfig,
         basePath: tempDir,
         validSdks: ['react', 'nextjs'],

--- a/scripts/build-docs.ts
+++ b/scripts/build-docs.ts
@@ -74,7 +74,7 @@ import { validateUniqueHeadings } from './lib/plugins/validateUniqueHeadings'
 import {
   analyzeAndFixRedirects as optimizeRedirects,
   readRedirects,
-type Redirect,
+  type Redirect,
   transformRedirectsToObject,
   writeRedirects,
 } from './lib/redirects'
@@ -392,40 +392,6 @@ export async function build(config: BuildConfig, store: Store = createBlankStore
   )
   console.info('✓ Applied manifest sdk scoping')
 
-  if (config.cleanDist) {
-    await fs.rm(config.distPath, { recursive: true })
-    console.info('✓ Removed dist folder')
-  }
-
-  await writeFile(
-    'manifest.json',
-    JSON.stringify({
-      navigation: await traverseTree(
-        { items: sdkScopedManifest },
-        async (item) => ({
-          title: item.title,
-          href: docsMap.get(item.href)?.sdk !== undefined ? scopeHrefToSDK(config)(item.href, ':sdk:') : item.href,
-          tag: item.tag,
-          wrap: item.wrap === config.manifestOptions.wrapDefault ? undefined : item.wrap,
-          icon: item.icon,
-          target: item.target,
-          sdk: item.sdk,
-        }),
-        // @ts-expect-error - This traverseTree function might just be the death of me
-        async (group) => ({
-          title: group.title,
-          collapse: group.collapse === config.manifestOptions.collapseDefault ? undefined : group.collapse,
-          tag: group.tag,
-          wrap: group.wrap === config.manifestOptions.wrapDefault ? undefined : group.wrap,
-          icon: group.icon,
-          hideTitle: group.hideTitle === config.manifestOptions.hideTitleDefault ? undefined : group.hideTitle,
-          sdk: group.sdk,
-          items: group.items,
-        }),
-      ),
-    }),
-  )
-
   const flatSDKScopedManifest = flattenTree(sdkScopedManifest)
 
   const validatedPartials = await Promise.all(
@@ -513,6 +479,40 @@ export async function build(config: BuildConfig, store: Store = createBlankStore
     }),
   )
   console.info(`✓ Validated all typedocs`)
+
+  if (config.cleanDist) {
+    await fs.rm(config.distPath, { recursive: true })
+    console.info('✓ Removed dist folder')
+  }
+
+  await writeFile(
+    'manifest.json',
+    JSON.stringify({
+      navigation: await traverseTree(
+        { items: sdkScopedManifest },
+        async (item) => ({
+          title: item.title,
+          href: docsMap.get(item.href)?.sdk !== undefined ? scopeHrefToSDK(config)(item.href, ':sdk:') : item.href,
+          tag: item.tag,
+          wrap: item.wrap === config.manifestOptions.wrapDefault ? undefined : item.wrap,
+          icon: item.icon,
+          target: item.target,
+          sdk: item.sdk,
+        }),
+        // @ts-expect-error - This traverseTree function might just be the death of me
+        async (group) => ({
+          title: group.title,
+          collapse: group.collapse === config.manifestOptions.collapseDefault ? undefined : group.collapse,
+          tag: group.tag,
+          wrap: group.wrap === config.manifestOptions.wrapDefault ? undefined : group.wrap,
+          icon: group.icon,
+          hideTitle: group.hideTitle === config.manifestOptions.hideTitleDefault ? undefined : group.hideTitle,
+          sdk: group.sdk,
+          items: group.items,
+        }),
+      ),
+    }),
+  )
 
   const coreVFiles = await Promise.all(
     docsArray.map(async (doc) => {

--- a/scripts/build-docs.ts
+++ b/scripts/build-docs.ts
@@ -680,7 +680,14 @@ template: wide
   })
 
   await fs.rm(config.distFinalPath, { recursive: true })
-  await fs.rename(config.distTempPath, config.distFinalPath)
+
+  if (process.env.VERCEL === '1') {
+    // In vercel ci the temp dir and the final dir will be on separate partitions so fs.rename() will fail
+    await fs.cp(config.distTempPath, config.distFinalPath, { recursive: true })
+    await fs.rm(config.distTempPath, { recursive: true })
+  } else {
+    await fs.rename(config.distTempPath, config.distFinalPath)
+  }
 
   return warnings
 }

--- a/scripts/build-docs.ts
+++ b/scripts/build-docs.ts
@@ -95,6 +95,7 @@ async function main() {
     partialsPath: '../docs/_partials',
     distPath: '../dist',
     typedocPath: '../clerk-typedoc',
+    publicPath: '../public',
     redirects: {
       static: {
         inputPath: '../redirects/static/docs.json',
@@ -666,6 +667,11 @@ template: wide
   if (staticRedirects !== null && dynamicRedirects !== null) {
     await writeRedirects(config, staticRedirects, dynamicRedirects)
     console.info('✓ Wrote redirects to disk')
+  }
+
+  if (config.publicPath) {
+    await fs.cp(config.publicPath, path.join(config.distTempPath, '_public'), { recursive: true })
+    console.info('✓ Copied public assets to dist')
   }
 
   const flatSdkSpecificVFiles = sdkSpecificVFiles

--- a/scripts/lib/config.ts
+++ b/scripts/lib/config.ts
@@ -15,6 +15,7 @@ type BuildConfigOptions = {
   partialsPath: string
   distPath: string
   typedocPath: string
+  publicPath?: string
   ignoreLinks: string[]
   ignoreWarnings?: {
     docs: Record<string, string[]>
@@ -75,6 +76,9 @@ export async function createConfig(config: BuildConfigOptions) {
 
     typedocRelativePath: config.typedocPath,
     typedocPath: resolve(config.typedocPath),
+
+    publicRelativePath: config.publicPath,
+    publicPath: config.publicPath ? resolve(config.publicPath) : undefined,
 
     ignoredLink: (url: string) => config.ignoreLinks.some((ignoreItem) => url.startsWith(ignoreItem)),
     ignoreWarnings: config.ignoreWarnings ?? {

--- a/scripts/lib/io.ts
+++ b/scripts/lib/io.ts
@@ -42,7 +42,7 @@ export const ensureDirectory =
 // write a file to the dist (output) folder
 export const writeDistFile = (config: BuildConfig) => async (filePath: string, contents: string) => {
   const ensureDir = ensureDirectory(config)
-  const fullPath = path.join(config.distPath, filePath)
+  const fullPath = path.join(config.distTempPath, filePath)
   await ensureDir(path.dirname(fullPath))
   await fs.writeFile(fullPath, contents, { encoding: 'utf-8' })
 }

--- a/scripts/lib/redirects.ts
+++ b/scripts/lib/redirects.ts
@@ -3,7 +3,7 @@ import fs from 'node:fs/promises'
 import path from 'node:path'
 import { parse as parseJSONC } from 'jsonc-parser'
 
-interface Redirect {
+export interface Redirect {
   source: string
   destination: string
   permanent: boolean


### PR DESCRIPTION
Building on top of https://github.com/clerk/clerk-docs/pull/2242 cuz that pr changes how the generated output artifact is managed

### What does this solve?

- We need a way to access the public images / assets that are stored in the clerk-docs repo from clerk.com

### What changed?

- copies the public folder in to dist/_public

### Checklist

- [x] I have clicked on "Files changed" and performed a thorough self-review
- [x] All existing checks pass
