### PR TITLE
put ios components dropdown within guides

### DIFF
--- a/docs/manifest.json
+++ b/docs/manifest.json
@@ -401,31 +401,31 @@
                         {
                           "title": "Sign in with Apple",
                           "href": "/docs/references/ios/sign-in-with-apple"
-                        }
-                      ]
-                    ]
-                  },
-                  {
-                    "title": "iOS Components",
-                    "collapse": true,
-                    "tag": "(Beta)",
-                    "items": [
-                      [
-                        {
-                          "title": "AuthView",
-                          "href": "/docs/references/ios/auth-view"
                         },
                         {
-                          "title": "UserButton",
-                          "href": "/docs/references/ios/user-button"
-                        },
-                        {
-                          "title": "UserProfileView",
-                          "href": "/docs/references/ios/user-profile-view"
-                        },
-                        {
-                          "title": "ClerkTheme",
-                          "href": "/docs/references/ios/clerk-theme"
+                          "title": "iOS Components",
+                          "collapse": true,
+                          "tag": "(Beta)",
+                          "items": [
+                            [
+                              {
+                                "title": "AuthView",
+                                "href": "/docs/references/ios/auth-view"
+                              },
+                              {
+                                "title": "UserButton",
+                                "href": "/docs/references/ios/user-button"
+                              },
+                              {
+                                "title": "UserProfileView",
+                                "href": "/docs/references/ios/user-profile-view"
+                              },
+                              {
+                                "title": "ClerkTheme",
+                                "href": "/docs/references/ios/clerk-theme"
+                              }
+                            ]
+                          ]
                         }
                       ]
                     ]


### PR DESCRIPTION
### What changed?

- Moves the iOS Components within the iOS Guides in the manifest.
- Visually this shouldn't change anything, but it makes the location of this drop down consistent with others in the manifest/sidebar.

### Checklist

- [x] I have clicked on "Files changed" and performed a thorough self-review
- [x] All existing checks pass
