### PR TITLE
Add callout about xms_edov Azure portal warning

### DIFF
--- a/docs/_partials/authentication/microsoft/noauth.mdx
+++ b/docs/_partials/authentication/microsoft/noauth.mdx
@@ -3,7 +3,7 @@
 For further security, Microsoft offers an optional `xms_edov` [claim](https://learn.microsoft.com/en-us/entra/identity-platform/optional-claims-reference), which provides additional context to determine whether the returned email is verified. 
 
 > [!NOTE]
-> When adding the `xms_edov` claim in the Azure portal, you may see a warning saying it's invalid or not recognized. You can safely ignore this warning - `xms_edov` is a valid but undocumented claim that Microsoft Entra ID supports for extra email verification security.
+> When adding the `xms_edov` claim in the Azure portal, you may see a warning saying it's invalid or not recognized. You can safely ignore this warning - `xms_edov` is fully supported and documented by Microsoft Entra ID for stronger email domain verification, but the Azure portal's token configuration UI may not recognize it yet. 
 
 To enable it, you must:
 

--- a/docs/_partials/authentication/microsoft/noauth.mdx
+++ b/docs/_partials/authentication/microsoft/noauth.mdx
@@ -1,9 +1,9 @@
 [nOAuth](https://www.descope.com/blog/post/noauth) is an exploit in Microsoft Entra ID OAuth apps that can lead to account takeovers via email address spoofing. Clerk mitigates this risk by enforcing stricter checks on verified email addresses.
 
-For further security, Microsoft offers an optional `xms_edov` [claim](https://learn.microsoft.com/en-us/entra/identity-platform/optional-claims-reference), which provides additional context to determine whether the returned email is verified. 
+For further security, Microsoft offers an optional `xms_edov` [claim](https://learn.microsoft.com/en-us/entra/identity-platform/optional-claims-reference), which provides additional context to determine whether the returned email is verified.
 
 > [!NOTE]
-> When adding the `xms_edov` claim in the Azure portal, you may see a warning saying it's invalid or not recognized. You can safely ignore this warning - `xms_edov` is fully supported and documented by Microsoft Entra ID for stronger email domain verification, but the Azure portal's token configuration UI may not recognize it yet. 
+> When adding the `xms_edov` claim in the Azure portal, you may see a warning saying it's invalid or not recognized. You can safely ignore this warning - `xms_edov` is fully supported and documented by Microsoft Entra ID for stronger email domain verification, but the Azure portal's token configuration UI may not recognize it yet.
 
 To enable it, you must:
 

--- a/docs/_partials/authentication/microsoft/noauth.mdx
+++ b/docs/_partials/authentication/microsoft/noauth.mdx
@@ -1,6 +1,9 @@
 [nOAuth](https://www.descope.com/blog/post/noauth) is an exploit in Microsoft Entra ID OAuth apps that can lead to account takeovers via email address spoofing. Clerk mitigates this risk by enforcing stricter checks on verified email addresses.
 
-For further security, Microsoft offers an optional `xms_edov` [claim](https://learn.microsoft.com/en-us/entra/identity-platform/optional-claims-reference), which provides additional context to determine whether the returned email is verified.
+For further security, Microsoft offers an optional `xms_edov` [claim](https://learn.microsoft.com/en-us/entra/identity-platform/optional-claims-reference), which provides additional context to determine whether the returned email is verified. 
+
+> [!NOTE]
+> When adding the `xms_edov` claim in the Azure portal, you may see a warning saying it's invalid or not recognized. You can safely ignore this warning - `xms_edov` is a valid but undocumented claim that Microsoft Entra ID supports for extra email verification security.
 
 To enable it, you must:
 

--- a/docs/_partials/authentication/microsoft/noauth.mdx
+++ b/docs/_partials/authentication/microsoft/noauth.mdx
@@ -2,7 +2,7 @@
 
 For further security, Microsoft offers an optional `xms_edov` [claim](https://learn.microsoft.com/en-us/entra/identity-platform/optional-claims-reference), which provides additional context to determine whether the returned email is verified.
 
-> [!NOTE]
+> [!IMPORTANT]
 > When adding the `xms_edov` claim in the Azure portal, you may see a warning saying it's invalid or not recognized. You can safely ignore this warning - `xms_edov` is fully supported and documented by Microsoft Entra ID for stronger email domain verification, but the Azure portal's token configuration UI may not recognize it yet.
 
 To enable it, you must:


### PR DESCRIPTION
### 🔎 Previews:

- https://clerk.com/docs/pr/ss-docs-10323/authentication/social-connections/microsoft#secure-your-app-against-the-n-o-auth-vulnerability
- https://clerk.com/docs/pr/ss-docs-10323/authentication/enterprise-connections/easie/microsoft
 
### What does this solve?

Linear ticket: https://linear.app/clerk/issue/DOCS-10323/xms-edov-call-out-regarding-portal

We occasionally get support tickets from developers confused by the warning message in the Azure portal regarding the `xms_edov` optional claim, thinking they misconfigured their Entra ID app. This PR clarifies that the warning is expected and safe to ignore, which should reduce unnecessary support tickets and confusion. 

### What changed?

Added a short note callout to the relevant section of the nOAuth setup guide, explaining that the warning is safe to ignore and the reasons behind the warning

### Checklist

- [ ] I have clicked on "Files changed" and performed a thorough self-review
- [ ] All existing checks pass
