### PR TITLE
How Clerk works: Clarify client token storage mechanism

### DIFF
--- a/docs/how-clerk-works/overview.mdx
+++ b/docs/how-clerk-works/overview.mdx
@@ -169,7 +169,7 @@ This example assumes that the user already signed up and their credentials are s
 1. The user initiates authentication by navigating to `example.com/sign-in`, entering their credentials (e.g. username/password), and submitting the form, usually by clicking a "submit" button. This makes a request to the server with the credentials.
 1. The server validates the credentials against a database and, upon successful validation:
    - Creates a session record in the database (stateful component).
-   - Generates a [signed JWT](/docs/backend-requests/resources/tokens-and-signatures) with its expiration set to the session lifetime (stateless component) - this JWT is stored on FAPI, and is not accessible to the application. Clerk calls this the **client token**.
+   - Generates a [signed JWT](/docs/backend-requests/resources/tokens-and-signatures) with its expiration set to the session lifetime (stateless component) - this JWT is stored as a cookie on the FAPI domain, and is not accessible to the application. Clerk calls this the **client token**.
    - Generates a **second** signed JWT that expires after 60 seconds which is returned directly to the application and contains user data like the user ID and other claims. Clerk calls this the **session token**.
 1. The server responds to the browser's request by sending the **client token** in a [`Set-Cookie` header](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie) in the response, which is set on the FAPI domain. Clerk's client-side SDK then makes a request to FAPI to get a **session token** and sets it on your app's domain.
 


### PR DESCRIPTION
I initially assumed it was stored within the FAPI app somewhere.
