### PR TITLE
Speed up docs dev script

### DIFF
--- a/scripts/lib/dev.ts
+++ b/scripts/lib/dev.ts
@@ -60,6 +60,8 @@ export const watchAndRebuild = (store: Store, config: BuildConfig, buildFunc: ty
 
       const output = await buildFunc(newConfig, store, abortController.signal)
 
+      abortController = null
+
       if (config.flags.controlled) {
         console.info('---rebuild-complete---')
       }


### PR DESCRIPTION

Currently taking just over a second on my machine
<img width="357" alt="Screenshot 2025-06-27 at 11 59 56 PM" src="https://github.com/user-attachments/assets/46cf7471-e816-4889-9cd2-dcd0fd82ed12" />

These optimizations bring it down to around 600ms
<img width="388" alt="Screenshot 2025-06-27 at 11 58 57 PM" src="https://github.com/user-attachments/assets/cfc8f0ce-9cd1-482b-b31c-2fb1c6de977b" />


### What does this solve?

- The dev script getting a little slow, for me a rebuild is taking around 1200ms

### What changed?

- Added some additional caching and symlinking the public folder instead of copying it around, getting the rebuild time down to ~600ms on my machine

### Checklist

- [x] I have clicked on "Files changed" and performed a thorough self-review
- [x] All existing checks pass
