### PR TITLE
chore(after-auth): Add `SessionTask` reference

### DIFF
--- a/docs/manifest.json
+++ b/docs/manifest.json
@@ -2330,6 +2330,10 @@
                                 "href": "/docs/references/javascript/types/session-status"
                               },
                               {
+                                "title": "`SessionTask`",
+                                "href": "/docs/references/javascript/types/session-task"
+                              },
+                              {
                                 "title": "`SessionVerification`",
                                 "href": "/docs/references/javascript/types/session-verification"
                               },

--- a/docs/references/javascript/types/session-task.mdx
+++ b/docs/references/javascript/types/session-task.mdx
@@ -1,0 +1,15 @@
+---
+title: '`SessionTask`'
+description: The SessionTask interface represents the current pending task of a session.
+---
+
+An interface that represents the current pending task of a session.
+
+## Properties
+
+<Properties>
+  - `key`
+  - \`'select-organization'\`
+
+  A unique identifier for the task. Currently, the only supported value is `'select-organization'`, which indicates that the user needs to select an organization before proceeding.
+</Properties>


### PR DESCRIPTION
### 🔎 Previews:

- https://clerk.com/docs/pr/laura-add-session-task/references/javascript/types/session-task

### What does this solve?

Includes type reference for the `SessionTask` type, part of after-auth flows.

### Checklist

- [x] I have clicked on "Files changed" and performed a thorough self-review
- [X] All existing checks pass
