### PR TITLE
Fix typo in javascript.mdx

### DIFF
--- a/docs/quickstarts/javascript.mdx
+++ b/docs/quickstarts/javascript.mdx
@@ -283,7 +283,7 @@ Use the following tabs to choose your preferred method.
         window.addEventListener('load', async function () {
           await Clerk.load()
 
-          if (clerk.isSignedIn) {
+          if (Clerk.isSignedIn) {
             document.getElementById('app').innerHTML = `
               <div id="user-button"></div>
             `


### PR DESCRIPTION
`Clerk` needs to be uppercase for <script> loaded library

### What does this solve?

The code as currently presented doesn't work

### What changed?

Fixes the typo for the variable name

### Checklist

- [X] I have clicked on "Files changed" and performed a thorough self-review
- [X] All existing checks pass
