### PR TITLE
Validate and copy over tooltips to dist

### DIFF
--- a/scripts/lib/config.ts
+++ b/scripts/lib/config.ts
@@ -23,6 +23,7 @@ type BuildConfigOptions = {
     docs: Record<string, string[]>
     partials: Record<string, string[]>
     typedoc: Record<string, string[]>
+    tooltips: Record<string, string[]>
   }
   manifestOptions: {
     wrapDefault: boolean
@@ -40,6 +41,10 @@ type BuildConfigOptions = {
     }
   }
   prompts?: {
+    inputPath: string
+    outputPath: string
+  }
+  tooltips?: {
     inputPath: string
     outputPath: string
   }
@@ -102,6 +107,7 @@ export async function createConfig(config: BuildConfigOptions) {
         docs: {},
         partials: {},
         typedoc: {},
+        tooltips: {},
       },
 
       manifestOptions: config.manifestOptions ?? {
@@ -129,6 +135,15 @@ export async function createConfig(config: BuildConfigOptions) {
             inputPathRelative: config.prompts.inputPath,
             outputPath: resolve(path.join(tempDist, config.prompts.outputPath)),
             outputPathRelative: config.prompts.outputPath,
+          }
+        : null,
+
+      tooltips: config.tooltips
+        ? {
+            inputPath: resolve(path.join(config.basePath, config.tooltips.inputPath)),
+            inputPathRelative: config.tooltips.inputPath,
+            outputPath: resolve(path.join(tempDist, config.tooltips.outputPath)),
+            outputPathRelative: config.tooltips.outputPath,
           }
         : null,
 

--- a/scripts/lib/error-messages.ts
+++ b/scripts/lib/error-messages.ts
@@ -74,6 +74,10 @@ export const errorMessages = {
   'markdown-read-error': (href: string): string => `Attempting to read in ${href}.mdx failed`,
   'partial-parse-error': (path: string): string => `Failed to parse the content of ${path}`,
 
+  // Tooltip errors
+  'tooltip-read-error': (path: string): string => `Failed to read in ${path} from tooltips file`,
+  'tooltip-parse-error': (path: string): string => `Failed to parse the content of ${path}`,
+
   // Typedoc errors
   'typedoc-folder-not-found': (path: string): string =>
     `Typedoc folder ${path} not found, run "npm run typedoc:download"`,

--- a/scripts/lib/io.ts
+++ b/scripts/lib/io.ts
@@ -24,6 +24,11 @@ export const readDocsFolder = (config: BuildConfig) => async () => {
     fileFilter: (entry) =>
       // Partials are inside the docs folder, so we need to exclude them
       `${config.docsRelativePath}/${entry.path}`.startsWith(config.partialsRelativePath) === false &&
+      // Tooltips are inside the docs folder too, also ignore them as they are not full pages
+      (config.tooltips?.inputPathRelative
+        ? `${config.docsRelativePath}/${entry.path}`.startsWith(config.tooltips.inputPathRelative) === false
+        : true) &&
+      // Ignore anything that isn't an .mdx file
       entry.path.endsWith('.mdx'),
   })
 

--- a/scripts/lib/tooltips.ts
+++ b/scripts/lib/tooltips.ts
@@ -1,6 +1,6 @@
-// responsible for reading in and parsing the partials markdown
-// for validation see validators/checkPartials.ts
-// for partials we currently do not allow them to embed other partials
+// responsible for reading in and parsing the tooltips markdown
+// for validation see validators/checkTooltips.ts
+// for tooltips we currently do not allow them to embed other tooltips
 // this also removes the .mdx suffix from the urls in the markdown
 
 import path from 'node:path'

--- a/scripts/lib/tooltips.ts
+++ b/scripts/lib/tooltips.ts
@@ -18,7 +18,8 @@ import { getTooltipsCache, type Store } from './store'
 
 export const readTooltipsFolder = (config: BuildConfig) => async () => {
   if (!config.tooltips) {
-    throw new Error('Tooltips are not enabled')
+    console.error('Tooltips are not enabled')
+    return []
   }
 
   return readdirp.promise(config.tooltips.inputPath, {

--- a/scripts/lib/tooltips.ts
+++ b/scripts/lib/tooltips.ts
@@ -1,0 +1,101 @@
+// responsible for reading in and parsing the partials markdown
+// for validation see validators/checkPartials.ts
+// for partials we currently do not allow them to embed other partials
+// this also removes the .mdx suffix from the urls in the markdown
+
+import path from 'node:path'
+import readdirp from 'readdirp'
+import { remark } from 'remark'
+import remarkFrontmatter from 'remark-frontmatter'
+import remarkMdx from 'remark-mdx'
+import type { Node } from 'unist'
+import reporter from 'vfile-reporter'
+import type { BuildConfig } from './config'
+import { errorMessages } from './error-messages'
+import { readMarkdownFile, writeDistFile } from './io'
+import { removeMdxSuffixPlugin } from './plugins/removeMdxSuffixPlugin'
+import { getTooltipsCache, type Store } from './store'
+
+export const readTooltipsFolder = (config: BuildConfig) => async () => {
+  if (!config.tooltips) {
+    throw new Error('Tooltips are not enabled')
+  }
+
+  return readdirp.promise(config.tooltips.inputPath, {
+    type: 'files',
+    fileFilter: '*.mdx',
+  })
+}
+
+export const readTooltip = (config: BuildConfig) => async (filePath: string) => {
+  if (!config.tooltips) {
+    throw new Error('Tooltips are not enabled')
+  }
+
+  const fullPath = path.join(config.tooltips.inputPath, filePath)
+
+  const [error, content] = await readMarkdownFile(fullPath)
+
+  if (error) {
+    throw new Error(errorMessages['tooltip-read-error'](fullPath), { cause: error })
+  }
+
+  let tooltipNode: Node | null = null
+
+  try {
+    const tooltipContentVFile = await remark()
+      .use(remarkFrontmatter)
+      .use(remarkMdx)
+      .use(() => (tree) => {
+        tooltipNode = tree
+      })
+      .use(removeMdxSuffixPlugin(config))
+      .process({
+        path: `docs/_tooltips/${filePath}`,
+        value: content,
+      })
+
+    const tooltipContentReport = reporter([tooltipContentVFile], { quiet: true })
+
+    if (tooltipContentReport !== '') {
+      console.error(tooltipContentReport)
+      process.exit(1)
+    }
+
+    if (tooltipNode === null) {
+      throw new Error(errorMessages['tooltip-parse-error'](filePath))
+    }
+
+    return {
+      path: `_tooltips/${filePath}`,
+      content,
+      vfile: tooltipContentVFile,
+      node: tooltipNode as Node,
+    }
+  } catch (error) {
+    console.error(`✗ Error parsing tooltip: ${filePath}`)
+    throw error
+  }
+}
+
+export const readTooltipsMarkdown = (config: BuildConfig, store: Store) => async (paths: string[]) => {
+  const read = readTooltip(config)
+  const tooltipsCache = getTooltipsCache(store)
+
+  return Promise.all(paths.map(async (markdownPath) => tooltipsCache(markdownPath, () => read(markdownPath))))
+}
+
+type Tooltips = Awaited<ReturnType<ReturnType<typeof readTooltipsMarkdown>>>
+
+export const writeTooltips = (config: BuildConfig, store: Store) => async (tooltips: Tooltips) => {
+  if (!config.tooltips) {
+    throw new Error('Tooltips are not enabled')
+  }
+
+  const write = writeDistFile(config, store)
+
+  for (const tooltip of tooltips) {
+    await write(tooltip.path, tooltip.content)
+    console.info(`✓ Wrote tooltip: ${tooltip.path}`)
+  }
+}

--- a/scripts/lib/tooltips.ts
+++ b/scripts/lib/tooltips.ts
@@ -96,7 +96,6 @@ export const writeTooltips = (config: BuildConfig, store: Store) => async (toolt
   const write = writeDistFile(config, store)
 
   for (const tooltip of tooltips) {
-    await write(tooltip.path, tooltip.content)
-    console.info(`✓ Wrote tooltip: ${tooltip.path}`)
+    await write(tooltip.path, tooltip.vfile.value as string)
   }
 }


### PR DESCRIPTION
### 🔎 Previews:

-

### What does this solve?

- New `_tooltip` folder getting added

### What changed?

- Includes the new tooltips in the dist to be put up on the vercel cdn
- Validates that the tooltips are valid markdown and embed the `SDKLink` if need be

### Checklist

- [x] I have clicked on "Files changed" and performed a thorough self-review
- [x] All existing checks pass
