### PR TITLE
Drastically speed up build script tests

### DIFF
--- a/scripts/build-docs.test.ts
+++ b/scripts/build-docs.test.ts
@@ -19,20 +19,20 @@ const tempConfig = {
   // Whether to preserve temp directories after tests
   // (helpful for debugging, but requires manual cleanup)
   preserveTemp: false,
+
+  // Whether to setup a git repository in each test
+  setupGit: false,
 }
 
 async function createTempFiles(
   files: { path: string; content: string }[],
-  options?: {
-    prefix?: string // Prefix for the temp directory name
-    preserveTemp?: boolean // Override global preserveTemp setting
-    useLocalTemp?: boolean // Override global useLocalTemp setting
-  },
+  {
+    tempDirectoryPrefix = 'clerk-docs-test-',
+    preserveTemp = tempConfig.preserveTemp,
+    useLocalTemp = tempConfig.useLocalTemp,
+    setupGit = tempConfig.setupGit,
+  } = {},
 ) {
-  const prefix = options?.prefix || 'clerk-docs-test-'
-  const preserve = options?.preserveTemp ?? tempConfig.preserveTemp
-  const useLocalTemp = options?.useLocalTemp ?? tempConfig.useLocalTemp
-
   // Determine base directory for temp files
   let baseDir: string
 
@@ -46,7 +46,7 @@ async function createTempFiles(
   }
 
   // Create temp folder with unique name
-  const tempDir = await fs.mkdtemp(path.join(baseDir, prefix))
+  const tempDir = await fs.mkdtemp(path.join(baseDir, tempDirectoryPrefix))
 
   // Create all files
   for (const file of files) {
@@ -60,27 +60,30 @@ async function createTempFiles(
     await fs.writeFile(filePath, file.content)
   }
 
-  // Initialize git repository
-  const git = simpleGit(tempDir)
-
-  await git.init()
-
-  // Locally set the git user config
-  await git.addConfig('user.name', 'Test User')
-  await git.addConfig('user.email', 'test@example.com')
-
-  // Add all files to git
-  await git.add('.')
-
-  // Use a fixed date for the initial commit
   const initialCommitDate = new Date()
-  initialCommitDate.setMilliseconds(0) // git will drop off the milliseconds so if we don't do that then the times will miss-match
-  await git.commit('Initial commit', undefined, {
-    '--date': initialCommitDate.toISOString(),
-  })
+
+  if (setupGit) {
+    // Initialize git repository
+    const git = simpleGit(tempDir)
+
+    await git.init()
+
+    // Locally set the git user config
+    await git.addConfig('user.name', 'Test User')
+    await git.addConfig('user.email', 'test@example.com')
+
+    // Add all files to git
+    await git.add('.')
+
+    // Use a fixed date for the initial commit
+    initialCommitDate.setMilliseconds(0) // git will drop off the milliseconds so if we don't do that then the times will miss-match
+    await git.commit('Initial commit', undefined, {
+      '--date': initialCommitDate.toISOString(),
+    })
+  }
 
   // Register cleanup unless preserveTemp is true
-  if (!preserve) {
+  if (!preserveTemp) {
     onTestFinished(async () => {
       try {
         await fs.rm(tempDir, { recursive: true, force: true })
@@ -112,7 +115,7 @@ async function createTempFiles(
     },
 
     // Pass through the git instance incase we need to use it for something
-    git,
+    git: setupGit ? simpleGit(tempDir) : undefined,
 
     // Return the initial commit date
     initialCommitDate,
@@ -162,23 +165,27 @@ const baseConfig = {
     collapseDefault: false,
     hideTitleDefault: false,
   },
-  skipApiErrors: true,
-  cleanDist: false,
-}
+  flags: {
+    skipGit: true,
+    clean: true,
+    skipApiErrors: true,
+  },
+} satisfies Partial<Parameters<typeof createConfig>[0]>
 
 describe('Basic Functionality', () => {
   test('Basic build test with simple files', async () => {
     // Create temp environment with minimal files array
-    const { tempDir, pathJoin, initialCommitDate } = await createTempFiles([
-      {
-        path: './docs/manifest.json',
-        content: JSON.stringify({
-          navigation: [[{ title: 'Simple Test', href: '/docs/simple-test' }]],
-        }),
-      },
-      {
-        path: './docs/simple-test.mdx',
-        content: `---
+    const { tempDir, pathJoin, initialCommitDate } = await createTempFiles(
+      [
+        {
+          path: './docs/manifest.json',
+          content: JSON.stringify({
+            navigation: [[{ title: 'Simple Test', href: '/docs/simple-test' }]],
+          }),
+        },
+        {
+          path: './docs/simple-test.mdx',
+          content: `---
 title: Simple Test
 description: This is a simple test page
 ---
@@ -186,14 +193,21 @@ description: This is a simple test page
 # Simple Test Page
 
 Testing with a simple page.`,
-      },
-    ])
+        },
+      ],
+      { setupGit: true },
+    )
 
     const output = await build(
       await createConfig({
         ...baseConfig,
         basePath: tempDir,
         validSdks: ['nextjs', 'react'],
+        flags: {
+          skipGit: false,
+          clean: true,
+          skipApiErrors: true,
+        },
       }),
     )
 
@@ -1038,7 +1052,7 @@ title: Quickstart
   })
 
   test('sdk in frontmatter filters the docs', async () => {
-    const { tempDir, pathJoin, initialCommitDate } = await createTempFiles([
+    const { tempDir, pathJoin } = await createTempFiles([
       {
         path: './docs/manifest.json',
         content: JSON.stringify({
@@ -1079,7 +1093,6 @@ Testing with a simple page.`,
 title: Simple Test
 sdk: react
 canonical: /docs/:sdk:/simple-test
-lastUpdated: ${initialCommitDate.toISOString()}
 ---
 
 # Simple Test Page
@@ -4264,7 +4277,7 @@ sdk: react, nextjs
 
 describe('API Errors Generation', () => {
   test('should generate api errors', async () => {
-    const { tempDir, readFile, listFiles } = await createTempFiles([
+    const { tempDir, readFile } = await createTempFiles([
       {
         path: './docs/manifest.json',
         content: JSON.stringify({
@@ -4292,8 +4305,12 @@ describe('API Errors Generation', () => {
       await createConfig({
         ...baseConfig,
         basePath: tempDir,
-        skipApiErrors: false,
         validSdks: ['react'],
+        flags: {
+          skipApiErrors: false,
+          skipGit: true,
+          clean: true,
+        },
       }),
     )
 

--- a/scripts/lib/config.ts
+++ b/scripts/lib/config.ts
@@ -38,11 +38,12 @@ type BuildConfigOptions = {
       outputPath: string
     }
   }
-  skipApiErrors?: boolean
-  cleanDist: boolean
   flags?: {
     watch?: boolean
     controlled?: boolean
+    skipGit?: boolean
+    clean?: boolean
+    skipApiErrors?: boolean
   }
 }
 
@@ -111,12 +112,12 @@ export async function createConfig(config: BuildConfigOptions) {
         }
       : null,
 
-    skipApiErrors: config.skipApiErrors ?? false,
-    cleanDist: config.cleanDist,
-
     flags: {
       watch: config.flags?.watch ?? false,
       controlled: config.flags?.controlled ?? false,
+      skipGit: config.flags?.skipGit ?? false,
+      clean: config.flags?.clean ?? false,
+      skipApiErrors: config.flags?.skipApiErrors ?? false,
     },
   }
 }

--- a/scripts/lib/getLastCommitDate.ts
+++ b/scripts/lib/getLastCommitDate.ts
@@ -2,7 +2,12 @@ import simpleGit from 'simple-git'
 import type { BuildConfig } from './config'
 
 export const getLastCommitDate = (config: BuildConfig) => {
+  if (config.flags.skipGit) {
+    return async () => null
+  }
+
   const git = simpleGit(config.docsPath)
+
   return async (filePath: string) => {
     const log = await git.log({ file: filePath, n: 1 })
     return log.latest?.date ? new Date(log.latest.date) : null

--- a/scripts/lib/plugins/insertFrontmatter.ts
+++ b/scripts/lib/plugins/insertFrontmatter.ts
@@ -1,18 +1,21 @@
 import { map as mdastMap } from 'unist-util-map'
+import { VFile } from 'vfile'
 import yaml from 'yaml'
+import type { Node } from 'unist'
 
-export const insertFrontmatter = (newFrontmatter: Record<string, string>) => () => (tree, vfile) => {
-  return mdastMap(tree, (node) => {
-    if (node.type !== 'yaml') return node
-    if (!('value' in node)) return node
-    if (typeof node.value !== 'string') return node
+export const insertFrontmatter =
+  (newFrontmatter: Record<string, string | undefined>) => () => (tree: Node, vfile: VFile) => {
+    return mdastMap(tree, (node) => {
+      if (node.type !== 'yaml') return node
+      if (!('value' in node)) return node
+      if (typeof node.value !== 'string') return node
 
-    const frontmatter = yaml.parse(node.value)
+      const frontmatter = yaml.parse(node.value)
 
-    const transformedFrontmatter = { ...frontmatter, ...newFrontmatter }
+      const transformedFrontmatter = { ...frontmatter, ...newFrontmatter }
 
-    node.value = yaml.stringify(transformedFrontmatter).split('\n').slice(0, -1).join('\n')
+      node.value = yaml.stringify(transformedFrontmatter).split('\n').slice(0, -1).join('\n')
 
-    return node
-  })
-}
+      return node
+    })
+  }


### PR DESCRIPTION
### What does this solve?

- Since adding the getting the latest commit date on a file in the build script, the testing has gotten a lot slower as it initializes the tests each time, this results in the tests taking 30+ seconds to run which isn't great for local development

### What changed?

- I've made the git repo init optional so it only runs on one test, making it slow but the whole tests script back to around 2 seconds to run

### Checklist

- [x] I have clicked on "Files changed" and performed a thorough self-review
- [x] All existing checks pass
