### PR TITLE
Update authenticateRequest() docs to show new returns

### DIFF
--- a/docs/references/backend/authenticate-request.mdx
+++ b/docs/references/backend/authenticate-request.mdx
@@ -164,56 +164,56 @@ It is recommended to set these options as [environment variables](/docs/deployme
   - `isAuthenticated`
   - `boolean`
 
-  Indicates whether the incoming request is authenticated.
+  Indicates whether the incoming request is authenticated. Initially `false`, becomes `true` once the request is authenticated.
 
   ---
 
   - `isSignedIn` (deprecated)
   - `boolean`
 
-  Indicates whether the incoming request is authenticated.
+  Deprecated. Indicates whether the incoming request is authenticated.
 
   ---
 
   - `status`
   - `'signed-in' | 'signed-out' | 'handshake'`
 
-  Indicates whether the incoming request is authenticated.
+  Indicates the authentication state.
 
   ---
 
   - `reason`
   - `string | null`
 
-  Indicates whether the incoming request is authenticated.
+  Indicates the error code or reason for the current state. When there is a signed-in user, the value will be `null`.
 
   ---
 
   - `message`
   - `string | null`
 
-  Indicates whether the incoming request is authenticated.
+  Indicates the full error message or additional context. When there is a signed-in user, the value will be `null`.
 
   ---
 
   - `tokenType`
-  - `string`
+  - `session_token` | `oauth_token` | `machine_token` | `api_key`
 
-  Indicates whether the incoming request is authenticated.
+  The type of token.
 
   ---
 
   - `token`
   - `string`
 
-  Indicates whether the incoming request is authenticated.
+  The value of the token.
 
   ---
 
-  - `toAuth`
+  - `toAuth()`
   - `function`
 
-  Indicates whether the incoming request is authenticated.
+  Returns the `Auth` object. This JavaScript object contains important information like the current user's session ID, user ID, and organization ID. Learn more about the [`Auth` object](/docs/references/backend/types/auth-object){{ target: '_blank' }}.
 
   ---
 </Properties>

--- a/docs/references/backend/authenticate-request.mdx
+++ b/docs/references/backend/authenticate-request.mdx
@@ -165,6 +165,57 @@ It is recommended to set these options as [environment variables](/docs/deployme
   - `boolean`
 
   Indicates whether the incoming request is authenticated.
+
+  ---
+
+  - `isSignedIn` (deprecated)
+  - `boolean`
+
+  Indicates whether the incoming request is authenticated.
+
+  ---
+
+  - `status`
+  - `'signed-in' | 'signed-out' | 'handshake'`
+
+  Indicates whether the incoming request is authenticated.
+
+  ---
+
+  - `reason`
+  - `string | null`
+
+  Indicates whether the incoming request is authenticated.
+
+  ---
+
+  - `message`
+  - `string | null`
+
+  Indicates whether the incoming request is authenticated.
+
+  ---
+
+  - `tokenType`
+  - `string`
+
+  Indicates whether the incoming request is authenticated.
+
+  ---
+
+  - `token`
+  - `string`
+
+  Indicates whether the incoming request is authenticated.
+
+  ---
+
+  - `toAuth`
+  - `function`
+
+  Indicates whether the incoming request is authenticated.
+
+  ---
 </Properties>
 
 ## Examples


### PR DESCRIPTION
### 🔎 Previews:

-

### What does this solve?

This clarifies the return value of `authenticateRequest` in the docs. Previously, the docs stated that `authenticateRequest` only returns `isAuthenticated`, but now, it returns additional properties. This PR updates the docs with the new properties after an investigation with @wobsoriano. 

### What changed?

- Added the new properties with descriptions, data type and values

### Checklist

- [ ] I have clicked on "Files changed" and performed a thorough self-review
- [ ] All existing checks pass
