### PR TITLE
fix: Frontend API proxy example for Next.js

### DIFF
--- a/docs/advanced-usage/using-proxies.mdx
+++ b/docs/advanced-usage/using-proxies.mdx
@@ -109,7 +109,7 @@ When using a proxy, all requests to the Frontend API will be made through your d
       import { NextResponse } from 'next/server'
       import { clerkMiddleware } from '@clerk/nextjs/server'
 
-      export default clerkMiddleware((auth, req) => {
+      function proxyMiddleware(req) {
         if (req.nextUrl.pathname.match('__clerk')) {
           const proxyHeaders = new Headers(req.headers)
           proxyHeaders.set('Clerk-Proxy-Url', process.env.NEXT_PUBLIC_CLERK_PROXY_URL || '')
@@ -132,7 +132,22 @@ When using a proxy, all requests to the Frontend API will be made through your d
             },
           })
         }
-      })
+
+        return null
+      }
+
+      const clerkHandler = clerkMiddleware()
+
+      export default function middleware(req) {
+        // First check if it's a proxy request
+        const proxyResponse = proxyMiddleware(req)
+        if (proxyResponse) {
+          return proxyResponse
+        }
+
+        // Otherwise, use Clerk's middleware
+        return clerkHandler(req)
+      }
 
       export const config = {
         matcher: [


### PR DESCRIPTION
### 🔎 Previews:

- https://clerk.com/docs/pr/2248/advanced-usage/using-proxies

### What does this solve?

- <!--- Describe your changes in detail. Why does this change need to happen? Include any links to Slack discussions, Linear comments, etc. -->
- The proxy middleware example does not work properly as the proxy logic is not executed until `clerkMiddleware()` authenticates the request. This is unnecessary and causes issues in the handshake flow.

### What changed?

- <!--- How does this PR solve the problem? -->
The implementation has been improved to guarantee that proxy routes are always checked and handled before the Clerk middleware executes. This execution order is critical because it ensures that requests to the proxy path (__clerk) are correctly intercepted and routed to Clerk's Frontend API before any authentication middleware runs, preventing potential conflicts in request handling.

### Checklist

- [ ] I have clicked on "Files changed" and performed a thorough self-review
- [ ] All existing checks pass
