### PR TITLE
Clarify that max_allowed_memberships=0 means unlimited membership

### DIFF
--- a/docs/references/backend/organization/create-organization.mdx
+++ b/docs/references/backend/organization/create-organization.mdx
@@ -52,7 +52,7 @@ function createOrganization(params: CreateParams): Promise<Organization>
   - `maxAllowedMemberships?`
   - `number`
 
-  The maximum number of memberships allowed in the organization.
+  The maximum number of memberships allowed in the organization. Setting this value to `0` removes any limit, allowing an unlimited number of memberships.
 </Properties>
 
 ## Example

--- a/docs/references/backend/types/backend-organization.mdx
+++ b/docs/references/backend/types/backend-organization.mdx
@@ -81,7 +81,7 @@ The Backend `Organization` object is similar to the [`Organization`](/docs/refer
   - `maxAllowedMemberships`
   - `number`
 
-  The maximum number of memberships allowed in the organization.
+  The maximum number of memberships allowed in the organization. A value of `0` means there is no limit on the number of members in the organization, allowing an unlimited number of members to join.
 
   ---
 

--- a/docs/references/javascript/organization.mdx
+++ b/docs/references/javascript/organization.mdx
@@ -69,7 +69,7 @@ To use these methods, you must have the **Organizations** feature [enabled in yo
   - `maxAllowedMemberships`
   - `number`
 
-  The maximum number of memberships allowed for the organization.
+  The maximum number of memberships allowed for the organization. A value of `0` means there is no limit on the number of members in the organization, allowing an unlimited number of members to join.
 
   ---
 
@@ -518,7 +518,7 @@ function update(params: UpdateOrganizationParams): Promise<Organization>
   - `maxAllowedMemberships?`
   - `number | undefined`
 
-  The maximum number of memberships allowed for the organization.
+  The maximum number of memberships allowed for the organization. Setting this value to `0` removes any limit, allowing an unlimited number of memberships.
 
   ---
 


### PR DESCRIPTION
### 🔎 Previews:

- https://clerk.com/docs/pr/2277/references/backend/organization/create-organization.mdx
- https://clerk.com/docs/pr/2277/references/backend/types/backend-organization.mdx
- https://clerk.com/docs/pr/2277/references/javascript/organization.mdx

### What does this solve?

This clarifies that setting `max_allowed_memberships=0` means there is no limit on the number of memberships an organization can have. This prevents confusion when customers see the value 0 in the system after enabling unlimited membership.

Linear: https://linear.app/clerk/issue/DOCS-10419/document-that-max-allowed-memberships=0-means-unlimited-membership

### What changed?

Added documentation explaining that `max_allowed_memberships=0` indicates unlimited memberships for an organization. This helps users understand that 0 removes the membership limit rather than setting it to zero.

### Checklist

- [ ] I have clicked on "Files changed" and performed a thorough self-review
- [ ] All existing checks pass