### PR TITLE
SignInWithApple updates for iOS components

### DIFF
--- a/docs/references/ios/sign-in-with-apple.mdx
+++ b/docs/references/ios/sign-in-with-apple.mdx
@@ -24,6 +24,10 @@ This guide will teach you how to add native Sign in with Apple to your Clerk app
 
   [Add the Sign in with Apple capability to your app](https://developer.apple.com/documentation/xcode/configuring-sign-in-with-apple#Add-the-Sign-in-with-Apple-capability-to-your-app).
 
+  > [!NOTE]
+  > If you are using Clerk's prebuilt components, you don't need to do anything else and can stop here. The SignInWithApple button will appear in your `AuthView` automatically.
+  > If you are buildng a custom flow, continue to follow the steps below.
+
   ## Obtain an Apple ID Credential
 
   To authenticate with Apple and Clerk, you need to obtain an [Apple ID Credential](https://developer.apple.com/documentation/authenticationservices/asauthorizationappleidcredential).

--- a/docs/references/ios/sign-in-with-apple.mdx
+++ b/docs/references/ios/sign-in-with-apple.mdx
@@ -25,7 +25,7 @@ This guide will teach you how to add native Sign in with Apple to your Clerk app
   [Add the Sign in with Apple capability to your app](https://developer.apple.com/documentation/xcode/configuring-sign-in-with-apple#Add-the-Sign-in-with-Apple-capability-to-your-app).
 
   > [!NOTE]
-  > If you are using Clerk's prebuilt components, you don't need to do anything else and can stop here. The SignInWithApple button will appear in your `AuthView` automatically.
+  > If you are using Clerk's prebuilt components, you don't need to do anything else and can stop here. The `SignInWithApple` button will appear in your `AuthView` automatically.
   > If you are buildng a custom flow, continue to follow the steps below.
 
   ## Obtain an Apple ID Credential


### PR DESCRIPTION
### 🔎 Previews:

- https://clerk.com/docs/pr/mike-ios-components-sign-in-with-apple/references/ios/sign-in-with-apple

### What does this solve?

- Lets users know that they can stop at a certain point in the SignInWithApple guide if they are using prebuilt components.
- I'm labeling this as blocked since it **should not be merged** yet but can be reviewed.

### Checklist

- [x] I have clicked on "Files changed" and performed a thorough self-review
- [x] All existing checks pass
