### PR TITLE
add `cssLayerName` property to `appearance` prop

### DIFF
--- a/docs/customization/overview.mdx
+++ b/docs/customization/overview.mdx
@@ -247,30 +247,116 @@ The following example shows how to style the primary button in a `<SignIn />` co
 
 The following example shows how to use the `cssLayerName` property to ensure that Tailwind's utility styles are applied after Clerk's styles:
 
-<CodeBlockTabs options={["layout.tsx", "global.css"]}>
-  ```tsx {{ filename: 'layout.tsx', mark: ["cssLayerName: 'clerk'"] }}
-  import { ClerkProvider } from '@clerk/nextjs'
+<Tabs items={["Next.js", "Astro", "Vue", "JavaScript"]}>
+  <Tab>
+    <CodeBlockTabs options={["layout.tsx", "global.css"]}>
+      ```tsx {{ mark: ["cssLayerName: 'clerk'"] }}
+      import { ClerkProvider } from '@clerk/nextjs'
 
-  export default function RootLayout({ children }: { children: React.ReactNode }) {
-    return (
-      <ClerkProvider
-        appearance={{
+      export default function RootLayout({ children }: { children: React.ReactNode }) {
+        return (
+          <ClerkProvider
+            appearance={{
+              cssLayerName: 'clerk',
+            }}
+          >
+            <html lang="en">
+              <body>{children}</body>
+            </html>
+          </ClerkProvider>
+        )
+      }
+      ```
+
+      ```css {{ mark: ['clerk'] }}
+      @layer theme, base, clerk, components, utilities;
+      @import 'tailwindcss';
+      ```
+    </CodeBlockTabs>
+  </Tab>
+  <Tab>
+    <CodeBlockTabs options={["astro.config.mjs", "global.css"]}>
+      ```ts {{ mark: ["cssLayerName: 'clerk'"] }}
+      import { defineConfig } from 'astro/config'
+      import node from '@astrojs/node'
+      import clerk from '@clerk/astro'
+      import tailwind from '@tailwindcss/vite'
+
+      export default defineConfig({
+        integrations: [
+          clerk({
+            appearance: {
+              cssLayerName: 'clerk',
+            },
+          }),
+        ],
+        output: 'server',
+        adapter: node({
+          mode: 'standalone',
+        }),
+        vite: {
+          plugins: [tailwind()],
+        },
+      })
+      ```
+
+      ```css {{ mark: ['clerk'] }}
+      @layer theme, base, clerk, components, utilities;
+      @import 'tailwindcss';
+      ```
+    </CodeBlockTabs>
+  </Tab>
+  <Tab>
+    <CodeBlockTabs options={["main.js", "global.css"]}>
+      ```tsx {{ mark: ["cssLayerName: 'clerk'"] }}
+      import { createApp } from 'vue'
+      import './style.css'
+      import App from './App.vue'
+      import { clerkPlugin } from '@clerk/vue'
+
+      const PUBLISHABLE_KEY = import.meta.env.VITE_CLERK_PUBLISHABLE_KEY
+
+      if (!PUBLISHABLE_KEY) {
+        throw new Error('Add your Clerk Publishable Key to the .env file')
+      }
+
+      const app = createApp(App)
+      app.use(clerkPlugin, {
+        appearance: {
           cssLayerName: 'clerk',
-        }}
-      >
-        <html lang="en">
-          <body>{children}</body>
-        </html>
-      </ClerkProvider>
-    )
-  }
-  ```
+        },
+        publishableKey: PUBLISHABLE_KEY,
+      })
+      app.mount('#app')
+      ```
 
-  ```css {{ filename: 'global.css', mark: ['clerk'] }}
-  @layer theme, base, clerk, components, utilities;
-  @import 'tailwindcss';
-  ```
-</CodeBlockTabs>
+      ```css {{ mark: ['clerk'] }}
+      @layer theme, base, clerk, components, utilities;
+      @import 'tailwindcss';
+      ```
+    </CodeBlockTabs>
+  </Tab>
+  <Tab>
+    <CodeBlockTabs options={["index.html", "global.css"]}>
+      ```html {{ mark: ["cssLayerName: 'clerk'"] }}
+      <script>
+        window.addEventListener('load', async function () {
+          await Clerk.load({
+            appearance: {
+              cssLayerName: 'clerk',
+            },
+          })
+        })
+      </script>
+      ```
+
+      ```css {{ mark: ['clerk'] }}
+      @layer theme, base, clerk, components, utilities;
+      @import 'tailwindcss';
+      ```
+    </CodeBlockTabs>
+  </Tab>
+</Tabs>
 
 #### Use CSS modules to style Clerk components
 

--- a/docs/customization/overview.mdx
+++ b/docs/customization/overview.mdx
@@ -243,6 +243,36 @@ The following example shows how to style the primary button in a `<SignIn />` co
   </Tab>
 </Tabs>
 
+> [!NOTE]
+> To use Tailwind CSS v4, you need to make use of the `cssLayerName` property to ensure that Tailwind's utility styles are applied after Clerk's styles.
+
+The following example shows how to use the `cssLayerName` property to ensure that Tailwind's utility styles are applied after Clerk's styles:
+
+<CodeBlockTabs options={["layout.tsx", "global.css"]}>
+```tsx {{ filename: 'layout.tsx', mark: ["cssLayerName: 'clerk'"] }}
+import { ClerkProvider } from '@clerk/nextjs'
+
+export default function RootLayout({ children }: { children: React.ReactNode }) {
+  return (
+    <ClerkProvider
+      appearance={{
+        cssLayerName: 'clerk',
+      }}
+    >
+      <html lang="en">
+        <body>{children}</body>
+      </html>
+    </ClerkProvider>
+  )
+}
+```
+
+```css {{ filename: 'global.css', mark: ['clerk'] }}
+@layer theme, base, clerk, components, utilities;
+@import 'tailwindcss';
+```
+</CodeBlockTabs>
+
 #### Use CSS modules to style Clerk components
 
 CSS modules are a great way to scope your CSS to a specific component.

--- a/docs/customization/overview.mdx
+++ b/docs/customization/overview.mdx
@@ -55,7 +55,6 @@ The `appearance` prop accepts the following properties:
   - `string`
 
   The name of the CSS layer for Clerk component styles. This is useful for advanced CSS customization, allowing you to control the cascade and prevent style conflicts by isolating Clerk's styles within a specific layer. For more information on CSS layers, see the [MDN documentation on @layer](https://developer.mozilla.org/en-US/docs/Web/CSS/@layer).
-
 </Properties>
 
 ## Using a prebuilt theme
@@ -249,28 +248,28 @@ The following example shows how to style the primary button in a `<SignIn />` co
 The following example shows how to use the `cssLayerName` property to ensure that Tailwind's utility styles are applied after Clerk's styles:
 
 <CodeBlockTabs options={["layout.tsx", "global.css"]}>
-```tsx {{ filename: 'layout.tsx', mark: ["cssLayerName: 'clerk'"] }}
-import { ClerkProvider } from '@clerk/nextjs'
+  ```tsx {{ filename: 'layout.tsx', mark: ["cssLayerName: 'clerk'"] }}
+  import { ClerkProvider } from '@clerk/nextjs'
 
-export default function RootLayout({ children }: { children: React.ReactNode }) {
-  return (
-    <ClerkProvider
-      appearance={{
-        cssLayerName: 'clerk',
-      }}
-    >
-      <html lang="en">
-        <body>{children}</body>
-      </html>
-    </ClerkProvider>
-  )
-}
-```
+  export default function RootLayout({ children }: { children: React.ReactNode }) {
+    return (
+      <ClerkProvider
+        appearance={{
+          cssLayerName: 'clerk',
+        }}
+      >
+        <html lang="en">
+          <body>{children}</body>
+        </html>
+      </ClerkProvider>
+    )
+  }
+  ```
 
-```css {{ filename: 'global.css', mark: ['clerk'] }}
-@layer theme, base, clerk, components, utilities;
-@import 'tailwindcss';
-```
+  ```css {{ filename: 'global.css', mark: ['clerk'] }}
+  @layer theme, base, clerk, components, utilities;
+  @import 'tailwindcss';
+  ```
 </CodeBlockTabs>
 
 #### Use CSS modules to style Clerk components

--- a/docs/customization/overview.mdx
+++ b/docs/customization/overview.mdx
@@ -274,6 +274,7 @@ The following example shows how to use the `cssLayerName` property to ensure tha
       ```
     </CodeBlockTabs>
   </Tab>
+
   <Tab>
     <CodeBlockTabs options={["astro.config.mjs", "global.css"]}>
       ```ts {{ mark: ["cssLayerName: 'clerk'"] }}
@@ -306,6 +307,7 @@ The following example shows how to use the `cssLayerName` property to ensure tha
       ```
     </CodeBlockTabs>
   </Tab>
+
   <Tab>
     <CodeBlockTabs options={["main.js", "global.css"]}>
       ```tsx {{ mark: ["cssLayerName: 'clerk'"] }}
@@ -336,6 +338,7 @@ The following example shows how to use the `cssLayerName` property to ensure tha
       ```
     </CodeBlockTabs>
   </Tab>
+
   <Tab>
     <CodeBlockTabs options={["index.html", "global.css"]}>
       ```html {{ mark: ["cssLayerName: 'clerk'"] }}

--- a/docs/customization/overview.mdx
+++ b/docs/customization/overview.mdx
@@ -138,114 +138,19 @@ Remove the `cl-` prefix from a class and use it as the key for a new object in t
 
 The following example shows how to style the primary button in a `<SignIn />` component with custom CSS classes:
 
-<Tabs items={["Next.js"]}>
-  <Tab>
-    <CodeBlockTabs options={["App Router", "Pages Router"]}>
-      ```tsx {{ filename: 'app/layout.tsx', mark: [[8, 14]] }}
-      import { ClerkProvider, SignIn } from '@clerk/nextjs'
-
-      export default function RootLayout({ children }: { children: React.ReactNode }) {
-        return (
-          <ClerkProvider>
-            <html lang="en">
-              <body>
-                <SignIn
-                  appearance={{
-                    elements: {
-                      formButtonPrimary: 'your-org-button org-red-button',
-                    },
-                  }}
-                />
-              </body>
-            </html>
-          </ClerkProvider>
-        )
-      }
-      ```
-
-      ```tsx {{ filename: 'app.tsx', mark: [[7, 13]] }}
-      import { ClerkProvider, SignIn } from '@clerk/nextjs'
-      import type { AppProps } from 'next/app'
-
-      function MyApp({ pageProps }: AppProps) {
-        return (
-          <ClerkProvider {...pageProps}>
-            <SignIn
-              appearance={{
-                elements: {
-                  formButtonPrimary: 'your-org-button org-red-button',
-                },
-              }}
-            />
-          </ClerkProvider>
-        )
-      }
-
-      export default MyApp
-      ```
-    </CodeBlockTabs>
-  </Tab>
-</Tabs>
+```tsx {{ mark: [4] }}
+<SignIn
+  appearance={{
+    elements: {
+      formButtonPrimary: 'your-org-button org-red-button',
+    },
+  }}
+/>
+```
 
 #### Use Tailwind classes to style Clerk components
 
-You can style the elements of a Clerk component with Tailwind.
-
-The following example shows how to style the primary button in a `<SignIn />` component with Tailwind classes:
-
-<Tabs items={["Next.js"]}>
-  <Tab>
-    <CodeBlockTabs options={["App Router", "Pages Router"]}>
-      ```tsx {{ filename: 'app/layout.tsx', mark: [[8, 14]] }}
-      import { ClerkProvider, SignIn } from '@clerk/nextjs'
-
-      export default function RootLayout({ children }: { children: React.ReactNode }) {
-        return (
-          <ClerkProvider>
-            <html lang="en">
-              <body>
-                <SignIn
-                  appearance={{
-                    elements: {
-                      formButtonPrimary: 'bg-slate-500 hover:bg-slate-400 text-sm',
-                    },
-                  }}
-                />
-              </body>
-            </html>
-          </ClerkProvider>
-        )
-      }
-      ```
-
-      ```tsx {{ filename: 'app.tsx', mark: [[7, 13]] }}
-      import { ClerkProvider, SignIn } from '@clerk/nextjs'
-      import type { AppProps } from 'next/app'
-
-      function MyApp({ pageProps }: AppProps) {
-        return (
-          <ClerkProvider {...pageProps}>
-            <SignIn
-              appearance={{
-                elements: {
-                  formButtonPrimary: 'bg-slate-500 hover:bg-slate-400 text-sm',
-                },
-              }}
-            />
-          </ClerkProvider>
-        )
-      }
-
-      export default MyApp
-      ```
-    </CodeBlockTabs>
-  </Tab>
-</Tabs>
-
-> [!NOTE]
-> To use Tailwind CSS v4, you need to make use of the `cssLayerName` property to ensure that Tailwind's utility styles are applied after Clerk's styles.
-
-The following example shows how to use the `cssLayerName` property to ensure that Tailwind's utility styles are applied after Clerk's styles:
+To use Tailwind CSS v4, you must set the `cssLayerName` property to `clerk` to ensure that Tailwind's utility styles are applied after Clerk's styles. It's recommended to add this to the `<ClerkProvider>` that wraps your app so that it's applied to all Clerk components, as shown in the following example:
 
 <Tabs items={["Next.js", "Astro", "Vue", "JavaScript"]}>
   <Tab>
@@ -360,6 +265,18 @@ The following example shows how to use the `cssLayerName` property to ensure tha
     </CodeBlockTabs>
   </Tab>
 </Tabs>
+
+Then, you can use Tailwind's classes to style the elements of the Clerk component. The following example shows how to use Tailwind classes to style the primary button in a `<SignIn />` component:
+
+```tsx {{ mark: [4] }}
+<SignIn
+  appearance={{
+    elements: {
+      formButtonPrimary: 'bg-slate-500 hover:bg-slate-400 text-sm',
+    },
+  }}
+/>
+```
 
 #### Use CSS modules to style Clerk components
 

--- a/docs/customization/overview.mdx
+++ b/docs/customization/overview.mdx
@@ -48,6 +48,14 @@ The `appearance` prop accepts the following properties:
   - `Captcha`
 
   Configuration options that affect the appearance of the CAPTCHA widget. For more information, see the [dedicated guide](/docs/customization/captcha).
+
+  ---
+
+  - `cssLayerName?`
+  - `string`
+
+  The name of the CSS layer for Clerk component styles. This is useful for advanced CSS customization, allowing you to control the cascade and prevent style conflicts by isolating Clerk's styles within a specific layer. For more information on CSS layers, see the [MDN documentation on @layer](https://developer.mozilla.org/en-US/docs/Web/CSS/@layer).
+
 </Properties>
 
 ## Using a prebuilt theme

--- a/docs/customization/overview.mdx
+++ b/docs/customization/overview.mdx
@@ -150,7 +150,7 @@ The following example shows how to style the primary button in a `<SignIn />` co
 
 #### Use Tailwind classes to style Clerk components
 
-To use Tailwind CSS v4, you must set the `cssLayerName` property to `clerk` to ensure that Tailwind's utility styles are applied after Clerk's styles. It's recommended to add this to the `<ClerkProvider>` that wraps your app so that it's applied to all Clerk components, as shown in the following example:
+To use Tailwind CSS v4, you must set the `cssLayerName` property to ensure that Tailwind's utility styles are applied after Clerk's styles. It's recommended to add this to the `<ClerkProvider>` that wraps your app so that it's applied to all Clerk components, as shown in the following example. The example names the layer `clerk` but you can name it anything you want.
 
 <Tabs items={["Next.js", "Astro", "Vue", "JavaScript"]}>
   <Tab>


### PR DESCRIPTION
### 🔎 Previews:

- https://clerk.com/docs/pr/alexcarpenter-appearance-css-layer-name/customization/overview

### What does this solve?

- To support Tailwind CSS v4 usage, we've introduced a new property within the top level appearance prop to enable rendering clerk styles within a native CSS layer.
- SDK PR: https://github.com/clerk/javascript/pull/5552

### What changed?

- <!--- How does this PR solve the problem? -->

### Checklist

- [x] I have clicked on "Files changed" and performed a thorough self-review
- [x] All existing checks pass
