### PR TITLE
chore: fix vercel deploy link

### DIFF
--- a/docs/integrations/vercel-marketplace.mdx
+++ b/docs/integrations/vercel-marketplace.mdx
@@ -11,7 +11,7 @@ The Vercel Marketplace allows Vercel users to install and configure third-party 
 > Deploy an example Next.js application and install the Clerk integration with our template.
 >
 > <a
->   href="https://vercel.com/new/clone?repository-url=https%3A%2F%2Fgithub.com%2Fclerk%2Fnextjs-auth-starter-template&project-name=nextjs-clerk&repository-name=nextjs-with-clerk&demo-title=Next.js+Clerk+Template&demo-description=A+Next.js+application+pre-configured+to+authenticate+users+with+Clerk.&demo-url=https%3A%2F%2Fnextjs-auth-starter-template-kit.vercel.app%2F&demo-image=%2F%2Fraw.githubusercontent.com%2Fclerk%2Fnextjs-auth-starter-template%2Frefs%2Fheads%2Fmain%2Fpublic%2Fog.png&integration-ids=oac_7uYNbc9CdDAZmNqbt3LEkO3a&products=%5B%7B%22type%22%3A%22integration%22%2C%22integrationSlug%22%3A%22clerk%22%2C%22productSlug%22%3A%22clerk%22%2C%22protocol%22%3A%22authentication%22%2C%22group%22%3A%22%22%7D%5D&teamSlug=clerk-production"
+>   href="https://vercel.com/new/clone?repository-url=https%3A%2F%2Fgithub.com%2Fclerk%2Fnextjs-auth-starter-template&project-name=nextjs-clerk&repository-name=nextjs-with-clerk&demo-title=Next.js+Clerk+Template&demo-description=A+Next.js+application+pre-configured+to+authenticate+users+with+Clerk.&demo-url=https%3A%2F%2Fnextjs-auth-starter-template-kit.vercel.app%2F&demo-image=%2F%2Fraw.githubusercontent.com%2Fclerk%2Fnextjs-auth-starter-template%2Frefs%2Fheads%2Fmain%2Fpublic%2Fog.png&products=%5B%7B%22type%22%3A%22integration%22%2C%22integrationSlug%22%3A%22clerk%22%2C%22productSlug%22%3A%22clerk%22%2C%22protocol%22%3A%22authentication%22%2C%22group%22%3A%22%22%7D%5D"
 >   target="_blank"
 > >
 >   <img src="https://vercel.com/button" alt="Deploy to Vercel" />


### PR DESCRIPTION
### 🔎 Previews:

-

### What does this solve?

- <!--- Describe your changes in detail. Why does this change need to happen? Include any links to Slack discussions, Linear comments, etc. --> Fixes the Vercel deploy link to not include our team slug

### What changed?

- <!--- How does this PR solve the problem? -->

### Checklist

- [ ] I have clicked on "Files changed" and performed a thorough self-review
- [ ] All existing checks pass
