### PR TITLE
fix: Update b2b billing docs with more clarity on custom permissions

### DIFF
--- a/docs/billing/b2b-saas.mdx
+++ b/docs/billing/b2b-saas.mdx
@@ -59,6 +59,9 @@ You can use Clerk's features, plans, and permissions to gate access to the conte
 
 The `has()` method is available for any JavaScript framework, while `<Protect>` is only available for React-based frameworks.
 
+> [!NOTE]
+> When billing is enabled, custom permissions will only appear in the session token and in API responses (including the result of the `has()` check) if the feature part of the permission key (`org:<feature>:<action>`) is a feature included in the organization's active plan. If the feature is not part of the plan, the `has()` check for permissions using that feature will return `false`.
+
 ### Example: Using `has()`
 
 Use the `has()` method to test if the organization has access to a **plan**:


### PR DESCRIPTION
### 🔎 Previews:

-

### What does this solve?

The B2B billing docs are lacking details on how custom permission checks work in tandem with billing plans.

### What changed?

This PR adds a callout that explains custom permissions won't appear in the session jwt, API response, or pass `has()` checks unless the `feature` part of the permission key is part of the org's active plan, if billing is enabled.

### Checklist

- [ ] I have clicked on "Files changed" and performed a thorough self-review
- [ ] All existing checks pass
