### PR TITLE
Add paid add-on callout for custom roles and permissions

### DIFF
--- a/docs/organizations/create-roles-permissions.mdx
+++ b/docs/organizations/create-roles-permissions.mdx
@@ -7,6 +7,9 @@ metadata:
 
 In the Clerk Dashboard, you can create roles, assign permissions to them, and change users' roles.
 
+> [!WARNING]
+> Custom roles and permissions require a [paid plan](/pricing){{ target: '_blank' }} and the Enhanced B2B SaaS Add-on for production use, but free to use in development mode so that you can try out what works for you. See the [pricing](/pricing){{ target: '_blank' }} page for more information.
+
 ## Create a new role for your organization
 
 1. In the Clerk Dashboard, navigate to [**Roles**](https://dashboard.clerk.com/last-active?path=organizations-settings/roles)

--- a/docs/organizations/roles-permissions.mdx
+++ b/docs/organizations/roles-permissions.mdx
@@ -21,7 +21,10 @@ For each instance, there are currently two default roles:
 > [!NOTE]
 > If you enabled organizations for your application before December 2023, the **Admin** role is `admin` and the **Member** role is `basic_member`, instead of `org:admin` and `org:member`, respectively.
 
-### Custom role
+### Custom roles
+
+> [!WARNING]
+> Custom roles requires a [paid plan](/pricing){{ target: '_blank' }} and the Enhanced B2B SaaS Add-on for production use, but free to use in development mode so that you can try out what works for you. See the [pricing](/pricing){{ target: '_blank' }} page for more information.
 
 You can create up to 10 custom organization roles per application instance to meet your application needs. If you need more than 10 roles, [contact support](/contact/support){{ target: '_blank' }}.
 
@@ -68,6 +71,9 @@ You can assign these system permissions to any role.
 > System permissions aren't included in [session claims](/docs/backend-requests/resources/session-tokens#default-claims). To check permissions on the server-side, you must [create custom permissions](/docs/organizations/create-roles-permissions).
 
 ### Custom permissions
+
+> [!WARNING]
+> Custom permissions requires a [paid plan](/pricing){{ target: '_blank' }} and the Enhanced B2B SaaS Add-on for production use, but free to use in development mode so that you can try out what works for you. See the [pricing](/pricing){{ target: '_blank' }} page for more information.
 
 When creating a new permission, follow the format `org:<feature>:<permission>`. You can then assign the permission to an existing role.
 

--- a/docs/organizations/roles-permissions.mdx
+++ b/docs/organizations/roles-permissions.mdx
@@ -24,7 +24,7 @@ For each instance, there are currently two default roles:
 ### Custom roles
 
 > [!WARNING]
-> Custom roles requires a [paid plan](/pricing){{ target: '_blank' }} and the Enhanced B2B SaaS Add-on for production use, but free to use in development mode so that you can try out what works for you. See the [pricing](/pricing){{ target: '_blank' }} page for more information.
+> Custom roles require a [paid plan](/pricing){{ target: '_blank' }} and the Enhanced B2B SaaS Add-on for production use, but free to use in development mode so that you can try out what works for you. See the [pricing](/pricing){{ target: '_blank' }} page for more information.
 
 You can create up to 10 custom organization roles per application instance to meet your application needs. If you need more than 10 roles, [contact support](/contact/support){{ target: '_blank' }}.
 
@@ -73,7 +73,7 @@ You can assign these system permissions to any role.
 ### Custom permissions
 
 > [!WARNING]
-> Custom permissions requires a [paid plan](/pricing){{ target: '_blank' }} and the Enhanced B2B SaaS Add-on for production use, but free to use in development mode so that you can try out what works for you. See the [pricing](/pricing){{ target: '_blank' }} page for more information.
+> Custom permissions require a [paid plan](/pricing){{ target: '_blank' }} and the Enhanced B2B SaaS Add-on for production use, but free to use in development mode so that you can try out what works for you. See the [pricing](/pricing){{ target: '_blank' }} page for more information.
 
 When creating a new permission, follow the format `org:<feature>:<permission>`. You can then assign the permission to an existing role.
 


### PR DESCRIPTION
### 🔎 Previews:

- https://clerk.com/docs/pr/ss-docs-10558/organizations/create-roles-permissions
- https://clerk.com/docs/pr/ss-docs-10558/organizations/roles-permissions#roles-and-permissions

### What does this solve?

This PR clarifies that custom roles and permissions are a paid add-on following user feedback and confusion. 

### What changed?

- Added a paid callout on the roles permissions page under Custom roles and Custom permissions
- Added a paid callout on the create custom roles and permissions page 

### Checklist

- [ ] I have clicked on "Files changed" and performed a thorough self-review
- [ ] All existing checks pass
