### PR TITLE
Add /docs/quickstart as ignored link

### DIFF
--- a/scripts/build-docs.test.ts
+++ b/scripts/build-docs.test.ts
@@ -154,6 +154,7 @@ const baseConfig = {
   partialsPath: '../docs/_partials',
   typedocPath: '../typedoc',
   distPath: '../dist',
+  ignorePaths: [],
   ignoreLinks: [],
   ignoreWarnings: {
     docs: {},
@@ -2773,7 +2774,7 @@ sdk: react
         ...baseConfig,
         basePath: tempDir,
         validSdks: ['react'],
-        ignoreLinks: ['/docs/ignored'],
+        ignorePaths: ['/docs/ignored'],
       }),
     )
 

--- a/scripts/build-docs.ts
+++ b/scripts/build-docs.ts
@@ -108,11 +108,11 @@ async function main() {
         outputPath: '_redirects/dynamic.jsonc',
       },
     },
-    ignoreLinks: [
+    ignoreLinks: ['/docs/quickstart'],
+    ignorePaths: [
       '/docs/core-1',
       '/docs/reference/backend-api',
       '/docs/reference/frontend-api',
-      '/docs/quickstart',
       '/pricing',
       '/support',
       '/discord',
@@ -235,7 +235,7 @@ export async function build(config: BuildConfig, store: Store = createBlankStore
     if (!item.href?.startsWith(config.baseDocsLink)) return item
     if (item.target !== undefined) return item
 
-    const ignore = config.ignoredLink(item.href)
+    const ignore = config.ignoredPaths(item.href) || config.ignoredLinks(item.href)
     if (ignore === true) return item
 
     docsInManifest.add(item.href)
@@ -272,7 +272,7 @@ export async function build(config: BuildConfig, store: Store = createBlankStore
         }
       }
 
-      const ignore = config.ignoredLink(item.href)
+      const ignore = config.ignoredPaths(item.href) || config.ignoredLinks(item.href)
       if (ignore === true) return item // even thou we are not processing them, we still need to keep them
 
       const doc = docsMap.get(item.href)

--- a/scripts/build-docs.ts
+++ b/scripts/build-docs.ts
@@ -112,6 +112,7 @@ async function main() {
       '/docs/core-1',
       '/docs/reference/backend-api',
       '/docs/reference/frontend-api',
+      '/docs/quickstart',
       '/pricing',
       '/support',
       '/discord',

--- a/scripts/lib/config.ts
+++ b/scripts/lib/config.ts
@@ -17,6 +17,7 @@ type BuildConfigOptions = {
   distPath: string
   typedocPath: string
   publicPath?: string
+  ignorePaths: string[]
   ignoreLinks: string[]
   ignoreWarnings?: {
     docs: Record<string, string[]>
@@ -85,7 +86,8 @@ export async function createConfig(config: BuildConfigOptions) {
     publicRelativePath: config.publicPath,
     publicPath: config.publicPath ? resolve(config.publicPath) : undefined,
 
-    ignoredLink: (url: string) => config.ignoreLinks.some((ignoreItem) => url.startsWith(ignoreItem)),
+    ignoredPaths: (url: string) => config.ignorePaths.some((ignoreItem) => url.startsWith(ignoreItem)),
+    ignoredLinks: (url: string) => config.ignoreLinks.some((ignoreItem) => url === ignoreItem),
     ignoreWarnings: config.ignoreWarnings ?? {
       docs: {},
       partials: {},

--- a/scripts/lib/plugins/validateAndEmbedLinks.ts
+++ b/scripts/lib/plugins/validateAndEmbedLinks.ts
@@ -47,7 +47,7 @@ export const validateAndEmbedLinks =
         url = href
       }
 
-      const ignore = config.ignoredLink(url)
+      const ignore = config.ignoredPaths(url) || config.ignoredLinks(url)
       if (ignore === true) return node
 
       const linkedDoc = docsMap.get(url)


### PR DESCRIPTION
### What does this solve?

- linking to `/docs/quickstart` will fail the validation in the build script as thats a special link not tied to a markdown file

### What changed?

- Added the link to the ignoredLinks in the build config so it doesn't fail on `docs/quickstart.mdx` not existing

### Checklist

- [x] I have clicked on "Files changed" and performed a thorough self-review
- [x] All existing checks pass
