### PR TITLE
Update SAML FAQ docs regarding identifiers

### DIFF
--- a/docs/authentication/enterprise-connections/overview.mdx
+++ b/docs/authentication/enterprise-connections/overview.mdx
@@ -65,7 +65,7 @@ For more information, see the [EASIE docs](https://easie.dev#security).
 
 ### Can I use multiple identifiers or authentication methods with Enterprise Connections?
 
-Yes, for SAML and OIDC connections, multiple identifiers (such as email, username, or other attributes) can be configured and used. By default, additional identifiers are **disabled** for new connections. 
+Yes, for SAML and OIDC connections, multiple identifiers (such as email, username, or other attributes) can be configured and used. By default, additional identifiers are **disabled** for new connections.
 
 To enable multiple identifiers for a SAML or OIDC connection:
 

--- a/docs/authentication/enterprise-connections/overview.mdx
+++ b/docs/authentication/enterprise-connections/overview.mdx
@@ -63,21 +63,19 @@ For more information, see the [EASIE docs](https://easie.dev#security).
 
 ## Frequently asked questions (FAQ)
 
-### Can I use multiple identifiers or authentication methods with Enterprise SSO?
+### Can I use multiple identifiers or authentication methods with Enterprise Connections?
 
 Yes, for SAML and OIDC connections, multiple identifiers (such as email, username, or other attributes) can be configured and used. By default, additional identifiers are **disabled** for new connections. 
 
-To enable multiple identifiers:
+To enable multiple identifiers for a SAML or OIDC connection:
 
 1. In the Clerk Dashboard, navigate to the [**SSO connections**](https://dashboard.clerk.com/last-active?path=user-authentication/sso-connections) page.
 1. Select the Enterprise connection you want to allow multiple identifiers for.
 1. Select the **Advanced** tab.
-1. Enable the **Allow multiple identifiers** option. 
+1. Enable the **Allow additional identifiers** option.
 1. Select **Save**.
 
-For EASIE connections, there can only be one identifier or authentication method.
-
-{/* A Clerk app can have multiple authentication strategies, but a domain that enables Enterprise SSO can't. Once Enterprise SSO is enabled for a domain, there can be no other authentication methods for that specific domain. This is in line with an organization's intent to manage their users' identity from one place. This allows your Clerk app to enable Enterprise SSO connections for certain domains while others use non-Enterprise SSO methods depending on each organization's needs. */}
+Please note that for EASIE connections, there can only be one identifier or authentication method.
 
 ### Will Enterprise SSO work for my existing users?
 

--- a/docs/authentication/enterprise-connections/overview.mdx
+++ b/docs/authentication/enterprise-connections/overview.mdx
@@ -63,9 +63,21 @@ For more information, see the [EASIE docs](https://easie.dev#security).
 
 ## Frequently asked questions (FAQ)
 
-### I've enabled other strategies but they don't work
+### Can I use multiple identifiers or authentication methods with Enterprise SSO?
 
-A Clerk app can have multiple authentication strategies, but a domain that enables Enterprise SSO can't. Once Enterprise SSO is enabled for a domain, there can be no other authentication methods for that specific domain. This is in line with an organization's intent to manage their users' identity from one place. This allows your Clerk app to enable Enterprise SSO connections for certain domains while others use non-Enterprise SSO methods depending on each organization's needs.
+Yes, for SAML and OIDC connections, multiple identifiers (such as email, username, or other attributes) can be configured and used. By default, additional identifiers are **disabled** for new connections. 
+
+To enable multiple identifiers:
+
+1. In the Clerk Dashboard, navigate to the [**SSO connections**](https://dashboard.clerk.com/last-active?path=user-authentication/sso-connections) page.
+1. Select the Enterprise connection you want to allow multiple identifiers for.
+1. Select the **Advanced** tab.
+1. Enable the **Allow multiple identifiers** option. 
+1. Select **Save**.
+
+For EASIE connections, there can only be one identifier or authentication method.
+
+{/* A Clerk app can have multiple authentication strategies, but a domain that enables Enterprise SSO can't. Once Enterprise SSO is enabled for a domain, there can be no other authentication methods for that specific domain. This is in line with an organization's intent to manage their users' identity from one place. This allows your Clerk app to enable Enterprise SSO connections for certain domains while others use non-Enterprise SSO methods depending on each organization's needs. */}
 
 ### Will Enterprise SSO work for my existing users?
 


### PR DESCRIPTION
### 🔎 Previews:

-

### What does this solve?

The current FAQ states that no other identifiers can be used, which is outdated. Per this [changelog](https://clerk.com/changelog/2024-09-30-disable-additional-accounts-for-saml), SAML connections support additional identifiers, though they are disabled by default and configurable in the dashboard. This PR updates the FAQ to reflect the new behavior and clarifies how additional identifiers can be enabled for SAML and OIDC connections.

### What changed?

Updated FAQ entry to remove outdated statement about identifiers + clarified how to enable multiple identifiers for SAML and OIDC connections. Clarified this is not the case for EASIE connections. 

### Checklist

- [ ] I have clicked on "Files changed" and performed a thorough self-review
- [ ] All existing checks pass
