### PR TITLE
Make the <LLMPrompt /> src prop optional

### DIFF
--- a/scripts/lib/prompts.ts
+++ b/scripts/lib/prompts.ts
@@ -61,7 +61,7 @@ export const checkPrompts =
         vfile,
         'LLMPrompt',
         'src',
-        true,
+        false,
         'docs',
         file.filePath,
         z.string(),


### PR DESCRIPTION
### What does this solve?

- The new validation requires it, but the component supports using either the `src` or `prompt` prop to supply the prompt, so this changes makes it optional

### Checklist

- [x] I have clicked on "Files changed" and performed a thorough self-review
- [x] All existing checks pass
