### PR TITLE
update nextjs quickstarts to support tailwind v4

### DIFF
--- a/docs/_partials/nextjs/update-globals-css.mdx
+++ b/docs/_partials/nextjs/update-globals-css.mdx
@@ -1,0 +1,5 @@
+In the previous step, the `cssLayerName` property is set on the `<ClerkProvider>` component. Now, you need to add the following line to the top of your `globals.css` file in order to include the layer you named in the `cssLayerName` property. The example names the layer `clerk` but you can name it anything you want. These steps are necessary for v4 of Tailwind as it ensures that Tailwind's utility styles are applied after Clerk's styles.
+
+```css {{ filename: 'globals.css' }}
+@layer theme, base, clerk, components, utilities;
+```

--- a/docs/quickstarts/nextjs-pages-router.mdx
+++ b/docs/quickstarts/nextjs-pages-router.mdx
@@ -116,7 +116,12 @@ description: Add authentication and user management to your Next.js app with Cle
 
     function MyApp({ Component, pageProps }: AppProps) {
       return (
-        <ClerkProvider {...pageProps}>
+        <ClerkProvider
+          {...pageProps}
+          appearance={{
+            cssLayerName: 'clerk',
+          }}
+        >
           <SignedOut>
             <SignInButton />
           </SignedOut>
@@ -130,6 +135,10 @@ description: Add authentication and user management to your Next.js app with Cle
 
     export default MyApp
     ```
+
+  ## Update `globals.css`
+
+  <Include src="_partials/nextjs/update-globals-css" />
 
   ## Create your first user
 

--- a/docs/quickstarts/nextjs.mdx
+++ b/docs/quickstarts/nextjs.mdx
@@ -114,7 +114,11 @@ description: Add authentication and user management to your Next.js app.
     children: React.ReactNode
   }>) {
     return (
-      <ClerkProvider>
+      <ClerkProvider
+        appearance={{
+          cssLayerName: 'clerk',
+        }}
+      >
         <html lang="en">
           <body className={`${geistSans.variable} ${geistMono.variable} antialiased`}>
             <header className="flex justify-end items-center p-4 gap-4 h-16">
@@ -137,6 +141,10 @@ description: Add authentication and user management to your Next.js app.
     )
   }
   ```
+
+  ## Update `globals.css`
+
+  <Include src="_partials/nextjs/update-globals-css" />
 
   ## Create your first user
 


### PR DESCRIPTION
https://linear.app/clerk/issue/DOCS-10539/update-quickstart-doc-to-include-csslayername-for-tailwind-4

### What does this solve?

To support Tailwind v4, users need to set `cssLayerName` in their ClerkProvider and then set that layer in their `globals.css` file.

⚠️  Related Dashboard PR: https://github.com/clerk/dashboard/pull/5919

### Checklist

- [x] I have clicked on "Files changed" and performed a thorough self-review
- [x] All existing checks pass
