### PR TITLE
Add example for using handleRedirectCallback()

### DIFF
--- a/docs/references/javascript/clerk.mdx
+++ b/docs/references/javascript/clerk.mdx
@@ -739,7 +739,12 @@ function handleRedirectCallback(
 
 #### Example
 
-See the [custom flow](/docs/custom-flows/oauth-connections) guide for a comprehensive example of how to use the `handleRedirectCallback()` method.
+```js
+await clerk.handleRedirectCallback({
+  signInForceRedirectUrl: '/dashboard',
+  signUpForceRedirectUrl: '/dashboard',
+})
+```
 
 ### `handleUnauthenticated()`
 


### PR DESCRIPTION
### 🔎 Previews:

-

### What does this solve?

The `handleRedirectCallback()` method doesn't include any examples like the rest of the methods in the docs. It links to the [custom flow page](https://clerk.com/docs/custom-flows/oauth-connections), which doesn't include an example either. This PR adds an example following the structure used for other methods within this page: https://clerk.com/docs/references/javascript/clerk. 

### What changed?

- Added an example of using the `handleRedirectCallback()` method - I kept it consistent with the rest of the examples on that page and removed the custom flow mention as that page didn't seem to have any mention of that method. 

### Checklist

- [ ] I have clicked on "Files changed" and performed a thorough self-review
- [ ] All existing checks pass
