### PR TITLE
Add callout for Native API in Chrome Extension SDK docs

### DIFF
--- a/docs/_partials/native-api-callout.mdx
+++ b/docs/_partials/native-api-callout.mdx
@@ -1,0 +1,2 @@
+> [!IMPORTANT]
+> Ensure that the Native API is enabled to integrate Clerk in your native application. In the Clerk Dashboard, navigate to the [**Native Applications**](https://dashboard.clerk.com/last-active?path=/native-applications) page.

--- a/docs/deployments/deploy-chrome-extension.mdx
+++ b/docs/deployments/deploy-chrome-extension.mdx
@@ -8,8 +8,7 @@ description: Learn how to deploy a Chrome Extension to production with Clerk.
 
 ## Create a production instance
 
-> [!NOTE]
-> Ensure that the Native API is enabled to integrate Clerk in your native application. In the Clerk Dashboard, navigate to the [**Native Applications**](https://dashboard.clerk.com/last-active?path=/native-applications) page.
+<Include src="_partials/native-api-callout" />
 
 For Clerk production instances, there must be a domain associated with the instance. Even though there may not be a web application associated with your Chrome Extension, a domain is still required. Follow the [guide on deploying your Clerk app to production](/docs/deployments/overview).
 

--- a/docs/deployments/deploy-chrome-extension.mdx
+++ b/docs/deployments/deploy-chrome-extension.mdx
@@ -8,6 +8,9 @@ description: Learn how to deploy a Chrome Extension to production with Clerk.
 
 ## Create a production instance
 
+> [!NOTE]
+> Ensure that the Native API is enabled to integrate Clerk in your native application. In the Clerk Dashboard, navigate to the [**Native Applications**](https://dashboard.clerk.com/last-active?path=/native-applications) page.
+
 For Clerk production instances, there must be a domain associated with the instance. Even though there may not be a web application associated with your Chrome Extension, a domain is still required. Follow the [guide on deploying your Clerk app to production](/docs/deployments/overview).
 
 ## Update your `.env.production` file

--- a/docs/quickstarts/chrome-extension.mdx
+++ b/docs/quickstarts/chrome-extension.mdx
@@ -19,8 +19,7 @@ description: Add authentication and user management to your Chrome Extension wit
   ]}
 />
 
-> [!NOTE]
-> Ensure that the Native API is enabled to integrate Clerk in your native application. In the Clerk Dashboard, navigate to the [**Native Applications**](https://dashboard.clerk.com/last-active?path=/native-applications) page.
+<Include src="_partials/native-api-callout" />
 
 <Steps>
   ## Configure your authentication options

--- a/docs/quickstarts/expo.mdx
+++ b/docs/quickstarts/expo.mdx
@@ -24,8 +24,7 @@ description: Add authentication and user management to your Expo app with Clerk.
   ]}
 />
 
-> [!NOTE]
-> Ensure that the Native API is enabled to integrate Clerk in your native application. In the Clerk Dashboard, navigate to the [**Native Applications**](https://dashboard.clerk.com/last-active?path=/native-applications) page.
+<Include src="_partials/native-api-callout" />
 
 <Steps>
   ## Install `@clerk/clerk-expo`

--- a/docs/quickstarts/ios.mdx
+++ b/docs/quickstarts/ios.mdx
@@ -13,8 +13,7 @@ description: Add authentication and user management to your iOS app with Clerk.
   ]}
 />
 
-> [!NOTE]
-> Ensure that the Native API is enabled to integrate Clerk in your native application. In the Clerk Dashboard, navigate to the [**Native Applications**](https://dashboard.clerk.com/last-active?path=/native-applications) page.
+<Include src="_partials/native-api-callout" />
 
 <Steps>
   ## Create an iOS Project


### PR DESCRIPTION
### 🔎 Previews:

- https://clerk.com/docs/pr/ss-docs-10550/deployments/deploy-chrome-extension

### What does this solve?

This PR adds a callout for Native API in the Chrome Extension SDK deployment docs, similar to what we have on the Quickstart page. 

### What changed?

- Added note callout for Native API in deployment docs for Chrome Extension SDK

### Checklist

- [ ] I have clicked on "Files changed" and performed a thorough self-review
- [ ] All existing checks pass
