### PR TITLE
Docs Proposal manifest generation - fix href generation

### DIFF
--- a/scripts/migration-assistant/generate-manifest.ts
+++ b/scripts/migration-assistant/generate-manifest.ts
@@ -188,11 +188,13 @@ function parseMarkdownToManifest(content: string) {
         title,
         href: generateHref(
           title,
+          currentTopLevelGroup?.title,
           currentSubGroup?.title,
           undefined,
-          undefined,
           itemSlug,
+          currentTopLevelCustomSlug || undefined,
           currentSubGroupCustomSlug || undefined,
+          pathStack.slice(0, -1), // Pass all parent path segments except the current item
         ),
       }
 
@@ -217,33 +219,55 @@ function parseMarkdownToManifest(content: string) {
 /**
  * Generate href from title and context
  * @param {string} title - The item title
- * @param {string} topLevel - The section title (formerly subsection)
- * @param {string} section - Unused (kept for backward compatibility)
+ * @param {string} topLevel - The top-level group title
+ * @param {string} subLevel - The sub-level group title
  * @param {string} manifestKey - The manifest key for separate manifests
  * @param {string} customSlug - The custom slug for the item
- * @param {string} topLevelCustomSlug - The custom slug for the top-level section
+ * @param {string} topLevelCustomSlug - The custom slug for the top-level group
+ * @param {string} subLevelCustomSlug - The custom slug for the sub-level group
+ * @param {string[]} parentPathSegments - Array of parent path segments for nested items
  * @returns {string} - The generated href
  */
 function generateHref(
   title: string,
-  topLevel?: string,
-  section?: string,
+  _topLevel?: string,
+  subLevel?: string,
   manifestKey?: string,
   customSlug?: string,
   topLevelCustomSlug?: string,
+  subLevelCustomSlug?: string,
+  parentPathSegments?: string[],
 ) {
   let href = '/docs'
+  let topLevel = _topLevel
+
+  // Special case for Home section - use root path
+  if (topLevel === 'Home') {
+    topLevel = ''
+  }
 
   // If this is a separate manifest, use the manifest key as the base path
   if (manifestKey) {
     href += `/${manifestKey}`
   }
 
-  // Add the section path (what used to be subsection, now top-level)
+  // Add the top-level group path
   if (topLevel) {
-    // Use custom slug if provided, otherwise slugify the title
-    const sectionSlug = topLevelCustomSlug || slugify(topLevel)
-    href += `/${sectionSlug}`
+    const topLevelSlug = topLevelCustomSlug || slugify(topLevel)
+    href += `/${topLevelSlug}`
+  }
+
+  // Add the sub-level group path
+  if (subLevel) {
+    const subLevelSlug = subLevelCustomSlug || slugify(subLevel)
+    href += `/${subLevelSlug}`
+  }
+
+  // Add any nested parent path segments (for deeply nested items)
+  if (parentPathSegments && parentPathSegments.length > 0) {
+    for (const segment of parentPathSegments) {
+      href += `/${segment}`
+    }
   }
 
   // Use custom slug for the item if provided, otherwise slugify the title


### PR DESCRIPTION
Fixes the href generation to include all levels of sidebar headings in the generated href.

<img width="628" height="790" alt="image" src="https://github.com/user-attachments/assets/d2cd7383-459f-4cf2-a0c9-2ac81f1982af" />
