### PR TITLE
Fix billing JS Backend types

### DIFF
--- a/docs/manifest.json
+++ b/docs/manifest.json
@@ -3420,16 +3420,16 @@
                                 "href": "/docs/references/backend/types/backend-allowlist-identifier"
                               },
                               {
-                                "title": "`CommercePlan`",
-                                "href": "/docs/references/backend/types/commerce-plan"
+                                "title": "Backend `CommercePlan` object",
+                                "href": "/docs/references/backend/types/backend-commerce-plan"
                               },
                               {
-                                "title": "`CommerceSubscription`",
-                                "href": "/docs/references/backend/types/commerce-subscription"
+                                "title": "Backend `CommerceSubscription` object",
+                                "href": "/docs/references/backend/types/backend-commerce-subscription"
                               },
                               {
-                                "title": "`CommerceSubscriptionItem`",
-                                "href": "/docs/references/backend/types/commerce-subscription-item"
+                                "title": "Backend `CommerceSubscriptionItem` object",
+                                "href": "/docs/references/backend/types/backend-commerce-subscription-item"
                               },
                               {
                                 "title": "Backend `EmailAddress` object",
@@ -3440,8 +3440,8 @@
                                 "href": "/docs/references/backend/types/backend-external-account"
                               },
                               {
-                                "title": "`Feature`",
-                                "href": "/docs/references/backend/types/feature"
+                                "title": "Backend `Feature` object",
+                                "href": "/docs/references/backend/types/backend-feature"
                               },
                               {
                                 "title": "Backend `Client` object",

--- a/docs/references/backend/billing/cancel-subscription-item.mdx
+++ b/docs/references/backend/billing/cancel-subscription-item.mdx
@@ -8,7 +8,7 @@ sdk: js-backend
 
 {/* clerk/javascript file: https://github.com/clerk/javascript/blob/main/packages/backend/src/api/endpoints/BillingApi.ts */}
 
-Cancels a subscription item. Returns the updated [`CommerceSubscriptionItem`](/docs/references/backend/types/commerce-subscription-item).
+Cancels a subscription item. Returns the updated [`CommerceSubscriptionItem`](/docs/references/backend/types/backend-commerce-subscription-item).
 
 ```ts
 function cancelSubscriptionItem(

--- a/docs/references/backend/billing/get-organization-billing-subscription.mdx
+++ b/docs/references/backend/billing/get-organization-billing-subscription.mdx
@@ -8,7 +8,7 @@ sdk: js-backend
 
 {/* clerk/javascript file: https://github.com/clerk/javascript/blob/main/packages/backend/src/api/endpoints/BillingApi.ts */}
 
-Retrieves an organization's billing subscription. Returns a [`CommerceSubscription`](/docs/references/backend/types/commerce-subscription).
+Retrieves an organization's billing subscription. Returns a [`CommerceSubscription`](/docs/references/backend/types/backend-commerce-subscription).
 
 ```ts
 function getOrganizationBillingSubscription(organizationId: string): Promise<CommerceSubscription>

--- a/docs/references/backend/billing/get-plan-list.mdx
+++ b/docs/references/backend/billing/get-plan-list.mdx
@@ -8,7 +8,7 @@ sdk: js-backend
 
 {/* clerk/javascript file: https://github.com/clerk/javascript/blob/main/packages/backend/src/api/endpoints/BillingApi.ts */}
 
-Retrieves a list of billing plans. Returns a [`PaginatedResourceResponse`](/docs/references/backend/types/paginated-resource-response) object with a `data` property that contains an array of [`CommercePlan`](/docs/references/backend/types/commerce-plan) objects, and a `totalCount` property that indicates the total number of plans.
+Retrieves a list of billing plans. Returns a [`PaginatedResourceResponse`](/docs/references/backend/types/paginated-resource-response) object with a `data` property that contains an array of [`CommercePlan`](/docs/references/backend/types/backend-commerce-plan) objects, and a `totalCount` property that indicates the total number of plans.
 
 ```ts
 function getPlanList(

--- a/docs/references/backend/billing/get-user-billing-subscription.mdx
+++ b/docs/references/backend/billing/get-user-billing-subscription.mdx
@@ -8,7 +8,7 @@ sdk: js-backend
 
 {/* clerk/javascript file: https://github.com/clerk/javascript/blob/main/packages/backend/src/api/endpoints/BillingApi.ts */}
 
-Retrieves a user's billing subscription. Returns a [`CommerceSubscription`](/docs/references/backend/types/commerce-subscription).
+Retrieves a user's billing subscription. Returns a [`CommerceSubscription`](/docs/references/backend/types/backend-commerce-subscription).
 
 ```ts
 function getUserBillingSubscription(userId: string): Promise<CommerceSubscription>

--- a/docs/references/backend/types/backend-commerce-plan.mdx
+++ b/docs/references/backend/types/backend-commerce-plan.mdx
@@ -1,6 +1,6 @@
 ---
 title: The Backend `CommercePlan` object
-description: The Backend `CommercePlan` object holds information about a plan of your application.
+description: The Backend CommercePlan object holds information about a plan of your application.
 sdk: js-backend
 ---
 

--- a/docs/references/backend/types/backend-commerce-plan.mdx
+++ b/docs/references/backend/types/backend-commerce-plan.mdx
@@ -1,5 +1,5 @@
 ---
-title: '`CommercePlan`'
+title: The Backend `CommercePlan` object
 description: The Backend `CommercePlan` object holds information about a plan of your application.
 sdk: js-backend
 ---
@@ -103,7 +103,7 @@ The `CommercePlan` object is similar to the [`CommercePlan`](/docs/references/ja
   ---
 
   - `features`
-  - [`Feature[]`](/docs/references/backend/types/feature)
+  - [`Feature[]`](/docs/references/backend/types/backend-feature)
 
   The features the plan offers.
 </Properties>

--- a/docs/references/backend/types/backend-commerce-plan.mdx
+++ b/docs/references/backend/types/backend-commerce-plan.mdx
@@ -6,7 +6,7 @@ sdk: js-backend
 
 <Include src="_partials/billing/api-experimental" />
 
-The `CommercePlan` object is similar to the [`CommercePlan`](/docs/references/javascript/types/commerce-plan-resource) object as it holds information about a plan, as well as methods for managing it. However, the `CommercePlan` object is different in that it is used in the [Backend API](https://clerk.com/docs/reference/backend-api/model/commerceplan){{ target: '_blank' }} and is not directly accessible from the Frontend API.
+The Backend `CommercePlan` object is similar to the [`CommercePlan`](/docs/references/javascript/types/commerce-plan-resource) object as it holds information about a plan, as well as methods for managing it. However, the `CommercePlan` object is different in that it is used in the [Backend API](https://clerk.com/docs/reference/backend-api/model/commerceplan){{ target: '_blank' }} and is not directly accessible from the Frontend API.
 
 ## Properties
 

--- a/docs/references/backend/types/backend-commerce-subscription-item.mdx
+++ b/docs/references/backend/types/backend-commerce-subscription-item.mdx
@@ -1,5 +1,5 @@
 ---
-title: '`CommerceSubscriptionItem`'
+title: The Backend `CommerceSubscriptionItem` object
 description: The Backend `CommerceSubscriptionItem` object holds information about a subscription item of your application.
 sdk: js-backend
 ---
@@ -61,7 +61,7 @@ The `CommerceSubscriptionItem` object is similar to the [`CommerceSubscriptionIt
   ---
 
   - `plan`
-  - <code>[CommercePlan](/docs/references/backend/types/commerce-plan)</code>
+  - <code>[CommercePlan](/docs/references/backend/types/backend-commerce-plan)</code>
 
   The plan associated with this subscription item.
 

--- a/docs/references/backend/types/backend-commerce-subscription-item.mdx
+++ b/docs/references/backend/types/backend-commerce-subscription-item.mdx
@@ -6,7 +6,7 @@ sdk: js-backend
 
 <Include src="_partials/billing/api-experimental" />
 
-The `CommerceSubscriptionItem` object is similar to the [`CommerceSubscriptionItem`](/docs/references/javascript/types/commerce-subscription-item-resource) object as it holds information about a subscription item, as well as methods for managing it. However, the `CommerceSubscriptionItem` object is different in that it is used in the [Backend API](https://clerk.com/docs/reference/backend-api/model/commercesubscriptionitem){{ target: '_blank' }} and is not directly accessible from the Frontend API.
+The Backend `CommerceSubscriptionItem` object is similar to the [`CommerceSubscriptionItem`](/docs/references/javascript/types/commerce-subscription-item-resource) object as it holds information about a subscription item, as well as methods for managing it. However, the `CommerceSubscriptionItem` object is different in that it is used in the [Backend API](https://clerk.com/docs/reference/backend-api/model/commercesubscriptionitem){{ target: '_blank' }} and is not directly accessible from the Frontend API.
 
 ## Properties
 

--- a/docs/references/backend/types/backend-commerce-subscription-item.mdx
+++ b/docs/references/backend/types/backend-commerce-subscription-item.mdx
@@ -1,6 +1,6 @@
 ---
 title: The Backend `CommerceSubscriptionItem` object
-description: The Backend `CommerceSubscriptionItem` object holds information about a subscription item of your application.
+description: The Backend CommerceSubscriptionItem object holds information about a subscription item of your application.
 sdk: js-backend
 ---
 

--- a/docs/references/backend/types/backend-commerce-subscription.mdx
+++ b/docs/references/backend/types/backend-commerce-subscription.mdx
@@ -1,6 +1,6 @@
 ---
-title: '`CommerceSubscription`'
-description: The Backend CommerceSubscription object holds information about a subscription of your application.
+title: The Backend `CommerceSubscription` object
+description: The Backend `CommerceSubscription` object holds information about a subscription of your application.
 sdk: js-backend
 ---
 
@@ -61,7 +61,7 @@ The `CommerceSubscription` object is similar to the [`CommerceSubscription`](/do
   ---
 
   - `subscriptionItems`
-  - <code>[CommerceSubscriptionItem](/docs/references/backend/types/commerce-subscription-item)\[]</code>
+  - <code>[CommerceSubscriptionItem](/docs/references/backend/types/backend-commerce-subscription-item)\[]</code>
 
   Array of subscription items in this subscription.
 

--- a/docs/references/backend/types/backend-commerce-subscription.mdx
+++ b/docs/references/backend/types/backend-commerce-subscription.mdx
@@ -1,6 +1,6 @@
 ---
 title: The Backend `CommerceSubscription` object
-description: The Backend `CommerceSubscription` object holds information about a subscription of your application.
+description: The Backend CommerceSubscription object holds information about a subscription of your application.
 sdk: js-backend
 ---
 

--- a/docs/references/backend/types/backend-commerce-subscription.mdx
+++ b/docs/references/backend/types/backend-commerce-subscription.mdx
@@ -6,7 +6,7 @@ sdk: js-backend
 
 <Include src="_partials/billing/api-experimental" />
 
-The `CommerceSubscription` object is similar to the [`CommerceSubscription`](/docs/references/javascript/types/commerce-subscription-resource) object as it holds information about a subscription, as well as methods for managing it. However, the `CommerceSubscription` object is different in that it is used in the [Backend API](https://clerk.com/docs/reference/backend-api/tag/billing/get/organizations/%7Borganization_id%7D/billing/subscription){{ target: '_blank' }} and is not directly accessible from the Frontend API.
+The Backend `CommerceSubscription` object is similar to the [`CommerceSubscription`](/docs/references/javascript/types/commerce-subscription-resource) object as it holds information about a subscription, as well as methods for managing it. However, the `CommerceSubscription` object is different in that it is used in the [Backend API](https://clerk.com/docs/reference/backend-api/tag/billing/get/organizations/%7Borganization_id%7D/billing/subscription){{ target: '_blank' }} and is not directly accessible from the Frontend API.
 
 ## Properties
 

--- a/docs/references/backend/types/backend-feature.mdx
+++ b/docs/references/backend/types/backend-feature.mdx
@@ -1,6 +1,6 @@
 ---
 title: '`Feature`'
-description: 'The Feature type represents a feature that a plan can offer.'
+description: The Feature object represents a feature that a plan can offer.
 sdk: js-backend
 ---
 

--- a/docs/references/backend/types/backend-feature.mdx
+++ b/docs/references/backend/types/backend-feature.mdx
@@ -1,6 +1,6 @@
 ---
-title: '`Feature`'
-description: The Feature object represents a feature that a plan can offer.
+title: The Backend `Feature` object
+description: The Backend Feature object represents a feature that a plan can offer.
 sdk: js-backend
 ---
 

--- a/docs/references/backend/types/backend-feature.mdx
+++ b/docs/references/backend/types/backend-feature.mdx
@@ -6,7 +6,7 @@ sdk: js-backend
 
 <Include src="_partials/billing/api-experimental" />
 
-The `Feature` object represents a feature of a subscription plan.
+The Backend `Feature` object represents a feature of a subscription plan.
 
 <Properties>
   - `id`


### PR DESCRIPTION
### 🔎 Previews:

- https://clerk.com/docs/pr/ss-fix-backend-types/references/backend/types/backend-commerce-plan
- https://clerk.com/docs/pr/ss-fix-backend-types/references/backend/types/backend-commerce-subscription
- https://clerk.com/docs/pr/ss-fix-backend-types/references/backend/types/backend-commerce-subscription-item
- https://clerk.com/docs/pr/ss-fix-backend-types/references/backend/types/backend-feature

### What does this solve?

While working on a separate PR around the JS Backend SDK, I noticed some discrepancies between the Billing types and the other types. This PR aims at making the following types consistent:

- `CommercePlan`
- `CommerceSubscription`
- `CommerceSubscriptionItem`
- `Feature`

### What changed?

- Renamed the folders to follow the same file name: `backend-xxx`
- Added `Backend` in front of the billing types to keep consistency
- Fixed the links to follow the new folder names
- Fixed the frontmatter to be consistent

**Note:** I know that ultimately, some of this will be handled by Typedoc, which I've handled in this [PR](https://github.com/clerk/javascript/pull/6721). But, as it's not using Typedoc, right now, I made the changes directly there. 

### Checklist

- [ ] I have clicked on "Files changed" and performed a thorough self-review
- [ ] All existing checks pass
