### PR TITLE
Align React Router integration docs with new terminology ("declarative mode")

### DIFF
--- a/docs/manifest.json
+++ b/docs/manifest.json
@@ -578,8 +578,8 @@
                           "href": "/docs/references/react-router/custom-sign-up-page"
                         },
                         {
-                          "title": "Library mode",
-                          "href": "/docs/references/react-router/library-mode"
+                          "title": "Declarative mode",
+                          "href": "/docs/references/react-router/declarative-mode"
                         },
                         {
                           "title": "Verifying OAuth access tokens",

--- a/docs/quickstarts/react-router.mdx
+++ b/docs/quickstarts/react-router.mdx
@@ -26,7 +26,7 @@ sdk: react-router
   ]}
 />
 
-React Router can be used as a framework or as a standalone library. This tutorial explains how to use React Router as a framework. To use React Router as a library instead, see the [library mode tutorial](/docs/references/react-router/library-mode).
+React Router can be used in different modes: **declarative**, **data**, or **framework**. This tutorial explains how to use React Router in **framework** mode. To use React Router in **declarative** mode instead, see the [declarative mode tutorial](/docs/references/react-router/declarative-mode).
 
 This tutorial assumes that you're using React Router **v7.1.2 or later** in framework mode.
 
@@ -233,6 +233,6 @@ This tutorial assumes that you're using React Router **v7.1.2 or later** in fram
 
   ---
 
-  - [Library mode](/docs/references/react-router/library-mode)
-  - Learn how to use Clerk with React Router in library mode to add authentication to your application.
+  - [Declarative mode](/docs/references/react-router/declarative-mode)
+  - Learn how to use Clerk with React Router in declarative mode to add authentication to your application.
 </Cards>

--- a/docs/quickstarts/react.mdx
+++ b/docs/quickstarts/react.mdx
@@ -197,7 +197,7 @@ This tutorial will demonstrate how to create a new React app using Vite and add 
 
 ## Next step: Add routing with React Router
 
-- [Integrate React Router into your Clerk app as a library](/docs/references/react-router/library-mode)
+- [Integrate React Router into your Clerk app in declarative mode](/docs/references/react-router/declarative-mode)
 
 ## More resources
 

--- a/docs/references/react-router/declarative-mode.mdx
+++ b/docs/references/react-router/declarative-mode.mdx
@@ -16,9 +16,9 @@ sdk: react-router
 
 React Router supports three different routing strategies, or ["modes"](https://reactrouter.com/start/modes):
 
-- Declarative mode: Enables basic routing features like matching URLs to components, navigating around the app, and providing active states with APIs like `<Link>`, `useNavigate()`, and `useLocation()`.
-- Data mode: Adds data loading, actions, pending states and more with APIs like loader, action, and useFetcher. To use React Router in data mode, see the [demo repository](https://github.com/clerk/clerk-react-quickstart/blob/integrate-react-router-dom-using-data-router-method/src/main.tsx). A guide is coming soon.
-- Framework mode: Use React Router as a framework to build your entire app. To use React Router as a framework instead, see the [React Router quickstart](/docs/quickstarts/react-router).
+- **Declarative mode:** Enables basic routing features like matching URLs to components, navigating around the app, and providing active states with APIs like `<Link>`, `useNavigate()`, and `useLocation()`.
+- **Data mode:** Adds data loading, actions, pending states and more with APIs like loader, action, and useFetcher. To use React Router in data mode, see the [demo repository](https://github.com/clerk/clerk-react-quickstart/blob/integrate-react-router-dom-using-data-router-method/src/main.tsx). A guide is coming soon.
+- **Framework mode:** Use React Router as a framework to build your entire app. To use React Router as a framework instead, see the [React Router quickstart](/docs/quickstarts/react-router).
 
 This guide will cover how to add React Router in **declarative mode**, assuming you have followed the [React quickstart](/docs/quickstarts/react).
 
@@ -48,7 +48,7 @@ This guide will cover how to add React Router in **declarative mode**, assuming 
   ## Set your Clerk API keys
 
   > [!NOTE]
-  > You will not need the Clerk Secret Key in React Router's library mode, as it should never be used on the client-side.
+  > You will not need the Clerk Secret Key in React Router's declarative mode, as it should never be used on the client-side.
 
   <SignedIn>
     Add your Clerk Publishable Key to your `.env` file. This key can always be retrieved from the [**API keys**](https://dashboard.clerk.com/last-active?path=api-keys) page of the Clerk Dashboard.

--- a/docs/references/react-router/overview.mdx
+++ b/docs/references/react-router/overview.mdx
@@ -21,7 +21,8 @@ The following references show how to integrate Clerk features into applications 
 
 ## React Router implementations
 
-React Router can be integrated with Clerk in two ways:
+React Router can be integrated with Clerk in three ways:
 
-- As a framework (recommended): Configure your app using [Clerk's React Router SDK](/docs/quickstarts/react-router)
-- As a library: Manually integrate React Router into your React + Vite app using [library mode](/docs/references/react-router/library-mode)
+- **Framework mode (recommended):** Configure your app using [Clerk's React Router SDK](/docs/quickstarts/react-router)
+- **Declarative mode:** Manually integrate React Router into your React + Vite app using [declarative mode](/docs/references/react-router/declarative-mode)
+- **Data mode:** Use React Router's data APIs to load data and manage state in your Clerk app. To use React Router in data mode, see the [demo repository](https://github.com/clerk/clerk-react-quickstart/blob/integrate-react-router-dom-using-data-router-method/src/main.tsx).

--- a/redirects/static/docs.json
+++ b/redirects/static/docs.json
@@ -2503,5 +2503,10 @@
     "source": "/docs/references/nextjs/connect-mcp-client",
     "destination": "/docs/mcp/connect-mcp-client",
     "permanent": true
+  },
+  {
+    "source": "/docs/references/react-router/library-mode",
+    "destination": "/docs/references/react-router/declarative-mode",
+    "permanent": true
   }
 ]


### PR DESCRIPTION
### 🔎 Previews:

-

### What does this solve?

Linear: https://linear.app/clerk/issue/DOCS-10632/feedback-for-referencesreact-routerlibrary-mode

React Router docs uses the "declarative" mode terminology rather than "library" mode. Our docs still referenced "library mode", which confused users comparing with the official React Router documentation. This update ensures our terminology matches React Router's current docs and makes it clear how Clerk integrates across declarative, data, and framework modes.

### What changed?

- Replaced all references to "library mode" or "as a library" with "declarative mode".
- Updated links to point to "/docs/references/react-router/declarative-mode" instead of "/library-mode" + added redirect.
- Adjusted section wording to mention all three supported modes (declarative, data, framework) for consistency with React Router v7.
- Added a partial for the "modes" overview used in two places. 
- Made these changes in the React Router onboarding in the Clerk Dashboard. PR is here: 

### Checklist

- [ ] I have clicked on "Files changed" and performed a thorough self-review
- [ ] All existing checks pass
