### PR TITLE
Sdk scope new beta billing components

### DIFF
--- a/docs/components/checkout-button.mdx
+++ b/docs/components/checkout-button.mdx
@@ -1,6 +1,7 @@
 ---
 title: "`<CheckoutButton />` component"
 description: "Clerk's <CheckoutButton /> component renders a button that opens the checkout drawer for plan subscriptions."
+sdk: react, nextjs
 ---
 
 ![The \<CheckoutButton /> component renders a button that opens the checkout drawer.](/docs/images/ui-components/checkout.png)

--- a/docs/components/plan-details-button.mdx
+++ b/docs/components/plan-details-button.mdx
@@ -1,6 +1,7 @@
 ---
 title: "`<PlanDetailsButton />` component"
 description: "Clerk's <PlanDetailsButton /> component renders a button that opens the plan details drawer."
+sdk: react, nextjs
 ---
 
 ![The \<PlanDetailsButton /> component renders a button that opens the plan details drawer.](/docs/images/ui-components/plan-details-button.png){{ style: { maxWidth: '460px' } }}

--- a/docs/components/subscription-details-button.mdx
+++ b/docs/components/subscription-details-button.mdx
@@ -1,6 +1,7 @@
 ---
 title: "`<SubscriptionDetailsButton />` component"
 description: "Clerk's <SubscriptionDetailsButton /> component renders a button that opens the subscription details drawer."
+sdk: react, nextjs
 ---
 
 ![The \<SubscriptionDetailsButton /> component renders a button that opens the subscription details drawer.](/docs/images/ui-components/subscription.png)


### PR DESCRIPTION
### 🔎 Previews:

- https://clerk.com/docs/pr/nick-sdk-scope-beta-billing-components/nextjs/components/checkout-button
- https://clerk.com/docs/pr/nick-sdk-scope-beta-billing-components/nextjs/components/plan-details-button
- https://clerk.com/docs/pr/nick-sdk-scope-beta-billing-components/nextjs/components/subscription-details-button

### What does this solve?

- With https://github.com/clerk/clerk-docs/pull/2086 merged, all the components and hooks are now sdk scoped, but these new components aren't part of the pr

### What changed?

- SDK scoped these new beta components to react and nextjs as that is all they are supported in right now

### Checklist

- [x] I have clicked on "Files changed" and performed a thorough self-review
- [x] All existing checks pass
