### PR TITLE
Fix incorrect tab label from "Frontend SDKs" to "Backend SDK" 

### DIFF
--- a/docs/users/creating-users.mdx
+++ b/docs/users/creating-users.mdx
@@ -19,7 +19,7 @@ You can create users in your app using Clerk's Backend API.
 
 Use the following tabs to see examples of how to create users using one of the following:
 
-- Frontend SDKs, such as Next.js, React, or Remix
+- Backend SDK
 - Express
 - cURL
 

--- a/docs/users/deleting-users.mdx
+++ b/docs/users/deleting-users.mdx
@@ -18,7 +18,7 @@ You can delete users in your app using Clerk's Backend API.
 
 Use the following tabs to see examples of how to delete users using one of the following:
 
-- Frontend SDKs, such as Next.js, React, or Remix
+- Backend SDK
 - Express
 - cURL
 


### PR DESCRIPTION
### 🔎 Previews:

- https://clerk.com/docs/pr/ss-docs-10671/users/deleting-users
- https://clerk.com/docs/pr/ss-docs-10671/users/creating-users

### What does this solve?

This fixes a misleading label in the **Using the Backend API** section of the [Deleting Users](https://clerk.com/docs/users/deleting-users) page. The tab group was incorrectly titled "Frontend SDKs," which didn't align with the tab of the code example. Noticed this was an issue for the [Creating Users](https://clerk.com/docs/users/creating-users) page too. 

The change was prompted by user feedback who spotted the issue.

### What changed?

- Updated the bullet point to say "Backend SDK" rather than "Frontend SDKs.." in the Deleting Users and Creating Users pages  

### Checklist

- [ ] I have clicked on "Files changed" and performed a thorough self-review
- [ ] All existing checks pass
