### PR TITLE
chore: Remove svix installation instructions

### DIFF
--- a/docs/webhooks/sync-data.mdx
+++ b/docs/webhooks/sync-data.mdx
@@ -68,28 +68,6 @@ These steps apply to any Clerk event. To make the setup process easier, it's rec
 
   Incoming webhook events don't contain auth information. They come from an external source and aren't signed in or out, so the route must be public to allow access. If you're using `clerkMiddleware()`, ensure that the `/api/webhooks(.*)` route is set as public. For information on configuring routes, see the [`clerkMiddleware()` guide](/docs/references/nextjs/clerk-middleware).
 
-  ## Install `svix`
-
-  Clerk uses [`svix`](https://www.npmjs.com/package/svix) to deliver and verify webhooks. Run the following command in your terminal to install the package:
-
-  <CodeBlockTabs options={["npm", "yarn", "pnpm", "bun"]}>
-    ```bash {{ filename: 'terminal' }}
-    npm install svix
-    ```
-
-    ```bash {{ filename: 'terminal' }}
-    yarn add svix
-    ```
-
-    ```bash {{ filename: 'terminal' }}
-    pnpm add svix
-    ```
-
-    ```bash {{ filename: 'terminal' }}
-    bun add svix
-    ```
-  </CodeBlockTabs>
-
   ## Create a route handler to verify the webhook
 
   Set up a Route Handler that uses Clerk's [`verifyWebhook()`](/docs/references/backend/verify-webhook) function to verify the incoming Clerk webhook and process the payload.


### PR DESCRIPTION
### 🔎 Previews:

- https://clerk.com/docs/pr/2287/webhooks/sync-data

### What does this solve?

- Removed `svix` installation instructions for `verifyWebhook()`

### What changed?

- https://github.com/clerk/javascript/pull/6059 refactors `verifyWebhook()` to manually verify the Clerk webhook and removes the need to install `svix`. Once that change is live customers no longer need to install `svix`

### Checklist

- [x] I have clicked on "Files changed" and performed a thorough self-review
- [x] All existing checks pass
