### PR TITLE
skipCache true not available server-side

### DIFF
--- a/docs/guides/force-token-refresh.mdx
+++ b/docs/guides/force-token-refresh.mdx
@@ -16,10 +16,7 @@ Both perform a network request, but `getToken({ skipCache: true })` will only ge
 
 The `getToken()` method retrieves the current user's session token. If `skipCache` is set to `true`, it will force a new token to be minted.
 
-`getToken()` is available on Clerk's authentication context, so it is accessible in both client-side and server-side code.
-
-- **Client-side:** Access `getToken()` from the [`useSession()`](/docs/hooks/use-session) or [`useAuth()`](/docs/hooks/use-auth) hooks.
-- **Server-side:** Access `getToken()` from the [`Auth`](/docs/references/backend/types/auth-object) object.
+`skipCache` is only available on the client-side. To access `getToken()` from the client-side, use the [`useSession()`](/docs/hooks/use-session) or [`useAuth()`](/docs/hooks/use-auth) hooks.
 
 ### Example
 

--- a/docs/guides/force-token-refresh.mdx
+++ b/docs/guides/force-token-refresh.mdx
@@ -16,7 +16,7 @@ Both perform a network request, but `getToken({ skipCache: true })` will only ge
 
 The `getToken()` method retrieves the current user's session token. If `skipCache` is set to `true`, it will force a new token to be minted.
 
-`skipCache` is only available on the client-side. To access `getToken()` from the client-side, use the [`useSession()`](/docs/hooks/use-session) or [`useAuth()`](/docs/hooks/use-auth) hooks.
+The `skipCache` property is only available on the client-side. To access `getToken()` from the client-side, use the [`useSession()`](/docs/hooks/use-session) or [`useAuth()`](/docs/hooks/use-auth) hooks.
 
 ### Example
 


### PR DESCRIPTION
### 🔎 Previews:

-

### What does this solve?

A user reported that skipCache true is not available server-side but our docs say allude to that being true
https://x.com/strehldev/status/1963607291816542654

### What changed?

Updates the docs appropriately

### Checklist

- [X] I have clicked on "Files changed" and performed a thorough self-review
- [X] All existing checks pass
