### PR TITLE
How Clerk works: Clarify session token is used

### DIFF
--- a/docs/how-clerk-works/overview.mdx
+++ b/docs/how-clerk-works/overview.mdx
@@ -192,7 +192,7 @@ This example assumes that the user already signed up and their credentials are s
      playsInline
      controls
    />
-1. And just like stateless auth, the next time the browser sends a request to the server, it sends the cookie containing the token. The server verifies the signature of the token to ensure that it's valid, and then uses the user ID within the token to fetch any required user data and process the request.
+1. And just like stateless auth, the next time the browser sends a request to the server, it sends the cookie containing the **session token**. The server verifies the signature of the token to ensure that it's valid, and then uses the user ID within the token to fetch any required user data and process the request.
    <Video
      src="/docs/images/how-clerk-works/hybrid-auth-2.mp4"
      width="1400"


### PR DESCRIPTION
"token" is ambiguous, so better to specify "session token"