### PR TITLE
Support custom ids in callouts - validation script

### DIFF
--- a/docs/customization/variables.mdx
+++ b/docs/customization/variables.mdx
@@ -139,11 +139,21 @@ The `variables` property is used to adjust the general styles of the component's
 
 You can customize Clerk components by passing an object of variables to the `variables` property of the [`appearance`](/docs/customization/overview) prop.
 
+> [!NOTE]
+> **Browser Compatibility Considerations**
+>
+> Clerk's theming system uses modern CSS features like [`color-mix()`](https://developer.mozilla.org/en-US/docs/Web/CSS/color_value/color-mix) and [relative color syntax](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_colors/Relative_colors) to automatically generate color variations from your base colors. These features require:
+>
+> - **`color-mix()`**: Chrome 111+, Firefox 113+, Safari 16.2+
+> - **Relative color syntax**: Chrome 119+, Firefox 120+, Safari 16.4+
+>
+> For broader browser support, when using the `variables` prop, **use direct color values** (e.g. `colorPrimary: '#6c47ff'`) instead of CSS variables or modern color functions.
+
 ### Apply `variables` to all Clerk components
 
 To customize all Clerk components, pass the `variables` property to the `appearance` prop of the [`<ClerkProvider>`](/docs/components/clerk-provider) component.
 
-In the following example, the primary color is set to blue and the text color is set to white. Because these styles are applied to the `<ClerkProvider>`, which wraps the entire application, these styles will be applied to all Clerk components that use the primary color and text color.
+In the following example, the primary color is set to blue and the text color is set to black. Because these styles are applied to the `<ClerkProvider>`, which wraps the entire application, these styles will be applied to all Clerk components that use the primary color and text color.
 
 <Tabs items={["Next.js", "React", "Remix", "Astro", "Vue", "Nuxt"]}>
   <Tab>
@@ -156,8 +166,8 @@ In the following example, the primary color is set to blue and the text color is
           <ClerkProvider
             appearance={{
               variables: {
-                colorPrimary: 'blue',
-                colorText: 'black',
+                colorPrimary: '#0000ff', // blue
+                colorText: '#000000', // black
               },
             }}
           >
@@ -178,8 +188,8 @@ In the following example, the primary color is set to blue and the text color is
           <ClerkProvider
             appearance={{
               variables: {
-                colorPrimary: 'blue',
-                colorText: 'black',
+                colorPrimary: '#0000ff', // blue
+                colorText: '#000000', // black
               },
             }}
           >
@@ -209,8 +219,8 @@ In the following example, the primary color is set to blue and the text color is
         <ClerkProvider
           appearance={{
             variables: {
-              colorPrimary: 'blue',
-              colorText: 'black',
+              colorPrimary: '#0000ff', // blue
+              colorText: '#000000', // black
             },
           }}
           publishableKey={clerkPubKey}
@@ -262,8 +272,8 @@ In the following example, the primary color is set to blue and the text color is
     export default ClerkApp(App, {
       appearance: {
         variables: {
-          colorPrimary: 'blue',
-          colorText: 'black',
+          colorPrimary: '#0000ff', // blue
+          colorText: '#000000', // black
         },
       },
     })
@@ -279,8 +289,8 @@ In the following example, the primary color is set to blue and the text color is
         clerk({
           appearance: {
             variables: {
-              colorPrimary: 'blue',
-              colorText: 'black',
+              colorPrimary: '#0000ff', // blue
+              colorText: '#000000', // black
             },
           },
         }),
@@ -299,8 +309,8 @@ In the following example, the primary color is set to blue and the text color is
     app.use(clerkPlugin, {
       appearance: {
         variables: {
-          colorPrimary: 'blue',
-          colorText: 'black',
+          colorPrimary: '#0000ff', // blue
+          colorText: '#000000', // black
         },
       },
     })
@@ -315,8 +325,8 @@ In the following example, the primary color is set to blue and the text color is
       clerk: {
         appearance: {
           variables: {
-            colorPrimary: 'blue',
-            colorText: 'black',
+            colorPrimary: '#0000ff', // blue
+            colorText: '#000000', // black
           },
         },
       },
@@ -329,7 +339,7 @@ In the following example, the primary color is set to blue and the text color is
 
 You can customize all instances of a Clerk component by passing the component to the `appearance` prop of the `<ClerkProvider>`. The `appearance` prop accepts the name of the Clerk component you want to style as a key.
 
-In the following example, the primary color is set to blue and the text color is set to white for all instances of the [`<SignIn />`](/docs/components/authentication/sign-in) component.
+In the following example, the primary color is set to blue and the text color is set to black for all instances of the [`<SignIn />`](/docs/components/authentication/sign-in) component.
 
 <Tabs items={["Next.js", "React", "Remix", "Astro", "Vue", "Nuxt"]}>
   <Tab>
@@ -343,8 +353,8 @@ In the following example, the primary color is set to blue and the text color is
             appearance={{
               signIn: {
                 variables: {
-                  colorPrimary: 'blue',
-                  colorText: 'black',
+                  colorPrimary: '#0000ff', // blue
+                  colorText: '#000000', // black
                 },
               },
             }}
@@ -367,8 +377,8 @@ In the following example, the primary color is set to blue and the text color is
             appearance={{
               signIn: {
                 variables: {
-                  colorPrimary: 'blue',
-                  colorText: 'black',
+                  colorPrimary: '#0000ff', // blue
+                  colorText: '#000000', // black
                 },
               },
             }}
@@ -400,8 +410,8 @@ In the following example, the primary color is set to blue and the text color is
           appearance={{
             signIn: {
               variables: {
-                colorPrimary: 'blue',
-                colorText: 'black',
+                colorPrimary: '#0000ff', // blue
+                colorText: '#000000', // black
               },
             },
           }}
@@ -455,8 +465,8 @@ In the following example, the primary color is set to blue and the text color is
       appearance: {
         signIn: {
           variables: {
-            colorPrimary: 'blue',
-            colorText: 'black',
+            colorPrimary: '#0000ff', // blue
+            colorText: '#000000', // black
           },
         },
       },
@@ -474,8 +484,8 @@ In the following example, the primary color is set to blue and the text color is
           appearance: {
             signIn: {
               variables: {
-                colorPrimary: 'blue',
-                colorText: 'black',
+                colorPrimary: '#0000ff', // blue
+                colorText: '#000000', // black
               },
             },
           },
@@ -496,8 +506,8 @@ In the following example, the primary color is set to blue and the text color is
       appearance: {
         signIn: {
           variables: {
-            colorPrimary: 'blue',
-            colorText: 'black',
+            colorPrimary: '#0000ff', // blue
+            colorText: '#000000', // black
           },
         },
       },
@@ -514,8 +524,8 @@ In the following example, the primary color is set to blue and the text color is
         appearance: {
           signIn: {
             variables: {
-              colorPrimary: 'blue',
-              colorText: 'black',
+              colorPrimary: '#0000ff', // blue
+              colorText: '#000000', // black
             },
           },
         },
@@ -529,7 +539,7 @@ In the following example, the primary color is set to blue and the text color is
 
 To customize a single Clerk component, pass the `variables` property to the `appearance` prop of the Clerk component.
 
-The following example shows how to customize the [`<SignIn />`](/docs/components/authentication/sign-in) component by setting the primary color to blue and the text color to white.
+The following example shows how to customize the [`<SignIn />`](/docs/components/authentication/sign-in) component by setting the primary color to blue and the text color to black.
 
 <Tabs items={["Next.js", "React", "Remix", "Astro", "Vue", "Nuxt"]}>
   <Tab>
@@ -542,8 +552,8 @@ The following example shows how to customize the [`<SignIn />`](/docs/components
           <SignIn
             appearance={{
               variables: {
-                colorPrimary: 'blue',
-                colorText: 'black',
+                colorPrimary: '#0000ff', // blue
+                colorText: '#000000', // black
               },
             }}
           />
@@ -558,8 +568,8 @@ The following example shows how to customize the [`<SignIn />`](/docs/components
         <SignIn
           appearance={{
             variables: {
-              colorPrimary: 'blue',
-              colorText: 'black',
+              colorPrimary: '#0000ff', // blue
+              colorText: '#000000', // black
             },
           }}
         />
@@ -578,8 +588,8 @@ The following example shows how to customize the [`<SignIn />`](/docs/components
       <SignIn
         appearance={{
           variables: {
-            colorPrimary: 'blue',
-            colorText: 'black',
+            colorPrimary: '#0000ff', // blue
+            colorText: '#000000', // black
           },
         }}
       />
@@ -600,8 +610,8 @@ The following example shows how to customize the [`<SignIn />`](/docs/components
           <SignIn
             appearance={{
               variables: {
-                colorPrimary: 'blue',
-                colorText: 'black',
+                colorPrimary: '#0000ff', // blue
+                colorText: '#000000', // black
               },
             }}
           />
@@ -619,8 +629,8 @@ The following example shows how to customize the [`<SignIn />`](/docs/components
 
     <SignIn
       appearance={{
-        colorPrimary: 'blue',
-        colorText: 'black',
+        colorPrimary: '#0000ff', // blue
+        colorText: '#000000', // black
       }}
     />
     ```
@@ -633,7 +643,7 @@ The following example shows how to customize the [`<SignIn />`](/docs/components
     </script>
 
     <template>
-      <SignIn :appearance="{ variables: { colorPrimary: '#3b82f6', colorText: '#111827' } }" />
+      <SignIn :appearance="{ variables: { colorPrimary: '#0000ff', colorText: '#000000' } }" />
     </template>
     ```
   </Tab>
@@ -645,7 +655,7 @@ The following example shows how to customize the [`<SignIn />`](/docs/components
     </script>
 
     <template>
-      <SignIn :appearance="{ colorPrimary: 'blue', colorText: 'black' }" />
+      <SignIn :appearance="{ colorPrimary: '#0000ff', colorText: '#000000' }" />
     </template>
     ```
   </Tab>
@@ -659,6 +669,15 @@ You can also use CSS variables to customize the appearance of Clerk components. 
 - You want to support automatic dark/light mode switching
 - You need to dynamically update colors based on user preferences
 - You're integrating Clerk into an existing application with established CSS variables
+
+However, it's important to consider browser compatibility when using Clerk's `variables` prop. Clerk's theming system uses modern CSS features like [`color-mix()`](https://developer.mozilla.org/en-US/docs/Web/CSS/color_value/color-mix) and [relative color syntax](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_colors/Relative_colors) to automatically generate color variations from your base colors. These features require:
+
+- **`color-mix()`**: Chrome 111+, Firefox 113+, Safari 16.2+
+- **Relative color syntax**: Chrome 119+, Firefox 120+, Safari 16.4+
+
+For broader browser support, when using the `variables` prop, it's recommended to **use direct color values** (e.g. `colorPrimary: '#6c47ff'`) instead of CSS variables or modern color functions.
+
+The following example demonstrates how to use CSS variables to customize the appearance of Clerk components, but for maximum browser compatibility, it's recommended to use direct color values instead.
 
 <CodeBlockTabs options={["global.css", "layout.tsx"]}>
   ```css {{ filename: '/src/app/global.css' }}
@@ -694,13 +713,3 @@ You can also use CSS variables to customize the appearance of Clerk components. 
   }
   ```
 </CodeBlockTabs>
-
-> [!NOTE]
-> **Browser Compatibility Considerations**
->
-> Clerk's theming system uses modern CSS features like [`color-mix()`](https://developer.mozilla.org/en-US/docs/Web/CSS/color_value/color-mix) and [relative color syntax](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_colors/Relative_colors) to automatically generate color variations from your base colors. These features require:
->
-> - **`color-mix()`**: Chrome 111+, Firefox 113+, Safari 16.2+
-> - **Relative color syntax**: Chrome 119+, Firefox 120+, Safari 16.4+
->
-> For broader browser support, use direct color values (e.g., `colorPrimary: '#6c47ff'`) in the `appearance` prop instead of CSS variables or modern color functions.

--- a/docs/customization/variables.mdx
+++ b/docs/customization/variables.mdx
@@ -139,7 +139,7 @@ The `variables` property is used to adjust the general styles of the component's
 
 You can customize Clerk components by passing an object of variables to the `variables` property of the [`appearance`](/docs/customization/overview) prop.
 
-> [!NOTE]
+> [!NOTE browser-compatibility-considerations]
 > **Browser Compatibility Considerations**
 >
 > Clerk's theming system uses modern CSS features like [`color-mix()`](https://developer.mozilla.org/en-US/docs/Web/CSS/color_value/color-mix) and [relative color syntax](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_colors/Relative_colors) to automatically generate color variations from your base colors. These features require:
@@ -663,15 +663,8 @@ The following example shows how to customize the [`<SignIn />`](/docs/components
 
 ### Using CSS variables
 
-> [!NOTE]
-> **Browser Compatibility Considerations**
->
-> Clerk's theming system uses modern CSS features like [`color-mix()`](https://developer.mozilla.org/en-US/docs/Web/CSS/color_value/color-mix) and [relative color syntax](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_colors/Relative_colors) to automatically generate color variations from your base colors. These features require:
->
-> - **`color-mix()`**: Chrome 111+, Firefox 113+, Safari 16.2+
-> - **Relative color syntax**: Chrome 119+, Firefox 120+, Safari 16.4+
->
-> For broader browser support, when using the `variables` prop, **use direct color values** (e.g. `colorPrimary: '#6c47ff'`) instead of CSS variables or modern color functions.
+> [!WARNING]
+> Please consider this approach with browser compatibility in mind, as it may not work in older browsers. See [Browser Compatibility Considerations](#browser-compatibility-considerations) for details.
 
 You can also use CSS variables to customize the appearance of Clerk components. This approach is particularly useful when:
 

--- a/docs/customization/variables.mdx
+++ b/docs/customization/variables.mdx
@@ -634,6 +634,7 @@ The following example shows how to customize the [`<SignIn />`](/docs/components
 
     <template>
       <SignIn :appearance="{ colorPrimary: 'blue', colorText: 'black' }" />
+      <SignIn :appearance="{ variables: { colorPrimary: '#3b82f6', colorText: '#111827' } }" />
     </template>
     ```
   </Tab>
@@ -650,3 +651,66 @@ The following example shows how to customize the [`<SignIn />`](/docs/components
     ```
   </Tab>
 </Tabs>
+
+
+### Using CSS variables
+
+You can also use CSS variables to customize the appearance of Clerk components. This approach is particularly useful when:
+
+- You have a pre-defined design system with CSS custom properties
+- You want to support automatic dark/light mode switching
+- You need to dynamically update colors based on user preferences
+- You're integrating Clerk into an existing application with established CSS variables
+
+<CodeBlockTabs options={["global.css", "layout.tsx"]}>
+  ```css {{ filename: '/src/app/global.css' }}
+  :root {
+    --brand-primary: oklch(49.1% 0.27 292.581);
+    --brand-background: oklch(98% 0.02 292.581);
+    --brand-text: oklch(15% 0.05 292.581);
+    --brand-border-radius: 8px;
+  }
+
+  @media (prefers-color-scheme: dark) {
+    :root {
+      --brand-primary: oklch(54.1% 0.281 293.009);
+      --brand-background: oklch(12% 0.05 293.009);
+      --brand-text: oklch(90% 0.05 293.009);
+    }
+  }
+  ```
+
+  ```tsx {{ filename: '/src/app/layout.tsx', mark: [[9, 15]] }}
+  import { ClerkProvider } from '@clerk/nextjs'
+  import './global.css'
+
+  export default function RootLayout({ children }: { children: React.ReactNode }) {
+    return (
+      <ClerkProvider
+        appearance={{
+          variables: {
+            colorPrimary: 'var(--brand-primary)',
+            colorBackground: 'var(--brand-background)',
+            colorText: 'var(--brand-text)',
+            borderRadius: 'var(--brand-border-radius)',
+          },
+        }}
+      >
+        <html lang="en">
+          <body>{children}</body>
+        </html>
+      </ClerkProvider>
+    )
+  }
+  ```
+</CodeBlockTabs>
+
+> [!NOTE]
+> **Browser Compatibility Considerations**
+>
+> Clerk's theming system uses modern CSS features like [`color-mix()`](https://developer.mozilla.org/en-US/docs/Web/CSS/color_value/color-mix) and [relative color syntax](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_colors/Relative_colors) to automatically generate color variations from your base colors. These features require:
+>
+> - **`color-mix()`**: Chrome 111+, Firefox 113+, Safari 16.2+
+> - **Relative color syntax**: Chrome 119+, Firefox 120+, Safari 16.4+
+>
+> For broader browser support, use direct color values (e.g., `colorPrimary: '#6c47ff'`) in the `appearance` prop instead of CSS variables or modern color functions.

--- a/docs/customization/variables.mdx
+++ b/docs/customization/variables.mdx
@@ -633,7 +633,6 @@ The following example shows how to customize the [`<SignIn />`](/docs/components
     </script>
 
     <template>
-      <SignIn :appearance="{ colorPrimary: 'blue', colorText: 'black' }" />
       <SignIn :appearance="{ variables: { colorPrimary: '#3b82f6', colorText: '#111827' } }" />
     </template>
     ```

--- a/docs/customization/variables.mdx
+++ b/docs/customization/variables.mdx
@@ -666,21 +666,16 @@ You can also use CSS variables to customize the appearance of Clerk components. 
   ```css {{ filename: '/src/app/global.css' }}
   :root {
     --brand-primary: oklch(49.1% 0.27 292.581);
-    --brand-background: oklch(98% 0.02 292.581);
-    --brand-text: oklch(15% 0.05 292.581);
-    --brand-border-radius: 8px;
   }
 
   @media (prefers-color-scheme: dark) {
     :root {
       --brand-primary: oklch(54.1% 0.281 293.009);
-      --brand-background: oklch(12% 0.05 293.009);
-      --brand-text: oklch(90% 0.05 293.009);
     }
   }
   ```
 
-  ```tsx {{ filename: '/src/app/layout.tsx', mark: [[9, 15]] }}
+  ```tsx {{ filename: '/src/app/layout.tsx', mark: [9] }}
   import { ClerkProvider } from '@clerk/nextjs'
   import './global.css'
 
@@ -690,9 +685,6 @@ You can also use CSS variables to customize the appearance of Clerk components. 
         appearance={{
           variables: {
             colorPrimary: 'var(--brand-primary)',
-            colorBackground: 'var(--brand-background)',
-            colorText: 'var(--brand-text)',
-            borderRadius: 'var(--brand-border-radius)',
           },
         }}
       >

--- a/docs/customization/variables.mdx
+++ b/docs/customization/variables.mdx
@@ -663,19 +663,22 @@ The following example shows how to customize the [`<SignIn />`](/docs/components
 
 ### Using CSS variables
 
+> [!NOTE]
+> **Browser Compatibility Considerations**
+>
+> Clerk's theming system uses modern CSS features like [`color-mix()`](https://developer.mozilla.org/en-US/docs/Web/CSS/color_value/color-mix) and [relative color syntax](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_colors/Relative_colors) to automatically generate color variations from your base colors. These features require:
+>
+> - **`color-mix()`**: Chrome 111+, Firefox 113+, Safari 16.2+
+> - **Relative color syntax**: Chrome 119+, Firefox 120+, Safari 16.4+
+>
+> For broader browser support, when using the `variables` prop, **use direct color values** (e.g. `colorPrimary: '#6c47ff'`) instead of CSS variables or modern color functions.
+
 You can also use CSS variables to customize the appearance of Clerk components. This approach is particularly useful when:
 
 - You have a pre-defined design system with CSS custom properties
 - You want to support automatic dark/light mode switching
 - You need to dynamically update colors based on user preferences
 - You're integrating Clerk into an existing application with established CSS variables
-
-However, it's important to consider browser compatibility when using Clerk's `variables` prop. Clerk's theming system uses modern CSS features like [`color-mix()`](https://developer.mozilla.org/en-US/docs/Web/CSS/color_value/color-mix) and [relative color syntax](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_colors/Relative_colors) to automatically generate color variations from your base colors. These features require:
-
-- **`color-mix()`**: Chrome 111+, Firefox 113+, Safari 16.2+
-- **Relative color syntax**: Chrome 119+, Firefox 120+, Safari 16.4+
-
-For broader browser support, when using the `variables` prop, it's recommended to **use direct color values** (e.g. `colorPrimary: '#6c47ff'`) instead of CSS variables or modern color functions.
 
 The following example demonstrates how to use CSS variables to customize the appearance of Clerk components, but for maximum browser compatibility, it's recommended to use direct color values instead.
 

--- a/docs/customization/variables.mdx
+++ b/docs/customization/variables.mdx
@@ -139,21 +139,11 @@ The `variables` property is used to adjust the general styles of the component's
 
 You can customize Clerk components by passing an object of variables to the `variables` property of the [`appearance`](/docs/customization/overview) prop.
 
-> [!NOTE browser-compatibility-considerations]
-> **Browser Compatibility Considerations**
->
-> Clerk's theming system uses modern CSS features like [`color-mix()`](https://developer.mozilla.org/en-US/docs/Web/CSS/color_value/color-mix) and [relative color syntax](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_colors/Relative_colors) to automatically generate color variations from your base colors. These features require:
->
-> - **`color-mix()`**: Chrome 111+, Firefox 113+, Safari 16.2+
-> - **Relative color syntax**: Chrome 119+, Firefox 120+, Safari 16.4+
->
-> For broader browser support, when using the `variables` prop, **use direct color values** (e.g. `colorPrimary: '#6c47ff'`) instead of CSS variables or modern color functions.
-
 ### Apply `variables` to all Clerk components
 
 To customize all Clerk components, pass the `variables` property to the `appearance` prop of the [`<ClerkProvider>`](/docs/components/clerk-provider) component.
 
-In the following example, the primary color is set to blue and the text color is set to black. Because these styles are applied to the `<ClerkProvider>`, which wraps the entire application, these styles will be applied to all Clerk components that use the primary color and text color.
+In the following example, the primary color is set to blue and the text color is set to white. Because these styles are applied to the `<ClerkProvider>`, which wraps the entire application, these styles will be applied to all Clerk components that use the primary color and text color.
 
 <Tabs items={["Next.js", "React", "Remix", "Astro", "Vue", "Nuxt"]}>
   <Tab>
@@ -166,8 +156,8 @@ In the following example, the primary color is set to blue and the text color is
           <ClerkProvider
             appearance={{
               variables: {
-                colorPrimary: '#0000ff', // blue
-                colorText: '#000000', // black
+                colorPrimary: 'blue',
+                colorText: 'black',
               },
             }}
           >
@@ -188,8 +178,8 @@ In the following example, the primary color is set to blue and the text color is
           <ClerkProvider
             appearance={{
               variables: {
-                colorPrimary: '#0000ff', // blue
-                colorText: '#000000', // black
+                colorPrimary: 'blue',
+                colorText: 'black',
               },
             }}
           >
@@ -219,8 +209,8 @@ In the following example, the primary color is set to blue and the text color is
         <ClerkProvider
           appearance={{
             variables: {
-              colorPrimary: '#0000ff', // blue
-              colorText: '#000000', // black
+              colorPrimary: 'blue',
+              colorText: 'black',
             },
           }}
           publishableKey={clerkPubKey}
@@ -272,8 +262,8 @@ In the following example, the primary color is set to blue and the text color is
     export default ClerkApp(App, {
       appearance: {
         variables: {
-          colorPrimary: '#0000ff', // blue
-          colorText: '#000000', // black
+          colorPrimary: 'blue',
+          colorText: 'black',
         },
       },
     })
@@ -289,8 +279,8 @@ In the following example, the primary color is set to blue and the text color is
         clerk({
           appearance: {
             variables: {
-              colorPrimary: '#0000ff', // blue
-              colorText: '#000000', // black
+              colorPrimary: 'blue',
+              colorText: 'black',
             },
           },
         }),
@@ -309,8 +299,8 @@ In the following example, the primary color is set to blue and the text color is
     app.use(clerkPlugin, {
       appearance: {
         variables: {
-          colorPrimary: '#0000ff', // blue
-          colorText: '#000000', // black
+          colorPrimary: 'blue',
+          colorText: 'black',
         },
       },
     })
@@ -325,8 +315,8 @@ In the following example, the primary color is set to blue and the text color is
       clerk: {
         appearance: {
           variables: {
-            colorPrimary: '#0000ff', // blue
-            colorText: '#000000', // black
+            colorPrimary: 'blue',
+            colorText: 'black',
           },
         },
       },
@@ -339,7 +329,7 @@ In the following example, the primary color is set to blue and the text color is
 
 You can customize all instances of a Clerk component by passing the component to the `appearance` prop of the `<ClerkProvider>`. The `appearance` prop accepts the name of the Clerk component you want to style as a key.
 
-In the following example, the primary color is set to blue and the text color is set to black for all instances of the [`<SignIn />`](/docs/components/authentication/sign-in) component.
+In the following example, the primary color is set to blue and the text color is set to white for all instances of the [`<SignIn />`](/docs/components/authentication/sign-in) component.
 
 <Tabs items={["Next.js", "React", "Remix", "Astro", "Vue", "Nuxt"]}>
   <Tab>
@@ -353,8 +343,8 @@ In the following example, the primary color is set to blue and the text color is
             appearance={{
               signIn: {
                 variables: {
-                  colorPrimary: '#0000ff', // blue
-                  colorText: '#000000', // black
+                  colorPrimary: 'blue',
+                  colorText: 'black',
                 },
               },
             }}
@@ -377,8 +367,8 @@ In the following example, the primary color is set to blue and the text color is
             appearance={{
               signIn: {
                 variables: {
-                  colorPrimary: '#0000ff', // blue
-                  colorText: '#000000', // black
+                  colorPrimary: 'blue',
+                  colorText: 'black',
                 },
               },
             }}
@@ -410,8 +400,8 @@ In the following example, the primary color is set to blue and the text color is
           appearance={{
             signIn: {
               variables: {
-                colorPrimary: '#0000ff', // blue
-                colorText: '#000000', // black
+                colorPrimary: 'blue',
+                colorText: 'black',
               },
             },
           }}
@@ -465,8 +455,8 @@ In the following example, the primary color is set to blue and the text color is
       appearance: {
         signIn: {
           variables: {
-            colorPrimary: '#0000ff', // blue
-            colorText: '#000000', // black
+            colorPrimary: 'blue',
+            colorText: 'black',
           },
         },
       },
@@ -484,8 +474,8 @@ In the following example, the primary color is set to blue and the text color is
           appearance: {
             signIn: {
               variables: {
-                colorPrimary: '#0000ff', // blue
-                colorText: '#000000', // black
+                colorPrimary: 'blue',
+                colorText: 'black',
               },
             },
           },
@@ -506,8 +496,8 @@ In the following example, the primary color is set to blue and the text color is
       appearance: {
         signIn: {
           variables: {
-            colorPrimary: '#0000ff', // blue
-            colorText: '#000000', // black
+            colorPrimary: 'blue',
+            colorText: 'black',
           },
         },
       },
@@ -524,8 +514,8 @@ In the following example, the primary color is set to blue and the text color is
         appearance: {
           signIn: {
             variables: {
-              colorPrimary: '#0000ff', // blue
-              colorText: '#000000', // black
+              colorPrimary: 'blue',
+              colorText: 'black',
             },
           },
         },
@@ -539,7 +529,7 @@ In the following example, the primary color is set to blue and the text color is
 
 To customize a single Clerk component, pass the `variables` property to the `appearance` prop of the Clerk component.
 
-The following example shows how to customize the [`<SignIn />`](/docs/components/authentication/sign-in) component by setting the primary color to blue and the text color to black.
+The following example shows how to customize the [`<SignIn />`](/docs/components/authentication/sign-in) component by setting the primary color to blue and the text color to white.
 
 <Tabs items={["Next.js", "React", "Remix", "Astro", "Vue", "Nuxt"]}>
   <Tab>
@@ -552,8 +542,8 @@ The following example shows how to customize the [`<SignIn />`](/docs/components
           <SignIn
             appearance={{
               variables: {
-                colorPrimary: '#0000ff', // blue
-                colorText: '#000000', // black
+                colorPrimary: 'blue',
+                colorText: 'black',
               },
             }}
           />
@@ -568,8 +558,8 @@ The following example shows how to customize the [`<SignIn />`](/docs/components
         <SignIn
           appearance={{
             variables: {
-              colorPrimary: '#0000ff', // blue
-              colorText: '#000000', // black
+              colorPrimary: 'blue',
+              colorText: 'black',
             },
           }}
         />
@@ -588,8 +578,8 @@ The following example shows how to customize the [`<SignIn />`](/docs/components
       <SignIn
         appearance={{
           variables: {
-            colorPrimary: '#0000ff', // blue
-            colorText: '#000000', // black
+            colorPrimary: 'blue',
+            colorText: 'black',
           },
         }}
       />
@@ -610,8 +600,8 @@ The following example shows how to customize the [`<SignIn />`](/docs/components
           <SignIn
             appearance={{
               variables: {
-                colorPrimary: '#0000ff', // blue
-                colorText: '#000000', // black
+                colorPrimary: 'blue',
+                colorText: 'black',
               },
             }}
           />
@@ -629,8 +619,8 @@ The following example shows how to customize the [`<SignIn />`](/docs/components
 
     <SignIn
       appearance={{
-        colorPrimary: '#0000ff', // blue
-        colorText: '#000000', // black
+        colorPrimary: 'blue',
+        colorText: 'black',
       }}
     />
     ```
@@ -643,7 +633,7 @@ The following example shows how to customize the [`<SignIn />`](/docs/components
     </script>
 
     <template>
-      <SignIn :appearance="{ variables: { colorPrimary: '#0000ff', colorText: '#000000' } }" />
+      <SignIn :appearance="{ colorPrimary: 'blue', colorText: 'black' }" />
     </template>
     ```
   </Tab>
@@ -655,57 +645,8 @@ The following example shows how to customize the [`<SignIn />`](/docs/components
     </script>
 
     <template>
-      <SignIn :appearance="{ colorPrimary: '#0000ff', colorText: '#000000' }" />
+      <SignIn :appearance="{ colorPrimary: 'blue', colorText: 'black' }" />
     </template>
     ```
   </Tab>
 </Tabs>
-
-### Using CSS variables
-
-> [!WARNING]
-> Please consider this approach with browser compatibility in mind, as it may not work in older browsers. See [Browser Compatibility Considerations](#browser-compatibility-considerations) for details.
-
-You can also use CSS variables to customize the appearance of Clerk components. This approach is particularly useful when:
-
-- You have a pre-defined design system with CSS custom properties
-- You want to support automatic dark/light mode switching
-- You need to dynamically update colors based on user preferences
-- You're integrating Clerk into an existing application with established CSS variables
-
-The following example demonstrates how to use CSS variables to customize the appearance of Clerk components, but for maximum browser compatibility, it's recommended to use direct color values instead.
-
-<CodeBlockTabs options={["global.css", "layout.tsx"]}>
-  ```css {{ filename: '/src/app/global.css' }}
-  :root {
-    --brand-primary: oklch(49.1% 0.27 292.581);
-  }
-
-  @media (prefers-color-scheme: dark) {
-    :root {
-      --brand-primary: oklch(54.1% 0.281 293.009);
-    }
-  }
-  ```
-
-  ```tsx {{ filename: '/src/app/layout.tsx', mark: [9] }}
-  import { ClerkProvider } from '@clerk/nextjs'
-  import './global.css'
-
-  export default function RootLayout({ children }: { children: React.ReactNode }) {
-    return (
-      <ClerkProvider
-        appearance={{
-          variables: {
-            colorPrimary: 'var(--brand-primary)',
-          },
-        }}
-      >
-        <html lang="en">
-          <body>{children}</body>
-        </html>
-      </ClerkProvider>
-    )
-  }
-  ```
-</CodeBlockTabs>

--- a/docs/customization/variables.mdx
+++ b/docs/customization/variables.mdx
@@ -652,7 +652,6 @@ The following example shows how to customize the [`<SignIn />`](/docs/components
   </Tab>
 </Tabs>
 
-
 ### Using CSS variables
 
 You can also use CSS variables to customize the appearance of Clerk components. This approach is particularly useful when:

--- a/scripts/build-docs.test.ts
+++ b/scripts/build-docs.test.ts
@@ -1746,6 +1746,7 @@ describe('Heading Validation', () => {
         path: './docs/duplicate-headings.mdx',
         content: `---
 title: Duplicate Headings
+description: Duplicate Headings page
 ---
 
 # Heading {{ id: 'custom-id' }}
@@ -1756,7 +1757,7 @@ title: Duplicate Headings
       },
     ])
 
-    const promise = build(
+    const output = await build(
       await createConfig({
         ...baseConfig,
         basePath: tempDir,
@@ -1764,7 +1765,7 @@ title: Duplicate Headings
       }),
     )
 
-    await expect(promise).rejects.toThrow(
+    expect(output).toContain(
       'Doc "/docs/duplicate-headings" contains a duplicate heading id "custom-id", please ensure all heading ids are unique',
     )
   })
@@ -1832,7 +1833,7 @@ sdk: react, nextjs
       },
     ])
 
-    const promise = build(
+    const output = await build(
       await createConfig({
         ...baseConfig,
         basePath: tempDir,
@@ -1840,7 +1841,7 @@ sdk: react, nextjs
       }),
     )
 
-    await expect(promise).rejects.toThrow(
+    expect(output).toContain(
       'Doc "/docs/quickstart.mdx" contains a duplicate heading id "title", please ensure all heading ids are unique',
     )
   })
@@ -1870,7 +1871,7 @@ description: Quickstart page
       },
     ])
 
-    const promise = build(
+    const output = await build(
       await createConfig({
         ...baseConfig,
         basePath: tempDir,
@@ -1878,7 +1879,7 @@ description: Quickstart page
       }),
     )
 
-    await expect(promise).rejects.toThrow(
+    expect(output).toContain(
       'Doc "/docs/quickstart.mdx" contains a duplicate heading id "title", please ensure all heading ids are unique',
     )
   })

--- a/scripts/build-docs.test.ts
+++ b/scripts/build-docs.test.ts
@@ -1882,6 +1882,40 @@ description: Quickstart page
       'Doc "/docs/quickstart.mdx" contains a duplicate heading id "title", please ensure all heading ids are unique',
     )
   })
+
+  test('Should support id in a call out block', async () => {
+    const { tempDir } = await createTempFiles([
+      {
+        path: './docs/manifest.json',
+        content: JSON.stringify({
+          navigation: [[{ title: 'Quickstart', href: '/docs/quickstart' }]],
+        }),
+      },
+      {
+        path: './docs/quickstart.mdx',
+        content: `---
+title: Quickstart
+description: Quickstart page
+---
+
+> [!NOTE my-callout]
+> This is a call out
+
+[Link to call out](#my-callout)
+`,
+      },
+    ])
+
+    const output = await build(
+      await createConfig({
+        ...baseConfig,
+        basePath: tempDir,
+        validSdks: ['react'],
+      }),
+    )
+
+    expect(output).toBe('')
+  })
 })
 
 describe('Includes and Partials', () => {

--- a/scripts/build-docs.ts
+++ b/scripts/build-docs.ts
@@ -83,6 +83,7 @@ import {
 import { type Prompt, readPrompts, writePrompts, checkPrompts } from './lib/prompts'
 import { removeMdxSuffix } from './lib/utils/removeMdxSuffix'
 import { writeLLMs as generateLLMs, writeLLMsFull as generateLLMsFull, listOutputDocsFiles } from './lib/llms'
+import { VFile } from 'vfile'
 
 // Only invokes the main function if we run the script directly eg npm run build, bun run ./scripts/build-docs.ts
 if (require.main === module) {
@@ -757,6 +758,8 @@ template: wide
   const docsWithOnlyIfComponents = docsArray.filter((doc) => doc.sdk === undefined && documentHasIfComponents(doc.node))
   const extractSDKsFromIfComponent = extractSDKsFromIfProp(config)
 
+  const headingValidationVFiles: VFile[] = []
+
   for (const doc of docsWithOnlyIfComponents) {
     // Extract all SDK values from <If /> all components
     const availableSDKs = new Set<SDK>()
@@ -784,7 +787,7 @@ template: wide
     })
 
     for (const sdk of availableSDKs) {
-      await remark()
+      const vfile = await remark()
         .use(remarkFrontmatter)
         .use(remarkMdx)
         .use(() => (inputTree) => {
@@ -814,6 +817,8 @@ template: wide
           path: doc.file.filePath,
           value: String(doc.vfile),
         })
+
+      headingValidationVFiles.push(vfile)
     }
   }
 
@@ -887,7 +892,14 @@ template: wide
   const typedocVFiles = validatedTypedocs.map((typedoc) => typedoc.vfile)
 
   const warnings = reporter(
-    [...coreVFiles, ...partialsVFiles, ...typedocVFiles, ...flatSdkSpecificVFiles, manifestVfile],
+    [
+      ...coreVFiles,
+      ...partialsVFiles,
+      ...typedocVFiles,
+      ...flatSdkSpecificVFiles,
+      manifestVfile,
+      ...headingValidationVFiles,
+    ],
     {
       quiet: true,
     },

--- a/scripts/lib/markdown.ts
+++ b/scripts/lib/markdown.ts
@@ -27,6 +27,8 @@ import { extractHeadingFromHeadingNode } from './utils/extractHeadingFromHeading
 import { Prompt, checkPrompts } from './prompts'
 import { markDocumentDirty, type Store } from './store'
 
+const calloutRegex = new RegExp(/^\[!(NOTE|TIP|IMPORTANT|WARNING|CAUTION|QUIZ)(\s+[0-9a-z-]+)?\]$/)
+
 export const parseInMarkdownFile =
   (config: BuildConfig, store: Store) =>
   async (
@@ -97,6 +99,35 @@ export const parseInMarkdownFile =
       // extract out the headings to check hashes in links
       .use(() => (tree, vfile) => {
         const documentContainsIfComponent = documentHasIfComponents(tree)
+
+        mdastVisit(
+          tree,
+          (node) => {
+            if (node.type !== 'text') return false
+            if (!('value' in node)) return false
+            if (typeof node.value !== 'string') return false
+            const lines = node.value.split('\n')
+            const callout = lines[0]
+            return calloutRegex.test(callout)
+          },
+          (node) => {
+            const callout = calloutRegex.exec((node as any).value.split('\n')[0].trim())
+
+            if (callout === null) {
+              throw new Error(`Invalid callout: ${node}`)
+            }
+
+            const id = callout[2]?.trim()
+
+            if (id !== undefined) {
+              if (documentContainsIfComponent === false && headingsHashes.has(id)) {
+                safeFail(config, vfile, file.filePath, section, 'duplicate-heading-id', [file.href, id])
+              }
+
+              headingsHashes.add(id)
+            }
+          },
+        )
 
         mdastVisit(
           tree,

--- a/scripts/lib/markdown.ts
+++ b/scripts/lib/markdown.ts
@@ -97,7 +97,7 @@ export const parseInMarkdownFile =
       .use(checkPartials(config, partials, file, { reportWarnings: false, embed: true }))
       .use(checkTypedoc(config, typedocs, file.filePath, { reportWarnings: false, embed: true }))
       // extract out the headings to check hashes in links
-      .use(() => (tree, vfile) => {
+      .use(() => (tree) => {
         const documentContainsIfComponent = documentHasIfComponents(tree)
 
         mdastVisit(
@@ -121,7 +121,7 @@ export const parseInMarkdownFile =
 
             if (id !== undefined) {
               if (documentContainsIfComponent === false && headingsHashes.has(id)) {
-                safeFail(config, vfile, file.filePath, section, 'duplicate-heading-id', [file.href, id])
+                safeMessage(config, vfile, file.filePath, section, 'duplicate-heading-id', [file.href, id])
               }
 
               headingsHashes.add(id)
@@ -137,7 +137,7 @@ export const parseInMarkdownFile =
 
             if (id !== undefined) {
               if (documentContainsIfComponent === false && headingsHashes.has(id)) {
-                safeFail(config, vfile, file.filePath, section, 'duplicate-heading-id', [file.href, id])
+                safeMessage(config, vfile, file.filePath, section, 'duplicate-heading-id', [file.href, id])
               }
 
               headingsHashes.add(id)
@@ -145,7 +145,7 @@ export const parseInMarkdownFile =
               const slug = slugify(toString(node).trim())
 
               if (documentContainsIfComponent === false && headingsHashes.has(slug)) {
-                safeFail(config, vfile, file.filePath, section, 'duplicate-heading-id', [file.href, slug])
+                safeMessage(config, vfile, file.filePath, section, 'duplicate-heading-id', [file.href, slug])
               }
 
               headingsHashes.add(slug)

--- a/scripts/lib/plugins/validateUniqueHeadings.ts
+++ b/scripts/lib/plugins/validateUniqueHeadings.ts
@@ -6,7 +6,7 @@ import { Node } from 'unist'
 import { visit as mdastVisit } from 'unist-util-visit'
 import type { VFile } from 'vfile'
 import { type BuildConfig } from '../config'
-import { safeFail, type WarningsSection } from '../error-messages'
+import { safeMessage, type WarningsSection } from '../error-messages'
 import { extractHeadingFromHeadingNode } from '../utils/extractHeadingFromHeadingNode'
 
 export const validateUniqueHeadings =
@@ -22,7 +22,7 @@ export const validateUniqueHeadings =
 
         if (id !== undefined) {
           if (headingsHashes.has(id)) {
-            safeFail(config, vfile, filePath, section, 'duplicate-heading-id', [filePath, id])
+            safeMessage(config, vfile, filePath, section, 'duplicate-heading-id', [filePath, id])
           }
 
           headingsHashes.add(id)
@@ -30,7 +30,7 @@ export const validateUniqueHeadings =
           const slug = slugify(toString(node).trim())
 
           if (headingsHashes.has(slug)) {
-            safeFail(config, vfile, filePath, section, 'duplicate-heading-id', [filePath, slug])
+            safeMessage(config, vfile, filePath, section, 'duplicate-heading-id', [filePath, slug])
           }
 
           headingsHashes.add(slug)


### PR DESCRIPTION
### What does this solve?

- In this pr https://github.com/clerk/clerk-docs/pull/2347 a feature of markdown callouts, using custom ids to link to them is being used for the first time, the validation side of the docs script didn't extract that to validate against

### What changed?

- Added a traversal of the markdown to extract out any callout custom ids

### Checklist

- [x] I have clicked on "Files changed" and performed a thorough self-review
- [x] All existing checks pass
