### PR TITLE
Clarify Inactivity Timeout defaults and plan availability

### DIFF
--- a/docs/authentication/configuration/session-options.mdx
+++ b/docs/authentication/configuration/session-options.mdx
@@ -18,11 +18,13 @@ Fortunately, with Clerk, you have the ability to fully control the lifetime of y
 
 ### Inactivity timeout
 
+<Include src="_partials/feature-not-free-callout" />
+
 Inactivity timeout is the duration after which a session will expire and the user will have to sign in again, if they haven't been active on your site.
 
 A user is considered inactive when the application is closed, or when the app stops refreshing the token.
 
-By default, the inactivity timeout is set to 7 days. You can set a custom inactivity timeout by following these steps:
+The inactivity timeout feature is disabled by default. You can enable it and configure a custom timeout by following these steps:
 
 1. In the Clerk Dashboard, navigate to the [**Sessions**](https://dashboard.clerk.com/last-active?path=sessions) page.
 1. Toggle on **Inactivity timeout**.


### PR DESCRIPTION
### 🔎 Previews:

-

### What does this solve?

- Slack issue: https://clerkinc.slack.com/archives/C01QFRQNHSN/p1750761246243239
- Linear: https://linear.app/clerk/issue/DOCS-10552/clarify-inactivity-timeout-defaults-and-plan-availability

This PR addresses incorrect documentation that stated the inactivity timeout feature is enabled by default. It clarifies that the feature is disabled by default and only available on Pro plans.

### What changed?

- Updated the documentation to reflect the correct default state of the inactivity timeout feature
- Clarified that the feature is only available on Pro plans using the not free feature callout partial 

### Checklist

- [ ] I have clicked on "Files changed" and performed a thorough self-review
- [ ] All existing checks pass
