### PR TITLE
include the prompts in the dist

### DIFF
--- a/scripts/lib/config.ts
+++ b/scripts/lib/config.ts
@@ -38,6 +38,10 @@ type BuildConfigOptions = {
       outputPath: string
     }
   }
+  prompts?: {
+    inputPath: string
+    outputPath: string
+  }
   flags?: {
     watch?: boolean
     controlled?: boolean
@@ -108,6 +112,13 @@ export async function createConfig(config: BuildConfigOptions) {
             inputPath: resolve(path.join(config.basePath, config.redirects.dynamic.inputPath)),
             outputPath: resolve(path.join(tempDist, config.redirects.dynamic.outputPath)),
           },
+        }
+      : null,
+
+    prompts: config.prompts
+      ? {
+          inputPath: resolve(path.join(config.basePath, config.prompts.inputPath)),
+          outputPath: resolve(path.join(tempDist, config.prompts.outputPath)),
         }
       : null,
 

--- a/scripts/lib/error-messages.ts
+++ b/scripts/lib/error-messages.ts
@@ -59,6 +59,10 @@ export const errorMessages = {
   'partials-inside-partials': (): string =>
     'Partials inside of partials is not yet supported (this is a bug with the build script, please report)',
 
+  // LLMPrompt component errors
+  'src-not-in-prompts': (src: string): string => `<LLMPrompt /> prop "src" must start with "prompts/"`,
+  'prompt-not-found': (src: string): string => `Prompt ${src} not found`,
+
   // Link validation errors
   'link-doc-not-found': (url: string): string => `Doc ${url} not found`,
   'link-hash-not-found': (hash: string, url: string): string => `Hash "${hash}" not found in ${url}`,

--- a/scripts/lib/markdown.ts
+++ b/scripts/lib/markdown.ts
@@ -24,6 +24,7 @@ import { checkTypedoc } from './plugins/checkTypedoc'
 import { extractFrontmatter, type Frontmatter } from './plugins/extractFrontmatter'
 import { documentHasIfComponents } from './utils/documentHasIfComponents'
 import { extractHeadingFromHeadingNode } from './utils/extractHeadingFromHeadingNode'
+import { Prompt, checkPrompts } from './prompts'
 
 export const parseInMarkdownFile =
   (config: BuildConfig) =>
@@ -31,6 +32,7 @@ export const parseInMarkdownFile =
     file: DocsFile,
     partials: { path: string; content: string; node: Node }[],
     typedocs: { path: string; content: string; node: Node }[],
+    prompts: Prompt[],
     inManifest: boolean,
     section: WarningsSection,
   ) => {
@@ -69,6 +71,7 @@ export const parseInMarkdownFile =
       )
       .use(checkPartials(config, partials, file, { reportWarnings: true, embed: false }))
       .use(checkTypedoc(config, typedocs, file.filePath, { reportWarnings: true, embed: false }))
+      .use(checkPrompts(config, prompts, file, { reportWarnings: true, update: false }))
       .process({
         path: file.relativeFilePath,
         value: fileContent,

--- a/scripts/lib/prompts.ts
+++ b/scripts/lib/prompts.ts
@@ -1,0 +1,93 @@
+import type { BuildConfig } from './config'
+import fs from 'node:fs/promises'
+import path from 'node:path'
+
+export interface Prompt {
+  filePath: string
+  name: string
+  content: string
+}
+
+export async function readPrompts(config: BuildConfig) {
+  const { inputPath, outputPath } = config.prompts ?? {}
+  if (!inputPath || !outputPath) {
+    throw new Error('Prompts paths not configured')
+  }
+
+  const files = await fs.readdir(inputPath)
+
+  return await Promise.all(
+    files.map(async (file) => {
+      return {
+        filePath: path.join('prompts', file),
+        name: file,
+        content: await fs.readFile(path.join(inputPath, file), 'utf-8'),
+      }
+    }),
+  )
+}
+
+export async function writePrompts(config: BuildConfig, prompts: Prompt[]) {
+  const { outputPath } = config.prompts ?? {}
+  if (!outputPath) {
+    throw new Error('Prompts output path not configured')
+  }
+
+  await fs.mkdir(outputPath, { recursive: true })
+
+  await Promise.all(prompts.map((prompt) => fs.writeFile(path.join(outputPath, prompt.name), prompt.content)))
+}
+
+import type { Node } from 'unist'
+import { map as mdastMap } from 'unist-util-map'
+import type { VFile } from 'vfile'
+import { safeMessage } from './error-messages'
+import type { DocsFile } from './io'
+import { extractComponentPropValueFromNode } from './utils/extractComponentPropValueFromNode'
+
+export const checkPrompts =
+  (config: BuildConfig, prompts: Prompt[], file: DocsFile, options: { reportWarnings: boolean; update: boolean }) =>
+  () =>
+  (tree: Node, vfile: VFile) => {
+    if (config.prompts === null) return
+
+    return mdastMap(tree, (node) => {
+      const promptSrc = extractComponentPropValueFromNode(
+        config,
+        node,
+        vfile,
+        'LLMPrompt',
+        'src',
+        true,
+        'docs',
+        file.filePath,
+      )
+
+      if (promptSrc === undefined) return node
+
+      if (promptSrc.startsWith('prompts/') === false) {
+        if (options.reportWarnings === true) {
+          safeMessage(config, vfile, file.filePath, 'docs', 'src-not-in-prompts', [promptSrc], node.position)
+        }
+        return node
+      }
+
+      const prompt = prompts.find((prompt) => prompt.filePath === promptSrc)
+
+      if (prompt === undefined) {
+        if (options.reportWarnings === true) {
+          safeMessage(config, vfile, file.filePath, 'docs', 'prompt-not-found', [promptSrc], node.position)
+        }
+        return node
+      }
+
+      if (options.update === true && config.prompts !== null) {
+        ;(node as any).attributes.find(({ name }) => name === 'src').value = promptSrc.replace(
+          'prompts/',
+          `${config.prompts.outputPath}/`,
+        )
+      }
+
+      return node
+    })
+  }


### PR DESCRIPTION
### What does this solve?

- recently a new `prompts` folder was added to the repo, used by the `LLMPrompts` component, the folder needs to be included in the dist for clerk.com to use it in https://github.com/clerk/clerk/pull/1074

### What changed?

- Like the typedoc markdown I've added in steps to load in the prompts, write them out to dist, and update the src in the llmprompts to point to the output location

### Checklist

- [x] I have clicked on "Files changed" and performed a thorough self-review
- [x] All existing checks pass
