### PR TITLE
Add additional context to the frontmatter for the sdk scoped pages

### DIFF
--- a/scripts/build-docs.test.ts
+++ b/scripts/build-docs.test.ts
@@ -1102,7 +1102,7 @@ Testing with a simple page.`,
     expect(await readFile(pathJoin('./dist/react/simple-test.mdx'))).toBe(`---
 title: Simple Test
 sdk: react
-sdkScoped: true
+sdkScoped: "true"
 canonical: /docs/:sdk:/simple-test
 availableSdks: react
 notAvailableSdks: ""
@@ -1116,7 +1116,7 @@ Testing with a simple page.`)
     expect(await readFile(pathJoin('./dist/simple-test.mdx'))).toBe(
       `---
 template: wide
-redirectPage: true
+redirectPage: "true"
 availableSdks: react
 notAvailableSdks: ""
 ---
@@ -1381,7 +1381,7 @@ This document is available for React and Next.js.`,
     expect(await readFile(pathJoin('./dist/sdk-document.mdx'))).toBe(
       `---
 template: wide
-redirectPage: true
+redirectPage: "true"
 availableSdks: react,nextjs
 notAvailableSdks: ""
 ---

--- a/scripts/build-docs.test.ts
+++ b/scripts/build-docs.test.ts
@@ -1102,7 +1102,11 @@ Testing with a simple page.`,
     expect(await readFile(pathJoin('./dist/react/simple-test.mdx'))).toBe(`---
 title: Simple Test
 sdk: react
+sdkScoped: true
 canonical: /docs/:sdk:/simple-test
+availableSdks: react
+notAvailableSdks: ""
+activeSdk: react
 ---
 
 # Simple Test Page
@@ -1110,7 +1114,13 @@ canonical: /docs/:sdk:/simple-test
 Testing with a simple page.`)
 
     expect(await readFile(pathJoin('./dist/simple-test.mdx'))).toBe(
-      `---\ntemplate: wide\n---\n<SDKDocRedirectPage title="Simple Test" href="/docs/:sdk:/simple-test" sdks={["react"]} />`,
+      `---
+template: wide
+redirectPage: true
+availableSdks: react
+notAvailableSdks: ""
+---
+<SDKDocRedirectPage title="Simple Test" href="/docs/:sdk:/simple-test" sdks={["react"]} />`,
     )
 
     const distFiles = await treeDir(pathJoin('./dist'))
@@ -1369,7 +1379,13 @@ This document is available for React and Next.js.`,
 
     // Verify landing page content
     expect(await readFile(pathJoin('./dist/sdk-document.mdx'))).toBe(
-      `---\ntemplate: wide\n---\n<SDKDocRedirectPage title="SDK Document" description="This document is available for React and Next.js." href="/docs/:sdk:/sdk-document" sdks={["react","nextjs"]} />`,
+      `---
+template: wide
+redirectPage: true
+availableSdks: react,nextjs
+notAvailableSdks: ""
+---
+<SDKDocRedirectPage title="SDK Document" description="This document is available for React and Next.js." href="/docs/:sdk:/sdk-document" sdks={["react","nextjs"]} />`,
     )
   })
 

--- a/scripts/build-docs.ts
+++ b/scripts/build-docs.ts
@@ -791,7 +791,7 @@ export async function build(config: BuildConfig, store: Store = createBlankStore
           `---
 ${yaml.stringify({
   template: 'wide',
-  redirectPage: true,
+  redirectPage: 'true',
   availableSdks: doc.sdk.join(','),
   notAvailableSdks: config.validSdks.filter((sdk) => !doc.sdk?.includes(sdk)).join(','),
 })}---
@@ -825,7 +825,7 @@ ${yaml.stringify({
             .use(validateUniqueHeadings(config, doc.file.filePath, 'docs'))
             .use(
               insertFrontmatter({
-                sdkScoped: true,
+                sdkScoped: 'true',
                 canonical: doc.sdk ? scopeHrefToSDK(config)(doc.file.href, ':sdk:') : doc.file.href,
                 lastUpdated: (await getCommitDate(doc.file.fullFilePath))?.toISOString() ?? undefined,
                 availableSdks: doc.sdk.join(','),

--- a/scripts/build-docs.ts
+++ b/scripts/build-docs.ts
@@ -1,3 +1,4 @@
+import yaml from 'yaml'
 // Things this script does
 
 // Validates
@@ -788,8 +789,12 @@ export async function build(config: BuildConfig, store: Store = createBlankStore
         await writeFile(
           doc.file.filePathInDocsFolder,
           `---
-template: wide
----
+${yaml.stringify({
+  template: 'wide',
+  redirectPage: true,
+  availableSdks: doc.sdk.join(','),
+  notAvailableSdks: config.validSdks.filter((sdk) => !doc.sdk?.includes(sdk)).join(','),
+})}---
 <SDKDocRedirectPage title="${doc.frontmatter.title}"${doc.frontmatter.description ? ` description="${doc.frontmatter.description}" ` : ' '}href="${scopeHrefToSDK(config)(doc.file.href, ':sdk:')}" sdks={${JSON.stringify(doc.sdk)}} />`,
         )
       } else {
@@ -820,8 +825,12 @@ template: wide
             .use(validateUniqueHeadings(config, doc.file.filePath, 'docs'))
             .use(
               insertFrontmatter({
+                sdkScoped: true,
                 canonical: doc.sdk ? scopeHrefToSDK(config)(doc.file.href, ':sdk:') : doc.file.href,
                 lastUpdated: (await getCommitDate(doc.file.fullFilePath))?.toISOString() ?? undefined,
+                availableSdks: doc.sdk.join(','),
+                notAvailableSdks: config.validSdks.filter((sdk) => !doc.sdk?.includes(sdk)).join(','),
+                activeSdk: targetSdk,
               }),
             )
             .process({

--- a/scripts/lib/plugins/insertFrontmatter.ts
+++ b/scripts/lib/plugins/insertFrontmatter.ts
@@ -4,7 +4,7 @@ import yaml from 'yaml'
 import type { Node } from 'unist'
 
 export const insertFrontmatter =
-  (newFrontmatter: Record<string, string | boolean | undefined>) => () => (tree: Node, vfile: VFile) => {
+  (newFrontmatter: Record<string, string | undefined>) => () => (tree: Node, vfile: VFile) => {
     return mdastMap(tree, (node) => {
       if (node.type !== 'yaml') return node
       if (!('value' in node)) return node

--- a/scripts/lib/plugins/insertFrontmatter.ts
+++ b/scripts/lib/plugins/insertFrontmatter.ts
@@ -4,7 +4,7 @@ import yaml from 'yaml'
 import type { Node } from 'unist'
 
 export const insertFrontmatter =
-  (newFrontmatter: Record<string, string | undefined>) => () => (tree: Node, vfile: VFile) => {
+  (newFrontmatter: Record<string, string | boolean | undefined>) => () => (tree: Node, vfile: VFile) => {
     return mdastMap(tree, (node) => {
       if (node.type !== 'yaml') return node
       if (!('value' in node)) return node


### PR DESCRIPTION
### 🔎 Previews:

Added `redirectpage`, `availableSdks` and `notAvailableSdks` to frontmatter for sdk scoped base redirect pages.
<img width="1151" height="187" alt="Screenshot 2025-07-24 at 7 18 03 PM" src="https://github.com/user-attachments/assets/4751dc87-c2d9-4096-b131-c1e4ed1466fd" />

Added `sdkScoped`, `availableSdks`, `notAvailableSdks` and `activeSdk` to frontmatter for sdk scoped pages.
<img width="938" height="235" alt="Screenshot 2025-07-24 at 7 19 14 PM" src="https://github.com/user-attachments/assets/73a8a928-fd8a-467f-95ed-0e7d58265441" />

### What does this solve?

- Need additional information in the frontmatter for us to put in the page metadata for algolia to use (https://github.com/clerk/clerk/compare/main...algolia-crawler)

### What changed?

- Added additional context

### Checklist

- [x] I have clicked on "Files changed" and performed a thorough self-review
- [ ] All existing checks pass
