### PR TITLE
Up the pnpm version for clerk/javascript to 10

### DIFF
--- a/.github/workflows/typedoc.yml
+++ b/.github/workflows/typedoc.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Install pnpm
         uses: pnpm/action-setup@v4
         with:
-          version: 9 # Should be the same as clerk/javascript
+          version: 10 # Should be the same as clerk/javascript
           run_install: false
 
       - name: Setup Node.js


### PR DESCRIPTION
### 🔎 Previews:

<img width="1002" height="584" alt="Screenshot 2025-07-15 at 12 10 17 PM" src="https://github.com/user-attachments/assets/942f9712-4518-49b9-8538-cc2944bad562" />

### What does this solve?

- Typedoc ci failing due to `clerk/javascript` repo pnpm version getting bumped to 10

### What changed?

- Upgraded version 10 to match

### Checklist

- [x] I have clicked on "Files changed" and performed a thorough self-review
- [x] All existing checks pass
