### PR TITLE
validation / build script - clean up warnings reporting

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,6 @@
     "format": "prettier . --write",
     "lint:check-links": "node ./scripts/check-links.mjs",
     "lint:formatting": "prettier . --check",
-    "lint:formatting:fix": "prettier . --write",
     "lint:check-quickstarts": "node ./scripts/check-quickstarts.mjs",
     "lint:check-frontmatter": "node ./scripts/check-frontmatter.mjs",
     "lint:validation": "npm run build",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,6 @@
     "lint:formatting": "prettier . --check",
     "lint:check-quickstarts": "node ./scripts/check-quickstarts.mjs",
     "lint:check-frontmatter": "node ./scripts/check-frontmatter.mjs",
-    "lint:validation": "npm run build",
     "build": "tsx ./scripts/build-docs.ts",
     "dev": "tsx ./scripts/build-docs.ts --watch",
     "test": "vitest --silent",

--- a/scripts/build-docs.test.ts
+++ b/scripts/build-docs.test.ts
@@ -920,7 +920,9 @@ test`,
     )
 
     expect(output).toContain(`warning Hash "my-heading" not found in /docs/page-2`)
-    expect(output).toContain(`warning Doc /docs/page-3 not found`)
+    expect(output).toContain(
+`warning Matching file not found for path: /docs/page-3. Expected file to exist at /docs/page-3.mdx`,
+)
   })
 
   test('should process target="_blank" links in manifest correctly', async () => {
@@ -2139,7 +2141,9 @@ title: Simple Test
       }),
     )
 
-    expect(output).toContain(`warning Doc /docs/non-existent-page not found`)
+    expect(output).toContain(
+`warning Matching file not found for path: /docs/non-existent-page. Expected file to exist at /docs/non-existent-page.mdx`,
+)
   })
 
   test('Validate link between two pages is valid', async () => {
@@ -3215,7 +3219,9 @@ title: Document with Warnings
     expect(await fileExists(pathJoin('./dist/document-with-warnings.mdx'))).toBe(true)
 
     // Check that warnings were reported
-    expect(output).toContain('warning Doc /docs/non-existent-document not found')
+    expect(output).toContain(
+'warning Matching file not found for path: /docs/non-existent-document. Expected file to exist at /docs/non-existent-document.mdx',
+)
     expect(output).toContain('warning sdk "invalid-sdk" in <If /> is not a valid SDK')
   })
 })
@@ -4371,7 +4377,9 @@ description: Generated API docs
       }),
     )
 
-    expect(output).toContain('Doc /docs/non-existent-file not found')
+    expect(output).toContain(
+      'warning Matching file not found for path: /docs/non-existent-file. Expected file to exist at /docs/non-existent-file.mdx',
+)
   })
 
   test('Should fail if typedoc file links to non-existent hash', async () => {

--- a/scripts/build-docs.test.ts
+++ b/scripts/build-docs.test.ts
@@ -921,8 +921,8 @@ test`,
 
     expect(output).toContain(`warning Hash "my-heading" not found in /docs/page-2`)
     expect(output).toContain(
-`warning Matching file not found for path: /docs/page-3. Expected file to exist at /docs/page-3.mdx`,
-)
+      `warning Matching file not found for path: /docs/page-3. Expected file to exist at /docs/page-3.mdx`,
+    )
   })
 
   test('should process target="_blank" links in manifest correctly', async () => {
@@ -2142,8 +2142,8 @@ title: Simple Test
     )
 
     expect(output).toContain(
-`warning Matching file not found for path: /docs/non-existent-page. Expected file to exist at /docs/non-existent-page.mdx`,
-)
+      `warning Matching file not found for path: /docs/non-existent-page. Expected file to exist at /docs/non-existent-page.mdx`,
+    )
   })
 
   test('Validate link between two pages is valid', async () => {
@@ -3220,8 +3220,8 @@ title: Document with Warnings
 
     // Check that warnings were reported
     expect(output).toContain(
-'warning Matching file not found for path: /docs/non-existent-document. Expected file to exist at /docs/non-existent-document.mdx',
-)
+      'warning Matching file not found for path: /docs/non-existent-document. Expected file to exist at /docs/non-existent-document.mdx',
+    )
     expect(output).toContain('warning sdk "invalid-sdk" in <If /> is not a valid SDK')
   })
 })
@@ -4379,7 +4379,7 @@ description: Generated API docs
 
     expect(output).toContain(
       'warning Matching file not found for path: /docs/non-existent-file. Expected file to exist at /docs/non-existent-file.mdx',
-)
+    )
   })
 
   test('Should fail if typedoc file links to non-existent hash', async () => {

--- a/scripts/build-docs.ts
+++ b/scripts/build-docs.ts
@@ -51,7 +51,7 @@ import { z } from 'zod'
 import { generateApiErrorDocs } from './lib/api-errors'
 import { createConfig, type BuildConfig } from './lib/config'
 import { watchAndRebuild } from './lib/dev'
-import { errorMessages, shouldIgnoreWarning } from './lib/error-messages'
+import { errorMessages, safeMessage, shouldIgnoreWarning } from './lib/error-messages'
 import { getLastCommitDate } from './lib/getLastCommitDate'
 import { ensureDirectory, readDocsFolder, writeDistFile, writeSDKFile } from './lib/io'
 import { flattenTree, ManifestGroup, readManifest, traverseTree, traverseTreeItemsFirst } from './lib/manifest'
@@ -227,7 +227,7 @@ export async function build(config: BuildConfig, store: Store = createBlankStore
     console.info('✓ Generated API Error MDX files')
   }
 
-  const userManifest = await getManifest()
+  const { manifest: userManifest, vfile: manifestVfile } = await getManifest()
   console.info('✓ Read Manifest')
 
   const docsFiles = await getDocsFolder()
@@ -303,9 +303,7 @@ export async function build(config: BuildConfig, store: Store = createBlankStore
       const doc = docsMap.get(item.href)
 
       if (doc === undefined) {
-        if (!shouldIgnoreWarning(config, `${item.href}.mdx`, 'docs', 'doc-not-found')) {
-          throw new Error(errorMessages['doc-not-found'](item.title, item.href))
-        }
+        safeMessage(config, manifestVfile, item.href, 'docs', 'doc-not-found', [item.title, item.href])
         return item
       }
 
@@ -813,9 +811,12 @@ template: wide
   const partialsVFiles = validatedPartials.map((partial) => partial.vfile)
   const typedocVFiles = validatedTypedocs.map((typedoc) => typedoc.vfile)
 
-  const warnings = reporter([...coreVFiles, ...partialsVFiles, ...typedocVFiles, ...flatSdkSpecificVFiles], {
-    quiet: true,
-  })
+  const warnings = reporter(
+    [...coreVFiles, ...partialsVFiles, ...typedocVFiles, ...flatSdkSpecificVFiles, manifestVfile],
+    {
+      quiet: true,
+    },
+  )
 
   await fs.rm(config.distFinalPath, { recursive: true })
 

--- a/scripts/lib/error-messages.ts
+++ b/scripts/lib/error-messages.ts
@@ -64,7 +64,8 @@ export const errorMessages = {
   'prompt-not-found': (src: string): string => `Prompt ${src} not found`,
 
   // Link validation errors
-  'link-doc-not-found': (url: string): string => `Doc ${url} not found`,
+  'link-doc-not-found': (url: string, file: string): string =>
+    `Matching file not found for path: ${url}. Expected file to exist at ${file}`,
   'link-hash-not-found': (hash: string, url: string): string => `Hash "${hash}" not found in ${url}`,
 
   // File reading errors

--- a/scripts/lib/manifest.ts
+++ b/scripts/lib/manifest.ts
@@ -8,10 +8,11 @@ import type { BuildConfig } from './config'
 import { errorMessages } from './error-messages'
 import { parseJSON } from './io'
 import { icon, sdk, tag, type Icon, type SDK, type Tag } from './schemas'
+import { VFile } from 'vfile'
 
-// read in the manifest
+// read in the manifest, create a vfile to write warnings to
 
-export const readManifest = (config: BuildConfig) => async (): Promise<Manifest> => {
+export const readManifest = (config: BuildConfig) => async () => {
   const { manifestSchema } = createManifestSchema(config)
   const unsafe_manifest = await fs.readFile(config.manifestFilePath, { encoding: 'utf-8' })
 
@@ -24,7 +25,10 @@ export const readManifest = (config: BuildConfig) => async (): Promise<Manifest>
   const manifest = await z.object({ navigation: manifestSchema }).safeParseAsync(json)
 
   if (manifest.success === true) {
-    return manifest.data.navigation
+    return {
+      manifest: manifest.data.navigation,
+      vfile: new VFile({ path: config.manifestRelativePath }),
+    }
   }
 
   throw new Error(errorMessages['manifest-parse-error'](fromError(manifest.error)))

--- a/scripts/lib/plugins/validateAndEmbedLinks.ts
+++ b/scripts/lib/plugins/validateAndEmbedLinks.ts
@@ -54,7 +54,15 @@ export const validateAndEmbedLinks =
       const linkedDoc = docsMap.get(url)
 
       if (linkedDoc === undefined) {
-        safeMessage(config, vfile, filePath, section, 'link-doc-not-found', [url], node.position)
+        safeMessage(
+          config,
+          vfile,
+          filePath,
+          section,
+          'link-doc-not-found',
+          [node.url as string, `${url}.mdx`],
+          node.position,
+        )
         return node
       }
 


### PR DESCRIPTION
This changes how two warnings / errors are reported from the build script.

- When a page links to another page, and that page doesn't exist

<img width="644" alt="Screenshot 2025-06-18 at 5 46 23 PM" src="https://github.com/user-attachments/assets/1efe462d-ca2b-4de6-877f-ae4934dac0f5" />

Updated to match the warning message from the check-links.mjs script

- When a page is in the manifest.json but doesn't exist 

<img width="649" alt="Screenshot 2025-06-18 at 5 47 46 PM" src="https://github.com/user-attachments/assets/e41a9b35-5855-4b74-8509-037063a54768" />

Updated so it doesn't close out after hitting the first broken link in the manifest

### Checklist

- [x] I have clicked on "Files changed" and performed a thorough self-review
- [x] All existing checks pass