### PR TITLE
Update B2B docs to reflect support for organization-level SSO connections

### DIFF
--- a/docs/guides/multi-tenant-architecture.mdx
+++ b/docs/guides/multi-tenant-architecture.mdx
@@ -46,7 +46,7 @@ B2B SaaS applications with the following characteristics are well-supported with
 
 - A single application deployment that serves multiple business customers (multi-tenant)
 - A shared user-pool model where a user can log in with a single account and belong to multiple organizations
-- Enabled connections are available to all users (as in, connections cannot be configured at the organization level)
+- Enabled connections can be available to all users or linked to specific organizations
 - The application may carry your own branding or some elements of your customer's branding
 - The application is served from a single domain (for example: `app.example.com`)
 


### PR DESCRIPTION
### 🔎 Previews:

- 

### What does this solve?

The B2B section in the multi-tenant architecture guide incorrectly stated that enabled connections cannot be configured at the organization level. Since Clerk now supports organization-level SSO connections, this  PR updates the docs to clarify that connections can be configured for all users or scoped to specific organizations.

### What changed?

Updated the B2B SaaS characteristics list to clarify that enabled connections can be available to all users or linked to specific organizations

### Checklist

- [ ] I have clicked on "Files changed" and performed a thorough self-review
- [ ] All existing checks pass
