### PR TITLE
Add script to link typedoc generated markdown folder to clerk-docs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -24,6 +24,7 @@
         "remark-gfm": "^4.0.0",
         "remark-mdx": "^3.0.1",
         "simple-git": "^3.27.0",
+        "symlink-dir": "^6.0.5",
         "tsx": "^4.19.2",
         "typescript": "^5.7.3",
         "unist-builder": "^4.0.0",
@@ -1530,6 +1531,16 @@
         "url": "https://opencollective.com/vitest"
       }
     },
+    "node_modules/@zkochan/rimraf": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@zkochan/rimraf/-/rimraf-3.0.2.tgz",
+      "integrity": "sha512-GBf4ua7ogWTr7fATnzk/JLowZDBnBJMm8RkMaC/KcvxZ9gxbMWix0/jImd815LmqKyIHZ7h7lADRddGMdGBuCA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.12"
+      }
+    },
     "node_modules/acorn": {
       "version": "8.11.2",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.11.2.tgz",
@@ -1622,6 +1633,19 @@
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/better-path-resolve": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/better-path-resolve/-/better-path-resolve-1.0.0.tgz",
+      "integrity": "sha512-pbnl5XzGBdrFU/wT4jqmJVPn2B6UHPBOhzMQkY/SPUPB6QtUXtmBHBIwCbXJol93mOpGMnQyP/+BB19q04xj7g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-windows": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
     },
     "node_modules/brace-expansion": {
       "version": "2.0.1",
@@ -2126,6 +2150,21 @@
         "node": ">=0.4.x"
       }
     },
+    "node_modules/fs-extra": {
+      "version": "11.3.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.3.0.tgz",
+      "integrity": "sha512-Z4XaCL6dUDHfP/jT25jJKMmtxvuwbkrD1vNSMFlo9lNLY2c5FHYSQgHPRZUjAB26TpDEoW9HCOgplrdbaPV/ew==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=14.14"
+      }
+    },
     "node_modules/fsevents": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
@@ -2186,6 +2225,13 @@
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
       }
+    },
+    "node_modules/graceful-fs": {
+      "version": "4.2.11",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
+      "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/is-extglob": {
       "version": "2.1.1",
@@ -2251,6 +2297,16 @@
         "@types/estree": "*"
       }
     },
+    "node_modules/is-windows": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-windows/-/is-windows-1.0.2.tgz",
+      "integrity": "sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/isexe": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
@@ -2280,6 +2336,19 @@
       "integrity": "sha512-HUgH65KyejrUFPvHFPbqOY0rsFip3Bo5wb4ngvdi1EpCYWUQDC5V+Y7mZws+DLkr4M//zQJoanu1SP+87Dv1oQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/jsonfile": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
+      "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "universalify": "^2.0.0"
+      },
+      "optionalDependencies": {
+        "graceful-fs": "^4.1.6"
+      }
     },
     "node_modules/locate-character": {
       "version": "3.0.0",
@@ -3919,6 +3988,20 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/rename-overwrite": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/rename-overwrite/-/rename-overwrite-6.0.3.tgz",
+      "integrity": "sha512-Daqe51STnrCUq/t4dbzCtfNBLElrqVpCtuWK0MuPrzUi6K/13E98y3E8/kzuMZt6IEmghMnF41J0AidrFqjZUA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@zkochan/rimraf": "^3.0.2",
+        "fs-extra": "11.3.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/require-directory": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
@@ -4214,6 +4297,23 @@
         "node": ">=16"
       }
     },
+    "node_modules/symlink-dir": {
+      "version": "6.0.5",
+      "resolved": "https://registry.npmjs.org/symlink-dir/-/symlink-dir-6.0.5.tgz",
+      "integrity": "sha512-xkihq5JPUZqxZbUOrz+fJprx5KZD0vPmesImGpoqFpPwmaFBpxBB4sl8GEwG2tE5/XVekSZw5I1D5NiwNvtwdQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "better-path-resolve": "^1.0.0",
+        "rename-overwrite": "^6.0.2"
+      },
+      "bin": {
+        "symlink-dir": "dist/cli.js"
+      },
+      "engines": {
+        "node": ">=18.12"
+      }
+    },
     "node_modules/tinybench": {
       "version": "2.9.0",
       "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
@@ -4476,6 +4576,16 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/universalify": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
+      "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10.0.0"
       }
     },
     "node_modules/vfile": {

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "test": "vitest --silent",
     "typedoc:download": "git clone https://github.com/clerk/generated-typedoc.git --single-branch --depth 1 clerk-typedoc && rm -rf clerk-typedoc/.git",
     "typedoc:update": "rm -rf clerk-typedoc && npm run typedoc:download",
+    "typedoc:link": "node scripts/link-typedoc.mjs",
     "move-doc": "node scripts/move-doc.mjs"
   },
   "devDependencies": {
@@ -33,6 +34,7 @@
     "remark-gfm": "^4.0.0",
     "remark-mdx": "^3.0.1",
     "simple-git": "^3.27.0",
+    "symlink-dir": "^6.0.5",
     "tsx": "^4.19.2",
     "typescript": "^5.7.3",
     "unist-builder": "^4.0.0",

--- a/scripts/link-typedoc.mjs
+++ b/scripts/link-typedoc.mjs
@@ -1,0 +1,15 @@
+
+// eg npm run typedoc:link ../javascript/.typedoc/docs
+
+import symlinkDir from 'symlink-dir'
+
+const TYPEDOC_DIR = './clerk-typedoc'
+
+const typedocFolderLocation = process.argv[2]
+
+if (!typedocFolderLocation) {
+  console.error('No typedoc folder location provided')
+  process.exit(1)
+}
+
+await symlinkDir(typedocFolderLocation, TYPEDOC_DIR)

--- a/scripts/link-typedoc.mjs
+++ b/scripts/link-typedoc.mjs
@@ -1,4 +1,3 @@
-
 // eg npm run typedoc:link ../javascript/.typedoc/docs
 
 import symlinkDir from 'symlink-dir'


### PR DESCRIPTION
### What does this solve?

- When working on the typedoc generated content, need to link the output in to clerk-docs repo to test out the generated markdown

### What changed?

- Added a `typedoc:link` script the package.json making it easy to setup

### Checklist

- [x] I have clicked on "Files changed" and performed a thorough self-review
- [x] All existing checks pass
