### PR TITLE
Add note about CNAME record needed for satellite domains in production

### DIFF
--- a/docs/advanced-usage/satellite-domains.mdx
+++ b/docs/advanced-usage/satellite-domains.mdx
@@ -51,6 +51,10 @@ To access authentication state from a satellite domain, users will be transparen
   - In production, the satellite domain will be `satellite.dev`.
   - In development, the satellite domain will be `localhost:3001`.
 
+  > [!IMPORTANT]
+  > To use your satellite domain in production, add a **CNAME record** to your domain provider pointing to your deployed app. Ensure you have access to your domain provider's DNS settings to complete this step.
+  > This is not required for developmen domains like `localhost`.
+
   ### Configure your satellite app
 
   There are two ways that you can configure your Clerk satellite application to work with the primary domain:


### PR DESCRIPTION
### 🔎 Previews:

-

### What does this solve?

The existing satellite domains documentation does not mention the necessary DNS configuration step (adding a CNAME record) required for satellite domains to resolve properly in production. This PR clarifies the DNS setup requirement and reminds users to ensure they have access to their domain provider’s DNS settings.

### What changed?

- Added an important note in the “Add your first satellite domain” section explaining that users must add a CNAME record with their domain provider pointing to their deployed application.
- Specified that this DNS configuration step is only necessary in production, not in development.

### Checklist

- [ ] I have clicked on "Files changed" and performed a thorough self-review
- [ ] All existing checks pass
