### PR TITLE
(nextjs) remove tailwind v4 instructions from quickstart

### DIFF
--- a/docs/quickstarts/nextjs.mdx
+++ b/docs/quickstarts/nextjs.mdx
@@ -114,11 +114,7 @@ description: Add authentication and user management to your Next.js app.
     children: React.ReactNode
   }>) {
     return (
-      <ClerkProvider
-        appearance={{
-          cssLayerName: 'clerk',
-        }}
-      >
+      <ClerkProvider>
         <html lang="en">
           <body className={`${geistSans.variable} ${geistMono.variable} antialiased`}>
             <header className="flex justify-end items-center p-4 gap-4 h-16">
@@ -141,10 +137,6 @@ description: Add authentication and user management to your Next.js app.
     )
   }
   ```
-
-  ## Update `globals.css`
-
-  <Include src="_partials/nextjs/update-globals-css" />
 
   ## Create your first user
 


### PR DESCRIPTION
### 🔎 Previews:

-

### What does this solve?

These tailwind v4 instructions regarding `cssLayerName` are only if the user is customizing their app using the `appearance` prop, which isn't necessary in the quickstart. Therefore, those instructions can be left in the appearance/customization docs, and left out of the quickstart.

⚠️  Related Dash PR: https://github.com/clerk/dashboard/pull/6003

### Checklist

- [ ] I have clicked on "Files changed" and performed a thorough self-review
- [ ] All existing checks pass
