### PR TITLE
Fix typos

### DIFF
--- a/docs/authentication/social-connections/overview.mdx
+++ b/docs/authentication/social-connections/overview.mdx
@@ -1,6 +1,6 @@
 ---
 title: Social connections (OAuth)
-description: Learn how to effortlessly add social connections to your application using popular social providers like Google, Facebook, Github and more.
+description: Learn how to effortlessly add social connections to your application using popular social providers like Google, Facebook, GitHub and more.
 ---
 
 Social connections, also known as OAuth connections in Clerk, allow users to gain access to your application by using their existing credentials from an Identity Provider (IdP), like Google or Microsoft. For example, if you enable Google as a social provider, then when a user wants to sign in to your application, they can select Google and use their Google account to sign in.

--- a/docs/customization/overview.mdx
+++ b/docs/customization/overview.mdx
@@ -77,7 +77,7 @@ First, you need to identify the underlying element of the Clerk component you wa
 
 For example, if you want to style the primary button in a Clerk component, you can right-click on the primary button and select "Inspect" from the menu. This will open the browser's developer tools and highlight the element in the HTML, as shown in the following image:
 
-![The inspect element tab opened with an element selected. It shows a list of classes and a lock icon in between human-readible classnames and randomly generated ones](/docs/images/customization/identifying_elements.png)
+![The inspect element tab opened with an element selected. It shows a list of classes and a lock icon in between human-readable classnames and randomly generated ones](/docs/images/customization/identifying_elements.png)
 
 When you select an element that is part of a Clerk component, you'll notice a list of classes like so:
 

--- a/docs/mcp/overview.mdx
+++ b/docs/mcp/overview.mdx
@@ -3,7 +3,7 @@ title: Model Context Protocol (MCP)
 description: Learn what a Model Context Protocol (MCP) service is, how it works, and how to build one using Clerk.
 ---
 
-The **[Model Context Protocol (MCP)](https://modelcontextprotocol.io/introduction)** is an open standard that lets large language model (LLM) apps, like Claude, ChatGPT, or Cursor, **securely access user data from external services** with the user's permission. Instead of asking users to sign in separately, MCP allows these AI apps to request permission to access specific data, such as emails or private Github repositories, directly through the app being used.
+The **[Model Context Protocol (MCP)](https://modelcontextprotocol.io/introduction)** is an open standard that lets large language model (LLM) apps, like Claude, ChatGPT, or Cursor, **securely access user data from external services** with the user's permission. Instead of asking users to sign in separately, MCP allows these AI apps to request permission to access specific data, such as emails or private GitHub repositories, directly through the app being used.
 
 There are two parties involved in MCP - "client" and "server". In web development, the terms "client" and "server" often refer to the frontend (browser) and backend (web server). However, in this context, these terms have different meanings:
 

--- a/docs/oauth/single-sign-on.mdx
+++ b/docs/oauth/single-sign-on.mdx
@@ -12,7 +12,7 @@ These features help you streamline authentication for your users, whether they'r
 
 ## Option 1: Let users authenticate into your Clerk application with social providers
 
-This feature allows users to sign up/sign in to your Clerk app using their existing credentials from popular social providers, also known as IdPs, like Google, Facebook, or Github. For example, if you enable Github as a social provider, then a user can sign in to your Clerk app by selecting Github as an option and authenticating with their Github account credentials.
+This feature allows users to sign up/sign in to your Clerk app using their existing credentials from popular social providers, also known as IdPs, like Google, Facebook, or GitHub. For example, if you enable GitHub as a social provider, then a user can sign in to your Clerk app by selecting GitHub as an option and authenticating with their GitHub account credentials.
 
 Refer to the appropriate provider's [guide](/docs/authentication/social-connections/overview) for implementation details.
 

--- a/docs/references/backend/organization/get-organization-membership-list.mdx
+++ b/docs/references/backend/organization/get-organization-membership-list.mdx
@@ -177,7 +177,7 @@ const { data, totalCount } = await clerkClient.organizations.getOrganizationMemb
 
 ### `getOrganizationMembershipList({ organizationId, offset })`
 
-Retrieves organizaiton membership list that is filtered by the number of results to skip.
+Retrieves organization membership list that is filtered by the number of results to skip.
 
 ```tsx
 const organizationId = 'org_123'

--- a/scripts/lib/io.ts
+++ b/scripts/lib/io.ts
@@ -75,7 +75,7 @@ export const writeSDKFile = (config: BuildConfig, store: Store) => {
   }
 }
 
-// not exactly io, but used to parse the json using a result patten
+// not exactly io, but used to parse the json using a result pattern
 export const parseJSON = (json: string) => {
   try {
     const output = JSON.parse(json)

--- a/scripts/migrate-api-reference-links.ts
+++ b/scripts/migrate-api-reference-links.ts
@@ -94,7 +94,7 @@ async function main() {
     )
 
     if (!response.ok) {
-      throw new Error('Failed to fetch OpenAPI spec from Github')
+      throw new Error('Failed to fetch OpenAPI spec from GitHub')
     }
 
     return await response.text()


### PR DESCRIPTION
### What does this solve?

Misspellings in the repo.

### What changed?

Found few misspellings.

### Checklist

- [x] I have clicked on "Files changed" and performed a thorough self-review
- [ ] All existing checks pass

@alexisintech There are 2 typos in back-end API.
```
error: `missmatch` should be `mismatch`
  --> ./data/api_errors.json:5122:23
     |
5122 |     "code": "resource_missmatch",
     |                       ^^^^^^^^^
     |
error: `instace` should be `instance`
  --> ./data/api_errors.json:6513:62
     |
6513 |     "longMessage": "You must opt in to this update %q on the instace updates page in order to use this feature.",
     |                                                              ^^^^^^^
     |
```

Please use https://github.com/crate-ci/typos