### PR TITLE
fix: subscriptionItem.pastDue name update

### DIFF
--- a/docs/billing/events-webhooks.mdx
+++ b/docs/billing/events-webhooks.mdx
@@ -17,7 +17,7 @@ A subscription is a top-level container unique to each user or organization. Sub
 | `subscription.created` | The top-level subscription is created. This usually happens when a user or organization is created. For existing users and organizations, a subscription will be created when billing is enabled for the application. |
 | `subscription.updated` | The top-level subscription is updated. This event is triggered when any property of the subscription has changed, except for status changes. For example, when the subscription items for the payer change. |
 | `subscription.active` | The top-level subscription transitions to active from a non-active status. This happens when any subscription item is set to active, including items from the free default plan. |
-| `subscription.past_due` | The top-level subscription contains a subscription item that has become past due. |
+| `subscription.pastDue` | The top-level subscription contains a subscription item that has become past due. |
 
 ## Subscription items
 
@@ -34,7 +34,7 @@ There can only be one `active` subscription item per payer and plan. In addition
 | `subscriptionItem.ended` | The subscription item has ended. |
 | `subscriptionItem.abandoned` | The subscription item is abandoned. This can happen to `upcoming` subscription items if the payer subscribes to another plan, or re-subscribes to a currently canceled plan. |
 | `subscriptionItem.incomplete` | The subscription item is incomplete. This means the payer has started a checkout for a plan, but the payment hasn't been successfully processed yet. Once payment succeeds, the subscription item transitions to an `active` status. |
-| `subscriptionItem.past_due` | The subscription item is past due because a recurring charge has failed. |
+| `subscriptionItem.pastDue` | The subscription item is past due because a recurring charge has failed. |
 
 ## Payment attempts
 


### PR DESCRIPTION
### 🔎 Previews:

-

### What does this solve?

Fixes typo for subscription item past due webhook name

### What changed?

Updated webhook name from `subscriptionItem.past_due` to `subscriptionItem.pastDue`

### Checklist

- [ ] I have clicked on "Files changed" and performed a thorough self-review
- [ ] All existing checks pass
