### PR TITLE
Add note about pricing to OAuth token verification mentions

### DIFF
--- a/docs/oauth/verify-oauth-tokens.mdx
+++ b/docs/oauth/verify-oauth-tokens.mdx
@@ -5,6 +5,9 @@ description: Learn how to verify OAuth tokens in your applications.
 
 If you are building an application that uses Clerk and would like to incorporate OAuth, you'll want to ensure that after the [**client**](/docs/oauth/overview#key-terminology) gets an OAuth access token, they can use it to make authenticated requests into your app (the [**resource service**](/docs/oauth/overview#key-terminology)) using the token.
 
+> [!NOTE]
+> OAuth tokens are machine tokens. Machine token usage is free during our public beta period but will be subject to pricing once generally available. Pricing is expected to be competitive and below market averages.
+
 Clerk's SDKs support this through the `acceptsToken` parameter that can be used in Clerk's route protection functions, such as [`auth()`](/docs/references/nextjs/auth), [`auth.protect()`](/docs/references/nextjs/auth#auth-protect), and [`authenticateRequest()`](/docs/references/backend/authenticate-request).
 
 For examples and best practices on verifying OAuth tokens with Clerk SDKs, see our framework-specific guides for:

--- a/docs/references/backend/user/get-user-oauth-access-token.mdx
+++ b/docs/references/backend/user/get-user-oauth-access-token.mdx
@@ -7,6 +7,9 @@ description: Use Clerk's Backend SDK to retrieve the corresponding OAuth access 
 
 Retrieve the corresponding OAuth access token for a user that has previously authenticated with a particular OAuth provider.
 
+> [!NOTE]
+> OAuth tokens are machine tokens. Machine token usage is free during our public beta period but will be subject to pricing once generally available. Pricing is expected to be competitive and below market averages.
+
 ```ts
 function getUserOauthAccessToken(
   userId: string,

--- a/docs/references/nextjs/verifying-oauth-access-tokens.mdx
+++ b/docs/references/nextjs/verifying-oauth-access-tokens.mdx
@@ -5,6 +5,9 @@ description: Learn how to use Clerk's helpers to verify OAuth access tokens in y
 
 When building a resource server that needs to accept and verify OAuth access tokens issued by Clerk, it's crucial to verify these tokens on your backend to ensure the request is coming from an authenticated client.
 
+> [!NOTE]
+> OAuth tokens are machine tokens. Machine token usage is free during our public beta period but will be subject to pricing once generally available. Pricing is expected to be competitive and below market averages.
+
 Clerk's Next.js SDK provides a built-in [`auth()`](/docs/references/nextjs/auth) function that supports token validation via the `acceptsToken` parameter. This lets you specify which type(s) of token your API route should accept. You can also use the [`auth.protect()`](/docs/references/nextjs/auth#auth-protect) method to check if a request includes a valid machine token (e.g. API key or OAuth token) and enforce access rules accordingly.
 
 By default, `acceptsToken` is set to `session_token`, which means OAuth tokens will **not** be accepted unless explicitly configured. You can pass either a **single token type** or an **array of token types** to `acceptsToken`. To learn more about the supported token types, see the [`auth()` parameters documentation](/docs/references/nextjs/auth#parameters).

--- a/docs/references/react-router/verifying-oauth-access-tokens.mdx
+++ b/docs/references/react-router/verifying-oauth-access-tokens.mdx
@@ -5,6 +5,9 @@ description: Learn how to use Clerk's helpers to verify OAuth access tokens in y
 
 When building a resource server that needs to accept and verify OAuth access tokens issued by Clerk, it's crucial to verify these tokens on your backend to ensure the request is coming from an authenticated client.
 
+> [!NOTE]
+> OAuth tokens are machine tokens. Machine token usage is free during our public beta period but will be subject to pricing once generally available. Pricing is expected to be competitive and below market averages.
+
 Clerk provides a built-in [`getAuth()`](/docs/references/react-router/get-auth) function that supports token validation via the `acceptsToken` parameter. This lets you specify which type(s) of token your API route should accept in your React Router app.
 
 By default, `acceptsToken` is set to `session_token`, which means OAuth tokens will **not** be accepted unless explicitly configured. You can pass either a **single token type** or an **array of token types** to `acceptsToken`. To learn more about the supported token types, see the [`getAuth()` parameters documentation](/docs/references/react-router/get-auth#parameters).

--- a/docs/references/tanstack-react-start/verifying-oauth-access-tokens.mdx
+++ b/docs/references/tanstack-react-start/verifying-oauth-access-tokens.mdx
@@ -5,6 +5,9 @@ description: Learn how to use Clerk's helpers to verify OAuth access tokens in y
 
 When building a resource server that needs to accept and verify OAuth access tokens issued by Clerk, it's crucial to verify these tokens on your backend to ensure the request is coming from an authenticated client.
 
+> [!NOTE]
+> OAuth tokens are machine tokens. Machine token usage is free during our public beta period but will be subject to pricing once generally available. Pricing is expected to be competitive and below market averages.
+
 Clerk provides a built-in [`getAuth()`](/docs/references/tanstack-react-start/get-auth) function that supports token validation via the `acceptsToken` parameter. This lets you specify which type(s) of token your API route should accept in your TanStack React Start application.
 
 By default, `acceptsToken` is set to `session_token`, which means OAuth tokens will **not** be accepted unless explicitly configured. You can pass either a **single token type** or an **array of token types** to `acceptsToken`. To learn more about the supported token types, see the [`getAuth()` parameters documentation](/docs/references/tanstack-react-start/get-auth#parameters).


### PR DESCRIPTION
### 🔎 Previews:

-

### What is this about?

Machine tokens are currently in public beta from Clerk, so usage is provided for free during this period. Machine token creation and verification however do have infrastructure costs, and it is a standard practice in the industry amongst auth providers to charge based on usage to cover these costs. As such, once the public beta period has ended, we are planning on rolling out usage-based pricing for machine token creation/verification.

Our current pricing model exercises are showing that we should be able to undercut industry average pricing substantially, as such, we want to assure those testing out the functionality that when pricing is rolled out, they should not expect any surprises or high costs. We do however not want anyone to be surprised when it is, so are adding notes about this to any place where machine token verification is mentioned in the docs, blog, changelog, etc.

### Checklist

- [ ] I have clicked on "Files changed" and performed a thorough self-review
- [ ] All existing checks pass
