### PR TITLE
fix: make production sync host domain correct

### DIFF
--- a/docs/references/chrome-extension/sync-host.mdx
+++ b/docs/references/chrome-extension/sync-host.mdx
@@ -32,7 +32,7 @@ Clerk allows you to sync the authentication state from your web app to your Chro
     </Tab>
 
     <Tab>
-      Add `PLASMO_PUBLIC_CLERK_SYNC_HOST` to your `.env.production` file. The value should be the domain your web app's production server runs on. For example, `https://clerk.com`.
+      Add `PLASMO_PUBLIC_CLERK_SYNC_HOST` to your `.env.production` file. The value should be the [domain your clerk frontend API](https://dashboard.clerk.com/last-active?path=domains) runs on. For example, `https://clerk.yourwebsite.com`.
 
       ```env {{ filename: '.env.production', mark: [3] }}
       PLASMO_PUBLIC_CLERK_PUBLISHABLE_KEY=pk_live_123


### PR DESCRIPTION
### 🔎 Previews:

-

### What does this solve?

Bug raised by me + one other in discord relating to sync host working in development, but not in production. I believe if users follow the current docs sync host will not function, even when not using a subdomain.

Posts: https://discord.com/channels/856971667393609759/1384961289209774240 + https://discord.com/channels/856971667393609759/1385314935365701652

I did some debugging on the chrome-extension package this evening and found that the function: `getClientCookie` returns null (called by `JWTHandler's` 'get' function) if you specify the sync host as https://app.mywebsite.com as the cookie domain for __client is .clerk.mywebsite.com.

This is due to the function returning: browser.cookies.get({ name, url: ensureFormattedUrl(url) }); - specifying url here causes `webextension-polyfill` lib to return what the browser would send, so in our example: https://app.mywebsite.com/  would NOT send `__client` as `__client` domain = .clerk.mywebsite.com, causing JWTHandler get() to return null, hence syncHost not working in prod.

### What changed?

Adds clear docs what users should add as their sync host domain

### Checklist

- [x] I have clicked on "Files changed" and performed a thorough self-review
- [x] All existing checks pass
