### PR TITLE
[DO NOT MERGE] Add Android content to `email-password.mdx`

### DIFF
--- a/docs/custom-flows/email-password.mdx
+++ b/docs/custom-flows/email-password.mdx
@@ -28,7 +28,7 @@ This guide will walk you through how to build a custom email/password sign-up an
   1. Collect the one-time code and attempt to complete the email address verification with it.
   1. If the email address verification is successful, set the newly created session as the active session.
 
-  <Tabs items={["Next.js", "JavaScript", "Expo", "iOS"]}>
+  <Tabs items={["Next.js", "JavaScript", "Expo", "iOS", "Android"]}>
     <Tab>
       This example is written for Next.js App Router but it can be adapted for any React-based framework.
 
@@ -459,6 +459,101 @@ This guide will walk you through how to build a custom email/password sign-up an
             // for more info on error handling
             dump(error)
           }
+        }
+      }
+      ```
+    </Tab>
+
+    <Tab>
+      ```kotlin {{ filename: 'EmailPasswordSignUpView.kt', collapsible: true }}
+        @Composable
+        fun EmailPasswordSignUpView(viewModel: EmailPasswordSignUpViewModel = viewModel()) {
+          var email by remember { mutableStateOf("") }
+          var password by remember { mutableStateOf("") }
+          var code by remember { mutableStateOf("") }
+          val state by viewModel.uiState.collectAsState()
+          Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+            when (state) {
+              EmailPasswordSignUpViewModel.UiState.Unverified -> {
+                Column(
+                  verticalArrangement = Arrangement.spacedBy(16.dp, Alignment.CenterVertically),
+                  horizontalAlignment = Alignment.CenterHorizontally,
+                ) {
+                  TextField(value = email, onValueChange = { email = it }, label = { Text("Email") })
+                  TextField(
+                    value = password,
+                    onValueChange = { password = it },
+                    visualTransformation = PasswordVisualTransformation(),
+                    label = { Text("Password") },
+                  )
+                  Button(onClick = { viewModel.submit(email, password) }) { Text("Next") }
+                }
+              }
+              EmailPasswordSignUpViewModel.UiState.Verified -> {
+                Text("Verified!")
+              }
+              EmailPasswordSignUpViewModel.UiState.Verifying -> {
+                Column(
+                  verticalArrangement = Arrangement.spacedBy(16.dp, Alignment.CenterVertically),
+                  horizontalAlignment = Alignment.CenterHorizontally,
+                ) {
+                  TextField(
+                    value = code,
+                    onValueChange = { code = it },
+                    label = { Text("Enter your verification code") },
+                  )
+                  Button(onClick = { viewModel.verify(code) }) { Text("Verify") }
+                }
+              }
+            }
+          }
+      }
+      ```
+
+      ```kotlin {{ filename: 'EmailPasswordSignUpViewModel.kt', collapsible: true }}
+      class EmailPasswordSignUpViewModel : ViewModel() {
+
+        private val _uiState = MutableStateFlow<UiState>(UiState.Unverified)
+        val uiState = _uiState.asStateFlow()
+
+        fun submit(email: String, password: String) {
+          viewModelScope.launch {
+            SignUp.create(SignUp.CreateParams.Standard(emailAddress = email, password = password))
+              .flatMap { it.prepareVerification(SignUp.PrepareVerificationParams.Strategy.EMAIL_CODE) }
+              .onSuccess {
+                // Update UI state to indicate verification is in progress
+                // and capture the OTP code
+                _uiState.value = UiState.Verifying
+              }
+          }
+        }
+
+        fun verify(code: String) {
+          val inProgressSignUp = Clerk.signUp ?: return
+          viewModelScope.launch {
+            inProgressSignUp
+              .attemptVerification(SignUp.AttemptVerificationParams.EmailCode(code = code))
+              .onSuccess {
+                if (it.status == SignUp.Status.COMPLETE) {
+                  _uiState.value = UiState.Verified
+                } else {
+                  // If the status is not complete, check why. User may need to
+                  // complete further steps.
+                }
+              }
+              .onFailure {
+                // See https://clerk.com/docs/custom-flows/error-handling
+                // for more info on error handling
+              }
+          }
+        }
+
+        sealed interface UiState {
+          data object Unverified : UiState
+
+          data object Verifying : UiState
+
+          data object Verified : UiState
         }
       }
       ```

--- a/docs/custom-flows/email-password.mdx
+++ b/docs/custom-flows/email-password.mdx
@@ -567,7 +567,7 @@ This guide will walk you through how to build a custom email/password sign-up an
   1. Initiate the sign-in process by creating a `SignIn` using the email address and password provided.
   1. If the attempt is successful, set the newly created session as the active session.
 
-  <Tabs items={["Next.js", "JavaScript", "Expo", "iOS"]}>
+  <Tabs items={["Next.js", "JavaScript", "Expo", "iOS", "Android"]}>
     <Tab>
       This example is written for Next.js App Router but it can be adapted for any React-based framework.
 
@@ -843,6 +843,68 @@ This guide will walk you through how to build a custom email/password sign-up an
             // for more info on error handling
             dump(error)
           }
+        }
+      }
+      ```
+    </Tab>
+
+    <Tab>
+      ```kotlin {{ filename: 'EmailPasswordSignInView.kt', collapsible: true }}
+        @Composable
+        fun EmailPasswordSignInView(viewModel: EmailPasswordSignInViewModel = viewModel()) {
+          var email by remember { mutableStateOf("") }
+          var password by remember { mutableStateOf("") }
+          val state by viewModel.uiState.collectAsState()
+
+          Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+            when (state) {
+              EmailPasswordSignInViewModel.UiState.SignedOut -> {
+                Column(
+                  verticalArrangement = Arrangement.spacedBy(16.dp, Alignment.CenterVertically),
+                  horizontalAlignment = Alignment.CenterHorizontally,
+                ) {
+                  TextField(value = email, onValueChange = { email = it }, label = { Text("Email") })
+                  TextField(
+                    value = password,
+                    onValueChange = { password = it },
+                    visualTransformation = PasswordVisualTransformation(),
+                    label = { Text("Password") },
+                  )
+                  Button(onClick = { viewModel.submit(email, password) }) { Text("Sign in") }
+                }
+              }
+              EmailPasswordSignInViewModel.UiState.SignedIn -> {
+                Text("Current session: ${Clerk.session?.id}")
+              }
+            }
+          }
+      }
+      ```
+
+      ```kotlin {{ filename: 'EmailPasswordSignInViewModel.kt', collapsible: true }}
+      class EmailPasswordSignInViewModel : ViewModel() {
+
+        private val _uiState = MutableStateFlow<UiState>(UiState.SignedOut)
+        val uiState = _uiState.asStateFlow()
+
+        fun submit(email: String, password: String) {
+          viewModelScope.launch {
+            SignUp.create(SignIn.CreateParams.Standard(emailAddress = email, password = password))
+              .onSuccess {
+                if(it.status == SignIn.Status.COMPLETE) {
+                  _uiState.value = UiState.SignedIn
+                } else {
+                  // If the status is not complete, check why. User may need to
+                  // complete further steps.
+                }
+              }
+          }
+        }
+
+        sealed interface UiState {
+          data object SignedOut : UiState
+
+          data object SignedIn : UiState
         }
       }
       ```

--- a/docs/custom-flows/email-password.mdx
+++ b/docs/custom-flows/email-password.mdx
@@ -525,6 +525,10 @@ This guide will walk you through how to build a custom email/password sign-up an
                 // and capture the OTP code
                 _uiState.value = UiState.Verifying
               }
+              .onFailure {
+                // See https://clerk.com/docs/custom-flows/error-handling
+                // for more info on error handling
+              }
           }
         }
 
@@ -897,6 +901,10 @@ This guide will walk you through how to build a custom email/password sign-up an
                   // If the status is not complete, check why. User may need to
                   // complete further steps.
                 }
+              }
+              .onFailure {
+                // See https://clerk.com/docs/custom-flows/error-handling
+                // for more info on error handling
               }
           }
         }

--- a/docs/custom-flows/email-password.mdx
+++ b/docs/custom-flows/email-password.mdx
@@ -28,7 +28,7 @@ This guide will walk you through how to build a custom email/password sign-up an
   1. Collect the one-time code and attempt to complete the email address verification with it.
   1. If the email address verification is successful, set the newly created session as the active session.
 
-  <Tabs items={["Next.js", "JavaScript", "Expo", "iOS", "Android"]}>
+  <Tabs items={["Next.js", "JavaScript", "Expo", "iOS", "Android (beta)"]}>
     <Tab>
       This example is written for Next.js App Router but it can be adapted for any React-based framework.
 


### PR DESCRIPTION
### 🔎 Previews:

-

This pull request updates the documentation for custom email/password flows to include Android-specific examples and Kotlin code snippets for both sign-up and sign-in processes. It enhances the guide by providing detailed implementations for Android developers using Jetpack Compose and ViewModel architecture.

### Updates to documentation for Android support:

* **Added Android as a tab option**: Updated the `<Tabs>` component to include "Android" alongside existing options like "Next.js" and "JavaScript" for both the sign-up and sign-in sections. [[1]](diffhunk://#diff-522941a131d76e7833ff1208d1e9483399972430714aa3e07df39916f12cb2eaL31-R31) [[2]](diffhunk://#diff-522941a131d76e7833ff1208d1e9483399972430714aa3e07df39916f12cb2eaL475-R570)

* **Added Kotlin example for sign-up flow**: Introduced a comprehensive Kotlin code snippet (`EmailPasswordSignUpView.kt` and `EmailPasswordSignUpViewModel.kt`) demonstrating the email/password sign-up flow with UI state management using Jetpack Compose and ViewModel.

* **Added Kotlin example for sign-in flow**: Included a Kotlin code snippet (`EmailPasswordSignInView.kt` and `EmailPasswordSignInViewModel.kt`) showcasing the email/password sign-in flow with session handling and UI state management.

### Checklist

- [x] I have clicked on "Files changed" and performed a thorough self-review
- [x] All existing checks pass
