### PR TITLE
Clarify how Machine scope changes are applied to tokens.

### DIFF
--- a/docs/machine-auth/m2m-tokens.mdx
+++ b/docs/machine-auth/m2m-tokens.mdx
@@ -45,6 +45,9 @@ This example creates two machines, `Machine A` and `Machine B`, and configures t
 
 Both machines are now configured to enable full bi-directional communication between them, allowing them to create tokens to authenticate requests in either direction.
 
+> [!IMPORTANT]
+> When you modify machine scopes, the changes only apply to newly created M2M tokens. Any existing M2M tokens that were created before the scope modification will retain their original scopes and will not be affected by the changes.
+
 Now that you have your machines set up, the next step is to create tokens that will allow them to authenticate requests between each other.
 
 ## Creating M2M tokens


### PR DESCRIPTION
### 🔎 Previews:

🔍 [Preview linking to section](https://clerk.com/docs/pr/clarify-machine-scopes/machine-auth/m2m-tokens#creating-machines)

### What does this solve?

There's an important distinction on how machine scopes are applied to m2m tokens.  Notably, they are not applied to m2m tokens which have already been created, but only new tokens.

### What changed?

Adds an Important callout in the section where we describe the process for creating a machine (and adding its scopes).

### Checklist

- [x] I have clicked on "Files changed" and performed a thorough self-review
- [x] All existing checks pass
