### PR TITLE
[DO NOT MERGE] Add android samples to `sign-out.mdx`

### DIFF
--- a/docs/custom-flows/sign-out.mdx
+++ b/docs/custom-flows/sign-out.mdx
@@ -12,7 +12,7 @@ The `signOut()` function signs a user out of all sessions in a [multi-session ap
 > [!NOTE]
 > The sign-out flow deactivates only the current session. Other valid sessions associated with the same user (e.g., if the user is signed in on another device) will remain active.
 
-<Tabs items={["Next.js", "JavaScript", "Expo", "iOS", "Android"]}>
+<Tabs items={["Next.js", "JavaScript", "Expo", "iOS", "Android (beta)"]}>
   <Tab>
     The [`useClerk()`](/docs/hooks/use-clerk) hook is used to access the `signOut()` function, which is called when the user clicks the sign-out button.
 

--- a/docs/custom-flows/sign-out.mdx
+++ b/docs/custom-flows/sign-out.mdx
@@ -12,7 +12,7 @@ The `signOut()` function signs a user out of all sessions in a [multi-session ap
 > [!NOTE]
 > The sign-out flow deactivates only the current session. Other valid sessions associated with the same user (e.g., if the user is signed in on another device) will remain active.
 
-<Tabs items={["Next.js", "JavaScript", "Expo", "iOS"]}>
+<Tabs items={["Next.js", "JavaScript", "Expo", "iOS", "Android"]}>
   <Tab>
     The [`useClerk()`](/docs/hooks/use-clerk) hook is used to access the `signOut()` function, which is called when the user clicks the sign-out button.
 
@@ -112,6 +112,58 @@ The `signOut()` function signs a user out of all sessions in a [multi-session ap
           dump(error)
         }
       }
+    }
+    ```
+  </Tab>
+
+  <Tab>
+    ```kotlin {{ filename: 'SignOutView.kt', collapsible: true }}
+    @Composable
+    fun SignOutView(viewModel: SignOutViewModel = viewModel()) {
+
+      val state by viewModel.uiState.collectAsState()
+
+      Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+          when (state) {
+            SignOutUiState.Loading -> CircularProgressIndicator()
+
+            SignOutUiState.SignedIn -> {
+              Text("Active session: ${Clerk.session?.id}")
+              Spacer(modifier = Modifier.height(16.dp))
+              Button(onClick = { viewModel.signOut() }) { Text("Sign Out") }
+            }
+            
+            SignOutUiState.SignedOut -> Text("You are signed out")
+          }
+      }
+    }
+    ```
+
+    ```kotlin {{ filename: 'SignOutViewModel.kt', collapsible: true }}
+    class SignOutViewModel : ViewModel() {
+
+      private val _uiState = MutableStateFlow<SignOutUiState>(SignOutUiState.Loading)
+      val uiState = _uiState.asStateFlow()
+
+      init {
+        if (Clerk.session != null) {
+          _uiState.value = SignOutUiState.SignedIn
+        } else {
+          _uiState.value = SignOutUiState.SignedOut
+        }
+      }
+
+      fun signOut() {
+        viewModelScope.launch {
+          Clerk.signOut().onSuccess { _uiState.value = SignOutUiState.SignedOut }
+        }
+      }
+    }
+
+    sealed interface SignOutUiState {
+      data object Loading : SignOutUiState
+      data object SignedIn : SignOutUiState
+      data object SignedOut : SignOutUiState
     }
     ```
   </Tab>


### PR DESCRIPTION
### 🔎 Previews:

This pull request updates the documentation for the `signOut()` function to include support for Android in the multi-session sign-out flow. It adds a new tab with Kotlin code examples for implementing the `signOut()` functionality on Android, alongside existing examples for other platforms.

### Documentation updates:

* [`docs/custom-flows/sign-out.mdx`](diffhunk://#diff-0044d1373ef4af998d22e5fb4237b35e82ffb2e929e7715c7ac35f070821dd44L15-R15): Added "Android" to the list of tabs in the `signOut()` documentation, expanding platform coverage.
* [`docs/custom-flows/sign-out.mdx`](diffhunk://#diff-0044d1373ef4af998d22e5fb4237b35e82ffb2e929e7715c7ac35f070821dd44R118-R169): Included Kotlin code examples (`SignOutView.kt` and `SignOutViewModel.kt`) to demonstrate the implementation of the `signOut()` function on Android, using Jetpack Compose and ViewModel patterns.

### Checklist

- [ ] I have clicked on "Files changed" and performed a thorough self-review
- [ ] All existing checks pass
