### PR TITLE
Fix Elements overview image src

### DIFF
--- a/docs/customization/elements/overview.mdx
+++ b/docs/customization/elements/overview.mdx
@@ -10,7 +10,7 @@ description: Learn how to use Clerk Elements to build custom UIs on top of the C
 
 Clerk Elements is a library of unstyled, composable components that can be used to build custom UIs on top of the Clerk APIs without having to manage the underlying logic.
 
-![Clerk Elements](/images/elements/elements-hero-light.webp){{ dark: '/images/elements/elements-hero-dark.webp' }}
+![Clerk Elements](/docs/images/elements/elements-hero-light.webp){{ dark: '/docs/images/elements/elements-hero-dark.webp' }}
 
 ## Why use Clerk Elements?
 


### PR DESCRIPTION
### 🔎 Previews:

-

I don't know why this image src being wrong isn't breaking it loading in prod?? but all other images on the docs src starts with `/docs/images` despite the images actually actually being in `/public/images`

### Checklist

- [ ] I have clicked on "Files changed" and performed a thorough self-review
- [ ] All existing checks pass
