### PR TITLE
Added note about OTP SMS templates being non-customizable

### DIFF
--- a/docs/authentication/configuration/email-sms-templates.mdx
+++ b/docs/authentication/configuration/email-sms-templates.mdx
@@ -101,6 +101,9 @@ The email WYSIWYG editor text area is intended mainly for authoring content. Tho
 
 ## Edit SMS templates
 
+> [!NOTE]
+> One-Time-Passcode (OTP) SMS templates cannot be customized. This is to ensure that the OTP messages are delivered in a consistent manner and format.
+
 To access the SMS templates:
 
 1. In the Clerk Dashboard, navigate to the [**SMS**](https://dashboard.clerk.com/last-active?path=customization/sms) page.

--- a/docs/authentication/configuration/email-sms-templates.mdx
+++ b/docs/authentication/configuration/email-sms-templates.mdx
@@ -101,14 +101,11 @@ The email WYSIWYG editor text area is intended mainly for authoring content. Tho
 
 ## Edit SMS templates
 
-> [!NOTE]
-> One-Time-Passcode (OTP) SMS templates cannot be customized. This is to ensure that the OTP messages are delivered in a consistent manner and format.
-
 To access the SMS templates:
 
 1. In the Clerk Dashboard, navigate to the [**SMS**](https://dashboard.clerk.com/last-active?path=customization/sms) page.
 1. Select a template to edit. You can also disable certain SMS notifications.
-1. A modal will appear that shows you what the template looks like, plus options to toggle the [**Delivered by Clerk**](#delivered-by-clerk) setting or to [request a change to the template](#request-change).
+1. You'll be redirected to the template's page where you can see what the template looks like, plus options to toggle the [**Delivered by Clerk**](#delivered-by-clerk) setting or to [request a change to the template](#request-change). One-time passcode (OTP) SMS templates cannot be customized, so the **Request changes** option will not be available for these templates.
 
 ### Delivered by Clerk
 


### PR DESCRIPTION
### What does this solve?

- OTP SMS templates cannot be modified. To eliminate confusion for users, this should be noted in the docs.
- [DOCS-10391](https://linear.app/clerk/issue/DOCS-10391/add-call-out-in-docs-for-sms-template-customisation-otp-templates)

### What changed?

- Added a note to the SMS Template section under "Email & SMS Templates" page to inform users that these templates cannot be modified

### Checklist

- [x] I have clicked on "Files changed" and performed a thorough self-review
- [x] All existing checks pass
