### PR TITLE
chore: Update getOrganizationMembershipList params

### DIFF
--- a/docs/references/backend/organization/get-organization-membership-list.mdx
+++ b/docs/references/backend/organization/get-organization-membership-list.mdx
@@ -41,6 +41,111 @@ function getOrganizationMembershipList(
   - `'phone_number' | 'email_address' | 'created_at' | 'first_name' | 'last_name' | 'username'`
 
   Return memberships in a particular order. Prefix with a `-` to reverse the order. Prefix with a `+` to list in ascending order. Defaults to `'-created_at'`.
+
+  ---
+
+  - `userId?`
+  - `string[]`
+
+  Returns memberships with the user ids specified. For each user id, the `+` and `-` can be prepended to the id, which denote whether the respective user id should be included or excluded from the result set. Accepts up to 100 user ids. Any user ids not found are ignored.
+
+  ---
+
+  - `emailAddress?`
+  - `string[]`
+
+  Returns users with the specified email addresses. Accepts up to 100 email addresses. Any email addresses not found are ignored.
+
+  ---
+
+  - `phoneNumber?`
+  - `string[]`
+
+  Returns users with the specified phone numbers. Accepts up to 100 phone numbers. Any phone numbers not found are ignored.
+
+  ---
+
+  - `username?`
+  - `string[]`
+
+  Returns users with the specified usernames. Accepts up to 100 usernames. Any usernames not found are ignored.
+
+  ---
+
+  - `web3Wallet?`
+  - `string[]`
+
+  Returns users with the specified web3 wallet addresses. Accepts up to 100 web3 wallet addresses. Any web3 wallet addressed not found are ignored.
+
+  ---
+
+  - `role?`
+  - `OrganizationMembershipRole[]`
+
+  Returns users with the specified roles. Accepts up to 100 roles. Any roles not found are ignored.
+
+  ---
+  
+  - `query?`
+  - `string`
+
+  Filters users that match the given query. For possible matches, we check the email addresses, phone numbers, usernames, Web3 wallet addresses, user IDs, first and last names. The query value doesn't need to match the exact value you are looking for, it is capable of partial matches as well.
+
+  ---
+
+  - `emailAddressQuery?`
+  - `string`
+
+  Filters users with emails that match the given query, via case-insensitive partial match. For example, `email_address_query=ello` will match a user with the email `HELLO@example.com`.
+
+  ---
+
+  - `phoneNumberQuery?`
+  - `string`
+
+  Filters users with phone numbers that match the given query, via case-insensitive partial match. For example, `phone_number_query=555` will match a user with the phone number `+1555xxxxxxx`.
+  
+  ---
+
+  - `usernameQuery?`
+  - `string`
+
+  Filters users with usernames that match the given query, via case-insensitive partial match. For example, `username_query=CoolUser` will match a user with the username `SomeCoolUser`.
+  
+  ---
+
+  - `nameQuery?`
+  - `string`
+
+  Filters users with names that match the given query, via case-insensitive partial match.
+  
+  ---
+
+  - `lastActiveAtBefore?`
+  - `number`
+
+  Filters users whose last session activity was before the given date (with millisecond precision). For example, use `1700690400000` to retrieve users whose last session activity was before 2023-11-23.
+
+  ---
+
+  - `lastActiveAtAfter?`
+  - `number`
+
+  Filters users whose last session activity was after the given date (with millisecond precision). For example, use `1700690400000` to retrieve users whose last session activity was after 2023-11-23.
+  
+  ---
+
+  - `createdAtBefore?`
+  - `number`
+
+  Filters users who have been created before the given date (with millisecond precision). For example, use `1730160000000` to retrieve users who have been created before 2024-10-29.
+
+  ---
+  
+  - `createdAtAfter?`
+  - `number`
+
+  Filters users who have been created after the given date (with millisecond precision). For example, use `1730160000000` to retrieve users who have been created after 2024-10-29.
 </Properties>
 
 ## Examples

--- a/docs/references/backend/organization/get-organization-membership-list.mdx
+++ b/docs/references/backend/organization/get-organization-membership-list.mdx
@@ -85,7 +85,7 @@ function getOrganizationMembershipList(
   Returns users with the specified roles. Accepts up to 100 roles. Any roles not found are ignored.
 
   ---
-  
+
   - `query?`
   - `string`
 
@@ -104,21 +104,21 @@ function getOrganizationMembershipList(
   - `string`
 
   Filters users with phone numbers that match the given query, via case-insensitive partial match. For example, `phone_number_query=555` will match a user with the phone number `+1555xxxxxxx`.
-  
+
   ---
 
   - `usernameQuery?`
   - `string`
 
   Filters users with usernames that match the given query, via case-insensitive partial match. For example, `username_query=CoolUser` will match a user with the username `SomeCoolUser`.
-  
+
   ---
 
   - `nameQuery?`
   - `string`
 
   Filters users with names that match the given query, via case-insensitive partial match.
-  
+
   ---
 
   - `lastActiveAtBefore?`
@@ -132,7 +132,7 @@ function getOrganizationMembershipList(
   - `number`
 
   Filters users whose last session activity was after the given date (with millisecond precision). For example, use `1700690400000` to retrieve users whose last session activity was after 2023-11-23.
-  
+
   ---
 
   - `createdAtBefore?`
@@ -141,7 +141,7 @@ function getOrganizationMembershipList(
   Filters users who have been created before the given date (with millisecond precision). For example, use `1730160000000` to retrieve users who have been created before 2024-10-29.
 
   ---
-  
+
   - `createdAtAfter?`
   - `number`
 

--- a/docs/references/backend/organization/get-organization-membership-list.mdx
+++ b/docs/references/backend/organization/get-organization-membership-list.mdx
@@ -16,10 +16,45 @@ function getOrganizationMembershipList(
 ## `GetOrganizationMembershipListParams`
 
 <Properties>
-  - `organizationId`
+  - `createdAtAfter?`
+  - `number`
+
+  Filters memberships who have been created after the given date (with millisecond precision). For example, use `1730160000000` to retrieve memberships who have been created after 2024-10-29.
+
+  ---
+
+  - `createdAtBefore?`
+  - `number`
+
+  Filters memberships who have been created before the given date (with millisecond precision). For example, use `1730160000000` to retrieve memberships who have been created before 2024-10-29.
+
+  ---
+
+  - `emailAddress?`
+  - `string[]`
+
+  Filters memberships for the email addresses specified. Accepts up to 100 email addresses. Any email addresses not found are ignored.
+
+  ---
+
+  - `emailAddressQuery?`
   - `string`
 
-  The ID of the organization to retrieve the list of memberships from.
+  Filters memberships with emails that match the given query, via case-insensitive partial match. For example, `email_address_query=ello` will match a membership with the email `HELLO@example.com`.
+
+  ---
+
+  - `lastActiveAtAfter?`
+  - `number`
+
+  Filters memberships whose last session activity was after the given date (with millisecond precision). For example, use `1700690400000` to retrieve memberships whose last session activity was after 2023-11-23.
+
+  ---
+
+  - `lastActiveAtBefore?`
+  - `number`
+
+  Filters memberships whose last session activity was before the given date (with millisecond precision). For example, use `1700690400000` to retrieve memberships whose last session activity was before 2023-11-23.
 
   ---
 
@@ -27,6 +62,13 @@ function getOrganizationMembershipList(
   - `number`
 
   The number of results to return. Must be an integer greater than zero and less than 501. Can be used for paginating the results together with `offset`. Defaults to `10`.
+
+  ---
+
+  - `nameQuery?`
+  - `string`
+
+  Filters memberships with names that match the given query, via case-insensitive partial match.
 
   ---
 
@@ -44,108 +86,66 @@ function getOrganizationMembershipList(
 
   ---
 
-  - `userId?`
-  - `string[]`
+  - `organizationId`
+  - `string`
 
-  Returns memberships with the user ids specified. For each user id, the `+` and `-` can be prepended to the id, which denote whether the respective user id should be included or excluded from the result set. Accepts up to 100 user ids. Any user ids not found are ignored.
-
-  ---
-
-  - `emailAddress?`
-  - `string[]`
-
-  Returns users with the specified email addresses. Accepts up to 100 email addresses. Any email addresses not found are ignored.
+  The ID of the organization to retrieve the list of memberships from.
 
   ---
 
   - `phoneNumber?`
   - `string[]`
 
-  Returns users with the specified phone numbers. Accepts up to 100 phone numbers. Any phone numbers not found are ignored.
-
-  ---
-
-  - `username?`
-  - `string[]`
-
-  Returns users with the specified usernames. Accepts up to 100 usernames. Any usernames not found are ignored.
-
-  ---
-
-  - `web3Wallet?`
-  - `string[]`
-
-  Returns users with the specified web3 wallet addresses. Accepts up to 100 web3 wallet addresses. Any web3 wallet addressed not found are ignored.
-
-  ---
-
-  - `role?`
-  - `string[]`
-
-  Returns users with the specified roles. Accepts up to 100 roles. Any roles not found are ignored.
-
-  ---
-
-  - `query?`
-  - `string`
-
-  Filters users that match the given query. For possible matches, we check the email addresses, phone numbers, usernames, Web3 wallet addresses, user IDs, first and last names. The query value doesn't need to match the exact value you are looking for, it is capable of partial matches as well.
-
-  ---
-
-  - `emailAddressQuery?`
-  - `string`
-
-  Filters users with emails that match the given query, via case-insensitive partial match. For example, `email_address_query=ello` will match a user with the email `HELLO@example.com`.
+  Filters memberships for the phone numbers specified. Accepts up to 100 phone numbers. Any phone numbers not found are ignored.
 
   ---
 
   - `phoneNumberQuery?`
   - `string`
 
-  Filters users with phone numbers that match the given query, via case-insensitive partial match. For example, `phone_number_query=555` will match a user with the phone number `+1555xxxxxxx`.
+  Filters memberships with phone numbers that match the given query, via case-insensitive partial match. For example, `phone_number_query=555` will match a membership with the phone number `+1555xxxxxxx`.
+
+  ---
+
+  - `query?`
+  - `string`
+
+  Filters memberships that match the given query. For possible matches, we check the email addresses, phone numbers, usernames, Web3 wallet addresses, user IDs, first and last names. The query value doesn't need to match the exact value you are looking for, it is capable of partial matches as well.
+
+  ---
+
+  - `role?`
+  - `string[]`
+
+  Filters memberships for the roles specified. Accepts up to 100 roles. Any roles not found are ignored.
+
+  ---
+
+  - `userId?`
+  - `string[]`
+
+  Filters memberships for the user IDs specified. For each user ID, the `+` and `-` can be prepended to the ID, which denote whether the respective user ID should be included or excluded from the result set. Accepts up to 100 user IDs. Any user IDs not found are ignored.
+
+  ---
+
+  - `username?`
+  - `string[]`
+
+  Filters memberships for the usernames specified. Accepts up to 100 usernames. Any usernames not found are ignored.
 
   ---
 
   - `usernameQuery?`
   - `string`
 
-  Filters users with usernames that match the given query, via case-insensitive partial match. For example, `username_query=CoolUser` will match a user with the username `SomeCoolUser`.
+  Filters memberships with usernames that match the given query, via case-insensitive partial match. For example, `username_query=CoolUser` will match a membership with the username `SomeCoolUser`.
 
   ---
 
-  - `nameQuery?`
-  - `string`
+  - `web3Wallet?`
+  - `string[]`
 
-  Filters users with names that match the given query, via case-insensitive partial match.
-
-  ---
-
-  - `lastActiveAtBefore?`
-  - `number`
-
-  Filters users whose last session activity was before the given date (with millisecond precision). For example, use `1700690400000` to retrieve users whose last session activity was before 2023-11-23.
-
-  ---
-
-  - `lastActiveAtAfter?`
-  - `number`
-
-  Filters users whose last session activity was after the given date (with millisecond precision). For example, use `1700690400000` to retrieve users whose last session activity was after 2023-11-23.
-
-  ---
-
-  - `createdAtBefore?`
-  - `number`
-
-  Filters users who have been created before the given date (with millisecond precision). For example, use `1730160000000` to retrieve users who have been created before 2024-10-29.
-
-  ---
-
-  - `createdAtAfter?`
-  - `number`
-
-  Filters users who have been created after the given date (with millisecond precision). For example, use `1730160000000` to retrieve users who have been created after 2024-10-29.
+  Filters memberships for the Web3 wallet addresses specified. Accepts up to 100 Web3 wallet addresses. Any Web3 wallet addresses not found are ignored.
 </Properties>
 
 ## Examples

--- a/docs/references/backend/organization/get-organization-membership-list.mdx
+++ b/docs/references/backend/organization/get-organization-membership-list.mdx
@@ -80,7 +80,7 @@ function getOrganizationMembershipList(
   ---
 
   - `role?`
-  - `OrganizationMembershipRole[]`
+  - `string[]`
 
   Returns users with the specified roles. Accepts up to 100 roles. Any roles not found are ignored.
 

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "format": "prettier . --write",
     "lint:check-links": "node ./scripts/check-links.mjs",
     "lint:formatting": "prettier . --check",
+    "lint:formatting:fix": "prettier . --write",
     "lint:check-quickstarts": "node ./scripts/check-quickstarts.mjs",
     "lint:check-frontmatter": "node ./scripts/check-frontmatter.mjs",
     "lint:validation": "npm run build",


### PR DESCRIPTION
### 🔎 Previews:

- https://clerk.com/docs/pr/2272/references/backend/organization/get-organization-membership-list

### What does this solve?

Outdated `client.organization.getOrganizationMembershipList` params.

### What changed?

Updates the existing `client.organization.getOrganizationMembershipList` params to reflect the latest options.

### Checklist

- [x] I have clicked on "Files changed" and performed a thorough self-review
- [x] All existing checks pass
