### PR TITLE
[DO NOT MERGE] Add Android samples to password reset flow

### DIFF
--- a/docs/custom-flows/forgot-password.mdx
+++ b/docs/custom-flows/forgot-password.mdx
@@ -21,7 +21,7 @@ This guide demonstrates how to use Clerk's API to build a custom flow for resett
 
 {/* TODO: Add vanilla JS example. */}
 
-<Tabs items={["Next.js", "iOS", "Android"]}>
+<Tabs items={["Next.js", "iOS", "Android (beta)"]}>
   <Tab>
     ```tsx {{ filename: 'app/forgot-password.tsx', collapsible: true }}
     'use client'

--- a/docs/custom-flows/forgot-password.mdx
+++ b/docs/custom-flows/forgot-password.mdx
@@ -191,7 +191,7 @@ This guide demonstrates how to use Clerk's API to build a custom flow for resett
 
   <Tab>
     ```kotlin {{ filename: 'ForgotPasswordView.kt', collapsible: true }}
-     @Composable
+      @Composable
       fun ForgotPasswordView(viewModel: ForgotPasswordViewModel = viewModel()) {
         val state by viewModel.uiState.collectAsState()
         Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
@@ -450,6 +450,135 @@ In this case, you can prompt the user to reset their password using the exact sa
     }
 
     export default ForgotPasswordPage
+    ```
+  </Tab>
+
+  <Tab>
+    ```kotlin {{ filename: 'ForgotPasswordView.kt', collapsible: true }}
+      @Composable
+      fun ForgotPasswordView(viewModel: ForgotPasswordViewModel = viewModel()) {
+        val state by viewModel.uiState.collectAsState()
+        Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+          when (state) {
+            ForgotPasswordViewModel.ForgotPasswordUiState.Complete -> {
+              Text("Active session: ${Clerk.session?.id}")
+            }
+            ForgotPasswordViewModel.ForgotPasswordUiState.Error -> {
+              // Handle error
+            }
+            ForgotPasswordViewModel.ForgotPasswordUiState.NeedsFirstFactor -> {
+              InputContent(
+                placeholder = "Enter your code",
+                buttonText = "Verify",
+                onClick = viewModel::verify,
+              )
+            }
+            ForgotPasswordViewModel.ForgotPasswordUiState.NeedsNewPassword -> {
+              InputContent(
+                placeholder = "Enter your new password",
+                buttonText = "Set new password",
+                onClick = viewModel::setNewPassword,
+                visualTransformation = PasswordVisualTransformation(),
+              )
+            }
+            ForgotPasswordViewModel.ForgotPasswordUiState.NeedsSecondFactor -> {
+              Text("2FA is required but this UI does not handle that")
+            }
+            ForgotPasswordViewModel.ForgotPasswordUiState.SignedOut -> {
+              InputContent(
+                placeholder = "Enter your phone number",
+                buttonText = "Forgot password?",
+                onClick = viewModel::createSignIn,
+              )
+            }
+          }
+        }
+    }
+
+    @Composable
+    fun InputContent(
+      placeholder: String,
+      buttonText: String,
+      visualTransformation: VisualTransformation = VisualTransformation.None,
+      onClick: (String) -> Unit,
+    ) {
+      var value by remember { mutableStateOf("") }
+      Column(
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = spacedBy(16.dp, Alignment.CenterVertically),
+      ) {
+        TextField(
+          value = value,
+          onValueChange = { value = it },
+          visualTransformation = visualTransformation,
+          placeholder = { Text(placeholder) },
+        )
+        Button(onClick = { onClick(value) }) { Text(buttonText) }
+      }
+    }
+    ```
+
+    ```kotlin {{ filename: 'ForgotPasswordViewModel.kt', collapsible: true }}
+    class ForgotPasswordViewModel : ViewModel() {
+
+      private val _uiState = MutableStateFlow<ForgotPasswordUiState>(ForgotPasswordUiState.SignedOut)
+      val uiState = _uiState.asStateFlow()
+
+      fun createSignIn(phoneNumber: String) {
+        viewModelScope.launch {
+          SignIn.create(SignIn.CreateParams.Strategy.ResetPasswordPhoneCode(identifier = phoneNumber))
+            .onSuccess { updateStateFromStatus(it.status) }
+            .onFailure { _uiState.value = ForgotPasswordUiState.Error }
+        }
+      }
+
+      fun verify(code: String) {
+        val inProgressSignIn = Clerk.signIn ?: return
+        viewModelScope.launch {
+          inProgressSignIn
+            .attemptFirstFactor(SignIn.AttemptFirstFactorParams.ResetPasswordPhoneCode(code))
+            .onSuccess { updateStateFromStatus(it.status) }
+            .onFailure { _uiState.value = ForgotPasswordUiState.Error }
+        }
+      }
+
+      fun setNewPassword(password: String) {
+        val inProgressSignIn = Clerk.signIn ?: return
+        viewModelScope.launch {
+          inProgressSignIn
+            .resetPassword(SignIn.ResetPasswordParams(password))
+            .onSuccess { updateStateFromStatus(it.status) }
+            .onFailure { _uiState.value = ForgotPasswordUiState.Error }
+        }
+      }
+
+      fun updateStateFromStatus(status: SignIn.Status) {
+        val state =
+          when (status) {
+            SignIn.Status.COMPLETE -> ForgotPasswordUiState.Complete
+            SignIn.Status.NEEDS_FIRST_FACTOR -> ForgotPasswordUiState.NeedsFirstFactor
+            SignIn.Status.NEEDS_SECOND_FACTOR -> ForgotPasswordUiState.NeedsSecondFactor
+            SignIn.Status.NEEDS_NEW_PASSWORD -> ForgotPasswordUiState.NeedsNewPassword
+            else -> ForgotPasswordUiState.Error
+          }
+
+        _uiState.value = state
+      }
+
+      sealed interface ForgotPasswordUiState {
+        data object SignedOut : ForgotPasswordUiState
+
+        data object NeedsFirstFactor : ForgotPasswordUiState
+
+        data object NeedsSecondFactor : ForgotPasswordUiState
+
+        data object NeedsNewPassword : ForgotPasswordUiState
+
+        data object Error : ForgotPasswordUiState
+
+        data object Complete : ForgotPasswordUiState
+      }
+    }
     ```
   </Tab>
 </Tabs>

--- a/docs/custom-flows/forgot-password.mdx
+++ b/docs/custom-flows/forgot-password.mdx
@@ -21,7 +21,7 @@ This guide demonstrates how to use Clerk's API to build a custom flow for resett
 
 {/* TODO: Add vanilla JS example. */}
 
-<Tabs items={["Next.js", "iOS"]}>
+<Tabs items={["Next.js", "iOS", "Android"]}>
   <Tab>
     ```tsx {{ filename: 'app/forgot-password.tsx', collapsible: true }}
     'use client'
@@ -186,47 +186,133 @@ This guide demonstrates how to use Clerk's API to build a custom flow for resett
         }
       }
     }
+    ```
+  </Tab>
 
-    extension ForgotPasswordView {
+  <Tab>
+    ```kotlin {{ filename: 'ForgotPasswordView.kt', collapsible: true }}
+     @Composable
+      fun ForgotPasswordView(viewModel: ForgotPasswordViewModel = viewModel()) {
+        val state by viewModel.uiState.collectAsState()
+        Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+          when (state) {
+            ForgotPasswordViewModel.ForgotPasswordUiState.Complete -> {
+              Text("Active session: ${Clerk.session?.id}")
+            }
+            ForgotPasswordViewModel.ForgotPasswordUiState.Error -> {
+              // Handle error
+            }
+            ForgotPasswordViewModel.ForgotPasswordUiState.NeedsFirstFactor -> {
+              InputContent(
+                placeholder = "Enter your code",
+                buttonText = "Verify",
+                onClick = viewModel::verify,
+              )
+            }
+            ForgotPasswordViewModel.ForgotPasswordUiState.NeedsNewPassword -> {
+              InputContent(
+                placeholder = "Enter your new password",
+                buttonText = "Set new password",
+                onClick = viewModel::setNewPassword,
+                visualTransformation = PasswordVisualTransformation(),
+              )
+            }
+            ForgotPasswordViewModel.ForgotPasswordUiState.NeedsSecondFactor -> {
+              Text("2FA is required but this UI does not handle that")
+            }
+            ForgotPasswordViewModel.ForgotPasswordUiState.SignedOut -> {
+              InputContent(
+                placeholder = "Enter your email",
+                buttonText = "Forgot password?",
+                onClick = viewModel::createSignIn,
+              )
+            }
+          }
+        }
+    }
 
-      func createSignIn(email: String) async {
-        do {
-          // Start the sign in reset password process
-          try await SignIn.create(strategy: .identifier(email, strategy: .resetPasswordEmailCode()))
-        } catch {
-          // See https://clerk.com/docs/custom-flows/error-handling
-          // for more info on error handling
-          dump(error)
+    @Composable
+    fun InputContent(
+      placeholder: String,
+      buttonText: String,
+      visualTransformation: VisualTransformation = VisualTransformation.None,
+      onClick: (String) -> Unit,
+    ) {
+      var value by remember { mutableStateOf("") }
+      Column(
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = spacedBy(16.dp, Alignment.CenterVertically),
+      ) {
+        TextField(
+          value = value,
+          onValueChange = { value = it },
+          visualTransformation = visualTransformation,
+          placeholder = { Text(placeholder) },
+        )
+        Button(onClick = { onClick(value) }) { Text(buttonText) }
+      }
+    }
+    ```
+
+    ```kotlin {{ filename: 'ForgotPasswordViewModel.kt', collapsible: true }}
+    class ForgotPasswordViewModel : ViewModel() {
+
+      private val _uiState = MutableStateFlow<ForgotPasswordUiState>(ForgotPasswordUiState.SignedOut)
+      val uiState = _uiState.asStateFlow()
+
+      fun createSignIn(email: String) {
+        viewModelScope.launch {
+          SignIn.create(SignIn.CreateParams.Strategy.ResetPasswordEmailCode(identifier = email))
+            .onSuccess { updateStateFromStatus(it.status) }
+            .onFailure { _uiState.value = ForgotPasswordUiState.Error }
         }
       }
 
-      func verify(code: String) async {
-        do {
-          // Access the in progress sign in stored on the client object.
-          guard let inProgressSignIn = clerk.client?.signIn else { return }
-
-          // Verify the code sent to the user's email
-          try await inProgressSignIn.attemptFirstFactor(strategy: .resetPasswordEmailCode(code: code))
-        } catch {
-          // See https://clerk.com/docs/custom-flows/error-handling
-          // for more info on error handling
-          dump(error)
+      fun verify(code: String) {
+        val inProgressSignIn = Clerk.signIn ?: return
+        viewModelScope.launch {
+          inProgressSignIn
+            .attemptFirstFactor(SignIn.AttemptFirstFactorParams.ResetPasswordEmailCode(code))
+            .onSuccess { updateStateFromStatus(it.status) }
+            .onFailure { _uiState.value = ForgotPasswordUiState.Error }
         }
       }
 
-      func setNewPassword(password: String) async {
-        do {
-          // Access the in progress sign in stored on the client object.
-          guard let inProgressSignIn = clerk.client?.signIn else { return }
-
-          // Reset the user's password.
-          // Upon successful reset, the user will be signed in
-          try await inProgressSignIn.resetPassword(.init(password: password, signOutOfOtherSessions: true))
-        } catch {
-          // See https://clerk.com/docs/custom-flows/error-handling
-          // for more info on error handling
-          dump(error)
+      fun setNewPassword(password: String) {
+        val inProgressSignIn = Clerk.signIn ?: return
+        viewModelScope.launch {
+          inProgressSignIn
+            .resetPassword(SignIn.ResetPasswordParams(password))
+            .onSuccess { updateStateFromStatus(it.status) }
+            .onFailure { _uiState.value = ForgotPasswordUiState.Error }
         }
+      }
+
+      fun updateStateFromStatus(status: SignIn.Status) {
+        val state =
+          when (status) {
+            SignIn.Status.COMPLETE -> ForgotPasswordUiState.Complete
+            SignIn.Status.NEEDS_FIRST_FACTOR -> ForgotPasswordUiState.NeedsFirstFactor
+            SignIn.Status.NEEDS_SECOND_FACTOR -> ForgotPasswordUiState.NeedsSecondFactor
+            SignIn.Status.NEEDS_NEW_PASSWORD -> ForgotPasswordUiState.NeedsNewPassword
+            else -> ForgotPasswordUiState.Error
+          }
+
+        _uiState.value = state
+      }
+
+      sealed interface ForgotPasswordUiState {
+        data object SignedOut : ForgotPasswordUiState
+
+        data object NeedsFirstFactor : ForgotPasswordUiState
+
+        data object NeedsSecondFactor : ForgotPasswordUiState
+
+        data object NeedsNewPassword : ForgotPasswordUiState
+
+        data object Error : ForgotPasswordUiState
+
+        data object Complete : ForgotPasswordUiState
       }
     }
     ```
@@ -243,7 +329,7 @@ In this case, you can prompt the user to reset their password using the exact sa
 
 {/* TODO: Add iOS and vanilla JS example. */}
 
-<Tabs items={["Next.js"]}>
+<Tabs items={["Next.js", "Android"]}>
   <Tab>
     ```tsx {{ filename: 'app/forgot-password.tsx', collapsible: true }}
     'use client'


### PR DESCRIPTION
### 🔎 Previews:

This pull request introduces improvements to the development environment and expands the documentation for custom password reset flows. The most notable changes include enabling auto-formatting in VS Code settings and adding Kotlin examples for Android in the "Forgot Password" documentation.

### Documentation Enhancements:
* [`docs/custom-flows/forgot-password.mdx`](diffhunk://#diff-5896155cc3aa50dedacadfa6a76b72ddea8daecd3e96a6a34ea7fdafc808e245R189-R315): Added Kotlin examples for Android password reset flows, including composable UI components (`ForgotPasswordView` and `InputContent`) and a `ForgotPasswordViewModel` to handle state and API interactions. [[1]](diffhunk://#diff-5896155cc3aa50dedacadfa6a76b72ddea8daecd3e96a6a34ea7fdafc808e245R189-R315) [[2]](diffhunk://#diff-5896155cc3aa50dedacadfa6a76b72ddea8daecd3e96a6a34ea7fdafc808e245R455-R583)
* [`docs/custom-flows/forgot-password.mdx`](diffhunk://#diff-5896155cc3aa50dedacadfa6a76b72ddea8daecd3e96a6a34ea7fdafc808e245L24-R24): Updated tab navigation to include "Android" alongside "Next.js" and "iOS" for broader platform coverage. [[1]](diffhunk://#diff-5896155cc3aa50dedacadfa6a76b72ddea8daecd3e96a6a34ea7fdafc808e245L24-R24) [[2]](diffhunk://#diff-5896155cc3aa50dedacadfa6a76b72ddea8daecd3e96a6a34ea7fdafc808e245L246-R332)

### Checklist

- [x] I have clicked on "Files changed" and performed a thorough self-review
- [x] All existing checks pass
