### PR TITLE
Move the sdk references down below the Development section in the sidebar

### DIFF
--- a/docs/manifest.json
+++ b/docs/manifest.json
@@ -33,65 +33,7 @@
                     ]
                   },
                   {
-                    "title": "General references",
-                    "items": [
-                      [
-                        {
-                          "title": "Overview",
-                          "href": "/docs/references/nextjs/overview"
-                        },
-                        {
-                          "title": "`clerkMiddleware()`",
-                          "wrap": false,
-                          "href": "/docs/references/nextjs/clerk-middleware"
-                        }
-                      ]
-                    ]
-                  },
-                  {
-                    "title": "App Router References",
-                    "items": [
-                      [
-                        {
-                          "title": "`auth()`",
-                          "wrap": false,
-                          "href": "/docs/references/nextjs/auth"
-                        },
-                        {
-                          "title": "`currentUser()`",
-                          "wrap": false,
-                          "href": "/docs/references/nextjs/current-user"
-                        },
-                        {
-                          "title": "Route Handlers",
-                          "href": "/docs/references/nextjs/route-handlers"
-                        },
-                        {
-                          "title": "Server Actions",
-                          "href": "/docs/references/nextjs/server-actions"
-                        }
-                      ]
-                    ]
-                  },
-                  {
-                    "title": "Pages Router References",
-                    "items": [
-                      [
-                        {
-                          "title": "`getAuth()`",
-                          "wrap": false,
-                          "href": "/docs/references/nextjs/get-auth"
-                        },
-                        {
-                          "title": "`buildClerkProps()`",
-                          "wrap": false,
-                          "href": "/docs/references/nextjs/build-clerk-props"
-                        }
-                      ]
-                    ]
-                  },
-                  {
-                    "title": "Guides",
+                    "title": "Next.js Guides",
                     "items": [
                       [
                         {
@@ -140,21 +82,6 @@
                         }
                       ]
                     ]
-                  },
-                  {
-                    "title": "Demo Repositories",
-                    "items": [
-                      [
-                        {
-                          "title": "App Router Demo Repo",
-                          "href": "https://github.com/clerk/clerk-nextjs-demo-app-router"
-                        },
-                        {
-                          "title": "Pages Router Demo Repo",
-                          "href": "https://github.com/clerk/clerk-nextjs-demo-pages-router"
-                        }
-                      ]
-                    ]
                   }
                 ]
               ]
@@ -179,28 +106,6 @@
                         }
                       ]
                     ]
-                  },
-                  {
-                    "title": "References",
-                    "items": [
-                      [
-                        {
-                          "title": "Overview",
-                          "href": "/docs/references/react/overview"
-                        }
-                      ]
-                    ]
-                  },
-                  {
-                    "title": "Demo Repository",
-                    "items": [
-                      [
-                        {
-                          "title": "React Demo Repo",
-                          "href": "https://github.com/clerk/clerk-react-quickstart"
-                        }
-                      ]
-                    ]
                   }
                 ]
               ]
@@ -222,225 +127,6 @@
                         {
                           "title": "Quickstart",
                           "href": "/docs/quickstarts/javascript"
-                        }
-                      ]
-                    ]
-                  },
-                  {
-                    "title": "References",
-                    "items": [
-                      [
-                        {
-                          "title": "Overview",
-                          "href": "/docs/references/javascript/overview"
-                        },
-                        {
-                          "title": "`Clerk`",
-                          "href": "/docs/references/javascript/clerk"
-                        },
-                        {
-                          "title": "`Client`",
-                          "href": "/docs/references/javascript/client"
-                        },
-                        {
-                          "title": "`Session`",
-                          "href": "/docs/references/javascript/session"
-                        },
-                        {
-                          "title": "`User`",
-                          "href": "/docs/references/javascript/user"
-                        },
-                        {
-                          "title": "`SignIn`",
-                          "href": "/docs/references/javascript/sign-in"
-                        },
-                        {
-                          "title": "`SignUp`",
-                          "href": "/docs/references/javascript/sign-up"
-                        },
-                        {
-                          "title": "`Organization`",
-                          "href": "/docs/references/javascript/organization"
-                        },
-                        {
-                          "title": "Types",
-                          "collapse": true,
-                          "items": [
-                            [
-                              {
-                                "title": "Overview",
-                                "href": "/docs/references/javascript/types/overview"
-                              },
-                              {
-                                "title": "`BackupCodeResource`",
-                                "href": "/docs/references/javascript/types/backup-code"
-                              },
-                              {
-                                "title": "`ClerkAPIError`",
-                                "href": "/docs/references/javascript/types/clerk-api-error"
-                              },
-                              {
-                                "title": "`ClerkPaginatedResponse`",
-                                "href": "/docs/references/javascript/types/clerk-paginated-response"
-                              },
-                              {
-                                "title": "`CustomMenuItem`",
-                                "href": "/docs/references/javascript/types/custom-menu-item"
-                              },
-                              {
-                                "title": "`CustomPage`",
-                                "href": "/docs/references/javascript/types/custom-page"
-                              },
-                              {
-                                "title": "`DeletedObject`",
-                                "href": "/docs/references/javascript/types/deleted-object"
-                              },
-                              {
-                                "title": "`EmailAddress`",
-                                "href": "/docs/references/javascript/types/email-address"
-                              },
-                              {
-                                "title": "`EmailLinkError`",
-                                "href": "/docs/references/javascript/types/email-link-error"
-                              },
-                              {
-                                "title": "`EnterpriseAccount`",
-                                "href": "/docs/references/javascript/types/enterprise-account"
-                              },
-                              {
-                                "title": "`EnterpriseAccountConnection`",
-                                "href": "/docs/references/javascript/types/enterprise-account-connection"
-                              },
-                              {
-                                "title": "`ExternalAccount`",
-                                "href": "/docs/references/javascript/types/external-account"
-                              },
-                              {
-                                "title": "Metadata types",
-                                "href": "/docs/references/javascript/types/metadata"
-                              },
-                              {
-                                "title": "`OrganizationCustomRoleKey`",
-                                "href": "/docs/references/javascript/types/organization-custom-role-key"
-                              },
-                              {
-                                "title": "`OrganizationCustomPermissionKey`",
-                                "href": "/docs/references/javascript/types/organization-custom-permission-key"
-                              },
-                              {
-                                "title": "`OrganizationDomain`",
-                                "href": "/docs/references/javascript/types/organization-domain"
-                              },
-                              {
-                                "title": "`OrganizationInvitation`",
-                                "href": "/docs/references/javascript/types/organization-invitation"
-                              },
-                              {
-                                "title": "`OrganizationMembership`",
-                                "href": "/docs/references/javascript/types/organization-membership"
-                              },
-                              {
-                                "title": "`OrganizationMembershipRequest`",
-                                "href": "/docs/references/javascript/types/organization-membership-request"
-                              },
-                              {
-                                "title": "`OrganizationSuggestion`",
-                                "href": "/docs/references/javascript/types/organization-suggestion"
-                              },
-                              {
-                                "title": "`PasskeyResource`",
-                                "href": "/docs/references/javascript/types/passkey-resource"
-                              },
-                              {
-                                "title": "`PermissionResource`",
-                                "href": "/docs/references/javascript/types/permission"
-                              },
-                              {
-                                "title": "`PhoneNumber`",
-                                "href": "/docs/references/javascript/types/phone-number"
-                              },
-                              {
-                                "title": "`PublicUserData`",
-                                "href": "/docs/references/javascript/types/public-user-data"
-                              },
-                              {
-                                "title": "`RedirectOptions`",
-                                "href": "/docs/references/javascript/types/redirect-options"
-                              },
-                              {
-                                "title": "`RoleResource`",
-                                "href": "/docs/references/javascript/types/role"
-                              },
-                              {
-                                "title": "`SamlAccount`",
-                                "href": "/docs/references/javascript/types/saml-account"
-                              },
-                              {
-                                "title": "`SamlAccountConnection`",
-                                "href": "/docs/references/javascript/types/saml-account-connection"
-                              },
-                              {
-                                "title": "`SessionStatus`",
-                                "href": "/docs/references/javascript/types/session-status"
-                              },
-                              {
-                                "title": "`SessionVerification`",
-                                "href": "/docs/references/javascript/types/session-verification"
-                              },
-                              {
-                                "title": "`SessionWithActivities`",
-                                "href": "/docs/references/javascript/types/session-with-activities"
-                              },
-                              {
-                                "title": "`SetActiveParams`",
-                                "href": "/docs/references/javascript/types/set-active-params"
-                              },
-                              {
-                                "title": "`SignInFirstFactor`",
-                                "href": "/docs/references/javascript/types/sign-in-first-factor"
-                              },
-                              {
-                                "title": "`SignInSecondFactor`",
-                                "href": "/docs/references/javascript/types/sign-in-second-factor"
-                              },
-                              {
-                                "title": "`SignInRedirectOptions`",
-                                "href": "/docs/references/javascript/types/sign-in-redirect-options"
-                              },
-                              {
-                                "title": "`SignUpRedirectOptions`",
-                                "href": "/docs/references/javascript/types/sign-up-redirect-options"
-                              },
-                              {
-                                "title": "`SignInInitialValues`",
-                                "href": "/docs/references/javascript/types/sign-in-initial-values"
-                              },
-                              {
-                                "title": "`SignUpInitialValues`",
-                                "href": "/docs/references/javascript/types/sign-up-initial-values"
-                              },
-                              {
-                                "title": "SSO types",
-                                "href": "/docs/references/javascript/types/sso"
-                              },
-                              {
-                                "title": "`TOTPResource`",
-                                "href": "/docs/references/javascript/types/totp"
-                              },
-                              {
-                                "title": "`UserOrganizationInvitation`",
-                                "href": "/docs/references/javascript/types/user-organization-invitation"
-                              },
-                              {
-                                "title": "`Verification`",
-                                "href": "/docs/references/javascript/types/verification"
-                              },
-                              {
-                                "title": "`Web3Wallet`",
-                                "href": "/docs/references/javascript/types/web3-wallet"
-                              }
-                            ]
-                          ]
                         }
                       ]
                     ]
@@ -474,83 +160,7 @@
                     ]
                   },
                   {
-                    "title": "References",
-                    "items": [
-                      [
-                        {
-                          "title": "Overview",
-                          "href": "/docs/references/astro/overview"
-                        },
-                        {
-                          "title": "`clerkMiddleware()`",
-                          "wrap": false,
-                          "href": "/docs/references/astro/clerk-middleware"
-                        },
-                        {
-                          "title": "`updateClerkOptions()`",
-                          "href": "/docs/references/astro/update-clerk-options"
-                        },
-                        {
-                          "title": "Integration",
-                          "href": "/docs/references/astro/integration"
-                        },
-                        {
-                          "title": "Locals",
-                          "wrap": false,
-                          "href": "/docs/references/astro/locals"
-                        }
-                      ]
-                    ]
-                  },
-                  {
-                    "title": "Client-side helpers",
-                    "items": [
-                      [
-                        {
-                          "title": "`$authStore`",
-                          "wrap": false,
-                          "href": "/docs/references/astro/auth-store"
-                        },
-                        {
-                          "title": "`$clerkStore`",
-                          "wrap": false,
-                          "href": "/docs/references/astro/clerk-store"
-                        },
-                        {
-                          "title": "`$userStore`",
-                          "wrap": false,
-                          "href": "/docs/references/astro/user-store"
-                        },
-                        {
-                          "title": "`$signInStore`",
-                          "wrap": false,
-                          "href": "/docs/references/astro/sign-in-store"
-                        },
-                        {
-                          "title": "`$signUpStore`",
-                          "wrap": false,
-                          "href": "/docs/references/astro/sign-up-store"
-                        },
-                        {
-                          "title": "`$sessionStore`",
-                          "wrap": false,
-                          "href": "/docs/references/astro/session-store"
-                        },
-                        {
-                          "title": "`$sessionListStore`",
-                          "wrap": false,
-                          "href": "/docs/references/astro/session-list-store"
-                        },
-                        {
-                          "title": "`$organizationStore`",
-                          "wrap": false,
-                          "href": "/docs/references/astro/organization-store"
-                        }
-                      ]
-                    ]
-                  },
-                  {
-                    "title": "Guides",
+                    "title": "Astro Guides",
                     "items": [
                       [
                         {
@@ -600,18 +210,7 @@
                     ]
                   },
                   {
-                    "title": "References",
-                    "items": [
-                      [
-                        {
-                          "title": "Overview",
-                          "href": "/docs/references/chrome-extension/overview"
-                        }
-                      ]
-                    ]
-                  },
-                  {
-                    "title": "Guides",
+                    "title": "Chrome Extension Guides",
                     "items": [
                       [
                         {
@@ -658,30 +257,7 @@
                     ]
                   },
                   {
-                    "title": "References",
-                    "items": [
-                      [
-                        {
-                          "title": "Overview",
-                          "href": "/docs/references/expo/overview"
-                        },
-                        {
-                          "title": "`useLocalCredentials()`",
-                          "href": "/docs/references/expo/use-local-credentials"
-                        },
-                        {
-                          "title": "`useOAuth()` (deprecated)",
-                          "href": "/docs/references/expo/use-oauth"
-                        },
-                        {
-                          "title": "`useSSO()`",
-                          "href": "/docs/references/expo/use-sso"
-                        }
-                      ]
-                    ]
-                  },
-                  {
-                    "title": "Guides",
+                    "title": "Expo Guides",
                     "items": [
                       [
                         {
@@ -703,26 +279,6 @@
                         {
                           "title": "Access the `Clerk` object outside of components",
                           "href": "/docs/references/expo/access-clerk-outside-components"
-                        }
-                      ]
-                    ]
-                  },
-                  {
-                    "title": "Web support",
-                    "collapse": true,
-                    "items": [
-                      [
-                        {
-                          "title": "Overview",
-                          "href": "/docs/references/expo/web-support/overview"
-                        },
-                        {
-                          "title": "Add a custom sign-in-or-up page",
-                          "href": "/docs/references/expo/web-support/custom-sign-in-or-up-page"
-                        },
-                        {
-                          "title": "Add a custom sign-up page",
-                          "href": "/docs/references/expo/web-support/custom-sign-up-page"
                         }
                       ]
                     ]
@@ -750,17 +306,6 @@
                         }
                       ]
                     ]
-                  },
-                  {
-                    "title": "References",
-                    "items": [
-                      [
-                        {
-                          "title": "Overview",
-                          "href": "/docs/references/express/overview"
-                        }
-                      ]
-                    ]
                   }
                 ]
               ]
@@ -782,17 +327,6 @@
                         {
                           "title": "Quickstart",
                           "href": "/docs/quickstarts/fastify"
-                        }
-                      ]
-                    ]
-                  },
-                  {
-                    "title": "References",
-                    "items": [
-                      [
-                        {
-                          "title": "Overview",
-                          "href": "/docs/references/fastify/overview"
                         }
                       ]
                     ]
@@ -822,7 +356,7 @@
                     ]
                   },
                   {
-                    "title": "Guides",
+                    "title": "Go Guides",
                     "items": [
                       [
                         {
@@ -835,10 +369,6 @@
                         }
                       ]
                     ]
-                  },
-                  {
-                    "title": "Go SDK repository",
-                    "href": "https://github.com/clerk/clerk-sdk-go"
                   }
                 ]
               ]
@@ -865,22 +395,7 @@
                     ]
                   },
                   {
-                    "title": "References",
-                    "items": [
-                      [
-                        {
-                          "title": "Overview",
-                          "href": "/docs/references/ios/overview"
-                        },
-                        {
-                          "title": "`getToken()`",
-                          "href": "/docs/references/ios/get-token"
-                        }
-                      ]
-                    ]
-                  },
-                  {
-                    "title": "Guides",
+                    "title": "iOS Guides",
                     "items": [
                       [
                         {
@@ -913,575 +428,6 @@
                         }
                       ]
                     ]
-                  },
-                  {
-                    "title": "References",
-                    "items": [
-                      [
-                        {
-                          "title": "User",
-                          "collapse": true,
-                          "items": [
-                            [
-                              {
-                                "title": "`getUserList()`",
-                                "wrap": false,
-                                "href": "/docs/references/backend/user/get-user-list"
-                              },
-                              {
-                                "title": "`getUser()`",
-                                "wrap": false,
-                                "href": "/docs/references/backend/user/get-user"
-                              },
-                              {
-                                "title": "`getCount()`",
-                                "wrap": false,
-                                "href": "/docs/references/backend/user/get-count"
-                              },
-                              {
-                                "title": "`getOrganizationMembershipList()`",
-                                "wrap": false,
-                                "href": "/docs/references/backend/user/get-organization-membership-list"
-                              },
-                              {
-                                "title": "`getUserOAuthAccessToken()`",
-                                "wrap": false,
-                                "href": "/docs/references/backend/user/get-user-oauth-access-token"
-                              },
-                              {
-                                "title": "`createUser()`",
-                                "wrap": false,
-                                "href": "/docs/references/backend/user/create-user"
-                              },
-                              {
-                                "title": "`verifyPassword()`",
-                                "wrap": false,
-                                "href": "/docs/references/backend/user/verify-password"
-                              },
-                              {
-                                "title": "`banUser()`",
-                                "wrap": false,
-                                "href": "/docs/references/backend/user/ban-user"
-                              },
-                              {
-                                "title": "`unbanUser()`",
-                                "wrap": false,
-                                "href": "/docs/references/backend/user/unban-user"
-                              },
-                              {
-                                "title": "`lockUser()`",
-                                "wrap": false,
-                                "href": "/docs/references/backend/user/lock-user"
-                              },
-                              {
-                                "title": "`unlockUser()`",
-                                "wrap": false,
-                                "href": "/docs/references/backend/user/unlock-user"
-                              },
-                              {
-                                "title": "`updateUser()`",
-                                "wrap": false,
-                                "href": "/docs/references/backend/user/update-user"
-                              },
-                              {
-                                "title": "`updateUserProfileImage()`",
-                                "wrap": false,
-                                "href": "/docs/references/backend/user/update-user-profile-image"
-                              },
-                              {
-                                "title": "`updateUserMetadata()`",
-                                "wrap": false,
-                                "href": "/docs/references/backend/user/update-user-metadata"
-                              },
-                              {
-                                "title": "`deleteUser()`",
-                                "wrap": false,
-                                "href": "/docs/references/backend/user/delete-user"
-                              },
-                              {
-                                "title": "`disableUserMFA()`",
-                                "wrap": false,
-                                "href": "/docs/references/backend/user/disable-user-mfa"
-                              },
-                              {
-                                "title": "`verifyTOTP()`",
-                                "wrap": false,
-                                "href": "/docs/references/backend/user/verify-totp"
-                              },
-                              {
-                                "title": "`deleteUserProfileImage()`",
-                                "wrap": false,
-                                "href": "/docs/references/backend/user/delete-user-profile-image"
-                              }
-                            ]
-                          ]
-                        },
-                        {
-                          "title": "Organization",
-                          "collapse": true,
-                          "items": [
-                            [
-                              {
-                                "title": "`getOrganization()`",
-                                "wrap": false,
-                                "href": "/docs/references/backend/organization/get-organization"
-                              },
-                              {
-                                "title": "`getOrganizationList()`",
-                                "wrap": false,
-                                "href": "/docs/references/backend/organization/get-organization-list"
-                              },
-                              {
-                                "title": "`getOrganizationInvitation()`",
-                                "wrap": false,
-                                "href": "/docs/references/backend/organization/get-organization-invitation"
-                              },
-                              {
-                                "title": "`getOrganizationMembershipList()`",
-                                "wrap": false,
-                                "href": "/docs/references/backend/organization/get-organization-membership-list"
-                              },
-                              {
-                                "title": "`getOrganizationInvitationList()`",
-                                "wrap": false,
-                                "href": "/docs/references/backend/organization/get-organization-invitation-list"
-                              },
-                              {
-                                "title": "`createOrganization()`",
-                                "wrap": false,
-                                "href": "/docs/references/backend/organization/create-organization"
-                              },
-                              {
-                                "title": "`createOrganizationMembership()`",
-                                "wrap": false,
-                                "href": "/docs/references/backend/organization/create-organization-membership"
-                              },
-                              {
-                                "title": "`createOrganizationInvitation()`",
-                                "wrap": false,
-                                "href": "/docs/references/backend/organization/create-organization-invitation"
-                              },
-                              {
-                                "title": "`createOrganizationInvitationBulk()`",
-                                "wrap": false,
-                                "href": "/docs/references/backend/organization/create-organization-invitation-bulk"
-                              },
-                              {
-                                "title": "`updateOrganization()`",
-                                "wrap": false,
-                                "href": "/docs/references/backend/organization/update-organization"
-                              },
-                              {
-                                "title": "`updateOrganizationLogo()`",
-                                "wrap": false,
-                                "href": "/docs/references/backend/organization/update-organization-logo"
-                              },
-                              {
-                                "title": "`updateOrganizationMembership()`",
-                                "wrap": false,
-                                "href": "/docs/references/backend/organization/update-organization-membership"
-                              },
-                              {
-                                "title": "`updateOrganizationMetadata()`",
-                                "wrap": false,
-                                "href": "/docs/references/backend/organization/update-organization-metadata"
-                              },
-                              {
-                                "title": "`updateOrganizationMembershipMetadata()`",
-                                "wrap": false,
-                                "href": "/docs/references/backend/organization/update-organization-membership-metadata"
-                              },
-                              {
-                                "title": "`deleteOrganization()`",
-                                "wrap": false,
-                                "href": "/docs/references/backend/organization/delete-organization"
-                              },
-                              {
-                                "title": "`deleteOrganizationLogo()`",
-                                "wrap": false,
-                                "href": "/docs/references/backend/organization/delete-organization-logo"
-                              },
-                              {
-                                "title": "`deleteOrganizationMembership()`",
-                                "wrap": false,
-                                "href": "/docs/references/backend/organization/delete-organization-membership"
-                              },
-                              {
-                                "title": "`revokeOrganizationInvitation()`",
-                                "wrap": false,
-                                "href": "/docs/references/backend/organization/revoke-organization-invitation"
-                              }
-                            ]
-                          ]
-                        },
-                        {
-                          "title": "Allowlist Identifiers",
-                          "collapse": true,
-                          "items": [
-                            [
-                              {
-                                "title": "`getAllowlistIdentifierList()`",
-                                "wrap": false,
-                                "href": "/docs/references/backend/allowlist/get-allowlist-identifier-list"
-                              },
-                              {
-                                "title": "`createAllowlistIdentifier()`",
-                                "wrap": false,
-                                "href": "/docs/references/backend/allowlist/create-allowlist-identifier"
-                              },
-                              {
-                                "title": "`deleteAllowlistIdentifier()`",
-                                "wrap": false,
-                                "href": "/docs/references/backend/allowlist/delete-allowlist-identifier"
-                              }
-                            ]
-                          ]
-                        },
-                        {
-                          "title": "Domains",
-                          "collapse": true,
-                          "items": [
-                            [
-                              {
-                                "title": "`deleteDomain()`",
-                                "wrap": false,
-                                "href": "/docs/references/backend/domains/delete-domain"
-                              }
-                            ]
-                          ]
-                        },
-                        {
-                          "title": "Sessions",
-                          "collapse": true,
-                          "items": [
-                            [
-                              {
-                                "title": "`getSession()`",
-                                "wrap": false,
-                                "href": "/docs/references/backend/sessions/get-session"
-                              },
-                              {
-                                "title": "`getSessionList()`",
-                                "wrap": false,
-                                "href": "/docs/references/backend/sessions/get-session-list"
-                              },
-                              {
-                                "title": "`getToken()`",
-                                "wrap": false,
-                                "href": "/docs/references/backend/sessions/get-token"
-                              },
-                              {
-                                "title": "`verifySession()`",
-                                "wrap": false,
-                                "href": "/docs/references/backend/sessions/verify-session"
-                              },
-                              {
-                                "title": "`revokeSession()`",
-                                "wrap": false,
-                                "href": "/docs/references/backend/sessions/revoke-session"
-                              }
-                            ]
-                          ]
-                        },
-                        {
-                          "title": "Client",
-                          "collapse": true,
-                          "items": [
-                            [
-                              {
-                                "title": "`getClient()`",
-                                "wrap": false,
-                                "href": "/docs/references/backend/client/get-client"
-                              },
-                              {
-                                "title": "`getClientList()`",
-                                "wrap": false,
-                                "href": "/docs/references/backend/client/get-client-list"
-                              },
-                              {
-                                "title": "`verifyClient()`",
-                                "wrap": false,
-                                "href": "/docs/references/backend/client/verify-client"
-                              }
-                            ]
-                          ]
-                        },
-                        {
-                          "title": "Invitations",
-                          "collapse": true,
-                          "items": [
-                            [
-                              {
-                                "title": "`getInvitationList()`",
-                                "wrap": false,
-                                "href": "/docs/references/backend/invitations/get-invitation-list"
-                              },
-                              {
-                                "title": "`createInvitation()`",
-                                "wrap": false,
-                                "href": "/docs/references/backend/invitations/create-invitation"
-                              },
-                              {
-                                "title": "`revokeInvitation()`",
-                                "wrap": false,
-                                "href": "/docs/references/backend/invitations/revoke-invitation"
-                              }
-                            ]
-                          ]
-                        },
-                        {
-                          "title": "Redirect Urls",
-                          "collapse": true,
-                          "items": [
-                            [
-                              {
-                                "title": "`getRedirectUrl()`",
-                                "wrap": false,
-                                "href": "/docs/references/backend/redirect-urls/get-redirect-url"
-                              },
-                              {
-                                "title": "`getRedirectUrlList()`",
-                                "wrap": false,
-                                "href": "/docs/references/backend/redirect-urls/get-redirect-url-list"
-                              },
-                              {
-                                "title": "`createRedirectUrl()`",
-                                "wrap": false,
-                                "href": "/docs/references/backend/redirect-urls/create-redirect-url"
-                              },
-                              {
-                                "title": "`deleteRedirectUrl()`",
-                                "wrap": false,
-                                "href": "/docs/references/backend/redirect-urls/delete-redirect-url"
-                              }
-                            ]
-                          ]
-                        },
-                        {
-                          "title": "Email addresses",
-                          "collapse": true,
-                          "items": [
-                            [
-                              {
-                                "title": "`getEmailAddress()`",
-                                "wrap": false,
-                                "href": "/docs/references/backend/email-addresses/get-email-address"
-                              },
-                              {
-                                "title": "`createEmailAddress()`",
-                                "wrap": false,
-                                "href": "/docs/references/backend/email-addresses/create-email-address"
-                              },
-                              {
-                                "title": "`updateEmailAddress()`",
-                                "wrap": false,
-                                "href": "/docs/references/backend/email-addresses/update-email-address"
-                              },
-                              {
-                                "title": "`deleteEmailAddress()`",
-                                "wrap": false,
-                                "href": "/docs/references/backend/email-addresses/delete-email-address"
-                              }
-                            ]
-                          ]
-                        },
-                        {
-                          "title": "Phone numbers",
-                          "collapse": true,
-                          "items": [
-                            [
-                              {
-                                "title": "`getPhoneNumber()`",
-                                "wrap": false,
-                                "href": "/docs/references/backend/phone-numbers/get-phone-number"
-                              },
-                              {
-                                "title": "`createPhoneNumber()`",
-                                "wrap": false,
-                                "href": "/docs/references/backend/phone-numbers/create-phone-number"
-                              },
-                              {
-                                "title": "`updatePhoneNumber()`",
-                                "wrap": false,
-                                "href": "/docs/references/backend/phone-numbers/update-phone-number"
-                              },
-                              {
-                                "title": "`deletePhoneNumber()`",
-                                "wrap": false,
-                                "href": "/docs/references/backend/phone-numbers/delete-phone-number"
-                              }
-                            ]
-                          ]
-                        },
-                        {
-                          "title": "SAML connections",
-                          "collapse": true,
-                          "items": [
-                            [
-                              {
-                                "title": "`getSamlConnectionList()`",
-                                "wrap": false,
-                                "href": "/docs/references/backend/saml-connections/get-saml-connection-list"
-                              },
-                              {
-                                "title": "`getSamlConnection()`",
-                                "wrap": false,
-                                "href": "/docs/references/backend/saml-connections/get-saml-connection"
-                              },
-                              {
-                                "title": "`createSamlConnection()`",
-                                "wrap": false,
-                                "href": "/docs/references/backend/saml-connections/create-saml-connection"
-                              },
-                              {
-                                "title": "`updateSamlConnection()`",
-                                "wrap": false,
-                                "href": "/docs/references/backend/saml-connections/update-saml-connection"
-                              },
-                              {
-                                "title": "`deleteSamlConnection()`",
-                                "wrap": false,
-                                "href": "/docs/references/backend/saml-connections/delete-saml-connection"
-                              }
-                            ]
-                          ]
-                        },
-                        {
-                          "title": "Sign-in tokens",
-                          "collapse": true,
-                          "items": [
-                            [
-                              {
-                                "title": "`createSignInToken()`",
-                                "wrap": false,
-                                "href": "/docs/references/backend/sign-in-tokens/create-sign-in-token"
-                              },
-                              {
-                                "title": "`revokeSignInToken()`",
-                                "wrap": false,
-                                "href": "/docs/references/backend/sign-in-tokens/revoke-sign-in-token"
-                              }
-                            ]
-                          ]
-                        },
-                        {
-                          "title": "Testing Tokens",
-                          "collapse": true,
-                          "items": [
-                            [
-                              {
-                                "title": "`createTestingToken()`",
-                                "wrap": false,
-                                "href": "/docs/references/backend/testing-tokens/create-testing-token"
-                              }
-                            ]
-                          ]
-                        },
-                        {
-                          "title": "`authenticateRequest()`",
-                          "wrap": false,
-                          "href": "/docs/references/backend/authenticate-request"
-                        },
-                        {
-                          "title": "`verifyToken()`",
-                          "wrap": false,
-                          "href": "/docs/references/backend/verify-token"
-                        },
-                        {
-                          "title": "`verifyWebhook()`",
-                          "wrap": false,
-                          "href": "/docs/references/backend/verify-webhook"
-                        },
-                        {
-                          "title": "Types",
-                          "collapse": true,
-                          "items": [
-                            [
-                              {
-                                "title": "`Auth` object",
-                                "href": "/docs/references/backend/types/auth-object"
-                              },
-                              {
-                                "title": "Backend `AllowlistIdentifier` object",
-                                "href": "/docs/references/backend/types/backend-allowlist-identifier"
-                              },
-                              {
-                                "title": "Backend `EmailAddress` object",
-                                "href": "/docs/references/backend/types/backend-email-address"
-                              },
-                              {
-                                "title": "Backend `ExternalAccount` object",
-                                "href": "/docs/references/backend/types/backend-external-account"
-                              },
-                              {
-                                "title": "Backend `Client` object",
-                                "href": "/docs/references/backend/types/backend-client"
-                              },
-                              {
-                                "title": "Backend `IdentificationLink` object",
-                                "href": "/docs/references/backend/types/backend-identification-link"
-                              },
-                              {
-                                "title": "Backend `Invitation` object",
-                                "href": "/docs/references/backend/types/backend-invitation"
-                              },
-                              {
-                                "title": "Backend `Organization` object",
-                                "href": "/docs/references/backend/types/backend-organization"
-                              },
-                              {
-                                "title": "Backend `OrganizationInvitation` object",
-                                "href": "/docs/references/backend/types/backend-organization-invitation"
-                              },
-                              {
-                                "title": "Backend `OrganizationMembership` object",
-                                "href": "/docs/references/backend/types/backend-organization-membership"
-                              },
-                              {
-                                "title": "Backend `PhoneNumber` object",
-                                "href": "/docs/references/backend/types/backend-phone-number"
-                              },
-                              {
-                                "title": "Backend `SamlAccount` object",
-                                "href": "/docs/references/backend/types/backend-saml-account"
-                              },
-                              {
-                                "title": "Backend `SamlConnection` object",
-                                "href": "/docs/references/backend/types/backend-saml-connection"
-                              },
-                              {
-                                "title": "Backend `Session` object",
-                                "href": "/docs/references/backend/types/backend-session"
-                              },
-                              {
-                                "title": "Backend `SessionActivity` object",
-                                "href": "/docs/references/backend/types/backend-session-activity"
-                              },
-                              {
-                                "title": "Backend `RedirectURL` object",
-                                "href": "/docs/references/backend/types/backend-redirect-url"
-                              },
-                              {
-                                "title": "Backend `User` object",
-                                "href": "/docs/references/backend/types/backend-user"
-                              },
-                              {
-                                "title": "Backend `Verification` object",
-                                "href": "/docs/references/backend/types/backend-verification"
-                              },
-                              {
-                                "title": "Backend `Web3Wallet` object",
-                                "href": "/docs/references/backend/types/backend-web3-wallet"
-                              },
-                              {
-                                "title": "`PaginatedResourceResponse`",
-                                "href": "/docs/references/backend/types/paginated-resource-response"
-                              }
-                            ]
-                          ]
-                        }
-                      ]
-                    ]
                   }
                 ]
               ]
@@ -1508,23 +454,7 @@
                     ]
                   },
                   {
-                    "title": "References",
-                    "items": [
-                      [
-                        {
-                          "title": "Overview",
-                          "href": "/docs/references/nuxt/overview"
-                        },
-                        {
-                          "title": "`clerkMiddleware()`",
-                          "wrap": false,
-                          "href": "/docs/references/nuxt/clerk-middleware"
-                        }
-                      ]
-                    ]
-                  },
-                  {
-                    "title": "Guides",
+                    "title": "Nuxt Guides",
                     "items": [
                       [
                         {
@@ -1565,27 +495,7 @@
                     ]
                   },
                   {
-                    "title": "References",
-                    "items": [
-                      [
-                        {
-                          "title": "Overview",
-                          "href": "/docs/references/react-router/overview"
-                        },
-                        {
-                          "title": "`rootAuthLoader()`",
-                          "wrap": false,
-                          "href": "/docs/references/react-router/root-auth-loader"
-                        },
-                        {
-                          "title": "`getAuth()`",
-                          "href": "/docs/references/react-router/get-auth"
-                        }
-                      ]
-                    ]
-                  },
-                  {
-                    "title": "Guides",
+                    "title": "React Router Guides",
                     "items": [
                       [
                         {
@@ -1636,28 +546,7 @@
                     ]
                   },
                   {
-                    "title": "References",
-                    "items": [
-                      [
-                        {
-                          "title": "Overview",
-                          "href": "/docs/references/remix/overview"
-                        },
-                        {
-                          "title": "`ClerkApp`",
-                          "wrap": false,
-                          "href": "/docs/references/remix/clerk-app"
-                        },
-                        {
-                          "title": "`rootAuthLoader()`",
-                          "wrap": false,
-                          "href": "/docs/references/remix/root-auth-loader"
-                        }
-                      ]
-                    ]
-                  },
-                  {
-                    "title": "Guides",
+                    "title": "Remix Guides",
                     "items": [
                       [
                         {
@@ -1708,18 +597,7 @@
                     ]
                   },
                   {
-                    "title": "References",
-                    "items": [
-                      [
-                        {
-                          "title": "Overview",
-                          "href": "/docs/references/ruby/overview"
-                        }
-                      ]
-                    ]
-                  },
-                  {
-                    "title": "Guides",
+                    "title": "Ruby Guides",
                     "items": [
                       [
                         {
@@ -1766,26 +644,7 @@
                     ]
                   },
                   {
-                    "title": "References",
-                    "items": [
-                      [
-                        {
-                          "title": "Overview",
-                          "href": "/docs/references/tanstack-react-start/overview"
-                        },
-                        {
-                          "title": "`getAuth()`",
-                          "href": "/docs/references/tanstack-react-start/get-auth"
-                        },
-                        {
-                          "title": "`createClerkHandler()`",
-                          "href": "/docs/references/tanstack-react-start/create-clerk-handler"
-                        }
-                      ]
-                    ]
-                  },
-                  {
-                    "title": "Guides",
+                    "title": "TanStack React Start Guides",
                     "items": [
                       [
                         {
@@ -1836,73 +695,7 @@
                     ]
                   },
                   {
-                    "title": "References",
-                    "items": [
-                      [
-                        {
-                          "title": "Overview",
-                          "href": "/docs/references/vue/overview"
-                        },
-                        {
-                          "title": "`clerkPlugin`",
-                          "href": "/docs/references/vue/clerk-plugin"
-                        },
-                        {
-                          "title": "`updateClerkOptions()`",
-                          "href": "/docs/references/vue/update-clerk-options"
-                        },
-                        {
-                          "title": "Client-side helpers",
-                          "items": [
-                            [
-                              {
-                                "title": "`useUser()`",
-                                "wrap": false,
-                                "href": "/docs/references/vue/use-user"
-                              },
-                              {
-                                "title": "`useClerk()`",
-                                "wrap": false,
-                                "href": "/docs/references/vue/use-clerk"
-                              },
-                              {
-                                "title": "`useAuth()`",
-                                "wrap": false,
-                                "href": "/docs/references/vue/use-auth"
-                              },
-                              {
-                                "title": "`useSignIn()`",
-                                "wrap": false,
-                                "href": "/docs/references/vue/use-sign-in"
-                              },
-                              {
-                                "title": "`useSignUp`",
-                                "wrap": false,
-                                "href": "/docs/references/vue/use-sign-up"
-                              },
-                              {
-                                "title": "`useSession()`",
-                                "wrap": false,
-                                "href": "/docs/references/vue/use-session"
-                              },
-                              {
-                                "title": "`useSessionList()`",
-                                "wrap": false,
-                                "href": "/docs/references/vue/use-session-list"
-                              },
-                              {
-                                "title": "`useOrganization()`",
-                                "wrap": false,
-                                "href": "/docs/references/vue/use-organization"
-                              }
-                            ]
-                          ]
-                        }
-                      ]
-                    ]
-                  },
-                  {
-                    "title": "Guides",
+                    "title": "Vue Guides",
                     "items": [
                       [
                         {
@@ -3303,6 +2096,1394 @@
                         {
                           "title": "Progressive sign-up",
                           "href": "/docs/upgrade-guides/progressive-sign-up"
+                        }
+                      ]
+                    ]
+                  }
+                ]
+              ]
+            }
+          ]
+        ]
+      },
+      {
+        "title": "SDK Reference",
+        "items": [
+          [
+            {
+              "title": "Next.js",
+              "hideTitle": true,
+              "sdk": ["nextjs"],
+              "items": [
+                [
+                  {
+                    "title": "References",
+                    "hideTitle": true,
+                    "items": [
+                      [
+                        {
+                          "title": "Overview",
+                          "href": "/docs/references/nextjs/overview"
+                        },
+                        {
+                          "title": "`clerkMiddleware()`",
+                          "wrap": false,
+                          "href": "/docs/references/nextjs/clerk-middleware"
+                        }
+                      ]
+                    ]
+                  },
+                  {
+                    "title": "App Router References",
+                    "collapse": true,
+                    "items": [
+                      [
+                        {
+                          "title": "`auth()`",
+                          "wrap": false,
+                          "href": "/docs/references/nextjs/auth"
+                        },
+                        {
+                          "title": "`currentUser()`",
+                          "wrap": false,
+                          "href": "/docs/references/nextjs/current-user"
+                        },
+                        {
+                          "title": "Route Handlers",
+                          "href": "/docs/references/nextjs/route-handlers"
+                        },
+                        {
+                          "title": "Server Actions",
+                          "href": "/docs/references/nextjs/server-actions"
+                        }
+                      ]
+                    ]
+                  },
+                  {
+                    "title": "Pages Router References",
+                    "collapse": true,
+                    "items": [
+                      [
+                        {
+                          "title": "`getAuth()`",
+                          "wrap": false,
+                          "href": "/docs/references/nextjs/get-auth"
+                        },
+                        {
+                          "title": "`buildClerkProps()`",
+                          "wrap": false,
+                          "href": "/docs/references/nextjs/build-clerk-props"
+                        }
+                      ]
+                    ]
+                  },
+                  {
+                    "title": "Demo Repositories",
+                    "collapse": true,
+                    "items": [
+                      [
+                        {
+                          "title": "App Router Demo Repo",
+                          "href": "https://github.com/clerk/clerk-nextjs-demo-app-router"
+                        },
+                        {
+                          "title": "Pages Router Demo Repo",
+                          "href": "https://github.com/clerk/clerk-nextjs-demo-pages-router"
+                        }
+                      ]
+                    ]
+                  }
+                ]
+              ]
+            },
+            {
+              "title": "React",
+              "hideTitle": true,
+              "sdk": ["react"],
+              "items": [
+                [
+                  {
+                    "title": "References",
+                    "hideTitle": true,
+                    "items": [
+                      [
+                        {
+                          "title": "Overview",
+                          "href": "/docs/references/react/overview"
+                        }
+                      ]
+                    ]
+                  },
+                  {
+                    "title": "Demo Repository",
+                    "collapse": true,
+                    "items": [
+                      [
+                        {
+                          "title": "React Demo Repo",
+                          "href": "https://github.com/clerk/clerk-react-quickstart"
+                        }
+                      ]
+                    ]
+                  }
+                ]
+              ]
+            },
+            {
+              "title": "JavaScript",
+              "hideTitle": true,
+              "sdk": ["js-frontend"],
+              "items": [
+                [
+                  {
+                    "title": "References",
+                    "hideTitle": true,
+                    "items": [
+                      [
+                        {
+                          "title": "Overview",
+                          "href": "/docs/references/javascript/overview"
+                        },
+                        {
+                          "title": "`Clerk`",
+                          "href": "/docs/references/javascript/clerk"
+                        },
+                        {
+                          "title": "`Client`",
+                          "href": "/docs/references/javascript/client"
+                        },
+                        {
+                          "title": "`Session`",
+                          "href": "/docs/references/javascript/session"
+                        },
+                        {
+                          "title": "`User`",
+                          "href": "/docs/references/javascript/user"
+                        },
+                        {
+                          "title": "`SignIn`",
+                          "href": "/docs/references/javascript/sign-in"
+                        },
+                        {
+                          "title": "`SignUp`",
+                          "href": "/docs/references/javascript/sign-up"
+                        },
+                        {
+                          "title": "`Organization`",
+                          "href": "/docs/references/javascript/organization"
+                        },
+                        {
+                          "title": "Types",
+                          "collapse": true,
+                          "items": [
+                            [
+                              {
+                                "title": "Overview",
+                                "href": "/docs/references/javascript/types/overview"
+                              },
+                              {
+                                "title": "`BackupCodeResource`",
+                                "href": "/docs/references/javascript/types/backup-code"
+                              },
+                              {
+                                "title": "`ClerkAPIError`",
+                                "href": "/docs/references/javascript/types/clerk-api-error"
+                              },
+                              {
+                                "title": "`ClerkPaginatedResponse`",
+                                "href": "/docs/references/javascript/types/clerk-paginated-response"
+                              },
+                              {
+                                "title": "`CustomMenuItem`",
+                                "href": "/docs/references/javascript/types/custom-menu-item"
+                              },
+                              {
+                                "title": "`CustomPage`",
+                                "href": "/docs/references/javascript/types/custom-page"
+                              },
+                              {
+                                "title": "`DeletedObject`",
+                                "href": "/docs/references/javascript/types/deleted-object"
+                              },
+                              {
+                                "title": "`EmailAddress`",
+                                "href": "/docs/references/javascript/types/email-address"
+                              },
+                              {
+                                "title": "`EmailLinkError`",
+                                "href": "/docs/references/javascript/types/email-link-error"
+                              },
+                              {
+                                "title": "`EnterpriseAccount`",
+                                "href": "/docs/references/javascript/types/enterprise-account"
+                              },
+                              {
+                                "title": "`EnterpriseAccountConnection`",
+                                "href": "/docs/references/javascript/types/enterprise-account-connection"
+                              },
+                              {
+                                "title": "`ExternalAccount`",
+                                "href": "/docs/references/javascript/types/external-account"
+                              },
+                              {
+                                "title": "Metadata types",
+                                "href": "/docs/references/javascript/types/metadata"
+                              },
+                              {
+                                "title": "`OrganizationCustomRoleKey`",
+                                "href": "/docs/references/javascript/types/organization-custom-role-key"
+                              },
+                              {
+                                "title": "`OrganizationCustomPermissionKey`",
+                                "href": "/docs/references/javascript/types/organization-custom-permission-key"
+                              },
+                              {
+                                "title": "`OrganizationDomain`",
+                                "href": "/docs/references/javascript/types/organization-domain"
+                              },
+                              {
+                                "title": "`OrganizationInvitation`",
+                                "href": "/docs/references/javascript/types/organization-invitation"
+                              },
+                              {
+                                "title": "`OrganizationMembership`",
+                                "href": "/docs/references/javascript/types/organization-membership"
+                              },
+                              {
+                                "title": "`OrganizationMembershipRequest`",
+                                "href": "/docs/references/javascript/types/organization-membership-request"
+                              },
+                              {
+                                "title": "`OrganizationSuggestion`",
+                                "href": "/docs/references/javascript/types/organization-suggestion"
+                              },
+                              {
+                                "title": "`PasskeyResource`",
+                                "href": "/docs/references/javascript/types/passkey-resource"
+                              },
+                              {
+                                "title": "`PermissionResource`",
+                                "href": "/docs/references/javascript/types/permission"
+                              },
+                              {
+                                "title": "`PhoneNumber`",
+                                "href": "/docs/references/javascript/types/phone-number"
+                              },
+                              {
+                                "title": "`PublicUserData`",
+                                "href": "/docs/references/javascript/types/public-user-data"
+                              },
+                              {
+                                "title": "`RedirectOptions`",
+                                "href": "/docs/references/javascript/types/redirect-options"
+                              },
+                              {
+                                "title": "`RoleResource`",
+                                "href": "/docs/references/javascript/types/role"
+                              },
+                              {
+                                "title": "`SamlAccount`",
+                                "href": "/docs/references/javascript/types/saml-account"
+                              },
+                              {
+                                "title": "`SamlAccountConnection`",
+                                "href": "/docs/references/javascript/types/saml-account-connection"
+                              },
+                              {
+                                "title": "`SessionStatus`",
+                                "href": "/docs/references/javascript/types/session-status"
+                              },
+                              {
+                                "title": "`SessionVerification`",
+                                "href": "/docs/references/javascript/types/session-verification"
+                              },
+                              {
+                                "title": "`SessionWithActivities`",
+                                "href": "/docs/references/javascript/types/session-with-activities"
+                              },
+                              {
+                                "title": "`SetActiveParams`",
+                                "href": "/docs/references/javascript/types/set-active-params"
+                              },
+                              {
+                                "title": "`SignInFirstFactor`",
+                                "href": "/docs/references/javascript/types/sign-in-first-factor"
+                              },
+                              {
+                                "title": "`SignInSecondFactor`",
+                                "href": "/docs/references/javascript/types/sign-in-second-factor"
+                              },
+                              {
+                                "title": "`SignInRedirectOptions`",
+                                "href": "/docs/references/javascript/types/sign-in-redirect-options"
+                              },
+                              {
+                                "title": "`SignUpRedirectOptions`",
+                                "href": "/docs/references/javascript/types/sign-up-redirect-options"
+                              },
+                              {
+                                "title": "`SignInInitialValues`",
+                                "href": "/docs/references/javascript/types/sign-in-initial-values"
+                              },
+                              {
+                                "title": "`SignUpInitialValues`",
+                                "href": "/docs/references/javascript/types/sign-up-initial-values"
+                              },
+                              {
+                                "title": "SSO types",
+                                "href": "/docs/references/javascript/types/sso"
+                              },
+                              {
+                                "title": "`TOTPResource`",
+                                "href": "/docs/references/javascript/types/totp"
+                              },
+                              {
+                                "title": "`UserOrganizationInvitation`",
+                                "href": "/docs/references/javascript/types/user-organization-invitation"
+                              },
+                              {
+                                "title": "`Verification`",
+                                "href": "/docs/references/javascript/types/verification"
+                              },
+                              {
+                                "title": "`Web3Wallet`",
+                                "href": "/docs/references/javascript/types/web3-wallet"
+                              }
+                            ]
+                          ]
+                        }
+                      ]
+                    ]
+                  }
+                ]
+              ]
+            },
+            {
+              "title": "Astro",
+              "hideTitle": true,
+              "sdk": ["astro"],
+              "items": [
+                [
+                  {
+                    "title": "References",
+                    "hideTitle": true,
+                    "items": [
+                      [
+                        {
+                          "title": "Overview",
+                          "href": "/docs/references/astro/overview"
+                        },
+                        {
+                          "title": "`clerkMiddleware()`",
+                          "wrap": false,
+                          "href": "/docs/references/astro/clerk-middleware"
+                        },
+                        {
+                          "title": "`updateClerkOptions()`",
+                          "href": "/docs/references/astro/update-clerk-options"
+                        },
+                        {
+                          "title": "Integration",
+                          "href": "/docs/references/astro/integration"
+                        },
+                        {
+                          "title": "Locals",
+                          "wrap": false,
+                          "href": "/docs/references/astro/locals"
+                        }
+                      ]
+                    ]
+                  },
+                  {
+                    "title": "Client-side helpers",
+                    "collapse": true,
+                    "items": [
+                      [
+                        {
+                          "title": "`$authStore`",
+                          "wrap": false,
+                          "href": "/docs/references/astro/auth-store"
+                        },
+                        {
+                          "title": "`$clerkStore`",
+                          "wrap": false,
+                          "href": "/docs/references/astro/clerk-store"
+                        },
+                        {
+                          "title": "`$userStore`",
+                          "wrap": false,
+                          "href": "/docs/references/astro/user-store"
+                        },
+                        {
+                          "title": "`$signInStore`",
+                          "wrap": false,
+                          "href": "/docs/references/astro/sign-in-store"
+                        },
+                        {
+                          "title": "`$signUpStore`",
+                          "wrap": false,
+                          "href": "/docs/references/astro/sign-up-store"
+                        },
+                        {
+                          "title": "`$sessionStore`",
+                          "wrap": false,
+                          "href": "/docs/references/astro/session-store"
+                        },
+                        {
+                          "title": "`$sessionListStore`",
+                          "wrap": false,
+                          "href": "/docs/references/astro/session-list-store"
+                        },
+                        {
+                          "title": "`$organizationStore`",
+                          "wrap": false,
+                          "href": "/docs/references/astro/organization-store"
+                        }
+                      ]
+                    ]
+                  }
+                ]
+              ]
+            },
+            {
+              "title": "Chrome Extension",
+              "hideTitle": true,
+              "sdk": ["chrome-extension"],
+              "items": [
+                [
+                  {
+                    "title": "References",
+                    "hideTitle": true,
+                    "items": [
+                      [
+                        {
+                          "title": "Overview",
+                          "href": "/docs/references/chrome-extension/overview"
+                        }
+                      ]
+                    ]
+                  }
+                ]
+              ]
+            },
+            {
+              "title": "Expo",
+              "hideTitle": true,
+              "sdk": ["expo"],
+              "items": [
+                [
+                  {
+                    "title": "References",
+                    "hideTitle": true,
+                    "items": [
+                      [
+                        {
+                          "title": "Overview",
+                          "href": "/docs/references/expo/overview"
+                        },
+                        {
+                          "title": "`useLocalCredentials()`",
+                          "href": "/docs/references/expo/use-local-credentials"
+                        },
+                        {
+                          "title": "`useOAuth()` (deprecated)",
+                          "href": "/docs/references/expo/use-oauth"
+                        },
+                        {
+                          "title": "`useSSO()`",
+                          "href": "/docs/references/expo/use-sso"
+                        }
+                      ]
+                    ]
+                  },
+                  {
+                    "title": "Web support",
+                    "collapse": true,
+                    "items": [
+                      [
+                        {
+                          "title": "Overview",
+                          "href": "/docs/references/expo/web-support/overview"
+                        },
+                        {
+                          "title": "Add a custom sign-in-or-up page",
+                          "href": "/docs/references/expo/web-support/custom-sign-in-or-up-page"
+                        },
+                        {
+                          "title": "Add a custom sign-up page",
+                          "href": "/docs/references/expo/web-support/custom-sign-up-page"
+                        }
+                      ]
+                    ]
+                  }
+                ]
+              ]
+            },
+            {
+              "title": "Express",
+              "hideTitle": true,
+              "sdk": ["expressjs"],
+              "items": [
+                [
+                  {
+                    "title": "References",
+                    "hideTitle": true,
+                    "items": [
+                      [
+                        {
+                          "title": "Overview",
+                          "href": "/docs/references/express/overview"
+                        }
+                      ]
+                    ]
+                  }
+                ]
+              ]
+            },
+            {
+              "title": "Fastify",
+              "hideTitle": true,
+              "sdk": ["fastify"],
+              "items": [
+                [
+                  {
+                    "title": "References",
+                    "hideTitle": true,
+                    "items": [
+                      [
+                        {
+                          "title": "Overview",
+                          "href": "/docs/references/fastify/overview"
+                        }
+                      ]
+                    ]
+                  }
+                ]
+              ]
+            },
+            {
+              "title": "Go",
+              "hideTitle": true,
+              "sdk": ["go"],
+              "items": [
+                [
+                  {
+                    "title": "Go SDK repository",
+                    "href": "https://github.com/clerk/clerk-sdk-go"
+                  }
+                ]
+              ]
+            },
+            {
+              "title": "iOS",
+              "hideTitle": true,
+              "sdk": ["ios"],
+              "items": [
+                [
+                  {
+                    "title": "References",
+                    "hideTitle": true,
+                    "items": [
+                      [
+                        {
+                          "title": "Overview",
+                          "href": "/docs/references/ios/overview"
+                        },
+                        {
+                          "title": "`getToken()`",
+                          "href": "/docs/references/ios/get-token"
+                        }
+                      ]
+                    ]
+                  }
+                ]
+              ]
+            },
+            {
+              "title": "JS Backend SDK",
+              "hideTitle": true,
+              "sdk": ["js-backend"],
+              "items": [
+                [
+                  {
+                    "title": "References",
+                    "hideTitle": true,
+                    "items": [
+                      [
+                        {
+                          "title": "User",
+                          "collapse": true,
+                          "items": [
+                            [
+                              {
+                                "title": "`getUserList()`",
+                                "wrap": false,
+                                "href": "/docs/references/backend/user/get-user-list"
+                              },
+                              {
+                                "title": "`getUser()`",
+                                "wrap": false,
+                                "href": "/docs/references/backend/user/get-user"
+                              },
+                              {
+                                "title": "`getCount()`",
+                                "wrap": false,
+                                "href": "/docs/references/backend/user/get-count"
+                              },
+                              {
+                                "title": "`getOrganizationMembershipList()`",
+                                "wrap": false,
+                                "href": "/docs/references/backend/user/get-organization-membership-list"
+                              },
+                              {
+                                "title": "`getUserOAuthAccessToken()`",
+                                "wrap": false,
+                                "href": "/docs/references/backend/user/get-user-oauth-access-token"
+                              },
+                              {
+                                "title": "`createUser()`",
+                                "wrap": false,
+                                "href": "/docs/references/backend/user/create-user"
+                              },
+                              {
+                                "title": "`verifyPassword()`",
+                                "wrap": false,
+                                "href": "/docs/references/backend/user/verify-password"
+                              },
+                              {
+                                "title": "`banUser()`",
+                                "wrap": false,
+                                "href": "/docs/references/backend/user/ban-user"
+                              },
+                              {
+                                "title": "`unbanUser()`",
+                                "wrap": false,
+                                "href": "/docs/references/backend/user/unban-user"
+                              },
+                              {
+                                "title": "`lockUser()`",
+                                "wrap": false,
+                                "href": "/docs/references/backend/user/lock-user"
+                              },
+                              {
+                                "title": "`unlockUser()`",
+                                "wrap": false,
+                                "href": "/docs/references/backend/user/unlock-user"
+                              },
+                              {
+                                "title": "`updateUser()`",
+                                "wrap": false,
+                                "href": "/docs/references/backend/user/update-user"
+                              },
+                              {
+                                "title": "`updateUserProfileImage()`",
+                                "wrap": false,
+                                "href": "/docs/references/backend/user/update-user-profile-image"
+                              },
+                              {
+                                "title": "`updateUserMetadata()`",
+                                "wrap": false,
+                                "href": "/docs/references/backend/user/update-user-metadata"
+                              },
+                              {
+                                "title": "`deleteUser()`",
+                                "wrap": false,
+                                "href": "/docs/references/backend/user/delete-user"
+                              },
+                              {
+                                "title": "`disableUserMFA()`",
+                                "wrap": false,
+                                "href": "/docs/references/backend/user/disable-user-mfa"
+                              },
+                              {
+                                "title": "`verifyTOTP()`",
+                                "wrap": false,
+                                "href": "/docs/references/backend/user/verify-totp"
+                              },
+                              {
+                                "title": "`deleteUserProfileImage()`",
+                                "wrap": false,
+                                "href": "/docs/references/backend/user/delete-user-profile-image"
+                              }
+                            ]
+                          ]
+                        },
+                        {
+                          "title": "Organization",
+                          "collapse": true,
+                          "items": [
+                            [
+                              {
+                                "title": "`getOrganization()`",
+                                "wrap": false,
+                                "href": "/docs/references/backend/organization/get-organization"
+                              },
+                              {
+                                "title": "`getOrganizationList()`",
+                                "wrap": false,
+                                "href": "/docs/references/backend/organization/get-organization-list"
+                              },
+                              {
+                                "title": "`getOrganizationInvitation()`",
+                                "wrap": false,
+                                "href": "/docs/references/backend/organization/get-organization-invitation"
+                              },
+                              {
+                                "title": "`getOrganizationMembershipList()`",
+                                "wrap": false,
+                                "href": "/docs/references/backend/organization/get-organization-membership-list"
+                              },
+                              {
+                                "title": "`getOrganizationInvitationList()`",
+                                "wrap": false,
+                                "href": "/docs/references/backend/organization/get-organization-invitation-list"
+                              },
+                              {
+                                "title": "`createOrganization()`",
+                                "wrap": false,
+                                "href": "/docs/references/backend/organization/create-organization"
+                              },
+                              {
+                                "title": "`createOrganizationMembership()`",
+                                "wrap": false,
+                                "href": "/docs/references/backend/organization/create-organization-membership"
+                              },
+                              {
+                                "title": "`createOrganizationInvitation()`",
+                                "wrap": false,
+                                "href": "/docs/references/backend/organization/create-organization-invitation"
+                              },
+                              {
+                                "title": "`createOrganizationInvitationBulk()`",
+                                "wrap": false,
+                                "href": "/docs/references/backend/organization/create-organization-invitation-bulk"
+                              },
+                              {
+                                "title": "`updateOrganization()`",
+                                "wrap": false,
+                                "href": "/docs/references/backend/organization/update-organization"
+                              },
+                              {
+                                "title": "`updateOrganizationLogo()`",
+                                "wrap": false,
+                                "href": "/docs/references/backend/organization/update-organization-logo"
+                              },
+                              {
+                                "title": "`updateOrganizationMembership()`",
+                                "wrap": false,
+                                "href": "/docs/references/backend/organization/update-organization-membership"
+                              },
+                              {
+                                "title": "`updateOrganizationMetadata()`",
+                                "wrap": false,
+                                "href": "/docs/references/backend/organization/update-organization-metadata"
+                              },
+                              {
+                                "title": "`updateOrganizationMembershipMetadata()`",
+                                "wrap": false,
+                                "href": "/docs/references/backend/organization/update-organization-membership-metadata"
+                              },
+                              {
+                                "title": "`deleteOrganization()`",
+                                "wrap": false,
+                                "href": "/docs/references/backend/organization/delete-organization"
+                              },
+                              {
+                                "title": "`deleteOrganizationLogo()`",
+                                "wrap": false,
+                                "href": "/docs/references/backend/organization/delete-organization-logo"
+                              },
+                              {
+                                "title": "`deleteOrganizationMembership()`",
+                                "wrap": false,
+                                "href": "/docs/references/backend/organization/delete-organization-membership"
+                              },
+                              {
+                                "title": "`revokeOrganizationInvitation()`",
+                                "wrap": false,
+                                "href": "/docs/references/backend/organization/revoke-organization-invitation"
+                              }
+                            ]
+                          ]
+                        },
+                        {
+                          "title": "Allowlist Identifiers",
+                          "collapse": true,
+                          "items": [
+                            [
+                              {
+                                "title": "`getAllowlistIdentifierList()`",
+                                "wrap": false,
+                                "href": "/docs/references/backend/allowlist/get-allowlist-identifier-list"
+                              },
+                              {
+                                "title": "`createAllowlistIdentifier()`",
+                                "wrap": false,
+                                "href": "/docs/references/backend/allowlist/create-allowlist-identifier"
+                              },
+                              {
+                                "title": "`deleteAllowlistIdentifier()`",
+                                "wrap": false,
+                                "href": "/docs/references/backend/allowlist/delete-allowlist-identifier"
+                              }
+                            ]
+                          ]
+                        },
+                        {
+                          "title": "Domains",
+                          "collapse": true,
+                          "items": [
+                            [
+                              {
+                                "title": "`deleteDomain()`",
+                                "wrap": false,
+                                "href": "/docs/references/backend/domains/delete-domain"
+                              }
+                            ]
+                          ]
+                        },
+                        {
+                          "title": "Sessions",
+                          "collapse": true,
+                          "items": [
+                            [
+                              {
+                                "title": "`getSession()`",
+                                "wrap": false,
+                                "href": "/docs/references/backend/sessions/get-session"
+                              },
+                              {
+                                "title": "`getSessionList()`",
+                                "wrap": false,
+                                "href": "/docs/references/backend/sessions/get-session-list"
+                              },
+                              {
+                                "title": "`getToken()`",
+                                "wrap": false,
+                                "href": "/docs/references/backend/sessions/get-token"
+                              },
+                              {
+                                "title": "`verifySession()`",
+                                "wrap": false,
+                                "href": "/docs/references/backend/sessions/verify-session"
+                              },
+                              {
+                                "title": "`revokeSession()`",
+                                "wrap": false,
+                                "href": "/docs/references/backend/sessions/revoke-session"
+                              }
+                            ]
+                          ]
+                        },
+                        {
+                          "title": "Client",
+                          "collapse": true,
+                          "items": [
+                            [
+                              {
+                                "title": "`getClient()`",
+                                "wrap": false,
+                                "href": "/docs/references/backend/client/get-client"
+                              },
+                              {
+                                "title": "`getClientList()`",
+                                "wrap": false,
+                                "href": "/docs/references/backend/client/get-client-list"
+                              },
+                              {
+                                "title": "`verifyClient()`",
+                                "wrap": false,
+                                "href": "/docs/references/backend/client/verify-client"
+                              }
+                            ]
+                          ]
+                        },
+                        {
+                          "title": "Invitations",
+                          "collapse": true,
+                          "items": [
+                            [
+                              {
+                                "title": "`getInvitationList()`",
+                                "wrap": false,
+                                "href": "/docs/references/backend/invitations/get-invitation-list"
+                              },
+                              {
+                                "title": "`createInvitation()`",
+                                "wrap": false,
+                                "href": "/docs/references/backend/invitations/create-invitation"
+                              },
+                              {
+                                "title": "`revokeInvitation()`",
+                                "wrap": false,
+                                "href": "/docs/references/backend/invitations/revoke-invitation"
+                              }
+                            ]
+                          ]
+                        },
+                        {
+                          "title": "Redirect Urls",
+                          "collapse": true,
+                          "items": [
+                            [
+                              {
+                                "title": "`getRedirectUrl()`",
+                                "wrap": false,
+                                "href": "/docs/references/backend/redirect-urls/get-redirect-url"
+                              },
+                              {
+                                "title": "`getRedirectUrlList()`",
+                                "wrap": false,
+                                "href": "/docs/references/backend/redirect-urls/get-redirect-url-list"
+                              },
+                              {
+                                "title": "`createRedirectUrl()`",
+                                "wrap": false,
+                                "href": "/docs/references/backend/redirect-urls/create-redirect-url"
+                              },
+                              {
+                                "title": "`deleteRedirectUrl()`",
+                                "wrap": false,
+                                "href": "/docs/references/backend/redirect-urls/delete-redirect-url"
+                              }
+                            ]
+                          ]
+                        },
+                        {
+                          "title": "Email addresses",
+                          "collapse": true,
+                          "items": [
+                            [
+                              {
+                                "title": "`getEmailAddress()`",
+                                "wrap": false,
+                                "href": "/docs/references/backend/email-addresses/get-email-address"
+                              },
+                              {
+                                "title": "`createEmailAddress()`",
+                                "wrap": false,
+                                "href": "/docs/references/backend/email-addresses/create-email-address"
+                              },
+                              {
+                                "title": "`updateEmailAddress()`",
+                                "wrap": false,
+                                "href": "/docs/references/backend/email-addresses/update-email-address"
+                              },
+                              {
+                                "title": "`deleteEmailAddress()`",
+                                "wrap": false,
+                                "href": "/docs/references/backend/email-addresses/delete-email-address"
+                              }
+                            ]
+                          ]
+                        },
+                        {
+                          "title": "Phone numbers",
+                          "collapse": true,
+                          "items": [
+                            [
+                              {
+                                "title": "`getPhoneNumber()`",
+                                "wrap": false,
+                                "href": "/docs/references/backend/phone-numbers/get-phone-number"
+                              },
+                              {
+                                "title": "`createPhoneNumber()`",
+                                "wrap": false,
+                                "href": "/docs/references/backend/phone-numbers/create-phone-number"
+                              },
+                              {
+                                "title": "`updatePhoneNumber()`",
+                                "wrap": false,
+                                "href": "/docs/references/backend/phone-numbers/update-phone-number"
+                              },
+                              {
+                                "title": "`deletePhoneNumber()`",
+                                "wrap": false,
+                                "href": "/docs/references/backend/phone-numbers/delete-phone-number"
+                              }
+                            ]
+                          ]
+                        },
+                        {
+                          "title": "SAML connections",
+                          "collapse": true,
+                          "items": [
+                            [
+                              {
+                                "title": "`getSamlConnectionList()`",
+                                "wrap": false,
+                                "href": "/docs/references/backend/saml-connections/get-saml-connection-list"
+                              },
+                              {
+                                "title": "`getSamlConnection()`",
+                                "wrap": false,
+                                "href": "/docs/references/backend/saml-connections/get-saml-connection"
+                              },
+                              {
+                                "title": "`createSamlConnection()`",
+                                "wrap": false,
+                                "href": "/docs/references/backend/saml-connections/create-saml-connection"
+                              },
+                              {
+                                "title": "`updateSamlConnection()`",
+                                "wrap": false,
+                                "href": "/docs/references/backend/saml-connections/update-saml-connection"
+                              },
+                              {
+                                "title": "`deleteSamlConnection()`",
+                                "wrap": false,
+                                "href": "/docs/references/backend/saml-connections/delete-saml-connection"
+                              }
+                            ]
+                          ]
+                        },
+                        {
+                          "title": "Sign-in tokens",
+                          "collapse": true,
+                          "items": [
+                            [
+                              {
+                                "title": "`createSignInToken()`",
+                                "wrap": false,
+                                "href": "/docs/references/backend/sign-in-tokens/create-sign-in-token"
+                              },
+                              {
+                                "title": "`revokeSignInToken()`",
+                                "wrap": false,
+                                "href": "/docs/references/backend/sign-in-tokens/revoke-sign-in-token"
+                              }
+                            ]
+                          ]
+                        },
+                        {
+                          "title": "Testing Tokens",
+                          "collapse": true,
+                          "items": [
+                            [
+                              {
+                                "title": "`createTestingToken()`",
+                                "wrap": false,
+                                "href": "/docs/references/backend/testing-tokens/create-testing-token"
+                              }
+                            ]
+                          ]
+                        },
+                        {
+                          "title": "`authenticateRequest()`",
+                          "wrap": false,
+                          "href": "/docs/references/backend/authenticate-request"
+                        },
+                        {
+                          "title": "`verifyToken()`",
+                          "wrap": false,
+                          "href": "/docs/references/backend/verify-token"
+                        },
+                        {
+                          "title": "`verifyWebhook()`",
+                          "wrap": false,
+                          "href": "/docs/references/backend/verify-webhook"
+                        },
+                        {
+                          "title": "Types",
+                          "collapse": true,
+                          "items": [
+                            [
+                              {
+                                "title": "`Auth` object",
+                                "href": "/docs/references/backend/types/auth-object"
+                              },
+                              {
+                                "title": "Backend `AllowlistIdentifier` object",
+                                "href": "/docs/references/backend/types/backend-allowlist-identifier"
+                              },
+                              {
+                                "title": "Backend `EmailAddress` object",
+                                "href": "/docs/references/backend/types/backend-email-address"
+                              },
+                              {
+                                "title": "Backend `ExternalAccount` object",
+                                "href": "/docs/references/backend/types/backend-external-account"
+                              },
+                              {
+                                "title": "Backend `Client` object",
+                                "href": "/docs/references/backend/types/backend-client"
+                              },
+                              {
+                                "title": "Backend `IdentificationLink` object",
+                                "href": "/docs/references/backend/types/backend-identification-link"
+                              },
+                              {
+                                "title": "Backend `Invitation` object",
+                                "href": "/docs/references/backend/types/backend-invitation"
+                              },
+                              {
+                                "title": "Backend `Organization` object",
+                                "href": "/docs/references/backend/types/backend-organization"
+                              },
+                              {
+                                "title": "Backend `OrganizationInvitation` object",
+                                "href": "/docs/references/backend/types/backend-organization-invitation"
+                              },
+                              {
+                                "title": "Backend `OrganizationMembership` object",
+                                "href": "/docs/references/backend/types/backend-organization-membership"
+                              },
+                              {
+                                "title": "Backend `PhoneNumber` object",
+                                "href": "/docs/references/backend/types/backend-phone-number"
+                              },
+                              {
+                                "title": "Backend `SamlAccount` object",
+                                "href": "/docs/references/backend/types/backend-saml-account"
+                              },
+                              {
+                                "title": "Backend `SamlConnection` object",
+                                "href": "/docs/references/backend/types/backend-saml-connection"
+                              },
+                              {
+                                "title": "Backend `Session` object",
+                                "href": "/docs/references/backend/types/backend-session"
+                              },
+                              {
+                                "title": "Backend `SessionActivity` object",
+                                "href": "/docs/references/backend/types/backend-session-activity"
+                              },
+                              {
+                                "title": "Backend `RedirectURL` object",
+                                "href": "/docs/references/backend/types/backend-redirect-url"
+                              },
+                              {
+                                "title": "Backend `User` object",
+                                "href": "/docs/references/backend/types/backend-user"
+                              },
+                              {
+                                "title": "Backend `Verification` object",
+                                "href": "/docs/references/backend/types/backend-verification"
+                              },
+                              {
+                                "title": "Backend `Web3Wallet` object",
+                                "href": "/docs/references/backend/types/backend-web3-wallet"
+                              },
+                              {
+                                "title": "`PaginatedResourceResponse`",
+                                "href": "/docs/references/backend/types/paginated-resource-response"
+                              }
+                            ]
+                          ]
+                        }
+                      ]
+                    ]
+                  }
+                ]
+              ]
+            },
+            {
+              "title": "Nuxt",
+              "hideTitle": true,
+              "sdk": ["nuxt"],
+              "items": [
+                [
+                  {
+                    "title": "References",
+                    "hideTitle": true,
+                    "items": [
+                      [
+                        {
+                          "title": "Overview",
+                          "href": "/docs/references/nuxt/overview"
+                        },
+                        {
+                          "title": "`clerkMiddleware()`",
+                          "wrap": false,
+                          "href": "/docs/references/nuxt/clerk-middleware"
+                        }
+                      ]
+                    ]
+                  }
+                ]
+              ]
+            },
+            {
+              "title": "React Router",
+              "hideTitle": true,
+              "sdk": ["react-router"],
+              "items": [
+                [
+                  {
+                    "title": "References",
+                    "hideTitle": true,
+                    "items": [
+                      [
+                        {
+                          "title": "Overview",
+                          "href": "/docs/references/react-router/overview"
+                        },
+                        {
+                          "title": "`rootAuthLoader()`",
+                          "wrap": false,
+                          "href": "/docs/references/react-router/root-auth-loader"
+                        },
+                        {
+                          "title": "`getAuth()`",
+                          "href": "/docs/references/react-router/get-auth"
+                        }
+                      ]
+                    ]
+                  }
+                ]
+              ]
+            },
+            {
+              "title": "Remix",
+              "hideTitle": true,
+              "sdk": ["remix"],
+              "items": [
+                [
+                  {
+                    "title": "References",
+                    "hideTitle": true,
+                    "items": [
+                      [
+                        {
+                          "title": "Overview",
+                          "href": "/docs/references/remix/overview"
+                        },
+                        {
+                          "title": "`ClerkApp`",
+                          "wrap": false,
+                          "href": "/docs/references/remix/clerk-app"
+                        },
+                        {
+                          "title": "`rootAuthLoader()`",
+                          "wrap": false,
+                          "href": "/docs/references/remix/root-auth-loader"
+                        }
+                      ]
+                    ]
+                  }
+                ]
+              ]
+            },
+            {
+              "title": "Ruby / Rails / Sinatra",
+              "hideTitle": true,
+              "sdk": ["ruby"],
+              "items": [
+                [
+                  {
+                    "title": "References",
+                    "hideTitle": true,
+                    "items": [
+                      [
+                        {
+                          "title": "Overview",
+                          "href": "/docs/references/ruby/overview"
+                        }
+                      ]
+                    ]
+                  }
+                ]
+              ]
+            },
+            {
+              "title": "TanStack React Start",
+              "hideTitle": true,
+              "sdk": ["tanstack-react-start"],
+              "items": [
+                [
+                  {
+                    "title": "References",
+                    "hideTitle": true,
+                    "items": [
+                      [
+                        {
+                          "title": "Overview",
+                          "href": "/docs/references/tanstack-react-start/overview"
+                        },
+                        {
+                          "title": "`getAuth()`",
+                          "href": "/docs/references/tanstack-react-start/get-auth"
+                        },
+                        {
+                          "title": "`createClerkHandler()`",
+                          "href": "/docs/references/tanstack-react-start/create-clerk-handler"
+                        }
+                      ]
+                    ]
+                  }
+                ]
+              ]
+            },
+            {
+              "title": "Vue",
+              "hideTitle": true,
+              "sdk": ["vue"],
+              "items": [
+                [
+                  {
+                    "title": "References",
+                    "hideTitle": true,
+                    "items": [
+                      [
+                        {
+                          "title": "Overview",
+                          "href": "/docs/references/vue/overview"
+                        },
+                        {
+                          "title": "`clerkPlugin`",
+                          "href": "/docs/references/vue/clerk-plugin"
+                        },
+                        {
+                          "title": "`updateClerkOptions()`",
+                          "href": "/docs/references/vue/update-clerk-options"
+                        },
+                        {
+                          "title": "Client-side helpers",
+                          "items": [
+                            [
+                              {
+                                "title": "`useUser()`",
+                                "wrap": false,
+                                "href": "/docs/references/vue/use-user"
+                              },
+                              {
+                                "title": "`useClerk()`",
+                                "wrap": false,
+                                "href": "/docs/references/vue/use-clerk"
+                              },
+                              {
+                                "title": "`useAuth()`",
+                                "wrap": false,
+                                "href": "/docs/references/vue/use-auth"
+                              },
+                              {
+                                "title": "`useSignIn()`",
+                                "wrap": false,
+                                "href": "/docs/references/vue/use-sign-in"
+                              },
+                              {
+                                "title": "`useSignUp`",
+                                "wrap": false,
+                                "href": "/docs/references/vue/use-sign-up"
+                              },
+                              {
+                                "title": "`useSession()`",
+                                "wrap": false,
+                                "href": "/docs/references/vue/use-session"
+                              },
+                              {
+                                "title": "`useSessionList()`",
+                                "wrap": false,
+                                "href": "/docs/references/vue/use-session-list"
+                              },
+                              {
+                                "title": "`useOrganization()`",
+                                "wrap": false,
+                                "href": "/docs/references/vue/use-organization"
+                              }
+                            ]
+                          ]
                         }
                       ]
                     ]


### PR DESCRIPTION
### 🔎 Previews:

- https://clerk-docs-git-nick-move-sdk-reference-docs-down-sidebar.clerkstage.dev/

### What does this solve?

- From docs sync discussion, general consensus on not having the sdk references up the top of the sidebar

### What changed?

- This extracts out the sdk specific references and puts them down below the Development section

### Checklist

- [x] I have clicked on "Files changed" and performed a thorough self-review
- [x] All existing checks pass
