### PR TITLE
Typedoc ci improvements

### DIFF
--- a/.github/workflows/typedoc.yml
+++ b/.github/workflows/typedoc.yml
@@ -2,7 +2,6 @@ name: Generate Typedocs
 
 on:
   workflow_dispatch:
-  push:
 
 jobs:
   typedoc:

--- a/.github/workflows/typedoc.yml
+++ b/.github/workflows/typedoc.yml
@@ -76,8 +76,10 @@ jobs:
           # 2. Check if branch already exists and handle accordingly
           if git ls-remote --exit-code --heads origin typedoc-${{ env.sha }} > /dev/null 2>&1; then
             echo "ℹ️  Branch typedoc-${{ env.sha }} already exists, checking it out and updating"
+            git stash push -m "Temporary stash for branch switch"
             git fetch origin typedoc-${{ env.sha }}
             git checkout typedoc-${{ env.sha }}
+            git stash pop
             git add .
             git commit -m "docs: update TypeDoc documentation from clerk/javascript@${{ env.sha }}"
             git push origin typedoc-${{ env.sha }}

--- a/.github/workflows/typedoc.yml
+++ b/.github/workflows/typedoc.yml
@@ -54,7 +54,7 @@ jobs:
       - name: Copy docs to main repo
         run: |
           # Copy the generated docs to the root of the main repo
-          cp -r ./clerk-javascript/.typedoc/docs/ ./clerk-docs/clerk-typedoc
+          cp -r ./clerk-javascript/.typedoc/docs/* ./clerk-docs/clerk-typedoc
 
       - name: Configure Git
         working-directory: ./clerk-docs

--- a/.github/workflows/typedoc.yml
+++ b/.github/workflows/typedoc.yml
@@ -11,10 +11,6 @@ jobs:
 
     runs-on: ubuntu-latest
     steps:
-      - name: Get current date
-        id: current_date
-        run: echo "date=$(date +'%Y-%m-%d')" >> $GITHUB_ENV
-
       - name: Checkout current repository
         uses: actions/checkout@v4
         with:
@@ -29,6 +25,11 @@ jobs:
           path: clerk-javascript
           fetch-depth: 1
           show-progress: false
+
+      - name: Get clerk/javascript commit SHA
+        id: clerk_sha
+        working-directory: ./clerk-javascript
+        run: echo "sha=$(git rev-parse --short HEAD)" >> $GITHUB_ENV
 
       - name: Install pnpm
         uses: pnpm/action-setup@v4
@@ -52,7 +53,7 @@ jobs:
       - name: Copy docs to main repo
         run: |
           # Copy the generated docs to the root of the main repo
-          cp -r ./clerk-javascript/.typedoc/docs ./clerk-docs/clerk-typedoc
+          cp -r ./clerk-javascript/.typedoc/docs/ ./clerk-docs/clerk-typedoc
 
       - name: Configure Git
         working-directory: ./clerk-docs
@@ -63,13 +64,19 @@ jobs:
       - name: Commit and push changes
         working-directory: ./clerk-docs
         run: |
-          git checkout -b typedoc-${{ env.date }}
+          git checkout -b typedoc-${{ env.sha }}
           git add .
-          git commit -m "initial"
-          git push origin typedoc-${{ env.date }}
+          git commit -m "docs: update TypeDoc documentation from clerk/javascript@${{ env.sha }}"
+          git push origin typedoc-${{ env.sha }}
 
       - name: Create Pull Request
         working-directory: ./clerk-docs
-        run: gh pr create --base main --head typedoc-${{ env.date }} --title "[ci] Update Typedoc (${{ env.date }})" --body "Auto-generated PR to update Typedoc documentation from clerk/javascript"
+        run: |
+          if gh pr list --head typedoc-${{ env.sha }} --json number --jq length | grep -q "^0$"; then
+            gh pr create --base main --head typedoc-${{ env.sha }} --title "[ci] Update Typedoc (${{ env.sha }})" --body "Auto-generated PR to update Typedoc documentation from clerk/javascript@${{ env.sha }}"
+            echo "✅ Created new PR for typedoc-${{ env.sha }}"
+          else
+            echo "ℹ️  PR already exists for typedoc-${{ env.sha }}, skipping creation"
+          fi
         env:
           GH_TOKEN: ${{ github.token }}

--- a/.github/workflows/typedoc.yml
+++ b/.github/workflows/typedoc.yml
@@ -76,7 +76,7 @@ jobs:
           # 2. Check if branch already exists and handle accordingly
           if git ls-remote --exit-code --heads origin typedoc-${{ env.sha }} > /dev/null 2>&1; then
             echo "ℹ️  Branch typedoc-${{ env.sha }} already exists, checking it out and updating"
-            git stash push -m "Temporary stash for branch switch"
+            git stash push -u -m "Temporary stash for branch switch"
             git fetch origin typedoc-${{ env.sha }}
             git checkout typedoc-${{ env.sha }}
             git stash pop

--- a/.github/workflows/typedoc.yml
+++ b/.github/workflows/typedoc.yml
@@ -2,6 +2,7 @@ name: Generate Typedocs
 
 on:
   workflow_dispatch:
+  push:
 
 jobs:
   typedoc:
@@ -61,22 +62,39 @@ jobs:
           git config --global user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git config --global user.name "github-actions[bot]"
 
-      - name: Commit and push changes
+      - name: Check for changes and create PR
         working-directory: ./clerk-docs
         run: |
-          git checkout -b typedoc-${{ env.sha }}
-          git add .
-          git commit -m "docs: update TypeDoc documentation from clerk/javascript@${{ env.sha }}"
-          git push origin typedoc-${{ env.sha }}
+          # 1. Check if there are any changes
+          if [ -z "$(git status --porcelain)" ]; then
+            echo "ℹ️  No changes detected in TypeDoc documentation, exiting early"
+            exit 0
+          fi
 
-      - name: Create Pull Request
-        working-directory: ./clerk-docs
-        run: |
-          if gh pr list --head typedoc-${{ env.sha }} --json number --jq length | grep -q "^0$"; then
-            gh pr create --base main --head typedoc-${{ env.sha }} --title "[ci] Update Typedoc (${{ env.sha }})" --body "Auto-generated PR to update Typedoc documentation from clerk/javascript@${{ env.sha }}"
-            echo "✅ Created new PR for typedoc-${{ env.sha }}"
+          echo "✅ Changes detected, processing..."
+
+          # 2. Check if branch already exists and handle accordingly
+          if git ls-remote --exit-code --heads origin typedoc-${{ env.sha }} > /dev/null 2>&1; then
+            echo "ℹ️  Branch typedoc-${{ env.sha }} already exists, checking it out and updating"
+            git fetch origin typedoc-${{ env.sha }}
+            git checkout typedoc-${{ env.sha }}
+            git add .
+            git commit -m "docs: update TypeDoc documentation from clerk/javascript@${{ env.sha }}"
+            git push origin typedoc-${{ env.sha }}
           else
-            echo "ℹ️  PR already exists for typedoc-${{ env.sha }}, skipping creation"
+            echo "✅ Creating new branch typedoc-${{ env.sha }}"
+            git checkout -b typedoc-${{ env.sha }}
+            git add .
+            git commit -m "docs: update TypeDoc documentation from clerk/javascript@${{ env.sha }}"
+            git push origin typedoc-${{ env.sha }}
+          fi
+
+          # 3. Check if PR already exists
+          if gh pr list --head typedoc-${{ env.sha }} --json number --jq length | grep -q "^0$"; then
+            echo "✅ Creating new PR for typedoc-${{ env.sha }}"
+            gh pr create --base main --head typedoc-${{ env.sha }} --title "[ci] Update Typedoc (${{ env.sha }})" --body "Auto-generated PR to update Typedoc documentation from clerk/javascript@${{ env.sha }}"
+          else
+            echo "ℹ️  PR already exists for typedoc-${{ env.sha }}, skipping PR creation"
           fi
         env:
           GH_TOKEN: ${{ github.token }}

--- a/.github/workflows/typedoc.yml
+++ b/.github/workflows/typedoc.yml
@@ -79,7 +79,21 @@ jobs:
             git stash push -u -m "Temporary stash for branch switch"
             git fetch origin typedoc-${{ env.sha }}
             git checkout typedoc-${{ env.sha }}
-            git stash pop
+            
+            # Try to pop stash, but don't fail if it conflicts (files already exist)
+            if git stash pop; then
+              echo "✅ Successfully applied stashed changes"
+            else
+              echo "ℹ️  Stash pop failed (likely files already exist), dropping stash and checking for changes"
+              git stash drop
+            fi
+            
+            # Check if there are any changes to commit after checkout/stash
+            if [ -z "$(git status --porcelain)" ]; then
+              echo "ℹ️  No new changes detected on existing branch, exiting successfully"
+              exit 0
+            fi
+            
             git add .
             git commit -m "docs: update TypeDoc documentation from clerk/javascript@${{ env.sha }}"
             git push origin typedoc-${{ env.sha }}


### PR DESCRIPTION
### 🔎 Previews:

-

### What does this solve?

- Fix the directory the ci, copies the typedocs to `./clerk-docs/clerk-typedocs/*` instead of `./clerk-docs/clerk-typedocs/docs/*`
- Uses the `clerk/javascript` short sha to make the branch in this pr, instead of the current date
- Doesn't attempt to create a new pr for that branch, if a pr for that branch already exists

### Checklist

- [x] I have clicked on "Files changed" and performed a thorough self-review
- [x] All existing checks pass
