### PR TITLE
Fix broken link in Clerk middleware docs

### DIFF
--- a/docs/references/nextjs/clerk-middleware.mdx
+++ b/docs/references/nextjs/clerk-middleware.mdx
@@ -10,7 +10,7 @@ The `clerkMiddleware()` helper integrates Clerk authentication into your Next.js
 Create a `middleware.ts` file at the root of your project, or in your `src/` directory if you have one.
 
 > [!NOTE]
-> For more information about Middleware in Next.js, see the [Next.js documentation](https://nextjs.org/docs/pages/building-your-application/routing/middleware).
+> For more information about Middleware in Next.js, see the [Next.js documentation](https://nextjs.org/docs/app/api-reference/file-conventions/middleware).
 
 ```tsx {{ filename: 'middleware.ts' }}
 import { clerkMiddleware } from '@clerk/nextjs/server'


### PR DESCRIPTION
### 🔎 Previews:

- https://clerk.com/docs/pr/ss-docs-10591/references/nextjs/clerk-middleware

### What does this solve?

Linear: https://linear.app/clerk/issue/DOCS-10591/broken-link-in-documentation

A user spotted a broken link within the [Clerk Middleware page](https://clerk.com/docs/references/nextjs/clerk-middleware) in one of the callouts. Clicking on the link leads to a 404. After investigating, I noticed it was due to Next.js moving things around in their own docs, so I looked for the new place mentioning Next.js middleware. 

### What changed?

- Replaced the broken link with the new correct link within the Next.js docs. Worth noting that the old link was leading to the Pages router docs, so replaced it with the App router docs. 

### Checklist

- [ ] I have clicked on "Files changed" and performed a thorough self-review
- [ ] All existing checks pass
