### PR TITLE
Update react router quickstart

### DIFF
--- a/docs/quickstarts/react-router.mdx
+++ b/docs/quickstarts/react-router.mdx
@@ -159,9 +159,7 @@ This tutorial assumes that you're using React Router **v7.1.2 or later** in fram
 
   <Include src="_partials/clerk-provider/explanation" />
 
-  It's required to pass `loaderData` to the `<ClerkProvider>` component. This data is provided by the `rootAuthLoader()` function. It's also recommended to pass the `signUpFallbackRedirectUrl` and `signInFallbackRedirectUrl` props to specify the fallback URL to redirect to after the user signs up or signs in, respectively, if there's no `redirect_url` in the path already. [Learn more about customizing how Clerk redirects](/docs/guides/custom-redirects).
-
-  You can control which content signed-in and signed-out users can see with Clerk's [prebuilt control components](/docs/components/overview#control-components).
+  It's required to pass `loaderData` to the `<ClerkProvider>` component. This data is provided by the `rootAuthLoader()` function.
 
   The following example adds `<ClerkProvider>` and creates a header using the following Clerk components:
 
@@ -177,11 +175,7 @@ This tutorial assumes that you're using React Router **v7.1.2 or later** in fram
 
   export default function App({ loaderData }: Route.ComponentProps) {
     return (
-      <ClerkProvider
-        loaderData={loaderData}
-        signUpFallbackRedirectUrl="/"
-        signInFallbackRedirectUrl="/"
-      >
+      <ClerkProvider loaderData={loaderData}>
         <header className="flex items-center justify-center py-8 px-4">
           <SignedOut>
             <SignInButton />


### PR DESCRIPTION
we don't want to encourage passing the fallbackRedirectUrl props as users should use env vars instead.
also, its not necessary to pass these, as there isn't a case where a redirect url wouldn't be in the path because there is no `/sign-in` or `/sign-up` routes set up that could be directly visited.

### Checklist

- [ ] I have clicked on "Files changed" and performed a thorough self-review
- [ ] All existing checks pass
