### PR TITLE
chore(tasks): Refer to `setActive({ navigate })` for checking pending tasks on custom flows

### DIFF
--- a/docs/custom-flows/overview.mdx
+++ b/docs/custom-flows/overview.mdx
@@ -28,7 +28,7 @@ The following steps outline the sign-up process:
 1. Prepare the verification.
 1. Attempt to complete the verification.
 1. If the verification is successful, set the newly created session as the active session by passing the `SignIn.createdSessionId` to the [`setActive()`](/docs/references/javascript/clerk#set-active) method on the `Clerk` object.
-1. Check for any pending tasks that need to be completed by accessing [`Session.currentTask`](/docs/references/javascript/types/session-task). Refer to [session tasks](/docs/authentication/configuration/session-tasks)
+1. Use the `navigate` parameter in [`setActive()`](/docs/references/javascript/clerk#set-active) to access `session.currentTask` and check for pending session tasks.
 
 #### The state of a `SignUp`
 
@@ -86,7 +86,7 @@ The following steps outline the sign-in process:
 1. Optionally, if you have enabled [multi-factor](/docs/authentication/configuration/sign-up-sign-in-options) for your application, you will need to prepare the second factor verification for users who have set up 2FA for their account.
 1. Attempt to complete the second factor verification.
 1. If verification is successful, set the newly created session as the active session by passing the `SignIn.createdSessionId` to the [`setActive()`](/docs/references/javascript/clerk#set-active) method on the `Clerk` object.
-1. Check for any pending tasks that need to be completed by accessing [`Session.currentTask`](/docs/references/javascript/types/session-task). Refer to [session tasks](/docs/authentication/configuration/session-tasks)
+1. Use the `navigate` parameter in [`setActive()`](/docs/references/javascript/clerk#set-active) to access `session.currentTask` and check for pending session tasks.
 
 ### Session tasks
 

--- a/docs/custom-flows/overview.mdx
+++ b/docs/custom-flows/overview.mdx
@@ -28,7 +28,7 @@ The following steps outline the sign-up process:
 1. Prepare the verification.
 1. Attempt to complete the verification.
 1. If the verification is successful, set the newly created session as the active session by passing the `SignIn.createdSessionId` to the [`setActive()`](/docs/references/javascript/clerk#set-active) method on the `Clerk` object.
-1. Use the `navigate` parameter in [`setActive()`](/docs/references/javascript/clerk#set-active) to access `session.currentTask` and check for pending session tasks.
+2. Use the `navigate` parameter in [`setActive()`](/docs/references/javascript/types/set-active-params) to access `session.currentTask` and check for pending session tasks.
 
 #### The state of a `SignUp`
 
@@ -86,7 +86,7 @@ The following steps outline the sign-in process:
 1. Optionally, if you have enabled [multi-factor](/docs/authentication/configuration/sign-up-sign-in-options) for your application, you will need to prepare the second factor verification for users who have set up 2FA for their account.
 1. Attempt to complete the second factor verification.
 1. If verification is successful, set the newly created session as the active session by passing the `SignIn.createdSessionId` to the [`setActive()`](/docs/references/javascript/clerk#set-active) method on the `Clerk` object.
-1. Use the `navigate` parameter in [`setActive()`](/docs/references/javascript/clerk#set-active) to access `session.currentTask` and check for pending session tasks.
+1. Use the `navigate` parameter in [`setActive()`](/docs/references/javascript/types/set-active-params) to access `session.currentTask` and check for pending session tasks
 
 ### Session tasks
 
@@ -98,7 +98,7 @@ For detailed information about configuring and implementing session tasks, see t
 
 After completing the sign-up or sign-in process, you should check if the user has any pending tasks:
 
-1. **Check for pending tasks**: Use the `navigate` parameter in [`setActive()`](/docs/references/javascript/clerk#set-active) to access `session.currentTask` and check for pending session tasks.
+1. **Check for pending tasks**: Use the `navigate` parameter in [`setActive()`](/docs/references/javascript/types/set-active-params) to access `session.currentTask` and check for pending session tasks.
 1. **Handle the task**: If a task exists, build UI to guide the user through completing the required action based on the task type. See the [available task types](/docs/authentication/configuration/session-tasks#available-tasks) to understand what actions may be required.
 1. **Complete the flow**: Once all required tasks are completed, the session becomes fully `active` and the user can access protected content.
 

--- a/docs/custom-flows/overview.mdx
+++ b/docs/custom-flows/overview.mdx
@@ -28,7 +28,7 @@ The following steps outline the sign-up process:
 1. Prepare the verification.
 1. Attempt to complete the verification.
 1. If the verification is successful, set the newly created session as the active session by passing the `SignIn.createdSessionId` to the [`setActive()`](/docs/references/javascript/clerk#set-active) method on the `Clerk` object.
-2. Use the `navigate` parameter in [`setActive()`](/docs/references/javascript/types/set-active-params) to access `session.currentTask` and check for pending session tasks.
+1. Use the `navigate` parameter in [`setActive()`](/docs/references/javascript/types/set-active-params) to access `session.currentTask` and check for pending session tasks.
 
 #### The state of a `SignUp`
 

--- a/docs/custom-flows/overview.mdx
+++ b/docs/custom-flows/overview.mdx
@@ -28,7 +28,7 @@ The following steps outline the sign-up process:
 1. Prepare the verification.
 1. Attempt to complete the verification.
 1. If the verification is successful, set the newly created session as the active session by passing the `SignIn.createdSessionId` to the [`setActive()`](/docs/references/javascript/clerk#set-active) method on the `Clerk` object.
-1. Use the `navigate` parameter in [`setActive()`](/docs/references/javascript/types/set-active-params) to access `session.currentTask` and check for pending session tasks.
+1. Use the `navigate` parameter in [`setActive()`](/docs/references/javascript/types/set-active-params) to access `Session.currentTask` and check for pending session tasks.
 
 #### The state of a `SignUp`
 
@@ -86,7 +86,7 @@ The following steps outline the sign-in process:
 1. Optionally, if you have enabled [multi-factor](/docs/authentication/configuration/sign-up-sign-in-options) for your application, you will need to prepare the second factor verification for users who have set up 2FA for their account.
 1. Attempt to complete the second factor verification.
 1. If verification is successful, set the newly created session as the active session by passing the `SignIn.createdSessionId` to the [`setActive()`](/docs/references/javascript/clerk#set-active) method on the `Clerk` object.
-1. Use the `navigate` parameter in [`setActive()`](/docs/references/javascript/types/set-active-params) to access `session.currentTask` and check for pending session tasks
+1. Use the `navigate` parameter in [`setActive()`](/docs/references/javascript/types/set-active-params) to access `Session.currentTask` and check for pending session tasks
 
 ### Session tasks
 
@@ -98,7 +98,7 @@ For detailed information about configuring and implementing session tasks, see t
 
 After completing the sign-up or sign-in process, you should check if the user has any pending tasks:
 
-1. **Check for pending tasks**: Use the `navigate` parameter in [`setActive()`](/docs/references/javascript/types/set-active-params) to access `session.currentTask` and check for pending session tasks.
+1. **Check for pending tasks**: Use the `navigate` parameter in [`setActive()`](/docs/references/javascript/types/set-active-params) to access `Session.currentTask` and check for pending session tasks.
 1. **Handle the task**: If a task exists, build UI to guide the user through completing the required action based on the task type. See the [available task types](/docs/authentication/configuration/session-tasks#available-tasks) to understand what actions may be required.
 1. **Complete the flow**: Once all required tasks are completed, the session becomes fully `active` and the user can access protected content.
 

--- a/docs/custom-flows/overview.mdx
+++ b/docs/custom-flows/overview.mdx
@@ -28,7 +28,7 @@ The following steps outline the sign-up process:
 1. Prepare the verification.
 1. Attempt to complete the verification.
 1. If the verification is successful, set the newly created session as the active session by passing the `SignIn.createdSessionId` to the [`setActive()`](/docs/references/javascript/clerk#set-active) method on the `Clerk` object.
-1. Use the `navigate` parameter in [`setActive()`](/docs/references/javascript/types/set-active-params) to access `Session.currentTask` and check for pending session tasks.
+1. Use the `navigate` parameter in [`setActive()`](/docs/references/javascript/types/set-active-params) to access [`Session.currentTask`](/docs/references/javascript/types/session-task) and check for pending session tasks.
 
 #### The state of a `SignUp`
 
@@ -86,7 +86,7 @@ The following steps outline the sign-in process:
 1. Optionally, if you have enabled [multi-factor](/docs/authentication/configuration/sign-up-sign-in-options) for your application, you will need to prepare the second factor verification for users who have set up 2FA for their account.
 1. Attempt to complete the second factor verification.
 1. If verification is successful, set the newly created session as the active session by passing the `SignIn.createdSessionId` to the [`setActive()`](/docs/references/javascript/clerk#set-active) method on the `Clerk` object.
-1. Use the `navigate` parameter in [`setActive()`](/docs/references/javascript/types/set-active-params) to access `Session.currentTask` and check for pending session tasks
+1. Use the `navigate` parameter in [`setActive()`](/docs/references/javascript/types/set-active-params) to access [`Session.currentTask`](/docs/references/javascript/types/session-task) and check for pending session tasks.
 
 ### Session tasks
 
@@ -98,7 +98,7 @@ For detailed information about configuring and implementing session tasks, see t
 
 After completing the sign-up or sign-in process, you should check if the user has any pending tasks:
 
-1. **Check for pending tasks**: Use the `navigate` parameter in [`setActive()`](/docs/references/javascript/types/set-active-params) to access `Session.currentTask` and check for pending session tasks.
+1. **Check for pending tasks**: Use the `navigate` parameter in [`setActive()`](/docs/references/javascript/types/set-active-params) to access [`Session.currentTask`](/docs/references/javascript/types/session-task) and check for pending session tasks.
 1. **Handle the task**: If a task exists, build UI to guide the user through completing the required action based on the task type. See the [available task types](/docs/authentication/configuration/session-tasks#available-tasks) to understand what actions may be required.
 1. **Complete the flow**: Once all required tasks are completed, the session becomes fully `active` and the user can access protected content.
 


### PR DESCRIPTION
### 🔎 Previews:

- https://clerk.com/docs/pr/laura-patch-custom-flow-task-instructions/custom-flows/overview

### What does this solve?

Update custom flows mentions that after sign-in or sign-up, `setActive({ navigate })` should be used to check against pending session tasks.

### Checklist

- [x] I have clicked on "Files changed" and performed a thorough self-review
- [x] All existing checks pass
