### PR TITLE
added username policies

### DIFF
--- a/docs/references/backend/user/create-user.mdx
+++ b/docs/references/backend/user/create-user.mdx
@@ -66,6 +66,9 @@ function createUser(params: CreateUserParams): Promise<User>
   - `string`
 
   The username to give to the user. Must be unique across your instance.
+  - Username must be between min_length and max_length characters long.
+  - Username must contain one non-number character.
+  - min_length and max_length can be configured from clerk dashboard.
 
   ---
 


### PR DESCRIPTION
When someone tries to create a Clerk user using the backend SDK and provides a `username` that doesn't meet Clerk’s username policy, Clerk returns a `422` response code indicating invalid input. However, the error message doesn't clearly state the exact issue, making it difficult for developers to identify the problem.  
To solve this, I’ve added clear instructions on how to properly format the `username`.

### 🔎 Preview  
<img width="833" height="189" alt="image" src="https://github.com/user-attachments/assets/417ccbba-88db-421f-a24c-9d90315ee19c" />

---

### ✅ What does this solve?

- Added username requirements to help developers avoid 422 errors during Clerk user creation.

---

### ✨ What changed?

- Included username policy guidelines in the docs to clarify validation rules.

---

### ✅ Checklist

- [x] I have clicked on **"Files changed"** and performed a thorough self-review  
- [x] All existing checks pass  
