### PR TITLE
Tanstack Start - Remove splat from sign-in page file route path

### DIFF
--- a/docs/references/tanstack-react-start/custom-sign-in-or-up-page.mdx
+++ b/docs/references/tanstack-react-start/custom-sign-in-or-up-page.mdx
@@ -15,11 +15,11 @@ To set up separate sign-in and sign-up pages, follow this guide, and then follow
 
   The following example demonstrates how to render the [`<SignIn />`](/docs/components/authentication/sign-in) component on a dedicated page using the [TanStack Router catch-all route](https://tanstack.com/router/latest/docs/framework/react/routing/routing-concepts#splat--catch-all-routes).
 
-  ```tsx {{ filename: 'src/routes/sign-in.$.tsx' }}
+  ```tsx {{ filename: 'src/routes/sign-in.tsx' }}
   import { SignIn } from '@clerk/tanstack-react-start'
   import { createFileRoute } from '@tanstack/react-router'
 
-  export const Route = createFileRoute('/sign-in/$')({
+  export const Route = createFileRoute('/sign-in')({
     component: Page,
   })
 


### PR DESCRIPTION
### 🔎 Previews:

-

### What does this solve?
- As part of the devinxi migration I see that some docs were updated in https://github.com/clerk/clerk-docs/pull/2315 
- Those updates included moving from `/sign-in/$` to `/sign-in`
- The new behavior of TSR considers `$` a path param and defaults to undefined. So if the user is logged out and visit `/` the redirect sends them to `/sign-in/undefined` 

### What changed?

- Updated the sign in page file route path to be `sign-in.tsx` instead of `sign-in.$.tsx`

### Checklist

- [x] I have clicked on "Files changed" and performed a thorough self-review
- [x] All existing checks pass
