### PR TITLE
Update requireAuth() helper docs

### DIFF
--- a/docs/references/express/overview.mdx
+++ b/docs/references/express/overview.mdx
@@ -52,9 +52,9 @@ app.use(clerkMiddleware(options))
 ## `requireAuth()`
 
 > [!WARNING]
-> The `requireAuth()` helper redirects unauthenticated users to the sign-in page so it should only be used for full-stack Express apps that render HTML pages.
+> The `requireAuth()` helper redirects unauthenticated users to the sign-in page so it should only be used for full-stack Express apps. If your client and server run on different origins, see the [cross-origin requests](/docs/backend-requests/making-requests#cross-origin-requests) guide.
 >
-> Do not use `requireAuth()` for API routes. For backend API calls, use [`clerkMiddleware()`](https://clerk.com/docs/references/express/overview#clerk-middleware) together with [`getAuth()`](https://clerk.com/docs/references/express/overview#get-auth) to verify the session and return standard HTTP status codes.
+> Do not use `requireAuth()` for API routes. For backend API calls, use [`clerkMiddleware()`](https://clerk.com/docs/references/express/overview#clerk-middleware) along with [`getAuth()`](https://clerk.com/docs/references/express/overview#get-auth) to verify sessions and return standard HTTP status codes.
 
 The `requireAuth()` middleware functions similarly to `clerkMiddleware()`, but also protects your routes by redirecting unauthenticated users to the homepage. It accepts the same [options](/docs/references/express/overview#clerk-middleware-options) as `clerkMiddleware()`.
 

--- a/docs/references/express/overview.mdx
+++ b/docs/references/express/overview.mdx
@@ -55,6 +55,9 @@ The `requireAuth()` middleware functions similarly to `clerkMiddleware()`, but a
 
 You can also specify a custom sign-in URL to redirect unauthenticated users to by setting the `CLERK_SIGN_IN_URL` environment variable or by passing a `signInUrl` option to the middleware. It's recommended to set the environment variable.
 
+> [!WARNING]
+> The `requireAuth()` helper redirects unauthenticated users to the sign-in page, so it should only be used for full-stack Express apps that render HTML pages. Do not use `requireAuth()` for API routes. For backend API calls, use [`clerkMiddleware()`](https://clerk.com/docs/references/express/overview#clerk-middleware) together with [`getAuth()`](https://clerk.com/docs/references/express/overview#get-auth) to verify the session and return standard HTTP status codes.
+
 ```js
 import { requireAuth } from '@clerk/express'
 import express from 'express'

--- a/docs/references/express/overview.mdx
+++ b/docs/references/express/overview.mdx
@@ -51,12 +51,14 @@ app.use(clerkMiddleware(options))
 
 ## `requireAuth()`
 
+> [!WARNING]
+> The `requireAuth()` helper redirects unauthenticated users to the sign-in page so it should only be used for full-stack Express apps that render HTML pages.
+>
+> Do not use `requireAuth()` for API routes. For backend API calls, use [`clerkMiddleware()`](https://clerk.com/docs/references/express/overview#clerk-middleware) together with [`getAuth()`](https://clerk.com/docs/references/express/overview#get-auth) to verify the session and return standard HTTP status codes.
+
 The `requireAuth()` middleware functions similarly to `clerkMiddleware()`, but also protects your routes by redirecting unauthenticated users to the homepage. It accepts the same [options](/docs/references/express/overview#clerk-middleware-options) as `clerkMiddleware()`.
 
 You can also specify a custom sign-in URL to redirect unauthenticated users to by setting the `CLERK_SIGN_IN_URL` environment variable or by passing a `signInUrl` option to the middleware. It's recommended to set the environment variable.
-
-> [!WARNING]
-> The `requireAuth()` helper redirects unauthenticated users to the sign-in page, so it should only be used for full-stack Express apps that render HTML pages. Do not use `requireAuth()` for API routes. For backend API calls, use [`clerkMiddleware()`](https://clerk.com/docs/references/express/overview#clerk-middleware) together with [`getAuth()`](https://clerk.com/docs/references/express/overview#get-auth) to verify the session and return standard HTTP status codes.
 
 ```js
 import { requireAuth } from '@clerk/express'


### PR DESCRIPTION
### 🔎 Previews:

- https://clerk.com/docs/pr/ss-docs-10460/references/express/overview#require-auth

### What does this solve?

Slack thread: https://clerkinc.slack.com/archives/C05GH6N5LLS/p1749057529795019?thread_ts=1749056599.729809&cid=C05GH6N5LLS
Linear: https://linear.app/clerk/issue/DOCS-10460/update-requireauth-helper-docs

This clarifies when and how the `requireAuth()` helper should be used in Express apps. We’ve seen user confusion ([Slack thread](https://clerkinc.slack.com/archives/C05GH6N5LLS/p1749057529795019?thread_ts=1749056599.729809&cid=C05GH6N5LLS)) about using `requireAuth()` for backend API routes - which it isn’t intended for since it redirects unauthenticated users to a sign-in page. This PR adds an explicit warning and clearer wording, and points users to the [cross-origin requests](https://clerk.com/docs/pr/ss-docs-10460/backend-requests/making-requests#cross-origin-requests) guide for correct API usage. This should help reduce misconfiguration and support requests.

### What changed?

- Added a clear warning callout to clarify the `requireAuth()` helper docs is only for full-stack Express apps, and cannot be used for pure backend API routes
- Linked the cross-origin requests guide in case of different origins in full-stack apps

### Checklist

- [ ] I have clicked on "Files changed" and performed a thorough self-review
- [ ] All existing checks pass