### PR TITLE
Fix incorrect types for sessionVerifyCreateParams from status to level

### DIFF
--- a/docs/references/javascript/session.mdx
+++ b/docs/references/javascript/session.mdx
@@ -397,14 +397,14 @@ await clerk.session.remove()
 Initiates the reverification flow. Returns a [`SessionVerification`](/docs/references/javascript/types/session-verification) instance with its status and supported factors.
 
 ```typescript
-function startVerification(params: SessionVerifyCreateParams): Promise<SessionVerificationResource>
+function startVerification(params: SessionVerifyCreateParams): Promise<SessionVerificationLevel>
 ```
 
 #### `SessionVerifyCreateParams`
 
 ```typescript
 type SessionVerifyCreateParams = {
-  status: 'pending' | 'verified' | 'failed'
+  level: 'first_factor' | 'second_factor' | 'multi_factor'
 }
 ```
 
@@ -412,7 +412,7 @@ type SessionVerifyCreateParams = {
 
 ```js
 await clerk.session.startVerification({
-  status: 'pending',
+  level: 'second_factor',
 })
 ```
 

--- a/docs/references/javascript/session.mdx
+++ b/docs/references/javascript/session.mdx
@@ -397,14 +397,14 @@ await clerk.session.remove()
 Initiates the reverification flow. Returns a [`SessionVerification`](/docs/references/javascript/types/session-verification) instance with its status and supported factors.
 
 ```typescript
-function startVerification(params: SessionVerifyCreateParams): Promise<SessionVerificationLevel>
+function startVerification(params: SessionVerifyCreateParams): Promise<SessionVerificationResource>
 ```
 
 #### `SessionVerifyCreateParams`
 
 ```typescript
 type SessionVerifyCreateParams = {
-  level: 'first_factor' | 'second_factor' | 'multi_factor'
+  level: 'pending' | 'verified' | 'failed'
 }
 ```
 

--- a/docs/references/javascript/session.mdx
+++ b/docs/references/javascript/session.mdx
@@ -412,7 +412,7 @@ type SessionVerifyCreateParams = {
 
 ```js
 await clerk.session.startVerification({
-  level: 'second_factor',
+  level: 'pending',
 })
 ```
 

--- a/docs/references/javascript/session.mdx
+++ b/docs/references/javascript/session.mdx
@@ -404,7 +404,7 @@ function startVerification(params: SessionVerifyCreateParams): Promise<SessionVe
 
 ```typescript
 type SessionVerifyCreateParams = {
-  level: 'pending' | 'verified' | 'failed'
+  level: 'first_factor' | 'second_factor' | 'multi_factor'
 }
 ```
 
@@ -412,7 +412,7 @@ type SessionVerifyCreateParams = {
 
 ```js
 await clerk.session.startVerification({
-  level: 'pending',
+  level: 'first_factor',
 })
 ```
 


### PR DESCRIPTION
### 🔎 Previews:

-  https://clerk.com/docs/pr/ss-docs-10556/references/javascript/session#session-verify-create-params

### What does this solve?

Linear: https://linear.app/clerk/issue/DOCS-10556/sessionverifycreateparams-are-incorrect

This PR fixes the incorrect types set for sessionVerifyCreateParams based on changes here: https://github.com/clerk/javascript/blob/d898eb71ca5ce76b213daa6448c3b989044f8e7f/packages/types/src/session.ts#L344. 

### What changed?

Replaced `status` type to `level` to align with the new type: `level: SessionVerificationLevel`. 

### Checklist

- [ ] I have clicked on "Files changed" and performed a thorough self-review
- [ ] All existing checks pass
