### PR TITLE
Migration Assistant

### DIFF
--- a/.github/workflows/migration.yml
+++ b/.github/workflows/migration.yml
@@ -1,5 +1,8 @@
 name: Run Migration Mapping Check
 
+permissions:
+  contents: read
+
 on:
   push:
     paths:

--- a/.github/workflows/migration.yml
+++ b/.github/workflows/migration.yml
@@ -2,10 +2,13 @@ name: Run Migration Mapping Check
 
 on:
   push:
-    paths:
-      - 'proposal-mapping.json'
-      - 'scripts/migration-assistant/map-content.ts'
-      - 'docs/**'
+
+# on:
+#   push:
+#     paths:
+#       - 'proposal-mapping.json'
+#       - 'scripts/migration-assistant/map-content.ts'
+#       - 'docs/**'
 
 jobs:
   migration:

--- a/.github/workflows/migration.yml
+++ b/.github/workflows/migration.yml
@@ -2,13 +2,11 @@ name: Run Migration Mapping Check
 
 on:
   push:
-
-# on:
-#   push:
-#     paths:
-#       - 'proposal-mapping.json'
-#       - 'scripts/migration-assistant/map-content.ts'
-#       - 'docs/**'
+    paths:
+      - 'proposal-mapping.json'
+      - 'proposal.md'
+      - 'scripts/migration-assistant/map-content.ts'
+      - 'docs/**'
 
 jobs:
   migration:

--- a/.github/workflows/migration.yml
+++ b/.github/workflows/migration.yml
@@ -1,0 +1,16 @@
+name: Run Migration Mapping Check
+
+on:
+  push:
+    paths:
+      - 'proposal-mapping.json'
+      - 'scripts/migration-assistant/map-content.ts'
+      - 'docs/**'
+
+jobs:
+  migration:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - run: npm i
+      - run: npm run migration:map-content

--- a/.github/workflows/migration.yml
+++ b/.github/workflows/migration.yml
@@ -16,4 +16,5 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - run: npm i
+      - run: npm run migration:generate-manifest
       - run: npm run migration:map-content

--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,4 @@ yarn.lock
 
 /docs/docs
 /docs/docs/
+public/manifest.proposal.json

--- a/flags.json
+++ b/flags.json
@@ -1,4 +1,4 @@
 {
-  "use-proposal-manifest": true,
-  "top-level-manifest-splitting": true
+  "use-proposal-manifest": false,
+  "top-level-manifest-splitting": false
 }

--- a/flags.json
+++ b/flags.json
@@ -1,0 +1,4 @@
+{
+  "use-proposal-manifest": true,
+  "top-level-manifest-splitting": true
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "@types/node": "^22.13.2",
         "chokidar": "^4.0.3",
         "concurrently": "^8.2.2",
+        "dotenv": "^17.2.0",
         "glob": "^11.0.1",
         "jsonc-parser": "^3.3.1",
         "prettier": "^3.2.5",
@@ -2012,6 +2013,19 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/dotenv": {
+      "version": "17.2.0",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.2.0.tgz",
+      "integrity": "sha512-Q4sgBT60gzd0BB0lSyYD3xM4YxrXA9y4uBDof1JNYGzOXrQdQ6yX+7XIAqoFOGQFOTK1D3Hts5OllpxMDZFONQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
       }
     },
     "node_modules/eastasianwidth": {

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "test": "vitest --silent",
     "typedoc:link": "node scripts/link-typedoc.mjs",
     "move-doc": "node scripts/move-doc.mjs",
-    "migration:generate-manifest": "tsx scripts/migration-assistant/generate-manifest.ts",
+    "migration:generate-manifest": "tsx watch scripts/migration-assistant/generate-manifest.ts",
     "migration:map-content": "tsx scripts/migration-assistant/map-content.ts"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -13,7 +13,9 @@
     "dev": "tsx watch ./scripts/build-docs.ts --watch",
     "test": "vitest --silent",
     "typedoc:link": "node scripts/link-typedoc.mjs",
-    "move-doc": "node scripts/move-doc.mjs"
+    "move-doc": "node scripts/move-doc.mjs",
+    "migration:generate-manifest": "tsx scripts/migration-assistant/generate-manifest.ts",
+    "migration:map-content": "tsx scripts/migration-assistant/map-content.ts"
   },
   "devDependencies": {
     "@parcel/watcher": "^2.5.1",

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "typedoc:link": "node scripts/link-typedoc.mjs",
     "move-doc": "node scripts/move-doc.mjs",
     "migration:generate-manifest": "tsx watch scripts/migration-assistant/generate-manifest.ts",
+    "migration:generate-manifest:watch": "tsx watch scripts/migration-assistant/generate-manifest.ts --watch",
     "migration:map-content": "tsx scripts/migration-assistant/map-content.ts"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "@types/node": "^22.13.2",
     "chokidar": "^4.0.3",
     "concurrently": "^8.2.2",
+    "dotenv": "^17.2.0",
     "glob": "^11.0.1",
     "jsonc-parser": "^3.3.1",
     "prettier": "^3.2.5",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "test": "vitest --silent",
     "typedoc:link": "node scripts/link-typedoc.mjs",
     "move-doc": "node scripts/move-doc.mjs",
-    "migration:generate-manifest": "tsx watch scripts/migration-assistant/generate-manifest.ts",
+    "migration:generate-manifest": "tsx scripts/migration-assistant/generate-manifest.ts",
     "migration:generate-manifest:watch": "tsx watch scripts/migration-assistant/generate-manifest.ts --watch",
     "migration:map-content": "tsx scripts/migration-assistant/map-content.ts"
   },

--- a/proposal-mapping.json
+++ b/proposal-mapping.json
@@ -1,0 +1,638 @@
+{
+  "how-clerk-works/overview.mdx": {
+    "newPath": "/docs/core-concepts/how-clerk-works",
+    "action": "consolidate"
+  },
+  "how-clerk-works/cookies.mdx": {
+    "newPath": "/docs/core-concepts/how-clerk-works",
+    "action": "consolidate"
+  },
+  "security/overview.mdx": {
+    "newPath": "/docs/core-concepts/security",
+    "action": "move"
+  },
+  "backend-requests/custom-session-token.mdx": {
+    "newPath": "/docs/guides/configure/session-token-customization",
+    "action": "move"
+  },
+  "backend-requests/jwt-templates.mdx": {
+    "newPath": "/docs/guides/configure/backend-requests",
+    "action": "consolidate"
+  },
+  "backend-requests/making-requests.mdx": {
+    "newPath": "/docs/guides/configure/backend-requests",
+    "action": "consolidate"
+  },
+  "backend-requests/manual-jwt.mdx": {
+    "newPath": "/docs/guides/configure/backend-requests",
+    "action": "consolidate"
+  },
+  "backend-requests/overview.mdx": {
+    "newPath": "/docs/guides/configure/backend-requests",
+    "action": "consolidate"
+  },
+  "backend-requests/resources/cookies.mdx": {
+    "newPath": "/docs/guides/configure/backend-requests",
+    "action": "consolidate"
+  },
+  "backend-requests/resources/rate-limits.mdx": {
+    "newPath": "/docs/guides/configure/backend-requests",
+    "action": "consolidate"
+  },
+  "backend-requests/resources/session-tokens.mdx": {
+    "newPath": "/docs/guides/configure/backend-requests",
+    "action": "consolidate"
+  },
+  "backend-requests/resources/tokens-and-signatures.mdx": {
+    "newPath": "/docs/guides/configure/backend-requests",
+    "action": "consolidate"
+  },
+  "webhooks/debug-your-webhooks.mdx": {
+    "newPath": "/docs/guides/configure/syncing-data-with-webhooks",
+    "action": "consolidate"
+  },
+  "webhooks/inngest.mdx": {
+    "newPath": "/docs/guides/configure/syncing-data-with-webhooks",
+    "action": "consolidate"
+  },
+  "webhooks/loops.mdx": {
+    "newPath": "/docs/guides/configure/syncing-data-with-webhooks",
+    "action": "consolidate"
+  },
+  "webhooks/overview.mdx": {
+    "newPath": "/docs/guides/configure/syncing-data-with-webhooks",
+    "action": "consolidate"
+  },
+  "webhooks/sync-data.mdx": {
+    "newPath": "/docs/guides/configure/syncing-data-with-webhooks",
+    "action": "consolidate"
+  },
+  "integrations/analytics/google-analytics.mdx": {
+    "newPath": "/docs/guides/configure/integrations",
+    "action": "consolidate"
+  },
+  "integrations/databases/convex.mdx": {
+    "newPath": "/docs/guides/configure/integrations",
+    "action": "consolidate"
+  },
+  "integrations/databases/fauna.mdx": {
+    "newPath": "/docs/guides/configure/integrations",
+    "action": "consolidate"
+  },
+  "integrations/databases/firebase.mdx": {
+    "newPath": "/docs/guides/configure/integrations",
+    "action": "consolidate"
+  },
+  "integrations/databases/grafbase.mdx": {
+    "newPath": "/docs/guides/configure/integrations",
+    "action": "consolidate"
+  },
+  "integrations/databases/hasura.mdx": {
+    "newPath": "/docs/guides/configure/integrations",
+    "action": "consolidate"
+  },
+  "integrations/databases/instantdb.mdx": {
+    "newPath": "/docs/guides/configure/integrations",
+    "action": "consolidate"
+  },
+  "integrations/databases/neon.mdx": {
+    "newPath": "/docs/guides/configure/integrations",
+    "action": "consolidate"
+  },
+  "integrations/databases/nhost.mdx": {
+    "newPath": "/docs/guides/configure/integrations",
+    "action": "consolidate"
+  },
+  "integrations/databases/supabase.mdx": {
+    "newPath": "/docs/guides/configure/integrations",
+    "action": "consolidate"
+  },
+  "integrations/overview.mdx": {
+    "newPath": "/docs/guides/configure/integrations",
+    "action": "consolidate"
+  },
+  "integrations/shopify.mdx": {
+    "newPath": "/docs/guides/configure/integrations",
+    "action": "consolidate"
+  },
+  "integrations/vercel-marketplace.mdx": {
+    "newPath": "/docs/guides/configure/integrations",
+    "action": "consolidate"
+  },
+  "ai-prompts/nextjs.mdx": {
+    "newPath": "/docs/core-concepts/ai-prompts",
+    "action": "consolidate"
+  },
+  "ai-prompts/overview.mdx": {
+    "newPath": "/docs/core-concepts/ai-prompts",
+    "action": "consolidate"
+  },
+  "ai-prompts/react.mdx": {
+    "newPath": "/docs/core-concepts/ai-prompts",
+    "action": "consolidate"
+  },
+  "security/bot-protection.mdx": {
+    "newPath": "/docs/guides/secure/bot-detection",
+    "action": "move"
+  },
+  "components/**": {
+    "newPath": "/docs/reference/components/**",
+    "action": "generate"
+  },
+  "hooks/**": {
+    "newPath": "/docs/reference/hooks/**",
+    "action": "generate"
+  },
+  "references/sdk/**": {
+    "newPath": "/docs/guides/development/sdk-development",
+    "action": "consolidate"
+  },
+  "references/**": {
+    "newPath": "/docs/reference/sdk/**",
+    "action": "generate"
+  },
+  "billing/b2b-saas.mdx": {
+    "newPath": "/docs/guides/billing/for-b2b",
+    "action": "move"
+  },
+  "billing/b2c-saas.mdx": {
+    "newPath": "/docs/guides/billing/for-b2c",
+    "action": "move"
+  },
+  "billing/overview.mdx": {
+    "newPath": "/docs/guides/billing/overview",
+    "action": "move"
+  },
+  "/docs/examples/testing/test-link": {
+    "newPath": null,
+    "action": "drop"
+  },
+  "deployments/migrate-from-cognito.mdx": {
+    "newPath": "/docs/guides/development/migrating-your-data",
+    "action": "move"
+  },
+  "deployments/migrate-from-firebase.mdx": {
+    "newPath": "/docs/guides/development/migrating-your-data",
+    "action": "move"
+  },
+  "deployments/migrate-overview.mdx": {
+    "newPath": "/docs/guides/development/migrating-your-data",
+    "action": "move"
+  },
+  "deployments/clerk-environment-variables.mdx": {
+    "newPath": "/docs/guides/development/clerk-environment-variables",
+    "action": "move"
+  },
+  "deployments/**": {
+    "newPath": "/docs/guides/development/deployment",
+    "action": "consolidate"
+  },
+  "custom-flows/accept-organization-invitations.mdx": {
+    "newPath": "/docs/examples",
+    "action": "convert-to-example"
+  },
+  "custom-flows/add-email.mdx": {
+    "newPath": "/docs/examples",
+    "action": "convert-to-example"
+  },
+  "custom-flows/add-phone.mdx": {
+    "newPath": "/docs/examples",
+    "action": "convert-to-example"
+  },
+  "custom-flows/application-invitations.mdx": {
+    "newPath": "/docs/examples",
+    "action": "convert-to-example"
+  },
+  "custom-flows/bot-sign-up-protection.mdx": {
+    "newPath": "/docs/examples",
+    "action": "convert-to-example"
+  },
+  "custom-flows/create-organizations.mdx": {
+    "newPath": "/docs/examples",
+    "action": "convert-to-example"
+  },
+  "custom-flows/email-links.mdx": {
+    "newPath": "/docs/examples",
+    "action": "convert-to-example"
+  },
+  "custom-flows/email-password-mfa.mdx": {
+    "newPath": "/docs/examples",
+    "action": "convert-to-example"
+  },
+  "custom-flows/email-password.mdx": {
+    "newPath": "/docs/examples",
+    "action": "convert-to-example"
+  },
+  "custom-flows/email-sms-otp.mdx": {
+    "newPath": "/docs/examples",
+    "action": "convert-to-example"
+  },
+  "custom-flows/embedded-email-links.mdx": {
+    "newPath": "/docs/examples",
+    "action": "convert-to-example"
+  },
+  "custom-flows/enterprise-connections.mdx": {
+    "newPath": "/docs/examples",
+    "action": "convert-to-example"
+  },
+  "custom-flows/error-handling.mdx": {
+    "newPath": "/docs/examples",
+    "action": "convert-to-example"
+  },
+  "custom-flows/forgot-password.mdx": {
+    "newPath": "/docs/examples",
+    "action": "convert-to-example"
+  },
+  "custom-flows/google-one-tap.mdx": {
+    "newPath": "/docs/examples",
+    "action": "convert-to-example"
+  },
+  "custom-flows/manage-membership-requests.mdx": {
+    "newPath": "/docs/examples",
+    "action": "convert-to-example"
+  },
+  "custom-flows/manage-organization-invitations.mdx": {
+    "newPath": "/docs/examples",
+    "action": "convert-to-example"
+  },
+  "custom-flows/manage-roles.mdx": {
+    "newPath": "/docs/examples",
+    "action": "convert-to-example"
+  },
+  "custom-flows/manage-sms-based-mfa.mdx": {
+    "newPath": "/docs/examples",
+    "action": "convert-to-example"
+  },
+  "custom-flows/manage-sso-connections.mdx": {
+    "newPath": "/docs/examples",
+    "action": "convert-to-example"
+  },
+  "custom-flows/manage-totp-based-mfa.mdx": {
+    "newPath": "/docs/examples",
+    "action": "convert-to-example"
+  },
+  "custom-flows/manage-user-org-invitations.mdx": {
+    "newPath": "/docs/examples",
+    "action": "convert-to-example"
+  },
+  "custom-flows/multi-session-applications.mdx": {
+    "newPath": "/docs/examples",
+    "action": "convert-to-example"
+  },
+  "custom-flows/oauth-connections.mdx": {
+    "newPath": "/docs/examples",
+    "action": "convert-to-example"
+  },
+  "custom-flows/organization-switcher.mdx": {
+    "newPath": "/docs/examples",
+    "action": "convert-to-example"
+  },
+  "custom-flows/overview.mdx": {
+    "newPath": "/docs/examples",
+    "action": "convert-to-example"
+  },
+  "custom-flows/passkeys.mdx": {
+    "newPath": "/docs/examples",
+    "action": "convert-to-example"
+  },
+  "custom-flows/sign-out.mdx": {
+    "newPath": "/docs/examples",
+    "action": "convert-to-example"
+  },
+  "custom-flows/update-organizations.mdx": {
+    "newPath": "/docs/examples",
+    "action": "convert-to-example"
+  },
+  "custom-flows/user-impersonation.mdx": {
+    "newPath": "/docs/examples",
+    "action": "convert-to-example"
+  },
+  "versioning/available-versions.mdx": {
+    "newPath": "/docs/guides/development/upgrading/versioning",
+    "action": "consolidate"
+  },
+  "versioning/overview.mdx": {
+    "newPath": "/docs/guides/development/upgrading/versioning",
+    "action": "consolidate"
+  },
+  "errors/overview.mdx": {
+    "newPath": "/docs/guides/development/troubleshooting",
+    "action": "move"
+  },
+  "authentication/web3/**": {
+    "newPath": "/docs/guides/configure/auth-strategies/web3",
+    "action": "consolidate"
+  },
+  "authentication/social-connections/**": {
+    "newPath": "/docs/guides/configure/social-connections/**",
+    "action": "generate"
+  },
+  "organizations/roles-permissions.mdx": {
+    "newPath": "/docs/guides/b2b/roles-and-permissions",
+    "action": "consolidate"
+  },
+  "organizations/verified-domains.mdx": {
+    "newPath": "/docs/guides/b2b/verified-domains",
+    "action": "move"
+  },
+  "security/clerk-csp.mdx": {
+    "newPath": "/docs/guides/secure/best-practices",
+    "action": "consolidate"
+  },
+  "security/csrf-protection.mdx": {
+    "newPath": "/docs/guides/secure/best-practices",
+    "action": "consolidate"
+  },
+  "security/email-link-protection.mdx": {
+    "newPath": "/docs/guides/secure/best-practices",
+    "action": "consolidate"
+  },
+  "security/fixation-protection.mdx": {
+    "newPath": "/docs/guides/secure/best-practices",
+    "action": "consolidate"
+  },
+  "security/password-protection.mdx": {
+    "newPath": "/docs/guides/secure/best-practices",
+    "action": "consolidate"
+  },
+  "security/unauthorized-sign-in.mdx": {
+    "newPath": "/docs/guides/secure/best-practices",
+    "action": "consolidate"
+  },
+  "security/user-lock-guide.mdx": {
+    "newPath": "/docs/guides/secure/best-practices",
+    "action": "consolidate"
+  },
+  "security/vulnerability-disclosure-policy.mdx": {
+    "newPath": "/docs/guides/secure/best-practices",
+    "action": "consolidate"
+  },
+  "security/xss-leak-protection.mdx": {
+    "newPath": "/docs/guides/secure/best-practices",
+    "action": "consolidate"
+  },
+  "testing/cypress/custom-commands.mdx": {
+    "newPath": "/docs/guides/development/testing-with-clerk",
+    "action": "consolidate"
+  },
+  "testing/cypress/overview.mdx": {
+    "newPath": "/docs/guides/development/testing-with-clerk",
+    "action": "consolidate"
+  },
+  "testing/cypress/test-account-portal.mdx": {
+    "newPath": "/docs/guides/development/testing-with-clerk",
+    "action": "consolidate"
+  },
+  "testing/overview.mdx": {
+    "newPath": "/docs/guides/development/testing-with-clerk",
+    "action": "consolidate"
+  },
+  "testing/playwright/overview.mdx": {
+    "newPath": "/docs/guides/development/testing-with-clerk",
+    "action": "consolidate"
+  },
+  "testing/playwright/test-authenticated-flows.mdx": {
+    "newPath": "/docs/guides/development/testing-with-clerk",
+    "action": "consolidate"
+  },
+  "testing/playwright/test-helpers.mdx": {
+    "newPath": "/docs/guides/development/testing-with-clerk",
+    "action": "consolidate"
+  },
+  "testing/postman-or-insomnia.mdx": {
+    "newPath": "/docs/guides/development/testing-with-clerk",
+    "action": "consolidate"
+  },
+  "testing/test-emails-and-phones.mdx": {
+    "newPath": "/docs/guides/development/testing-with-clerk",
+    "action": "consolidate"
+  },
+  "authentication/enterprise-connections/account-linking.mdx": {
+    "newPath": "/docs/guides/configure/auth-strategies/enterprise-connections",
+    "action": "consolidate"
+  },
+  "authentication/enterprise-connections/authentication-flows.mdx": {
+    "newPath": "/docs/guides/configure/auth-strategies/enterprise-connections",
+    "action": "consolidate"
+  },
+  "authentication/enterprise-connections/easie/google.mdx": {
+    "newPath": "/docs/guides/configure/auth-strategies/enterprise-connections",
+    "action": "consolidate"
+  },
+  "authentication/enterprise-connections/easie/microsoft.mdx": {
+    "newPath": "/docs/guides/configure/auth-strategies/enterprise-connections",
+    "action": "consolidate"
+  },
+  "authentication/enterprise-connections/jit-provisioning.mdx": {
+    "newPath": "/docs/guides/configure/auth-strategies/enterprise-connections",
+    "action": "consolidate"
+  },
+  "authentication/enterprise-connections/oidc/custom-provider.mdx": {
+    "newPath": "/docs/guides/configure/auth-strategies/enterprise-connections",
+    "action": "consolidate"
+  },
+  "authentication/enterprise-connections/overview.mdx": {
+    "newPath": "/docs/guides/configure/auth-strategies/enterprise-connections",
+    "action": "consolidate"
+  },
+  "authentication/enterprise-connections/saml/azure.mdx": {
+    "newPath": "/docs/guides/configure/auth-strategies/enterprise-connections",
+    "action": "consolidate"
+  },
+  "authentication/enterprise-connections/saml/custom-provider.mdx": {
+    "newPath": "/docs/guides/configure/auth-strategies/enterprise-connections",
+    "action": "consolidate"
+  },
+  "authentication/enterprise-connections/saml/google.mdx": {
+    "newPath": "/docs/guides/configure/auth-strategies/enterprise-connections",
+    "action": "consolidate"
+  },
+  "authentication/enterprise-connections/saml/okta.mdx": {
+    "newPath": "/docs/guides/configure/auth-strategies/enterprise-connections",
+    "action": "consolidate"
+  },
+  "troubleshooting/create-a-minimal-reproduction.mdx": {
+    "newPath": "/docs/guides/development/troubleshooting",
+    "action": "consolidate"
+  },
+  "troubleshooting/email-deliverability.mdx": {
+    "newPath": "/docs/guides/development/troubleshooting",
+    "action": "consolidate"
+  },
+  "troubleshooting/overview.mdx": {
+    "newPath": "/docs/guides/development/troubleshooting",
+    "action": "consolidate"
+  },
+  "troubleshooting/script-loading.mdx": {
+    "newPath": "/docs/guides/development/troubleshooting",
+    "action": "consolidate"
+  },
+  "upgrade-guides/long-term-support.mdx": {
+    "newPath": "/docs/guides/development/upgrading/versioning",
+    "action": "consolidate"
+  },
+  "upgrade-guides/sdk-versioning.mdx": {
+    "newPath": "/docs/guides/development/upgrading/versioning",
+    "action": "consolidate"
+  },
+  "customization/overview.mdx": {
+    "newPath": "/docs/guides/customizing-clerk/appearance-prop",
+    "action": "consolidate"
+  },
+  "customization/themes.mdx": {
+    "newPath": "/docs/guides/customizing-clerk/appearance-prop",
+    "action": "consolidate"
+  },
+  "customization/user-button.mdx": {
+    "newPath": "/docs/guides/customizing-clerk/appearance-prop",
+    "action": "consolidate"
+  },
+  "customization/user-profile.mdx": {
+    "newPath": "/docs/guides/customizing-clerk/appearance-prop",
+    "action": "consolidate"
+  },
+  "customization/variables.mdx": {
+    "newPath": "/docs/guides/customizing-clerk/appearance-prop",
+    "action": "consolidate"
+  },
+  "organizations/overview.mdx": {
+    "newPath": "/docs/guides/b2b/overview",
+    "action": "move"
+  },
+  "organizations/manage-sso.mdx": {
+    "newPath": "/docs/guides/b2b/managing-orgs",
+    "action": "consolidate"
+  },
+  "organizations/invitations.mdx": {
+    "newPath": "/docs/guides/b2b/managing-orgs",
+    "action": "consolidate"
+  },
+  "organizations/create-roles-permissions.mdx": {
+    "newPath": "/docs/guides/b2b/roles-and-permissions",
+    "action": "consolidate"
+  },
+  "organizations/creator-role.mdx": {
+    "newPath": "/docs/guides/b2b/roles-and-permissions",
+    "action": "consolidate"
+  },
+  "organizations/default-role.mdx": {
+    "newPath": "/docs/guides/b2b/roles-and-permissions",
+    "action": "consolidate"
+  },
+  "quickstarts/**": {
+    "newPath": "/docs/getting-started/quickstart/**",
+    "action": "generate"
+  },
+  "upgrade-guides/expo/v2.mdx": {
+    "newPath": "/docs/guides/development/upgrading/upgrade-guides/expo-v2",
+    "action": "move"
+  },
+  "upgrade-guides/node-to-express.mdx": {
+    "newPath": "/docs/guides/development/upgrading/upgrade-guides/node-to-express",
+    "action": "move"
+  },
+  "upgrade-guides/url-based-session-syncing.mdx": {
+    "newPath": "/docs/guides/development/upgrading/upgrade-guides/url-session-syncing",
+    "action": "move"
+  },
+  "upgrade-guides/core-2/**": {
+    "newPath": "/docs/guides/development/upgrading/upgrade-guides/core-2",
+    "action": "consolidate"
+  },
+  "customization/elements/**": {
+    "newPath": "/docs/examples",
+    "action": "convert-to-example"
+  },
+  "customization/elements/overview.mdx": {
+    "newPath": "/docs/guides/customizing-clerk/elements",
+    "action": "move"
+  },
+  "customization/elements/reference/**": {
+    "newPath": "/docs/reference/components/elements/**",
+    "action": "generate"
+  },
+  "customization/organization-profile.mdx": {
+    "newPath": "/docs/guides/customizing-clerk/adding-items",
+    "action": "move"
+  },
+  "customization/localization.mdx": {
+    "newPath": "/docs/guides/customizing-clerk/localization",
+    "action": "move"
+  },
+  "upgrade-guides/progressive-sign-up.mdx": {
+    "newPath": "/docs/guides/development/upgrading/upgrade-guides/progressive-sign-ups",
+    "action": "move"
+  },
+  "account-portal/**": {
+    "newPath": "/docs/guides/customizing-clerk/account-portal",
+    "action": "consolidate"
+  },
+  "authentication/configuration/legal-compliance.mdx": {
+    "newPath": "/docs/guides/secure/legal-compliance",
+    "action": "move"
+  },
+  "authentication/configuration/restrictions.mdx": {
+    "newPath": "/docs/guides/secure/restricting-access",
+    "action": "move"
+  },
+  "users/user-impersonation.mdx": {
+    "newPath": "/docs/guides/users/impersonation",
+    "action": "move"
+  },
+  "users/creating-users.mdx": {
+    "newPath": "/docs/guides/users/managing",
+    "action": "consolidate"
+  },
+  "users/deleting-users.mdx": {
+    "newPath": "/docs/guides/users/managing",
+    "action": "consolidate"
+  },
+  "users/invitations.mdx": {
+    "newPath": "/docs/guides/users/managing",
+    "action": "consolidate"
+  },
+  "users/metadata.mdx": {
+    "newPath": "/docs/guides/users/managing",
+    "action": "consolidate"
+  },
+  "users/overview.mdx": {
+    "newPath": "/docs/guides/users/managing",
+    "action": "consolidate"
+  },
+  "upgrade-guides/nextjs/v6.mdx": {
+    "newPath": "/docs/guides/development/upgrading/upgrade-guides/next-v6",
+    "action": "move"
+  },
+  "authentication/configuration/email-sms-templates.mdx": {
+    "newPath": "/docs/guides/customizing-clerk/email-and-sms-templates",
+    "action": "move"
+  },
+  "advanced-usage/satellite-domains.mdx": {
+    "newPath": "/docs/guides/clerk-dashboard/dns-domains",
+    "action": "consolidate"
+  },
+  "upgrade-guides/overview.mdx": {
+    "newPath": "/docs/guides/development/upgrading",
+    "action": "move"
+  },
+  "guides/reverification.mdx": {
+    "newPath": "/docs/guides/secure/re-verification-step-up",
+    "action": "move"
+  },
+  "advanced-usage/using-proxies.mdx": {
+    "newPath": "/docs/guides/clerk-dashboard/dns-domains",
+    "action": "consolidate"
+  },
+  "authentication/configuration/session-options.mdx": {
+    "newPath": "/docs/guides/secure/session-options",
+    "action": "move"
+  },
+  "guides/multi-tenant-architecture.mdx": {
+    "newPath": "/docs/core-concepts/multi-tenant-architecture",
+    "action": "move"
+  },
+  "authentication/configuration/force-mfa.mdx": {
+    "newPath": "/docs/guides/secure/mfa",
+    "action": "consolidate"
+  }
+}

--- a/proposal.md
+++ b/proposal.md
@@ -1,0 +1,134 @@
+# Top Level Links
+
+- Home
+- Getting Started
+- Guides
+- Examples
+- Reference
+
+## Home
+
+### Core Concepts
+
+- How Clerk Works
+- Integrate Clerk
+- Clerk Objects
+- Security at Clerk [security]
+- System Limits
+- AI Prompt Library [ai-prompts]
+- Multi-tenant Architecture
+
+## Getting Started [getting-started]
+
+### Quickstart
+
+- App Router
+- Pages Router
+
+### Clerk Dashboard
+
+- Setting up your Clerk account
+- Configure your application
+
+### Next Steps
+
+- Custom sign-in/up pages
+- Protect specific routes
+- Read user and session data
+- Add middleware
+
+## Guides [guides]
+
+### Securing your App [secure]
+
+- Restricting Access
+- Multifactor Authentication (MFA) [mfa]
+- Bot Detection
+- Banning Users
+- Prevent brute force attacks
+- Re-verification (Step-up)
+- Legal Compliance
+- Security Best Practices [best-practices]
+- Session Options
+
+### Managing Users [users]
+
+- Managing Users [managing]
+- Reading Clerk Data [reading]
+- Extending Clerk Data [extending]
+- Syncing Clerk Data [syncing]
+- Impersonation
+
+### B2B
+
+- Overview
+- Managing Organizations [managing-orgs]
+- Verified Domains
+- Roles and Permissions
+- SSO / Enterprise Connections
+
+### Billing
+
+- Overview
+- Billing for B2C [for-b2c]
+- Billing for B2B [for-b2b]
+
+### Customizing Clerk
+
+- UI Customization (Appearance Prop) [appearance-prop]
+- Account Portal
+- Adding items to UI Components [adding-items]
+- Email and SMS Templates
+- Localization (i18n) [localization]
+- Clerk Elements (beta) [elements]
+
+### Configuring your App [configure]
+
+- Authentication Strategies [auth-strategies]
+  - Social Connections
+  - Enterprise Connections
+  - Web3
+- Session Token customization
+- Syncing data with webhooks
+- Backend Requests
+- Integrations
+
+### Clerk Dashboard
+
+- Overview
+- Account Portal
+- DNS & Domains
+- Plans & Billing
+
+### Development
+
+- Deployment
+- Testing with Clerk
+- Managing Environments
+- Migrating your Data
+- Clerk environment variables
+- SDK Development
+- Upgrading Clerk [upgrading]
+  - Versioning & LTS [versioning]
+  - Upgrade Guides
+    - Core 2
+    - Node to Express
+    - Expo v2 [expo-v2]
+    - @clerk/nextjs v6 [next-v6]
+    - URL based session syncing [url-session-syncing]
+    - Progressive Sign Ups
+- Troubleshooting
+
+## Examples [examples]
+
+### Testing
+
+- Test Link
+
+## Reference [reference]
+
+### API Reference [reference]
+
+- SDK Reference [sdk]
+- UI Components [components]
+- API Reference

--- a/scripts/build-docs.test.ts
+++ b/scripts/build-docs.test.ts
@@ -160,6 +160,7 @@ const baseConfig = {
     docs: {},
     partials: {},
     typedoc: {},
+    tooltips: {},
   },
   manifestOptions: {
     wrapDefault: true,
@@ -3729,6 +3730,7 @@ description: This page has a description
             },
             partials: {},
             typedoc: {},
+            tooltips: {},
           },
         }),
       )
@@ -3776,6 +3778,7 @@ description: This page has a description
             },
             partials: {},
             typedoc: {},
+            tooltips: {},
           },
         }),
       )
@@ -3827,6 +3830,7 @@ description: This page has a description
             },
             partials: {},
             typedoc: {},
+            tooltips: {},
           },
         }),
       )
@@ -3880,6 +3884,7 @@ description: This page has a description
             },
             partials: {},
             typedoc: {},
+            tooltips: {},
           },
         }),
       )
@@ -3932,6 +3937,7 @@ description: This page has a description
             },
             partials: {},
             typedoc: {},
+            tooltips: {},
           },
         }),
       )
@@ -3972,6 +3978,7 @@ title: Missing Description
             },
             partials: {},
             typedoc: {},
+            tooltips: {},
           },
         }),
       )
@@ -4027,6 +4034,7 @@ description: The page being linked to
             },
             partials: {},
             typedoc: {},
+            tooltips: {},
           },
         }),
       )
@@ -4084,6 +4092,7 @@ description: This page has a description
             },
             partials: {},
             typedoc: {},
+            tooltips: {},
           },
         }),
       )
@@ -4128,6 +4137,7 @@ description: Test page with partial
             },
             docs: {},
             typedoc: {},
+            tooltips: {},
           },
         }),
       )
@@ -4313,6 +4323,7 @@ interface Client {
           },
           partials: {},
           typedoc: {},
+          tooltips: {},
         },
       }),
     )

--- a/scripts/build-docs.test.ts
+++ b/scripts/build-docs.test.ts
@@ -226,6 +226,7 @@ Testing with a simple page.`)
 
     expect(await fileExists(pathJoin('./dist/manifest.json'))).toBe(true)
     expect(JSON.parse(await readFile(pathJoin('./dist/manifest.json')))).toEqual({
+      flags: {},
       navigation: [[{ title: 'Simple Test', href: '/docs/simple-test' }]],
     })
   })
@@ -564,6 +565,7 @@ title: Simple Test
     const manifest = JSON.parse(await readFile(pathJoin('./dist/manifest.json')))
 
     expect(manifest).toEqual({
+      flags: {},
       navigation: [
         [
           {
@@ -668,6 +670,7 @@ title: Item 2
     const manifest = JSON.parse(await readFile(pathJoin('./dist/manifest.json')))
 
     expect(manifest).toEqual({
+      flags: {},
       navigation: [
         [
           {
@@ -727,6 +730,7 @@ title: Item 1
     const manifest = JSON.parse(await readFile(pathJoin('./dist/manifest.json')))
 
     expect(manifest).toEqual({
+      flags: {},
       navigation: [
         [
           {
@@ -823,6 +827,7 @@ title: Item 1
     const manifest = JSON.parse(await readFile(pathJoin('./dist/manifest.json')))
 
     expect(manifest).toEqual({
+      flags: {},
       navigation: [
         [
           {
@@ -962,6 +967,7 @@ This is a normal document.`,
     // Check that the manifest contains the target="_blank" attribute
     const manifest = JSON.parse(await readFile(pathJoin('./dist/manifest.json')))
     expect(manifest).toEqual({
+      flags: {},
       navigation: [
         [
           { title: 'Normal Link', href: '/docs/normal-link' },
@@ -1023,6 +1029,7 @@ title: Quickstart
 
     expect(await fileExists(pathJoin('./dist/manifest.json'))).toBe(true)
     expect(JSON.parse(await readFile(pathJoin('./dist/manifest.json')))).toEqual({
+      flags: {},
       navigation: [
         [
           {
@@ -1083,6 +1090,7 @@ Testing with a simple page.`,
     )
 
     expect(JSON.parse(await readFile(pathJoin('./dist/manifest.json')))).toEqual({
+      flags: {},
       navigation: [[{ title: 'Simple Test', href: '/docs/:sdk:/simple-test', sdk: ['react'] }]],
     })
 
@@ -1150,6 +1158,7 @@ Testing with a simple page.`,
     )
 
     expect(JSON.parse(await readFile(pathJoin('./dist/manifest.json')))).toEqual({
+      flags: {},
       navigation: [[{ title: 'Simple Test', href: '/docs/:sdk:/simple-test', sdk: ['react', 'vue', 'astro'] }]],
     })
 
@@ -1441,6 +1450,7 @@ Content for React users.`,
     )
 
     expect(JSON.parse(await readFile(pathJoin('./dist/manifest.json')))).toEqual({
+      flags: {},
       navigation: [
         [
           {

--- a/scripts/build-docs.ts
+++ b/scripts/build-docs.ts
@@ -86,6 +86,7 @@ import { removeMdxSuffix } from './lib/utils/removeMdxSuffix'
 import { writeLLMs as generateLLMs, writeLLMsFull as generateLLMsFull, listOutputDocsFiles } from './lib/llms'
 import { VFile } from 'vfile'
 import { readTooltipsFolder, readTooltipsMarkdown, writeTooltips } from './lib/tooltips'
+import { Flags, readSiteFlags, writeSiteFlags } from './lib/siteFlags'
 
 // Only invokes the main function if we run the script directly eg npm run build, bun run ./scripts/build-docs.ts
 if (require.main === module) {
@@ -122,6 +123,10 @@ async function main() {
     tooltips: {
       inputPath: '../docs/_tooltips',
       outputPath: '_tooltips',
+    },
+    siteFlags: {
+      inputPath: '../flags.json',
+      outputPath: '_flags.json',
     },
     ignoreLinks: ['/docs/quickstart'],
     ignorePaths: [
@@ -252,6 +257,15 @@ export async function build(config: BuildConfig, store: Store = createBlankStore
   if (config.prompts) {
     prompts = await readPrompts(config)
     console.info(`✓ Read ${prompts.length} prompts`)
+  }
+
+  abortSignal?.throwIfAborted()
+
+  let siteFlags: Flags = {}
+
+  if (config.siteFlags) {
+    siteFlags = await readSiteFlags(config)
+    console.info(`✓ Read ${Object.keys(siteFlags).length} site flags`)
   }
 
   abortSignal?.throwIfAborted()
@@ -651,6 +665,7 @@ export async function build(config: BuildConfig, store: Store = createBlankStore
   await writeFile(
     'manifest.json',
     JSON.stringify({
+      flags: siteFlags,
       navigation: await traverseTree(
         { items: sdkScopedManifest },
         async (item) => {
@@ -968,6 +983,13 @@ template: wide
       const llms = await generateLLMs(outputtedDocsFiles)
       await writeFile(config.llms.overviewPath, llms)
     }
+  }
+
+  abortSignal?.throwIfAborted()
+
+  if (config.siteFlags) {
+    await writeSiteFlags(config, siteFlags)
+    console.info(`✓ Wrote ${Object.keys(siteFlags).length} site flags to disk`)
   }
 
   abortSignal?.throwIfAborted()

--- a/scripts/lib/config.ts
+++ b/scripts/lib/config.ts
@@ -52,6 +52,10 @@ type BuildConfigOptions = {
     overviewPath?: string
     fullPath?: string
   }
+  siteFlags?: {
+    inputPath: string
+    outputPath: string
+  }
   flags?: {
     watch?: boolean
     controlled?: boolean
@@ -151,6 +155,15 @@ export async function createConfig(config: BuildConfigOptions) {
         ? {
             overviewPath: config.llms.overviewPath,
             fullPath: config.llms.fullPath,
+          }
+        : null,
+
+      siteFlags: config.siteFlags
+        ? {
+            inputPath: resolve(path.join(config.basePath, config.siteFlags.inputPath)),
+            inputPathRelative: config.siteFlags.inputPath,
+            outputPath: resolve(path.join(tempDist, config.siteFlags.outputPath)),
+            outputPathRelative: config.siteFlags.outputPath,
           }
         : null,
 

--- a/scripts/lib/siteFlags.ts
+++ b/scripts/lib/siteFlags.ts
@@ -1,0 +1,34 @@
+import type { BuildConfig } from './config'
+import fs from 'node:fs/promises'
+import path from 'node:path'
+import { z } from 'zod'
+
+export async function readSiteFlags(config: BuildConfig) {
+  const { inputPath, outputPath } = config.siteFlags ?? {}
+  if (!inputPath || !outputPath) {
+    throw new Error('Site flags paths not configured')
+  }
+
+  const flags = await fs.readFile(inputPath, 'utf-8')
+
+  if (!flags) {
+    throw new Error(`Site flags not found at ${inputPath}`)
+  }
+
+  return z.record(z.string(), z.boolean()).parse(JSON.parse(flags))
+}
+
+export type Flags = Awaited<ReturnType<typeof readSiteFlags>>
+
+export async function writeSiteFlags(config: BuildConfig, flags: Flags) {
+  const { outputPath } = config.siteFlags ?? {}
+  if (!outputPath) {
+    throw new Error('Prompts output path not configured')
+  }
+
+  // Create the directory if it doesn't exist
+  await fs.mkdir(path.dirname(outputPath), { recursive: true })
+
+  // Write the flags to the file
+  await fs.writeFile(outputPath, JSON.stringify(flags))
+}

--- a/scripts/migration-assistant/README.md
+++ b/scripts/migration-assistant/README.md
@@ -1,0 +1,220 @@
+# Migration Assistant
+
+The Migration Assistant is a set of tools designed to help manage the documentation migration for Clerk Docs. It helps convert markdown-based proposals into structured manifests and validates content mappings between the legacy and new documentation structures.
+
+## Overview
+
+The migration assistant consists of two main scripts that work together to:
+
+1. **Generate navigation manifests** from markdown proposals
+2. **Validate content mappings** between legacy and new documentation structures
+3. **Identify gaps** in content migration planning
+
+## Scripts
+
+### 1. `generate-manifest.ts`
+
+Converts a markdown-based proposal into a structured JSON manifest.
+
+**What it does:**
+
+- Reads `proposal.md` (markdown file with the new IA structure)
+- Parses markdown headers (`##`, `###`) and list items (`-`) into a hierarchical navigation structure
+- Supports custom URL slugs using bracket notation: `Title [custom-slug]`
+- Generates `public/manifest.proposal.json` with the navigation structure
+- Validates the generated manifest against a Zod schema
+
+**Input:** `proposal.md`
+**Output:** `public/manifest.proposal.json`
+
+### 2. `map-content.ts`
+
+Analyzes the relationship between legacy content and the proposed new structure.
+
+**What it does:**
+
+- Reads `proposal-mapping.json` (mapping of legacy files to new locations)
+- Scans all existing `.mdx` files in the `docs/` directory
+- Compares mappings against the proposed manifest structure
+- Identifies issues and provides detailed reports
+
+**Reports on:**
+
+- **Unhandled legacy files** - Files that exist but aren't mapped anywhere
+- **Invalid mappings** - Mappings pointing to destinations that don't exist in the manifest
+- **Pages needing new content** - Manifest paths that don't have content sources
+- **Summary statistics** - Counts of different mapping actions
+
+**Input:** `proposal-mapping.json`, `public/manifest.proposal.json`, existing `.mdx` files
+**Output:** Console reports and warnings
+
+## Key Files
+
+### Configuration Files
+
+- **`proposal.md`** - Markdown file defining the new structure
+- **`proposal-mapping.json`** - JSON file mapping legacy content to new locations
+- **`flags.json`** - Feature flags (contains `use-proposal-manifest` flag)
+
+### Generated Files
+
+- **`public/manifest.proposal.json`** - Generated navigation manifest from the proposal
+
+## Mapping Actions
+
+The `proposal-mapping.json` file supports several action types:
+
+- **`move`** - Move content to a new location as-is
+- **`consolidate`** - Combine multiple files into a single new location
+- **`generate`** - Create new content (placeholder for content that needs to be written)
+- **`convert-to-example`** - Convert documentation into github example
+- **`drop`** - Remove content entirely
+
+### Mapping Format
+
+```json
+{
+  "path/to/legacy/file.mdx": {
+    "newPath": "/docs/new/location",
+    "action": "move"
+  },
+  "glob/pattern/**": {
+    "newPath": "/docs/new/section/**",
+    "action": "generate"
+  }
+}
+```
+
+**Glob Pattern Support:**
+
+- `**` - Matches any number of directories and files
+- `*` - Matches any characters except `/` within a single path segment
+- Patterns are expanded to match actual files automatically
+
+## Usage
+
+### Running the Scripts
+
+```bash
+# Generate manifest from proposal.md
+npm run migration:generate-manifest
+
+# Generate manifest with file watching (auto-regenerate on changes)
+npm run migration:generate-manifest:watch
+
+# Analyze content mappings
+npm run migration:map-content
+```
+
+### Environment Variables
+
+- **`DOCS_WARNINGS_ONLY=true`** - Show detailed grouped warnings instead of simplified output
+
+```bash
+# Detailed warnings mode
+DOCS_WARNINGS_ONLY=true npm run migration:map-content
+```
+
+## Workflow
+
+### 1. Define New Information Architecture
+
+Edit `proposal.md` to define your new documentation structure:
+
+```markdown
+## Section Name [custom-slug]
+
+### Subsection
+
+- Page Title [custom-page-slug]
+- Another Page
+  - Nested Page
+```
+
+### 2. Generate Manifest
+
+```bash
+npm run migration:generate-manifest
+```
+
+This creates `public/manifest.proposal.json` with the navigation structure.
+
+### 3. Map Legacy Content
+
+Edit `proposal-mapping.json` to map existing content to new locations:
+
+```json
+{
+  "old/path/file.mdx": {
+    "newPath": "/docs/new/location",
+    "action": "move"
+  }
+}
+```
+
+### 4. Validate Mappings
+
+```bash
+npm run migration:map-content
+```
+
+Review the output for:
+
+- Unhandled files that need mapping
+- Invalid mappings pointing to non-existent destinations
+- Missing content for manifest pages
+
+### 5. Iterate
+
+Repeat steps 1-4 until all content is properly mapped and validated.
+
+## Output Examples
+
+### Standard Output
+
+```
+📋 UNHANDLED LEGACY FILES:
+   • path/to/unmapped/file.mdx
+
+❌ INVALID MAPPINGS:
+   • source.mdx → /docs/nonexistent/path (move)
+
+📝 MANIFEST PATHS:
+   • /docs/section/page
+
+📊 SUMMARY:
+   • Legacy files: 150
+   • Manifest paths: 120
+   • Handled files: 140
+   • Unhandled files: 10
+```
+
+### Detailed Warnings Mode
+
+With `DOCS_WARNINGS_ONLY=true`:
+
+```
+⚠️  Found 5 unhandled legacy files:
+
+📁 authentication/ (3 files)
+   • authentication/legacy-page.mdx
+   • authentication/old-guide.mdx
+
+📁 guides/ (2 files)
+   • guides/deprecated.mdx
+```
+
+## Tips
+
+1. **Start broad** - Use glob patterns in mappings to handle multiple files at once
+2. **Use the watch mode** while iterating on the proposal structure
+3. **Run validation frequently** to catch mapping issues early
+4. **Group related consolidations** to make the migration easier to manage
+5. **Document custom slugs** clearly in your proposal for better URL structure
+
+## Troubleshooting
+
+- **Validation errors**: Check that your `proposal.md` follows the expected markdown structure
+- **Glob patterns not working**: Ensure patterns use `**` for recursive matching and avoid shell glob syntax
+- **Missing files in output**: Check that files aren't excluded by the `**/_*/**` ignore pattern
+- **Invalid manifest structure**: Run the generate script to see detailed Zod validation errors

--- a/scripts/migration-assistant/generate-manifest.ts
+++ b/scripts/migration-assistant/generate-manifest.ts
@@ -1,0 +1,271 @@
+import fs from 'fs/promises'
+import path from 'path'
+import { z } from 'zod'
+
+const PROPOSAL_PATH = path.join(process.cwd(), './proposal.md')
+const OUTPUT_PATH = path.join(process.cwd(), './public/manifest.proposal.json')
+
+// Convert to lowercase and replace spaces with hyphens
+const slugify = (str: string) =>
+  str
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-|-$/g, '')
+
+/**
+ * Parse markdown content and convert to a single navigation structure
+ * @param {string} content - The markdown content
+ * @returns {Object} - Object containing navigation structure
+ */
+function parseMarkdownToManifest(content: string) {
+  const lines = content.split('\n')
+  const navigation: any[] = []
+  let currentTopLevel: { title: string; items: any[] } | null = null
+  let currentTopLevelCustomSlug: string | null = null
+  let currentItemGroup: any[] = []
+  let pathStack: string[] = [] // Stack to track nested path components
+
+  const finishCurrentItemGroup = () => {
+    if (currentItemGroup && currentItemGroup.length > 0) {
+      if (currentTopLevel) {
+        currentTopLevel.items.push([...currentItemGroup])
+      }
+      currentItemGroup = []
+    }
+  }
+
+  const finishCurrentTopLevel = () => {
+    finishCurrentItemGroup()
+    if (currentTopLevel) {
+      navigation.push([currentTopLevel])
+      currentTopLevel = null
+    }
+    currentTopLevelCustomSlug = null
+    pathStack = []
+  }
+
+  for (const line of lines) {
+    const trimmed = line.trim()
+
+    // Skip empty lines
+    if (!trimmed) continue
+
+    // Skip the "Top Level Links" section and its content
+    if (trimmed === '# Top Level Links') {
+      continue
+    }
+
+    // Skip top level sections (## Header) - we'll process their subsections
+    if (trimmed.startsWith('## ')) {
+      continue
+    }
+
+    // Subsections (### Header) - these become top-level sections
+    if (trimmed.startsWith('### ')) {
+      finishCurrentTopLevel()
+      const titleWithBrackets = trimmed.substring(4)
+      const bracketMatch = titleWithBrackets.match(/^(.+?)\s*\[([^\]]+)\]$/)
+
+      let title: string, customSlug: string | null
+      if (bracketMatch) {
+        title = bracketMatch[1].trim()
+        customSlug = bracketMatch[2].trim()
+      } else {
+        title = titleWithBrackets.trim()
+        customSlug = null
+      }
+
+      currentTopLevel = {
+        title,
+        items: [],
+      }
+      currentTopLevelCustomSlug = customSlug
+      currentItemGroup = []
+      pathStack = []
+      continue
+    }
+
+    // List items (- Item) - handle indentation levels
+    if (trimmed.startsWith('- ')) {
+      // Calculate indentation level (number of leading spaces before the -)
+      const leadingSpaces = line.length - line.trimStart().length
+      const indentLevel = Math.floor(leadingSpaces / 2) // Assuming 2 spaces per indent level
+
+      const titleWithBrackets = trimmed.substring(2)
+      // Parse bracket syntax for list items
+      const bracketMatch = titleWithBrackets.match(/^(.+?)\s*\[([^\]]+)\]$/)
+
+      let title: string, customSlug: string | null
+      if (bracketMatch) {
+        title = bracketMatch[1].trim()
+        customSlug = bracketMatch[2].trim()
+      } else {
+        title = titleWithBrackets.trim()
+        customSlug = null
+      }
+
+      // Update pathStack based on indentation level
+      // Keep only the path components for levels above the current one
+      pathStack = pathStack.slice(0, indentLevel)
+
+      // Add current item to pathStack
+      const itemSlug = customSlug || slugify(title)
+      pathStack.push(itemSlug)
+
+      // Create the content item
+      const linkItem = {
+        title,
+        href: generateHref(
+          title,
+          currentTopLevel?.title,
+          undefined,
+          undefined,
+          itemSlug,
+          currentTopLevelCustomSlug || undefined,
+        ),
+      }
+
+      // Initialize item group if needed
+      if (!currentItemGroup) {
+        currentItemGroup = []
+      }
+
+      // Add item to current group
+      currentItemGroup.push(linkItem)
+    }
+  }
+
+  // Finish any remaining content
+  finishCurrentTopLevel()
+
+  return {
+    navigation,
+  }
+}
+
+/**
+ * Generate href from title and context
+ * @param {string} title - The item title
+ * @param {string} topLevel - The section title (formerly subsection)
+ * @param {string} section - Unused (kept for backward compatibility)
+ * @param {string} manifestKey - The manifest key for separate manifests
+ * @param {string} customSlug - The custom slug for the item
+ * @param {string} topLevelCustomSlug - The custom slug for the top-level section
+ * @returns {string} - The generated href
+ */
+function generateHref(
+  title: string,
+  topLevel?: string,
+  section?: string,
+  manifestKey?: string,
+  customSlug?: string,
+  topLevelCustomSlug?: string,
+) {
+  let href = '/docs'
+
+  // If this is a separate manifest, use the manifest key as the base path
+  if (manifestKey) {
+    href += `/${manifestKey}`
+  }
+
+  // Add the section path (what used to be subsection, now top-level)
+  if (topLevel) {
+    // Use custom slug if provided, otherwise slugify the title
+    const sectionSlug = topLevelCustomSlug || slugify(topLevel)
+    href += `/${sectionSlug}`
+  }
+
+  // Use custom slug for the item if provided, otherwise slugify the title
+  const itemSlug = customSlug || slugify(title)
+  href += `/${itemSlug}`
+
+  return href
+}
+
+export type ManifestItem = {
+  title: string
+  href: string
+}
+
+export type ManifestGroup = {
+  title: string
+  items: Manifest
+}
+
+export type Manifest = (ManifestItem | ManifestGroup)[][]
+
+const manifestItem: z.ZodType<ManifestItem> = z
+  .object({
+    title: z.string(),
+    href: z.string(),
+  })
+  .strict()
+
+const manifestGroup: z.ZodType<ManifestGroup> = z
+  .object({
+    title: z.string(),
+    items: z.lazy(() => manifestSchema),
+  })
+  .strict()
+
+const manifestSchema: z.ZodType<Manifest> = z.array(z.array(z.union([manifestItem, manifestGroup])))
+
+/**
+ * Validate the manifest against the schema
+ * @param {Object} manifest - The manifest to validate
+ * @returns {boolean} - Whether the manifest is valid
+ */
+function validateManifest(manifest: object) {
+  const result = z.object({ navigation: manifestSchema }).safeParse(manifest)
+
+  if (!result.success) {
+    console.error('Validation errors:')
+    console.error(result.error.errors)
+    return false
+  }
+
+  return true
+}
+
+/**
+ * Main function to generate the manifest
+ */
+async function generateManifest() {
+  console.log('🚀 Starting manifest generation...')
+
+  // Read the ia-proposal.md file
+  const proposalContent = await fs.readFile(PROPOSAL_PATH, 'utf-8')
+  console.log('✅ Read ia-proposal.md')
+
+  // Parse markdown to multiple navigation structures
+  const manifest = parseMarkdownToManifest(proposalContent)
+  console.log('✅ Parsed markdown structure')
+
+  // Validate manifest against schema
+  if (!validateManifest(manifest)) {
+    console.error('❌ Manifest validation failed')
+    process.exit(1)
+  }
+  console.log('✅ Main manifest validation passed')
+
+  // Write the main manifest.new.json file
+  await fs.writeFile(OUTPUT_PATH, JSON.stringify(manifest))
+  console.log('✅ Written manifest.proposal.json')
+}
+
+async function watchAndRebuild() {
+  const { argv } = process
+
+  if (argv.includes('--watch')) {
+    const watcher = fs.watch(PROPOSAL_PATH)
+    for await (const event of watcher) {
+      generateManifest()
+    }
+  }
+}
+
+// Run the bootstrap if this file is executed directly
+if (import.meta.url === `file://${process.argv[1]}`) {
+  generateManifest()
+  watchAndRebuild()
+}

--- a/scripts/migration-assistant/generate-manifest.ts
+++ b/scripts/migration-assistant/generate-manifest.ts
@@ -304,7 +304,7 @@ async function generateManifest() {
 
   // Read the ia-proposal.md file
   const proposalContent = await fs.readFile(PROPOSAL_PATH, 'utf-8')
-  console.log('✅ Read ia-proposal.md')
+  console.log(`✅ Read ${PROPOSAL_PATH}`)
 
   // Parse markdown to multiple navigation structures
   const manifest = parseMarkdownToManifest(proposalContent)

--- a/scripts/migration-assistant/map-content.ts
+++ b/scripts/migration-assistant/map-content.ts
@@ -1,3 +1,4 @@
+import 'dotenv/config'
 import { readFile } from 'fs/promises'
 import { glob } from 'glob'
 import { join, relative } from 'path'
@@ -10,7 +11,7 @@ const MANIFEST_PATH = join(process.cwd(), './public/manifest.json')
 const DOCS_PATH = join(process.cwd(), './docs')
 
 // Environment variable to control output
-const WARNINGS_ONLY = process.env.DOCS_IA_WARNINGS_ONLY === 'true'
+const WARNINGS_ONLY = process.env.DOCS_WARNINGS_ONLY === 'true'
 
 /**
  * Read and parse the mapping.json file
@@ -425,7 +426,7 @@ async function main() {
       console.log(`   • Invalid mappings: ${invalidMappings.length}`)
 
       if (unhandledFiles.length > 0 || pagesToCreate.length > 0) {
-        console.log('\n💡 Run with DOCS_IA_WARNINGS_ONLY=true to see detailed warnings and grouped files')
+        console.log('\n💡 Run with DOCS_WARNINGS_ONLY=true to see detailed warnings and grouped files')
       }
     }
   } catch (error) {

--- a/scripts/migration-assistant/map-content.ts
+++ b/scripts/migration-assistant/map-content.ts
@@ -1,0 +1,438 @@
+import { readFile } from 'fs/promises'
+import { glob } from 'glob'
+import { join, relative } from 'path'
+import type { Manifest } from './generate-manifest'
+
+// Path to the docs directory and mapping file
+const MAPPING_PATH = join(process.cwd(), './proposal-mapping.json')
+const MANIFEST_PROPOSAL_PATH = join(process.cwd(), './public/manifest.proposal.json')
+const MANIFEST_PATH = join(process.cwd(), './public/manifest.json')
+const DOCS_PATH = join(process.cwd(), './docs')
+
+// Environment variable to control output
+const WARNINGS_ONLY = process.env.DOCS_IA_WARNINGS_ONLY === 'true'
+
+/**
+ * Read and parse the mapping.json file
+ * @returns {Promise<Object>} Parsed mapping object
+ */
+async function readMapping() {
+  try {
+    const mappingContent = await readFile(MAPPING_PATH, 'utf-8')
+    return JSON.parse(mappingContent) as Record<
+      string,
+      { newPath: string; action: 'consolidate' | 'move' | 'generate' | 'convert-to-example' | 'drop' }
+    >
+  } catch (error) {
+    console.error(`❌ Error reading mapping.json: ${error.message}`)
+    return {}
+  }
+}
+
+type Mapping = Awaited<ReturnType<typeof readMapping>>
+
+/**
+ * Read all manifest files and extract destination paths
+ * @returns {Promise<string[]>} Array of all destination paths from manifests
+ */
+async function readProposalManifestPaths() {
+  const content = await readFile(MANIFEST_PROPOSAL_PATH, 'utf-8')
+  const manifest = JSON.parse(content) as { navigation: Manifest }
+  return { manifest, paths: parseManifestPaths(manifest) }
+}
+
+async function getManifestPaths() {
+  const content = await readFile(MANIFEST_PATH, 'utf-8')
+  const manifest = JSON.parse(content) as { navigation: Manifest }
+  return { manifest, paths: parseManifestPaths(manifest) }
+}
+
+function parseManifestPaths(manifest: { navigation: Manifest }) {
+  const manifestPaths: string[] = []
+
+  // Extract paths from navigation structure
+  const extractPaths = (groups: Manifest) => {
+    for (const group of groups) {
+      for (const item of group) {
+        if ('href' in item) {
+          manifestPaths.push(item.href)
+        }
+
+        if ('items' in item) {
+          extractPaths(item.items)
+        }
+      }
+    }
+  }
+
+  extractPaths(manifest.navigation)
+
+  return [...new Set(manifestPaths)].sort() // Remove duplicates and sort
+}
+
+/**
+ * Recursively find all .mdx files in a directory
+ * @param {string} dir - Directory to search
+ * @param {string} baseDir - Base directory for relative paths
+ * @returns {Promise<string[]>} Array of relative file paths
+ */
+async function findMdxFiles(dir: string, baseDir = dir) {
+  const files = await glob(`${dir}/**/*.mdx`, { ignore: ['**/_*/**'] })
+  return files.map((file) => relative(baseDir, file))
+}
+
+/**
+ * Find unhandled files by comparing with mapping
+ * @param {string[]} allFiles - All MDX files found
+ * @param {Object} mapping - Mapping configuration
+ * @returns {string[]} Array of unhandled file paths
+ */
+function findUnhandledFiles(allFiles: string[], mapping: Mapping) {
+  const handledFiles = new Set(Object.keys(mapping))
+  return allFiles.filter((file) => !handledFiles.has(file))
+}
+
+/**
+ * Find pages that need to be created (in manifest but no mapping source)
+ * @param manifestPaths - All paths from manifest files
+ * @param mapping - Mapping configuration
+ * @returns Array of paths that need new content
+ */
+function findPagesToCreate(manifestPaths: string[], mapping: Mapping) {
+  const mappedDestinations = new Set(Object.values(mapping).map((entry) => entry.newPath))
+
+  // Also collect manifest paths that are explicitly marked for dropping
+  const droppedPaths = new Set()
+  for (const [key, value] of Object.entries(mapping)) {
+    if (value.action === 'drop' && key.startsWith('/docs/')) {
+      droppedPaths.add(key)
+    }
+  }
+
+  return manifestPaths.filter((path) => !mappedDestinations.has(path) && !droppedPaths.has(path))
+}
+
+/**
+ * Display warnings for unhandled files and pages to create
+ * @param {string[]} unhandledFiles - Array of unhandled file paths
+ * @param {string[]} pagesToCreate - Array of paths that need new content
+ * @param {Object} expandedMapping - Expanded mapping configuration
+ * @param {Array} invalidMappings - Array of invalid mapping objects
+ */
+function displayWarnings(
+  unhandledFiles: string[],
+  pagesToCreate: string[],
+  expandedMapping: Mapping,
+  invalidMappings: InvalidMapping,
+) {
+  let hasWarnings = false
+
+  if (unhandledFiles.length > 0) {
+    hasWarnings = true
+    console.log(`⚠️  Found ${unhandledFiles.length} unhandled legacy files:\n`)
+
+    // Group by directory for better readability
+    const groupedFiles: Record<string, string[]> = {}
+    unhandledFiles.forEach((file) => {
+      const dir = file.includes('/') ? file.split('/')[0] : 'root'
+      if (!groupedFiles[dir]) groupedFiles[dir] = []
+      groupedFiles[dir].push(file)
+    })
+
+    // Display grouped warnings
+    Object.entries(groupedFiles)
+      .sort(([a], [b]) => a.localeCompare(b))
+      .forEach(([dir, files]) => {
+        console.log(`📁 ${dir}/ (${files.length} files)`)
+        files.sort().forEach((file) => {
+          console.log(`   • ${file}`)
+        })
+        console.log()
+      })
+  }
+
+  if (invalidMappings.length > 0) {
+    hasWarnings = true
+    if (unhandledFiles.length > 0) console.log('\n' + '─'.repeat(60) + '\n')
+
+    console.log(`❌ Found ${invalidMappings.length} invalid mappings (destinations not in manifests):\n`)
+
+    // Group by destination directory for better readability
+    const groupedMappings: Record<string, InvalidMapping> = {}
+    invalidMappings.forEach((mapping) => {
+      const parts = mapping.destination.split('/')
+      const section = parts.length > 2 ? parts[2] : 'root' // /docs/[section]/...
+      if (!groupedMappings[section]) groupedMappings[section] = []
+      groupedMappings[section].push(mapping)
+    })
+
+    // Display grouped invalid mappings
+    Object.entries(groupedMappings)
+      .sort(([a], [b]) => a.localeCompare(b))
+      .forEach(([section, mappings]) => {
+        console.log(`📂 ${section}/ (${mappings.length} mappings)`)
+        mappings.forEach((mapping) => {
+          console.log(`   • ${mapping.source} → ${mapping.destination} (${mapping.action})`)
+        })
+        console.log()
+      })
+  }
+
+  if (pagesToCreate.length > 0) {
+    hasWarnings = true
+    if (unhandledFiles.length > 0 || invalidMappings.length > 0) console.log('\n' + '─'.repeat(60) + '\n')
+
+    console.log(`📝 Found ${pagesToCreate.length} pages that need new content:\n`)
+
+    // Group by section for better readability
+    const groupedPages: Record<string, string[]> = {}
+    pagesToCreate.forEach((path) => {
+      const parts = path.split('/')
+      const section = parts.length > 2 ? parts[2] : 'root' // /docs/[section]/...
+      if (!groupedPages[section]) groupedPages[section] = []
+      groupedPages[section].push(path)
+    })
+
+    // Display grouped pages to create
+    Object.entries(groupedPages)
+      .sort(([a], [b]) => a.localeCompare(b))
+      .forEach(([section, paths]) => {
+        console.log(`📂 ${section}/ (${paths.length} pages)`)
+        paths.sort().forEach((path) => {
+          console.log(`   • ${path}`)
+        })
+        console.log()
+      })
+  }
+
+  if (!hasWarnings) {
+    console.log('✅ All legacy files are handled, all mappings are valid, and all manifest pages have content sources')
+    return
+  }
+
+  // Count files that need to be converted to examples
+  const convertToExampleFiles = Object.values(expandedMapping).filter(
+    (mapping) => mapping.action === 'convert-to-example',
+  ).length
+
+  // Count files that will be generated
+  const generateFiles = Object.values(expandedMapping).filter((mapping) => mapping.action === 'generate').length
+
+  console.log(
+    `\n📊 Summary: ${unhandledFiles.length} unhandled files, ${invalidMappings.length} invalid mappings, ${pagesToCreate.length} pages need new content, ${convertToExampleFiles} convert to examples, ${generateFiles} pages need to be generated, ${Object.keys(expandedMapping).length} files mapped`,
+  )
+}
+
+/**
+ * Check if a pattern is a glob pattern
+ * @param {string} pattern - The pattern to check
+ * @returns {boolean} - Whether the pattern contains glob characters
+ */
+function isGlobPattern(pattern: string) {
+  return pattern.includes('*') || pattern.includes('?')
+}
+
+/**
+ * Convert a glob pattern to a regex
+ * @param {string} pattern - The glob pattern
+ * @returns {RegExp} - The corresponding regex
+ */
+function globToRegex(pattern: string) {
+  // Escape special regex characters except * and ?
+  const escaped = pattern
+    .replace(/[.+^${}()|[\]\\]/g, '\\$&')
+    .replace(/\*\*/g, '§DOUBLESTAR§') // Temporary placeholder
+    .replace(/\*/g, '[^/]*') // Single * matches anything except /
+    .replace(/§DOUBLESTAR§/g, '.*') // ** matches anything including /
+    .replace(/\?/g, '[^/]') // ? matches single char except /
+
+  return new RegExp(`^${escaped}$`)
+}
+
+/**
+ * Apply glob pattern to generate new path
+ * @param {string} filePath - The source file path
+ * @param {string} globPattern - The glob pattern used as key
+ * @param {string} newPathPattern - The new path pattern (may contain globs)
+ * @returns {string} - The generated new path
+ */
+function applyGlobMapping(filePath: string, globPattern: string, newPathPattern: string) {
+  // If newPathPattern doesn't contain globs, return as-is
+  if (!isGlobPattern(newPathPattern)) {
+    return newPathPattern
+  }
+
+  // Handle ** glob replacement
+  if (globPattern.includes('**') && newPathPattern.includes('**')) {
+    const globPrefix = globPattern.split('**')[0]
+    const newPathPrefix = newPathPattern.split('**')[0]
+    const newPathSuffix = newPathPattern.split('**')[1] || ''
+
+    if (filePath.startsWith(globPrefix)) {
+      const matchedPart = filePath.slice(globPrefix.length)
+      return newPathPrefix + matchedPart.replace(/\.mdx$/, '') + newPathSuffix
+    }
+  }
+
+  // Handle single * replacement (simplified)
+  if (globPattern.includes('*') && newPathPattern.includes('*')) {
+    const globParts = globPattern.split('*')
+    const newPathParts = newPathPattern.split('*')
+
+    if (globParts.length === 2 && newPathParts.length === 2) {
+      const [globPrefix, globSuffix] = globParts
+      const [newPrefix, newSuffix] = newPathParts
+
+      if (filePath.startsWith(globPrefix) && filePath.endsWith(globSuffix)) {
+        const matchedPart = filePath.slice(globPrefix.length, -globSuffix.length || undefined)
+        return newPrefix + matchedPart + newSuffix
+      }
+    }
+  }
+
+  return newPathPattern
+}
+
+/**
+ * Expand glob patterns in mapping to actual file matches
+ * @param {Object} mapping - The mapping configuration
+ * @param {string[]} allFiles - All available files
+ * @returns {Object} - Expanded mapping with actual file paths
+ */
+function expandGlobMapping(mapping: Mapping, allFiles: string[]) {
+  const expandedMapping: Mapping = {}
+
+  for (const [key, value] of Object.entries(mapping)) {
+    if (isGlobPattern(key)) {
+      const regex = globToRegex(key)
+      const matchingFiles = allFiles.filter((file) => regex.test(file))
+
+      for (const file of matchingFiles) {
+        expandedMapping[file] = {
+          ...value,
+          newPath: applyGlobMapping(file, key, value.newPath),
+        }
+      }
+    } else {
+      // Include non-glob patterns as-is
+      expandedMapping[key] = value
+    }
+  }
+
+  return expandedMapping
+}
+
+/**
+ * Find invalid mapping destinations (mapped to paths that don't exist in manifests)
+ * @param {Object} expandedMapping - Expanded mapping configuration
+ * @param {string[]} manifestPaths - All paths from manifest files
+ * @returns {string[]} Array of invalid mapping destinations
+ */
+function findInvalidMappings(expandedMapping: Mapping, manifestPaths: string[]) {
+  const manifestPathsSet = new Set(manifestPaths)
+  const invalidMappings: Array<{ source: string; destination: string; action: 'consolidate' | 'move' }> = []
+
+  for (const [sourcePath, mapping] of Object.entries(expandedMapping)) {
+    // Skip drop actions - they're intentionally removing paths
+    // Skip generate actions - they're creating new content that won't exist in manifests yet
+    // Skip convert-to-example actions - they're converting to examples that won't exist as specific manifest paths
+    if (mapping.action === 'drop' || mapping.action === 'generate' || mapping.action === 'convert-to-example') {
+      continue
+    }
+
+    if (!manifestPathsSet.has(mapping.newPath)) {
+      invalidMappings.push({
+        source: sourcePath,
+        destination: mapping.newPath,
+        action: mapping.action,
+      })
+    }
+  }
+
+  return invalidMappings
+}
+
+type InvalidMapping = Awaited<ReturnType<typeof findInvalidMappings>>
+
+/**
+ * Main function to parse docs content and check mappings
+ */
+async function main() {
+  if (!WARNINGS_ONLY) {
+    console.log('🔍 Scanning for MDX files in ./docs')
+  }
+
+  try {
+    const [mdxFiles, mapping, { paths: manifestPaths }] = await Promise.all([
+      findMdxFiles(DOCS_PATH),
+      readMapping(),
+      readProposalManifestPaths(),
+    ])
+
+    // Expand glob patterns in mapping to actual file matches
+    const expandedMapping = expandGlobMapping(mapping, mdxFiles)
+
+    const unhandledFiles = findUnhandledFiles(mdxFiles, expandedMapping)
+    const pagesToCreate = findPagesToCreate(manifestPaths, expandedMapping)
+    const invalidMappings = findInvalidMappings(expandedMapping, manifestPaths)
+
+    if (WARNINGS_ONLY) {
+      console.log('🔍 Checking for unhandled legacy files and pages to create...\n')
+      displayWarnings(unhandledFiles, pagesToCreate, expandedMapping, invalidMappings)
+    } else {
+      // Simplified output mode
+      console.log('📋 UNHANDLED LEGACY FILES:\n')
+      if (unhandledFiles.length > 0) {
+        unhandledFiles.sort().forEach((file) => {
+          console.log(`   • ${file}`)
+        })
+      } else {
+        console.log('   ✅ All legacy files are handled')
+      }
+
+      console.log('\n❌ INVALID MAPPINGS (destinations not in manifests):\n')
+      if (invalidMappings.length > 0) {
+        invalidMappings.forEach((mapping) => {
+          console.log(`   • ${mapping.source} → ${mapping.destination} (${mapping.action})`)
+        })
+      } else {
+        console.log('   ✅ All mappings point to valid manifest paths')
+      }
+
+      console.log('\n📝 MANIFEST PATHS:\n')
+      manifestPaths.forEach((path) => {
+        console.log(`   • ${path}`)
+      })
+
+      // Count files that need to be converted to examples
+      const convertToExampleFiles = Object.values(expandedMapping).filter(
+        (mapping) => mapping.action === 'convert-to-example',
+      ).length
+
+      // Count files that will be generated
+      const generateFiles = Object.values(expandedMapping).filter((mapping) => mapping.action === 'generate').length
+
+      console.log('\n📊 SUMMARY:')
+      console.log(`   • Legacy files: ${mdxFiles.length}`)
+      console.log(`   • Manifest paths: ${manifestPaths.length}`)
+      console.log(`   • Original mapping entries: ${Object.keys(mapping).length}`)
+      console.log(`   • Expanded mapping entries: ${Object.keys(expandedMapping).length}`)
+      console.log(`   • Handled files: ${Object.keys(expandedMapping).length}`)
+      console.log(`   • Unhandled files: ${unhandledFiles.length}`)
+      console.log(`   • Pages needing new content: ${pagesToCreate.length}`)
+      console.log(`   • Convert to examples: ${convertToExampleFiles}`)
+      console.log(`   • Pages need to be generated: ${generateFiles}`)
+      console.log(`   • Invalid mappings: ${invalidMappings.length}`)
+
+      if (unhandledFiles.length > 0 || pagesToCreate.length > 0) {
+        console.log('\n💡 Run with DOCS_IA_WARNINGS_ONLY=true to see detailed warnings and grouped files')
+      }
+    }
+  } catch (error) {
+    console.error('❌ Error scanning docs:', error.message)
+    process.exit(1)
+  }
+}
+
+// Run the script
+main()

--- a/vercel.json
+++ b/vercel.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://openapi.vercel.sh/vercel.json",
-  "buildCommand": "npm run build && npm run migration:generate-manifest",
+  "buildCommand": "npm run migration:generate-manifest && npm run build",
   "devCommand": "npm run dev",
   "installCommand": "npm install",
   "outputDirectory": "dist",

--- a/vercel.json
+++ b/vercel.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://openapi.vercel.sh/vercel.json",
-  "buildCommand": "npm run build",
+  "buildCommand": "npm run build && npm run migration:generate-manifest",
   "devCommand": "npm run dev",
   "installCommand": "npm install",
   "outputDirectory": "dist",


### PR DESCRIPTION
sibling pr / blocked by: https://github.com/clerk/clerk/pull/1396

### 🔎 Previews:

- https://clerk-git-nick-docs-migration.clerkstage.dev/docs/pr/nick-example-preview-proposal - built off the `nick/example-preview-proposal` which branches off this pr but enables the feature flags

### What does this solve?

- We need a robust solution for migrating the docs towards a content goal post

### What changed?

- A new `proposal.md` file, using markdown edit this file to reach for the sidebar that is desired
- A new `proposal-mapping.json` file, Take the generated `public/manifest.proposal.json` file and by hand generate this file that defines the migration expectations to get from the current docs to the new docs
- Added three new package.json scripts:
  - `migration:generate-manifest` - Takes the `proposal.md` file and generates a Manifest proposal
  - `migration:generate-manifest:watch` - Same as above but with hot reload
  - `migration:map-content` - Takes the mappings file and the current file structure and grades how close the docs are to matching the proposal - guiding us to work towards completion
- Added github action to call ./scripts/migration-assistant/map-content.ts that checks proposed-mapping.json and reports how close we are towards the proposal
- Added feature flags to the docs, so we can add features to `clerk/clerk` but only have them enabled on pr merges in this repo

The two flags that can be enabled:

```json
{
  "use-proposal-manifest": true,
  "top-level-manifest-splitting": true
}
```

### Checklist

- [x] I have clicked on "Files changed" and performed a thorough self-review
- [x] All existing checks pass
