### PR TITLE
Add more context and information around configuring scopes in Twitter social connection

### DIFF
--- a/docs/authentication/social-connections/x-twitter.mdx
+++ b/docs/authentication/social-connections/x-twitter.mdx
@@ -36,7 +36,7 @@ To make the setup process easier, it's recommended to keep two browser tabs open
 
   1. In the Clerk Dashboard, navigate to the [**SSO connections**](https://dashboard.clerk.com/last-active?path=user-authentication/sso-connections) page.
   1. Select the **Add connection** button, and select **For all users**.
-  1. In the **Choose provider** dropdown, select **X/Twitter**.
+  1. In the **Choose provider** dropdown, select **X/Twitter**. 
   1. Save the **Redirect URI** somewhere secure. Keep the modal and page open.
 
   ## Create an X/Twitter application
@@ -58,6 +58,21 @@ To make the setup process easier, it's recommended to keep two browser tabs open
   ## Set the Client ID and Client Secret in the Clerk Dashboard
 
   <Include src="_partials/authentication/social-connections/set-client-id-secret" />
+
+  ## Configure OAuth Scopes in the Clerk Dashboard (optional)
+
+  To configure OAuth scopes for X/Twitter as a social connection in Clerk:
+
+  1. In the Clerk Dashboard, navigate to the [**SSO connections**](https://dashboard.clerk.com/last-active?path=user-authentication/sso-connections) page.
+  1. Select your existing X/Twitter connection.
+  1. Locate the **Scopes** field in the configuration modal.
+  1. Under **Scopes**, you can define what data and actions your app can request from a user’s X/Twitter account. Essential scopes such as `users.read` and `tweet.read` are pre-configured and automatically included by Clerk. For a complete list of available scopes and their details, see [X/Twitter OAuth 2.0 Scopes documentation](https://docs.x.com/resources/fundamentals/authentication/oauth-2-0/authorization-code#scopes).
+
+  > [!TIP]
+  > The scopes you define should align with your app’s functionality and your selected **App Permissions** in the X/Twitter Developer Portal.
+  > For example, if you only select **Read** in the Developer Portal, Clerk’s request for `tweet.write` will be rejected, even if you request it in Clerk’s configuration.
+ 
+  For more information on social connections and configuring additional OAuth scopes, see this [dedicated section](https://clerk.com/docs/authentication/social-connections/overview#configure-additional-o-auth-scopes) in our Clerk docs. 
 
   ## Test your connection
 

--- a/docs/authentication/social-connections/x-twitter.mdx
+++ b/docs/authentication/social-connections/x-twitter.mdx
@@ -39,6 +39,19 @@ To make the setup process easier, it's recommended to keep two browser tabs open
   1. In the **Choose provider** dropdown, select **X/Twitter**.
   1. Save the **Redirect URI** somewhere secure. Keep the modal and page open.
 
+  ## Configure additional OAuth scopes (optional)
+
+  Scopes are the permissions your app requests from a user's X/Twitter account. Clerk pre-configures the required OAuth scopes for X/Twitter as a social connection, but you can configure additional scopes if needed. The scopes you define should align with your app's functionality and your selected **App Permissions** in the X/Twitter Developer Portal. For example, if you only select **Read** in the X/Twitter Developer Portal, Clerk's request for `tweet.write` will be rejected, even if you include it in Clerk's configuration.
+
+  To configure OAuth scopes for X/Twitter as a social connection in Clerk:
+
+  {/* TODO: "The modal should still be open" would be a good opportunity for a tooltip, and then we put the callout below into the tooltip. */}
+
+  1. In the Clerk Dashboard, the modal should still be open. Under **Scopes**, add any additional scopes you need. For a complete list of available scopes and their details, see [X/Twitter OAuth 2.0 Scopes documentation](https://docs.x.com/resources/fundamentals/authentication/oauth-2-0/authorization-code#scopes).
+
+  > [!NOTE]
+  > If the modal or page is no longer open, navigate to the [**SSO connections**](https://dashboard.clerk.com/last-active?path=user-authentication/sso-connections) page in the Clerk Dashboard. Select the connection.
+
   ## Create an X/Twitter application
 
   When signing up for a new X/Twitter Developer account, you'll be required to describe your app's use cases. After completing this step, you'll be redirected to the **Dashboard** page. Under **Projects**, you'll see an automatically generated app with a randomly generated string as its name.
@@ -58,21 +71,6 @@ To make the setup process easier, it's recommended to keep two browser tabs open
   ## Set the Client ID and Client Secret in the Clerk Dashboard
 
   <Include src="_partials/authentication/social-connections/set-client-id-secret" />
-
-  ## Configure OAuth scopes in the Clerk Dashboard (optional)
-
-  To configure OAuth scopes for X/Twitter as a social connection in Clerk:
-
-  1. In the Clerk Dashboard, navigate to the [**SSO connections**](https://dashboard.clerk.com/last-active?path=user-authentication/sso-connections) page.
-  1. Select your existing X/Twitter connection.
-  1. Locate the **Scopes** field in the configuration modal.
-  1. Under **Scopes**, you can define what data and actions your app can request from a user’s X/Twitter account. Essential scopes such as `users.read` and `tweet.read` are pre-configured and automatically included by Clerk. For a complete list of available scopes and their details, see [X/Twitter OAuth 2.0 Scopes documentation](https://docs.x.com/resources/fundamentals/authentication/oauth-2-0/authorization-code#scopes).
-
-  > [!TIP]
-  > The scopes you define should align with your app’s functionality and your selected **App Permissions** in the X/Twitter Developer Portal.
-  > For example, if you only select **Read** in the Developer Portal, Clerk’s request for `tweet.write` will be rejected, even if you include it in Clerk’s configuration.
-
-  Learn more about social connections and configuring additional OAuth scopes in this [dedicated section](https://clerk.com/docs/authentication/social-connections/overview#configure-additional-o-auth-scopes) of the Clerk docs.
 
   ## Test your connection
 

--- a/docs/authentication/social-connections/x-twitter.mdx
+++ b/docs/authentication/social-connections/x-twitter.mdx
@@ -59,7 +59,7 @@ To make the setup process easier, it's recommended to keep two browser tabs open
 
   <Include src="_partials/authentication/social-connections/set-client-id-secret" />
 
-  ## Configure OAuth Scopes in the Clerk Dashboard (optional)
+  ## Configure OAuth scopes in the Clerk Dashboard (optional)
 
   To configure OAuth scopes for X/Twitter as a social connection in Clerk:
 
@@ -70,9 +70,9 @@ To make the setup process easier, it's recommended to keep two browser tabs open
 
   > [!TIP]
   > The scopes you define should align with your app’s functionality and your selected **App Permissions** in the X/Twitter Developer Portal.
-  > For example, if you only select **Read** in the Developer Portal, Clerk’s request for `tweet.write` will be rejected, even if you request it in Clerk’s configuration.
+  > For example, if you only select **Read** in the Developer Portal, Clerk’s request for `tweet.write` will be rejected, even if you include it in Clerk’s configuration.
  
-  For more information on social connections and configuring additional OAuth scopes, see this [dedicated section](https://clerk.com/docs/authentication/social-connections/overview#configure-additional-o-auth-scopes) in our Clerk docs. 
+  Learn more about social connections and configuring additional OAuth scopes in this [dedicated section](https://clerk.com/docs/authentication/social-connections/overview#configure-additional-o-auth-scopes) of the Clerk docs. 
 
   ## Test your connection
 

--- a/docs/authentication/social-connections/x-twitter.mdx
+++ b/docs/authentication/social-connections/x-twitter.mdx
@@ -36,7 +36,7 @@ To make the setup process easier, it's recommended to keep two browser tabs open
 
   1. In the Clerk Dashboard, navigate to the [**SSO connections**](https://dashboard.clerk.com/last-active?path=user-authentication/sso-connections) page.
   1. Select the **Add connection** button, and select **For all users**.
-  1. In the **Choose provider** dropdown, select **X/Twitter**. 
+  1. In the **Choose provider** dropdown, select **X/Twitter**.
   1. Save the **Redirect URI** somewhere secure. Keep the modal and page open.
 
   ## Create an X/Twitter application
@@ -71,8 +71,8 @@ To make the setup process easier, it's recommended to keep two browser tabs open
   > [!TIP]
   > The scopes you define should align with your app’s functionality and your selected **App Permissions** in the X/Twitter Developer Portal.
   > For example, if you only select **Read** in the Developer Portal, Clerk’s request for `tweet.write` will be rejected, even if you include it in Clerk’s configuration.
- 
-  Learn more about social connections and configuring additional OAuth scopes in this [dedicated section](https://clerk.com/docs/authentication/social-connections/overview#configure-additional-o-auth-scopes) of the Clerk docs. 
+
+  Learn more about social connections and configuring additional OAuth scopes in this [dedicated section](https://clerk.com/docs/authentication/social-connections/overview#configure-additional-o-auth-scopes) of the Clerk docs.
 
   ## Test your connection
 

--- a/docs/authentication/social-connections/x-twitter.mdx
+++ b/docs/authentication/social-connections/x-twitter.mdx
@@ -29,8 +29,6 @@ To make the setup process easier, it's recommended to keep two browser tabs open
 > [!WARNING]
 > X/Twitter v2 doesn't currently provide users' email addresses. Users must manually enter their email address when they return to your application after authenticating with X/Twitter.
 
-To make the setup process easier, it's recommended to keep two browser tabs open: one for the [Clerk Dashboard](https://dashboard.clerk.com/last-active?path=user-authentication/sso-connections) and one for your [X/Twitter Developer Portal](https://developer.twitter.com/en/portal/dashboard).
-
 <Steps>
   ## Enable X/Twitter as a social connection
 


### PR DESCRIPTION
### 🔎 Previews:

- https://clerk.com/docs/pr/2281/authentication/social-connections/x-twitter

### What does this solve?

This PR adds a direct link to the official X/Twitter OAuth 2.0 Scopes documentation in the X/Twitter social connection guide. This update responds to a user request to make it easier for developers to review the available scopes when setting up their social connection.

Linear: https://linear.app/clerk/issue/DOCS-10412/feedback-for-authenticationsocial-connectionsx-twitter

### What changed?

- Added a new section about X/Twitter OAuth scopes (Step 4 in the guide) to provide more details and clarity
- Added a link to the [X/Twitter OAuth 2.0 Scopes documentation](https://docs.x.com/resources/fundamentals/authentication/oauth-2-0/authorization-code#scopes) within the configuration instructions.
- **Unrelated to this specific issue**: I noticed the duplication of a sentence, and since it was in the same file, I removed it as part of this PR. 

This ensures that developers can easily find and review the available scopes for X/Twitter while setting up their social connection

### Suggestion

I added this as a dedicated section to ensure enough context is given. If preferred, I can instead add it as a fifth bullet point under **Enable X/Twitter as a social connection** to keep the guide more concise.

### Checklist

- [ ] I have clicked on "Files changed" and performed a thorough self-review
- [ ] All existing checks pass
