### PR TITLE
docs: extra space in tailwind class, SignIn elements with Shadcnui example password/email_code CardTitle mismatch

### DIFF
--- a/docs/customization/elements/examples/shadcn-ui.mdx
+++ b/docs/customization/elements/examples/shadcn-ui.mdx
@@ -482,10 +482,7 @@ You must also configure the appropriate settings in Clerk:
                   <SignIn.Strategy name="password">
                     <Card className="w-full sm:w-96">
                       <CardHeader>
-                        <CardTitle>Check your email</CardTitle>
-                        <CardDescription>
-                          Enter the verification code sent to your email
-                        </CardDescription>
+                        <CardTitle>Enter your password</CardTitle>
                         <p className="text-sm text-muted-foreground">
                           Welcome back <SignIn.SafeIdentifier />
                         </p>

--- a/docs/customization/elements/examples/sign-in.mdx
+++ b/docs/customization/elements/examples/sign-in.mdx
@@ -72,7 +72,7 @@ Before you build your sign-in flow, you need to configure the appropriate settin
                 <Clerk.FieldError className="block text-sm text-red-400" />
               </Clerk.Field>
               <Clerk.Field name="password" className="space-y-2">
-                <Clerk.Label className="text-sm  font-medium text-zinc-950">Password</Clerk.Label>
+                <Clerk.Label className="text-sm font-medium text-zinc-950">Password</Clerk.Label>
                 <Clerk.Input
                   type="password"
                   required


### PR DESCRIPTION

### What does this solve?
Using the example code from the docs produces a password input with text directions for email. This happens inside `<SignIn.Strategy name="password" ...`
<img width="605" alt="image" src="https://github.com/user-attachments/assets/f1f901e9-24f1-4b83-913c-5c56b15b70d6" />


<!--- Describe your changes in detail. Why does this change need to happen? Include any links to Slack discussions, Linear comments, etc. -->

### What changed?

- Updates the `CardTitle` to "Enter your password" and removes `CardDescription` as there isn't much more to say
- Removes extra space in tailwind class

### Checklist

- [x] I have clicked on "Files changed" and performed a thorough self-review
- [x] All existing checks pass
