### PR TITLE
Fix incorrect m2m create method

### DIFF
--- a/docs/machine-auth/m2m-tokens.mdx
+++ b/docs/machine-auth/m2m-tokens.mdx
@@ -86,12 +86,12 @@ const m2mToken = await clerkClient.m2m.createToken()
 console.log(m2mToken)
 ```
 
-While it is strongly recommended to use environment variables for security, if you need to pass in the machine secret key directly rather than using an environment variable, you can do so by passing it as an argument to the `create` method, as shown in the following example:
+While it is strongly recommended to use environment variables for security, if you need to pass in the machine secret key directly rather than using an environment variable, you can do so by passing it as an argument to the `createToken` method, as shown in the following example:
 
 ```ts
 import { clerkClient } from '@clerk/express'
 
-const m2mTokenObject = await clerkClient.m2m.create({
+const m2mTokenObject = await clerkClient.m2m.createToken({
   machineSecretKey: 'ak_xxx',
 })
 console.log(m2mTokenObject)


### PR DESCRIPTION
### 🔎 Previews:

- https://clerk.com/docs/pr/rob-fix-m2m-docs/machine-auth/m2m-tokens#creating-m2-m-tokens

### What does this solve?

- Fixes incorrect method when creating m2m tokens

### What changed?

- Replaced `m2m.create()` with `m2m.createToken()`

### Checklist

- [x] I have clicked on "Files changed" and performed a thorough self-review
- [x] All existing checks pass
