### PR TITLE
Update create-a-minimal-reproduction.mdx

### DIFF
--- a/docs/troubleshooting/create-a-minimal-reproduction.mdx
+++ b/docs/troubleshooting/create-a-minimal-reproduction.mdx
@@ -19,6 +19,7 @@ The best way to create a minimal reproduction is to start fresh, with a minimal 
 - [Vanilla JS](https://github.com/clerk/clerk-js-starter)
 - [Expo](https://github.com/clerk/clerk-expo-quickstart)
 - [Remix](https://github.com/clerk/clerk-remix-v2)
+- [Express](https://github.com/clerk/clerk-express-quickstart)
 - [React Router](https://github.com/clerk/clerk-react-router-quickstart)
 - [Redwood](https://github.com/clerk/clerk-redwood-starter)
 - [Rails](https://github.com/clerk/clerk-rails-starter)


### PR DESCRIPTION
### 🔎 Previews:

N/A

### What does this solve?

added express quickstart repo to the list based off user feedback from support ticket

### What changed?

when visiting https://clerk.com/docs/troubleshooting/create-a-minimal-reproduction, users will be able to see Express as an option

### Checklist

- [ ] I have clicked on "Files changed" and performed a thorough self-review
- [ ] All existing checks pass
