### PR TITLE
Include the last updated date from git in the generated out markdown frontmatter

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7,9 +7,6 @@
     "": {
       "name": "clerk-docs-2023",
       "version": "0.1.0",
-      "dependencies": {
-        "simple-git": "^3.27.0"
-      },
       "devDependencies": {
         "@parcel/watcher": "^2.5.1",
         "@sindresorhus/slugify": "^2.2.1",
@@ -26,6 +23,7 @@
         "remark-frontmatter": "^5.0.0",
         "remark-gfm": "^4.0.0",
         "remark-mdx": "^3.0.1",
+        "simple-git": "^3.27.0",
         "tsx": "^4.19.2",
         "typescript": "^5.7.3",
         "unist-builder": "^4.0.0",
@@ -727,6 +725,7 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/@kwsites/file-exists/-/file-exists-1.1.1.tgz",
       "integrity": "sha512-m9/5YGR18lIwxSFDwfE3oA7bWuq9kdau6ugN4H2rJeyhFQZcG9AgSHkQtSD15a8WvTgfz9aikZMrKPHvbpqFiw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "debug": "^4.1.1"
@@ -736,6 +735,7 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/@kwsites/promise-deferred/-/promise-deferred-1.1.1.tgz",
       "integrity": "sha512-GaHYm+c0O9MjZRu0ongGBRbinu8gVAMd2UZjji6jVmqKtZluZnptXGWhz1E8j8D2HJ3f/yMxKAUC0b+57wncIw==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@parcel/watcher": {
@@ -1877,6 +1877,7 @@
       "version": "4.4.0",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.0.tgz",
       "integrity": "sha512-6WTZ/IxCY/T6BALoZHaE4ctp9xm+Z5kY/pzYaCHRFeyVhojxlrm+46y68HA6hr0TcwEssoxNiDEUJQjfPZ/RYA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ms": "^2.1.3"
@@ -3619,6 +3620,7 @@
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/nanoid": {
@@ -4055,6 +4057,7 @@
       "version": "3.27.0",
       "resolved": "https://registry.npmjs.org/simple-git/-/simple-git-3.27.0.tgz",
       "integrity": "sha512-ivHoFS9Yi9GY49ogc6/YAi3Fl9ROnF4VyubNylgCkA+RVqLaKWnDSzXOVzya8csELIaWaYNutsEuAhZrtOjozA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@kwsites/file-exists": "^1.1.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,6 +7,9 @@
     "": {
       "name": "clerk-docs-2023",
       "version": "0.1.0",
+      "dependencies": {
+        "simple-git": "^3.27.0"
+      },
       "devDependencies": {
         "@parcel/watcher": "^2.5.1",
         "@sindresorhus/slugify": "^2.2.1",
@@ -719,6 +722,21 @@
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
+    },
+    "node_modules/@kwsites/file-exists": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@kwsites/file-exists/-/file-exists-1.1.1.tgz",
+      "integrity": "sha512-m9/5YGR18lIwxSFDwfE3oA7bWuq9kdau6ugN4H2rJeyhFQZcG9AgSHkQtSD15a8WvTgfz9aikZMrKPHvbpqFiw==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.1.1"
+      }
+    },
+    "node_modules/@kwsites/promise-deferred": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@kwsites/promise-deferred/-/promise-deferred-1.1.1.tgz",
+      "integrity": "sha512-GaHYm+c0O9MjZRu0ongGBRbinu8gVAMd2UZjji6jVmqKtZluZnptXGWhz1E8j8D2HJ3f/yMxKAUC0b+57wncIw==",
+      "license": "MIT"
     },
     "node_modules/@parcel/watcher": {
       "version": "2.5.1",
@@ -1859,7 +1877,6 @@
       "version": "4.4.0",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.0.tgz",
       "integrity": "sha512-6WTZ/IxCY/T6BALoZHaE4ctp9xm+Z5kY/pzYaCHRFeyVhojxlrm+46y68HA6hr0TcwEssoxNiDEUJQjfPZ/RYA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ms": "^2.1.3"
@@ -3602,7 +3619,6 @@
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/nanoid": {
@@ -4033,6 +4049,21 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/simple-git": {
+      "version": "3.27.0",
+      "resolved": "https://registry.npmjs.org/simple-git/-/simple-git-3.27.0.tgz",
+      "integrity": "sha512-ivHoFS9Yi9GY49ogc6/YAi3Fl9ROnF4VyubNylgCkA+RVqLaKWnDSzXOVzya8csELIaWaYNutsEuAhZrtOjozA==",
+      "license": "MIT",
+      "dependencies": {
+        "@kwsites/file-exists": "^1.1.1",
+        "@kwsites/promise-deferred": "^1.1.1",
+        "debug": "^4.3.5"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/steveukx/git-js?sponsor=1"
       }
     },
     "node_modules/source-map-js": {

--- a/package.json
+++ b/package.json
@@ -45,5 +45,8 @@
     "yaml": "^2.7.0",
     "zod": "^3.24.2",
     "zod-validation-error": "^3.4.0"
+  },
+  "dependencies": {
+    "simple-git": "^3.27.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "remark-frontmatter": "^5.0.0",
     "remark-gfm": "^4.0.0",
     "remark-mdx": "^3.0.1",
+    "simple-git": "^3.27.0",
     "tsx": "^4.19.2",
     "typescript": "^5.7.3",
     "unist-builder": "^4.0.0",
@@ -45,8 +46,5 @@
     "yaml": "^2.7.0",
     "zod": "^3.24.2",
     "zod-validation-error": "^3.4.0"
-  },
-  "dependencies": {
-    "simple-git": "^3.27.0"
   }
 }

--- a/scripts/build-docs.test.ts
+++ b/scripts/build-docs.test.ts
@@ -2,6 +2,7 @@ import fs from 'node:fs/promises'
 import path from 'node:path'
 import os from 'node:os'
 import { glob } from 'glob'
+import simpleGit from 'simple-git'
 
 import { describe, expect, onTestFinished, test } from 'vitest'
 import { build } from './build-docs'
@@ -59,6 +60,20 @@ async function createTempFiles(
     await fs.writeFile(filePath, file.content)
   }
 
+  // Initialize git repository
+  const git = simpleGit(tempDir)
+  await git.init()
+
+  // Add all files to git
+  await git.add('.')
+
+  // Use a fixed date for the initial commit
+  const initialCommitDate = new Date()
+  initialCommitDate.setMilliseconds(0) // git will drop off the milliseconds so if we don't do that then the times will miss-match
+  await git.commit('Initial commit', undefined, {
+    '--date': initialCommitDate.toISOString(),
+  })
+
   // Register cleanup unless preserveTemp is true
   if (!preserve) {
     onTestFinished(async () => {
@@ -90,6 +105,12 @@ async function createTempFiles(
     readFile: async (filePath: string): Promise<string> => {
       return fs.readFile(path.join(tempDir, filePath), 'utf-8')
     },
+
+    // Pass through the git instance incase we need to use it for something
+    git,
+
+    // Return the initial commit date
+    initialCommitDate,
   }
 }
 
@@ -141,7 +162,7 @@ const baseConfig = {
 describe('Basic Functionality', () => {
   test('Basic build test with simple files', async () => {
     // Create temp environment with minimal files array
-    const { tempDir, pathJoin } = await createTempFiles([
+    const { tempDir, pathJoin, initialCommitDate } = await createTempFiles([
       {
         path: './docs/manifest.json',
         content: JSON.stringify({
@@ -175,6 +196,7 @@ Testing with a simple page.`,
     expect(await readFile(pathJoin('./dist/simple-test.mdx'))).toBe(`---
 title: Simple Test
 description: This is a simple test page
+lastUpdated: ${initialCommitDate.toISOString()}
 ---
 
 # Simple Test Page
@@ -1009,7 +1031,7 @@ title: Quickstart
   })
 
   test('sdk in frontmatter filters the docs', async () => {
-    const { tempDir, pathJoin } = await createTempFiles([
+    const { tempDir, pathJoin, initialCommitDate } = await createTempFiles([
       {
         path: './docs/manifest.json',
         content: JSON.stringify({
@@ -1050,6 +1072,7 @@ Testing with a simple page.`,
 title: Simple Test
 sdk: react
 canonical: /docs/:sdk:/simple-test
+lastUpdated: ${initialCommitDate.toISOString()}
 ---
 
 # Simple Test Page

--- a/scripts/build-docs.test.ts
+++ b/scripts/build-docs.test.ts
@@ -62,7 +62,12 @@ async function createTempFiles(
 
   // Initialize git repository
   const git = simpleGit(tempDir)
+
   await git.init()
+
+  // Locally set the git user config
+  await git.addConfig('user.name', 'Test User')
+  await git.addConfig('user.email', 'test@example.com')
 
   // Add all files to git
   await git.add('.')

--- a/scripts/lib/getLastCommitDate.ts
+++ b/scripts/lib/getLastCommitDate.ts
@@ -1,0 +1,10 @@
+import simpleGit from 'simple-git'
+import type { BuildConfig } from './config'
+
+export const getLastCommitDate = (config: BuildConfig) => {
+  const git = simpleGit(config.docsPath)
+  return async (filePath: string) => {
+    const log = await git.log({ file: filePath, n: 1 })
+    return log.latest?.date ? new Date(log.latest.date) : null
+  }
+}


### PR DESCRIPTION
### 🔎 Previews:

- https://clerk-docs-git-nick-record-file-last-updated-date.clerkstage.dev/

### What does this solve?

- We need a way to get when a file was last updated, luckily this information is managed already for us fairly accurately by git

### What changed?

- Used a module called 'simple-git' to grab the datetime out and embed it in to the frontmatter in ISO format

### Checklist

- [x] I have clicked on "Files changed" and performed a thorough self-review
- [x] All existing checks pass
