### PR TITLE
Integrate existing sdk scoped documents

### DIFF
--- a/scripts/build-docs.test.ts
+++ b/scripts/build-docs.test.ts
@@ -2291,6 +2291,57 @@ title: Core Page
     )
   })
 
+  test('Swap out links for <SDKLink /> when a link points to a sdk manifest filtered page', async () => {
+    const { tempDir, pathJoin } = await createTempFiles([
+      {
+        path: './docs/manifest.json',
+        content: JSON.stringify({
+          navigation: [
+            [
+              {
+                title: 'nextjs',
+                sdk: ['nextjs'],
+                items: [[{ title: 'SDK Filtered Page', href: '/docs/reference/nextjs/sdk-filtered-page' }]],
+              },
+              { title: 'Core Page', href: '/docs/core-page' },
+            ],
+          ],
+        }),
+      },
+      {
+        path: './docs/reference/nextjs/sdk-filtered-page.mdx',
+        content: `---
+title: SDK Filtered Page
+---
+
+SDK filtered page`,
+      },
+      {
+        path: './docs/core-page.mdx',
+        content: `---
+title: Core Page
+---
+
+# Core page
+
+[SDK Filtered Page](/docs/reference/nextjs/sdk-filtered-page)
+`,
+      },
+    ])
+
+    await build(
+      await createConfig({
+        ...baseConfig,
+        basePath: tempDir,
+        validSdks: ['react', 'nextjs'],
+      }),
+    )
+
+    expect(await readFile(pathJoin('./dist/core-page.mdx'))).toContain(
+      `<SDKLink href="/docs/reference/nextjs/sdk-filtered-page" sdks={["nextjs"]}>SDK Filtered Page</SDKLink>`,
+    )
+  })
+
   test('Should swap out links for <SDKLink /> in partials', async () => {
     const { tempDir, pathJoin } = await createTempFiles([
       {

--- a/scripts/lib/plugins/validateAndEmbedLinks.ts
+++ b/scripts/lib/plugins/validateAndEmbedLinks.ts
@@ -26,6 +26,7 @@ export const validateAndEmbedLinks =
   ) =>
   () =>
   (tree: Node, vfile: VFile) => {
+    const scopeHref = scopeHrefToSDK(config)
     const checkCardsComponentScope = watchComponentScope('Cards')
 
     return mdastMap(tree, (node) => {
@@ -75,18 +76,26 @@ export const validateAndEmbedLinks =
           const firstChild = node.children?.[0]
           const childIsCodeBlock = firstChild?.type === 'inlineCode'
 
+          const injectSDK =
+            linkedDoc.frontmatter.sdk !== undefined &&
+            linkedDoc.frontmatter.sdk.length >= 1 &&
+            !url.endsWith(`/${linkedDoc.frontmatter.sdk[0]}`) &&
+            !url.includes(`/${linkedDoc.frontmatter.sdk[0]}/`)
+
+          const href = `${injectSDK ? scopeHref(url, ':sdk:') : url}${hash !== undefined ? `#${hash}` : ''}`
+
           if (childIsCodeBlock) {
             firstChild.type = 'text'
 
             return SDKLink({
-              href: `${scopeHrefToSDK(config)(url, ':sdk:')}${hash !== undefined ? `#${hash}` : ''}`,
+              href,
               sdks: linkedDoc.sdk,
               code: true,
             })
           }
 
           return SDKLink({
-            href: `${scopeHrefToSDK(config)(url, ':sdk:')}${hash !== undefined ? `#${hash}` : ''}`,
+            href,
             sdks: linkedDoc.sdk,
             code: false,
             children: node.children,


### PR DESCRIPTION
Blocked by https://github.com/clerk/clerk/pull/1209 as it uses new components in that pr

### 🔎 Previews:

-

### What does this solve?

- The existing sdk scoped pages by manifest and url aren't getting picked up and replaced with the `<SDKLink />` to make them smart

### What changed?

- This swaps out the links that point to urls like `/docs/reference/nextjs/overview` as it's scoped by the manifest to `nextjs`

### Checklist

- [ ] I have clicked on "Files changed" and performed a thorough self-review
- [ ] All existing checks pass
