### PR TITLE
(/components/authentication/sign-in) fix incorrect env var

### DIFF
--- a/docs/components/authentication/sign-in.mdx
+++ b/docs/components/authentication/sign-in.mdx
@@ -115,7 +115,7 @@ All props are optional.
   - `withSignUp`
   - `boolean`
 
-  Opt into sign-in-or-up flow by setting this prop to `true`. When `true`, if a user does not exist, they will be prompted to sign up. If a user exists, they will be prompted to sign in. Defaults to `true` if the `CLERK_SIGN_UP_URL` environment variable is set. Otherwise, defaults to `false`.
+  Opt into sign-in-or-up flow by setting this prop to `true`. When `true`, if a user does not exist, they will be prompted to sign up. If a user exists, they will be prompted to sign in. Defaults to `true` if the `CLERK_SIGN_IN_URL` environment variable is set. Otherwise, defaults to `false`.
 </Properties>
 
 ## Usage with frameworks


### PR DESCRIPTION
### What does this solve?

https://linear.app/clerk/issue/DOCS-10430/feedback-for-referencesnextjscustom-sign-in-or-up-page
There was an incorrect environment variable `CLERK_SIGN_UP_URL` should be `CLERK_SIGN_IN_URL`

### Checklist

- [ ] I have clicked on "Files changed" and performed a thorough self-review
- [ ] All existing checks pass
