### PR TITLE
Added the billing system permissions for clarification

### DIFF
--- a/docs/organizations/roles-permissions.mdx
+++ b/docs/organizations/roles-permissions.mdx
@@ -53,12 +53,14 @@ Clerk provides a set of system permissions that power [Clerk's Frontend API](/do
 
 Clerk's system permissions consist of the following:
 
-- Manage Organization (`org:sys_profile:manage`)
-- Delete Organization (`org:sys_profile:delete`)
+- Manage organization (`org:sys_profile:manage`)
+- Delete organization (`org:sys_profile:delete`)
 - Read members (`org:sys_memberships:read`)
 - Manage members (`org:sys_memberships:manage`)
 - Read domains (`org:sys_domains:read`)
 - Manage domains (`org:sys_domains:manage`)
+- Read billing (`org:sys_billing:read`)
+- Manage billing (`org:sys_billing:manage`)
 
 You can assign these system permissions to any role.
 


### PR DESCRIPTION
### 🔎 Previews:

- https://clerk.com/docs/pr/2289/organizations/roles-permissions

### What does this solve?

This PR addresses feedback from a user regarding having to update the permissions in roles / permissions for admins to manage / read billing. There isn't much context to the ticket, [but here it is](https://app.plain.com/workspace/w_01GT53BQWV3DFW6ECTWZNQ1E9K/thread/th_01JV9M1KZCFWB4V4E3VE4CJ678/). So, had to dive a bit deeper into this one, and found that system permissions do include **Read billing** and **Manage billing**, as seen on the image below:

<img width="884" alt="Screenshot 2025-06-04 at 10 39 25 am" src="https://github.com/user-attachments/assets/9d4f1beb-29ad-4c3a-9e64-3b8a0cfa9a9a" />

However, those aren't listed on the docs:

<img width="447" alt="Screenshot 2025-06-04 at 10 49 11 am" src="https://github.com/user-attachments/assets/e082f6bf-8b18-4bc8-a66d-6f82585bae95" />

I figured that was where the misunderstanding came from the user. But, not 100% sure why they say they had to update the permission for those if they're already included in the system permissions. I may be missing something here, so keen to hear thoughts. 

Linear: https://linear.app/clerk/issue/DOCS-10394/update-docs-to-mention-permissions-needed-for-org-admins-to-manage

### What changed?

- Added **Read billing** and **Manage billing** system permissions to the list 
- Lowercased organization twice to be consistent with rest of the list

### Checklist

- [ ] I have clicked on "Files changed" and performed a thorough self-review
- [ ] All existing checks pass