### PR TITLE
build script tests - Sort the files we list to ensure consistent array

### DIFF
--- a/scripts/build-docs.test.ts
+++ b/scripts/build-docs.test.ts
@@ -102,11 +102,13 @@ async function createTempFiles(
     pathJoin: (...paths: string[]) => path.join(tempDir, ...paths),
 
     // Get a list of all files in the temp directory
-    listFiles: async () => {
-      return glob('**/*', {
-        cwd: tempDir,
-        nodir: true,
-      })
+    listFiles: async (folderPath?: string) => {
+      return (
+        await glob('**/*', {
+          cwd: folderPath ? path.join(tempDir, folderPath) : tempDir,
+          nodir: true,
+        })
+      ).sort() // ensure a consistent order for tests
     },
 
     // Read file contents
@@ -1721,11 +1723,7 @@ activeSdk: react
 # React Guide
 `)
 
-    expect((await listFiles()).filter((f) => f.startsWith('dist/'))).toEqual([
-      'dist/manifest.json',
-      'dist/directory.json',
-      'dist/references/react/guide.mdx',
-    ])
+    expect(await listFiles('dist/')).toEqual(['directory.json', 'manifest.json', 'references/react/guide.mdx'])
 
     expect(JSON.parse(await readFile('./dist/manifest.json'))).toEqual({
       flags: {},
@@ -1791,11 +1789,7 @@ activeSdk: react
 # React Guide
 `)
 
-    expect((await listFiles()).filter((f) => f.startsWith('dist/'))).toEqual([
-      'dist/manifest.json',
-      'dist/guide.mdx',
-      'dist/directory.json',
-    ])
+    expect(await listFiles('dist/')).toEqual(['directory.json', 'guide.mdx', 'manifest.json'])
 
     expect(JSON.parse(await readFile('./dist/manifest.json'))).toEqual({
       flags: {},
@@ -1869,11 +1863,7 @@ sdk: nextjs
     })
 
     // Should process document without redirect page
-    expect((await listFiles()).filter((f) => f.startsWith('dist/'))).toEqual([
-      'dist/manifest.json',
-      'dist/directory.json',
-      'dist/quickstarts/nextjs-pages-router.mdx',
-    ])
+    expect(await listFiles('dist/')).toEqual(['directory.json', 'manifest.json', 'quickstarts/nextjs-pages-router.mdx'])
 
     expect(await readFile('./dist/quickstarts/nextjs-pages-router.mdx')).toBe(`---
 title: Next.js Quickstart (Pages Router)
@@ -5146,13 +5136,13 @@ notAvailableSdks: ""
 ---
 <SDKDocRedirectPage title="API Documentation" description="x" href="/docs/:sdk:/api-doc" sdks={["nextjs","remix","react"]} />`)
 
-    expect((await listFiles()).filter((f) => f.startsWith('dist/'))).toEqual([
-      'dist/manifest.json',
-      'dist/directory.json',
-      'dist/api-doc.mdx',
-      'dist/remix/api-doc.mdx',
-      'dist/react/api-doc.mdx',
-      'dist/nextjs/api-doc.mdx',
+    expect(await listFiles('dist/')).toEqual([
+      'api-doc.mdx',
+      'directory.json',
+      'manifest.json',
+      'nextjs/api-doc.mdx',
+      'react/api-doc.mdx',
+      'remix/api-doc.mdx',
     ])
   })
 
@@ -5239,12 +5229,12 @@ notAvailableSdks: ""
 ---
 <SDKDocRedirectPage title="Documentation" href="/docs/:sdk:/test" sdks={["react","nextjs"]} />`)
 
-    expect((await listFiles()).filter((f) => f.startsWith('dist/'))).toEqual([
-      'dist/test.mdx',
-      'dist/manifest.json',
-      'dist/directory.json',
-      'dist/react/test.mdx',
-      'dist/nextjs/test.mdx',
+    expect(await listFiles('dist/')).toEqual([
+      'directory.json',
+      'manifest.json',
+      'nextjs/test.mdx',
+      'react/test.mdx',
+      'test.mdx',
     ])
   })
 


### PR DESCRIPTION
### What does this solve?

- The tests to list the output files and ensure they are what we expect can be flaky, as the glob() function doesn't always return the array in the same order

### What changed?

- sorts the glob array output before returning it

### Checklist

- [x] I have clicked on "Files changed" and performed a thorough self-review
- [x] All existing checks pass
