### PR TITLE
Update preview comment to use slugified branch name for docs preview URL

### DIFF
--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -5,8 +5,7 @@ env:
   PREVIEW_BASE_URL: https://clerk.com
 
 on:
-  pull_request:
-    types: [opened]
+  push:
 
 jobs:
   pr_preview:

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -29,5 +29,5 @@ jobs:
               issue_number: context.issue.number,
               owner: context.repo.owner,
               repo: context.repo.repo,
-              body: 'Hey, here's your docs preview: ' + process.env.PREVIEW_BASE_URL + '/docs/pr/' + slugifiedBranch,
+              body: "Hey, here's your docs preview: " + process.env.PREVIEW_BASE_URL + "/docs/pr/" + slugifiedBranch,
             })

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -5,12 +5,10 @@ env:
   PREVIEW_BASE_URL: https://clerk.com
 
 on:
-  pull_request:
-    types: [opened]
+  push:
 
 jobs:
   pr_preview:
-    if: ${{ github.event.pull_request.head.repo.owner.login == 'clerk' }}
     runs-on: ubuntu-latest
     permissions:
       pull-requests: write

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -5,7 +5,8 @@ env:
   PREVIEW_BASE_URL: https://clerk.com
 
 on:
-  push:
+  pull_request:
+    types: [opened]
 
 jobs:
   pr_preview:

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -19,9 +19,15 @@ jobs:
         uses: actions/github-script@v7
         with:
           script: |
+            const branchName = context.payload.pull_request.head.ref;
+            const slugifiedBranch = branchName
+              .toLowerCase()
+              .replace(/[^a-z0-9]/g, '-')
+              .replace(/^-+|-+$/g, '');
+
             github.rest.issues.createComment({
               issue_number: context.issue.number,
               owner: context.repo.owner,
               repo: context.repo.repo,
-              body: 'Hey, here’s your docs preview: ' + process.env.PREVIEW_BASE_URL + '/docs/pr/' + context.issue.number,
+              body: 'Hey, here's your docs preview: ' + process.env.PREVIEW_BASE_URL + '/docs/pr/' + slugifiedBranch,
             })


### PR DESCRIPTION
### What changed?

- Switched from `/docs/pr/1234` to `/docs/pr/branch-name` for https://github.com/clerk/clerk/pull/1074

### Checklist

- [ ] I have clicked on "Files changed" and performed a thorough self-review
- [ ] All existing checks pass
