### PR TITLE
Fix typo in important callout MCP guide 

### DIFF
--- a/docs/references/nextjs/connect-mcp-client.mdx
+++ b/docs/references/nextjs/connect-mcp-client.mdx
@@ -86,7 +86,7 @@ To complete the integration, you'll need to connect an MCP-compatible client to 
        ```bash
        claude mcp add --transport http clerk-mcp-server http://localhost:3000/mcp
        ```
-       > [!IMPORTAIPRTANT]
+       > [!IMPORTANT]
        > Replace `http://localhost:3000/mcp` with your production URL if you've deployed your MCP server.
     1. Run `claude` to enter the Claude Code interface.
     1. Execute the `/mcp` command to see available tools. From there, you can go through the authentication process to connect your MCP server.


### PR DESCRIPTION
### 🔎 Previews:

- https://clerk.com/docs/pr/ss-docs-10566/references/nextjs/connect-mcp-client

### What does this solve?

This small PR fixes a typo in the newly created MCP guide. 

### What changed?

Fixed typo! 

### Checklist

- [ ] I have clicked on "Files changed" and performed a thorough self-review
- [ ] All existing checks pass
