### PR TITLE
Embed sdk scoping from manifest to frontmatter

### DIFF
--- a/docs/references/javascript/types/commerce-payment-resource.mdx
+++ b/docs/references/javascript/types/commerce-payment-resource.mdx
@@ -1,6 +1,7 @@
 ---
 title: '`CommercePaymentResource`'
 description: 'The CommercePaymentResource type represents a payment attempt for a user or organization.'
+sdk: js-frontend
 ---
 
 The `CommercePaymentResource` type represents a payment attempt for a user or organization.

--- a/docs/references/javascript/types/commerce-statement-group.mdx
+++ b/docs/references/javascript/types/commerce-statement-group.mdx
@@ -1,6 +1,7 @@
 ---
 title: '`CommerceStatementGroup`'
 description: 'The CommerceStatementGroup type represents a group of payment items within a statement.'
+sdk: js-frontend
 ---
 
 The `CommerceStatementGroup` type represents a group of payment items within a statement.

--- a/docs/references/javascript/types/commerce-statement-resource.mdx
+++ b/docs/references/javascript/types/commerce-statement-resource.mdx
@@ -1,6 +1,7 @@
 ---
 title: '`CommerceStatementResource`'
 description: 'The CommerceStatementResource type represents a billing statement for a user or organization.'
+sdk: js-frontend
 ---
 
 The `CommerceStatementResource` type represents a billing statement for a user or organization.

--- a/docs/references/javascript/types/commerce-statement-totals.mdx
+++ b/docs/references/javascript/types/commerce-statement-totals.mdx
@@ -1,6 +1,7 @@
 ---
 title: '`CommerceStatementTotals`'
 description: 'The CommerceStatementTotals type represents the total costs, taxes, and other pricing details for a statement.'
+sdk: js-frontend
 ---
 
 The `CommerceStatementTotals` type represents the total costs, taxes, and other pricing details for a statement.

--- a/docs/references/javascript/types/session-task.mdx
+++ b/docs/references/javascript/types/session-task.mdx
@@ -1,6 +1,7 @@
 ---
 title: '`SessionTask`'
 description: The SessionTask interface represents the current pending task of a session.
+sdk: js-frontend
 ---
 
 An interface that represents the current [pending task](/docs/authentication/configuration/session-tasks) of a session.


### PR DESCRIPTION
### 🔎 Previews:

-

### What does this solve?

- <!--- Describe your changes in detail. Why does this change need to happen? Include any links to Slack discussions, Linear comments, etc. -->

### What changed?

- Ran `npm run migrate-sdk-scoping`

### Checklist

- [ ] I have clicked on "Files changed" and performed a thorough self-review
- [ ] All existing checks pass
