### PR TITLE
Remove '~' dedicated instant redirect page

### DIFF
--- a/scripts/build-docs.test.ts
+++ b/scripts/build-docs.test.ts
@@ -1087,7 +1087,6 @@ Testing with a simple page.`,
 
     expect(JSON.parse(await readFile(pathJoin('./dist/directory.json')))).toEqual([
       { path: 'simple-test.mdx', url: '/docs/simple-test' },
-      { path: '~/simple-test.mdx', url: '/docs/~/simple-test' },
       { path: 'react/simple-test.mdx', url: '/docs/react/simple-test' },
     ])
 
@@ -1105,18 +1104,13 @@ Testing with a simple page.`)
       `---\ntemplate: wide\n---\n<SDKDocRedirectPage title="Simple Test" href="/docs/:sdk:/simple-test" sdks={["react"]} />`,
     )
 
-    expect(await readFile(pathJoin('./dist/~/simple-test.mdx'))).toBe(
-      `---\ntemplate: wide\n---\n<SDKDocRedirectPage instant title="Simple Test" href="/docs/:sdk:/simple-test" sdks={["react"]} />`,
-    )
-
     const distFiles = await treeDir(pathJoin('./dist'))
 
-    expect(distFiles.length).toBe(5)
+    expect(distFiles.length).toBe(4)
     expect(distFiles).toContain('simple-test.mdx')
     expect(distFiles).toContain('manifest.json')
     expect(distFiles).toContain('directory.json')
     expect(distFiles).toContain('react/simple-test.mdx')
-    expect(distFiles).toContain('~/simple-test.mdx')
   })
 
   test('3 sdks in frontmatter generates 3 variants', async () => {
@@ -1154,7 +1148,6 @@ Testing with a simple page.`,
 
     expect(JSON.parse(await readFile(pathJoin('./dist/directory.json')))).toEqual([
       { path: 'simple-test.mdx', url: '/docs/simple-test' },
-      { path: '~/simple-test.mdx', url: '/docs/~/simple-test' },
       { path: 'vue/simple-test.mdx', url: '/docs/vue/simple-test' },
       { path: 'react/simple-test.mdx', url: '/docs/react/simple-test' },
       { path: 'astro/simple-test.mdx', url: '/docs/astro/simple-test' },
@@ -1162,11 +1155,10 @@ Testing with a simple page.`,
 
     const distFiles = await treeDir(pathJoin('./dist'))
 
-    expect(distFiles.length).toBe(7)
+    expect(distFiles.length).toBe(6)
     expect(distFiles).toContain('manifest.json')
     expect(distFiles).toContain('directory.json')
     expect(distFiles).toContain('simple-test.mdx')
-    expect(distFiles).toContain('~/simple-test.mdx')
     expect(distFiles).toContain('react/simple-test.mdx')
     expect(distFiles).toContain('vue/simple-test.mdx')
     expect(distFiles).toContain('astro/simple-test.mdx')
@@ -1368,10 +1360,6 @@ This document is available for React and Next.js.`,
     // Verify landing page content
     expect(await readFile(pathJoin('./dist/sdk-document.mdx'))).toBe(
       `---\ntemplate: wide\n---\n<SDKDocRedirectPage title="SDK Document" description="This document is available for React and Next.js." href="/docs/:sdk:/sdk-document" sdks={["react","nextjs"]} />`,
-    )
-
-    expect(await readFile(pathJoin('./dist/~/sdk-document.mdx'))).toBe(
-      `---\ntemplate: wide\n---\n<SDKDocRedirectPage instant title="SDK Document" description="This document is available for React and Next.js." href="/docs/:sdk:/sdk-document" sdks={["react","nextjs"]} />`,
     )
   })
 
@@ -2791,7 +2779,7 @@ description: A page that contains cards
     const indexContent = await readFile('./dist/index.mdx')
 
     expect(indexContent).toContain('* [Standard card](/docs/standard-card)')
-    expect(indexContent).toContain('* [SDK Scoped Card](/docs/~/sdk-scoped-page)')
+    expect(indexContent).toContain('* [SDK Scoped Card](/docs/sdk-scoped-page)')
   })
 
   test('Url hash links should be included when swapping out sdk scoped links to <SDKLink />', async () => {

--- a/scripts/build-docs.ts
+++ b/scripts/build-docs.ts
@@ -777,14 +777,6 @@ template: wide
 ---
 <SDKDocRedirectPage title="${doc.frontmatter.title}"${doc.frontmatter.description ? ` description="${doc.frontmatter.description}" ` : ' '}href="${scopeHrefToSDK(config)(doc.file.href, ':sdk:')}" sdks={${JSON.stringify(doc.sdk)}} />`,
         )
-
-        await writeFile(
-          `~/${doc.file.filePathInDocsFolder}`,
-          `---
-template: wide
----
-<SDKDocRedirectPage instant title="${doc.frontmatter.title}"${doc.frontmatter.description ? ` description="${doc.frontmatter.description}" ` : ' '}href="${scopeHrefToSDK(config)(doc.file.href, ':sdk:')}" sdks={${JSON.stringify(doc.sdk)}} />`,
-        )
       } else {
         await writeFile(doc.file.filePathInDocsFolder, typedocTableSpecialCharacters.decode(doc.vfile.value as string))
       }

--- a/scripts/lib/plugins/validateAndEmbedLinks.ts
+++ b/scripts/lib/plugins/validateAndEmbedLinks.ts
@@ -88,9 +88,6 @@ export const validateAndEmbedLinks =
 
       // we are specifically skipping over replacing links inside Cards until we can figure out a way to have the cards display what sdks they support
       if (inCardsComponent === true) {
-        if (injectSDK) {
-          node.url = scopeHref(url, '~')
-        }
         return node
       }
 

--- a/scripts/lib/utils/scopeHrefToSDK.ts
+++ b/scripts/lib/utils/scopeHrefToSDK.ts
@@ -3,7 +3,7 @@
 import type { BuildConfig } from '../config'
 import type { SDK } from '../schemas'
 
-export const scopeHrefToSDK = (config: BuildConfig) => (href: string, targetSDK: SDK | ':sdk:' | '~') => {
+export const scopeHrefToSDK = (config: BuildConfig) => (href: string, targetSDK: SDK | ':sdk:') => {
   // This is external so can't change it
   if (href.startsWith('/docs') === false) return href
 
@@ -11,7 +11,7 @@ export const scopeHrefToSDK = (config: BuildConfig) => (href: string, targetSDK:
 
   // This is a little hacky so we might change it
   // if the url already contains the sdk, we don't need to change it
-  if (hrefSegments.includes(targetSDK) && targetSDK !== '~') {
+  if (hrefSegments.includes(targetSDK)) {
     return href
   }
 


### PR DESCRIPTION
With https://github.com/clerk/clerk/pull/1377 merged no need to generate `~` instant redirect pages.

### Checklist

- [x] I have clicked on "Files changed" and performed a thorough self-review
- [x] All existing checks pass
