### PR TITLE
Clarify normalizeProvider function to reverify SSO connection in custom flow

### DIFF
--- a/docs/custom-flows/manage-sso-connections.mdx
+++ b/docs/custom-flows/manage-sso-connections.mdx
@@ -41,8 +41,9 @@ const capitalize = (provider: string) => {
   return `${provider.slice(0, 1).toUpperCase()}${provider.slice(1)}`
 }
 
-// Remove the 'oauth' prefix from the provider name
+// Remove the 'oauth' prefix from the strategy string
 // E.g. 'oauth_discord' -> 'discord'
+// Used to match the strategy with the 'provider' field in externalAccounts
 const normalizeProvider = (provider: string) => {
   return provider.split('_')[1]
 }

--- a/docs/custom-flows/manage-sso-connections.mdx
+++ b/docs/custom-flows/manage-sso-connections.mdx
@@ -24,6 +24,7 @@ This guide uses Discord, Google, and GitHub as examples.
    - It uses the `user` object to access the [`createExternalAccount()`](/docs/references/javascript/user#create-external-account) method.
    - The `createExternalAccount()` method is used to create a new external account using the `strategy` that is passed in. It's passed to the [`useReverification()`](/docs/hooks/use-reverification) hook to require the user to reverify their credentials before being able to add an external account to their account.
 1. The `unconnectedOptions` array is used to filter out any existing external accounts from the `options` array.
+1. The `normalizeProvider()` function is used to strip the `oauth` prefix from each strategy so it can be matched with the provider field in the user's existing external accounts.
 1. In the UI, the `unconnectedOptions` array is used to create a list of buttons for the user to add new external accounts.
 1. In the UI, the `User` object is used to access the `externalAccounts` property, which is mapped through to create a list of the user's existing external accounts. If there is an error, it is displayed to the user in the 'Status' column. If the account didn't verify when the user added it, a 'Reverify' button is displayed, which will redirect the user to the provider in order to verify their account.
 
@@ -40,7 +41,7 @@ const capitalize = (provider: string) => {
   return `${provider.slice(0, 1).toUpperCase()}${provider.slice(1)}`
 }
 
-// Remove the prefix from the provider name
+// Remove the 'oauth' prefix from the provider name
 // E.g. 'oauth_discord' -> 'discord'
 const normalizeProvider = (provider: string) => {
   return provider.split('_')[1]


### PR DESCRIPTION
### 🔎 Previews:

- https://clerk.com/docs/pr/ss-docs-10519/custom-flows/manage-sso-connections

### What does this solve?

This PR clarifies the existence of a `normalizeProvider` function, used to remove the `oauth` prefix of each strategy to match with the provider field in the user's existing external accounts. There was nothing to fix in the code itself, as it was correct, but user may have missed the presence and importance of the `normalizeProvider` function. 

- Slack thread for context: https://clerkinc.slack.com/archives/C01QFRQNHSN/p1749618595504739
- Linear ticket: https://linear.app/clerk/issue/DOCS-10519/clarify-the-normalizeprovider-function-to-reverify-sso-connection-in
- Twitter user comment: https://x.com/divandcode/status/1932534112365260915

### What changed?

- Added extra explanation around the `normalizeProvider` function to clarify its use
- Modified the comment in the code to be more precise

### Checklist

- [ ] I have clicked on "Files changed" and performed a thorough self-review
- [ ] All existing checks pass
