### PR TITLE
[do not merge] Add shadcn theme note about css import

### DIFF
--- a/docs/customization/themes.mdx
+++ b/docs/customization/themes.mdx
@@ -38,10 +38,9 @@ When using the [shadcn/ui](https://ui.shadcn.com/) library, you can use the `sha
 > If you are _not_ using the `shadcn` input component, we recommend importing the shadcn.css file within your global.css file. Tailwind scans source files as plain text to detect which classes to generate - classes that only exist in external configurations won't be included in the final CSS.
 >
 > ```css
-> @import "tailwindcss";
-> @import "@clerk/themes/shadcn.css";
+> @import 'tailwindcss';
+> @import '@clerk/themes/shadcn.css';
 > ```
-
 
 ## "Dark" theme
 

--- a/docs/customization/themes.mdx
+++ b/docs/customization/themes.mdx
@@ -35,7 +35,7 @@ When using the [shadcn/ui](https://ui.shadcn.com/) library, you can use the `sha
 </Tabs>
 
 > [!NOTE]
-> If you are _not_ using the `shadcn` input component, we recommend importing the shadcn.css file within your global.css file. Tailwind scans source files as plain text to detect which classes to generate - classes that only exist in external configurations won't be included in the final CSS.
+> If you are _not_ using the `shadcn` input component, it's recommended to import the `shadcn.css` file within your `global.css` file. Tailwind scans source files as plain text to detect which classes to generate - classes that only exist in external configurations won't be included in the final CSS.
 >
 > ```css
 > @import 'tailwindcss';

--- a/docs/customization/themes.mdx
+++ b/docs/customization/themes.mdx
@@ -35,7 +35,7 @@ When using the [shadcn/ui](https://ui.shadcn.com/) library, you can use the `sha
 </Tabs>
 
 > [!NOTE]
-> If you are _not_ using the `shadcn` input component, it's recommended to import the `shadcn.css` file within your `global.css` file. Tailwind scans source files as plain text to detect which classes to generate - classes that only exist in external configurations won't be included in the final CSS.
+> It's recommended to also import the `shadcn.css` file within your `global.css` file. Tailwind scans source files as plain text to detect which classes to generate - classes that only exist in external configurations won't be included in the final CSS.
 >
 > ```css
 > @import 'tailwindcss';

--- a/docs/customization/themes.mdx
+++ b/docs/customization/themes.mdx
@@ -24,6 +24,14 @@ Applied by default when no other theme is provided.
 
 When using the [shadcn/ui](https://ui.shadcn.com/) library, you can use the `shadcn` theme to apply the shadcn/ui styles to your Clerk components. This will adapt to both light and dark mode automatically.
 
+> [!IMPORTANT]
+> It's recommended to also import the `shadcn.css` file within your `global.css` file. Tailwind scans source files as plain text to detect which classes to generate - classes that only exist in external configurations won't be included in the final CSS.
+>
+> ```css
+> @import 'tailwindcss';
+> @import '@clerk/themes/shadcn.css';
+> ```
+
 <Tabs items={["Light mode", "Dark mode"]}>
   <div style={{padding: "1rem 0", filter: "drop-shadow(rgba(0, 0, 0, 0.16) 0px 12px 24px)"}}>
     ![A sign-in form with a shadcn theme in light mode](/docs/images/themes/shadcn_light_mode.svg)
@@ -33,14 +41,6 @@ When using the [shadcn/ui](https://ui.shadcn.com/) library, you can use the `sha
     ![A sign-in form with a shadcn theme in dark mode](/docs/images/themes/shadcn_dark_mode.svg)
   </div>
 </Tabs>
-
-> [!NOTE]
-> It's recommended to also import the `shadcn.css` file within your `global.css` file. Tailwind scans source files as plain text to detect which classes to generate - classes that only exist in external configurations won't be included in the final CSS.
->
-> ```css
-> @import 'tailwindcss';
-> @import '@clerk/themes/shadcn.css';
-> ```
 
 ## "Dark" theme
 

--- a/docs/customization/themes.mdx
+++ b/docs/customization/themes.mdx
@@ -34,6 +34,15 @@ When using the [shadcn/ui](https://ui.shadcn.com/) library, you can use the `sha
   </div>
 </Tabs>
 
+> [!NOTE]
+> If you are _not_ using the `shadcn` input component, we recommend importing the shadcn.css file within your global.css file. Tailwind scans source files as plain text to detect which classes to generate - classes that only exist in external configurations won't be included in the final CSS.
+>
+> ```css
+> @import "tailwindcss";
+> @import "@clerk/themes/shadcn.css";
+> ```
+
+
 ## "Dark" theme
 
 <div style={{padding: "1rem 0", filter: "drop-shadow(rgba(0, 0, 0, 0.16) 0px 12px 24px)"}}>


### PR DESCRIPTION
### 🔎 Previews:

- https://clerk.com/docs/pr/alexcarpenter-shadcn-theme-note/customization/themes#shadcn-theme

### What does this solve?

- Adds note to shadcn theme usage about importing the CSS file to resolve Tailwind picking up the classes used within the theme.

### What changed?

- <!--- How does this PR solve the problem? -->

### Checklist

- [x] I have clicked on "Files changed" and performed a thorough self-review
- [x] All existing checks pass
