### PR TITLE
Always embed the canonical link in the frontmatter, disable search for the redirect pages

### DIFF
--- a/scripts/build-docs.test.ts
+++ b/scripts/build-docs.test.ts
@@ -1817,6 +1817,45 @@ activeSdk: react
     ])
   })
 
+  test('should add sdkScoped false and canonical URL to non-SDK-scoped documents', async () => {
+    const { tempDir, readFile } = await createTempFiles([
+      {
+        path: './docs/manifest.json',
+        content: JSON.stringify({
+          navigation: [[{ title: 'API Doc', href: '/docs/api-doc' }]],
+        }),
+      },
+      {
+        path: './docs/api-doc.mdx',
+        content: `---
+title: API Documentation
+description: x
+---
+
+# API Documentation
+`,
+      },
+    ])
+
+    await build(
+      await createConfig({
+        ...baseConfig,
+        basePath: tempDir,
+        validSdks: ['react'],
+      }),
+    )
+
+    expect(await readFile('./dist/api-doc.mdx')).toBe(`---
+title: API Documentation
+description: x
+sdkScoped: "false"
+canonical: /docs/api-doc
+---
+
+# API Documentation
+`)
+  })
+
   test('should not inject :sdk: for single SDK documents when multiple SDKs are available', async () => {
     const { tempDir, readFile, listFiles } = await createTempFiles([
       {
@@ -5409,43 +5448,4 @@ activeSdk: react
 Updated Documentation specific to React.js
 `)
   })
-})
-
-test('x', async () => {
-  const { tempDir, readFile, writeFile, pathJoin } = await createTempFiles([
-    {
-      path: './docs/manifest.json',
-      content: JSON.stringify({
-        navigation: [[{ title: 'API Doc', href: '/docs/api-doc' }]],
-      }),
-    },
-    {
-      path: './docs/api-doc.mdx',
-      content: `---
-title: API Documentation
-description: x
----
-
-# API Documentation
-`,
-    },
-  ])
-
-  await build(
-    await createConfig({
-      ...baseConfig,
-      basePath: tempDir,
-      validSdks: ['react'],
-    }),
-  )
-
-  expect(await readFile('./dist/api-doc.mdx')).toBe(`---
-title: API Documentation
-description: x
-sdkScoped: "false"
-canonical: /docs/api-doc
----
-
-# API Documentation
-`)
 })

--- a/scripts/build-docs.test.ts
+++ b/scripts/build-docs.test.ts
@@ -1321,6 +1321,8 @@ template: wide
 redirectPage: "true"
 availableSdks: react,nextjs
 notAvailableSdks: ""
+search:
+  exclude: true
 ---
 <SDKDocRedirectPage title="SDK Document" description="This document is available for React and Next.js." href="/docs/:sdk:/sdk-document" sdks={["react","nextjs"]} />`,
     )
@@ -5137,6 +5139,8 @@ template: wide
 redirectPage: "true"
 availableSdks: nextjs,remix,react
 notAvailableSdks: ""
+search:
+  exclude: true
 ---
 <SDKDocRedirectPage title="API Documentation" description="x" href="/docs/:sdk:/api-doc" sdks={["nextjs","remix","react"]} />`)
 
@@ -5230,6 +5234,8 @@ template: wide
 redirectPage: "true"
 availableSdks: react,nextjs
 notAvailableSdks: ""
+search:
+  exclude: true
 ---
 <SDKDocRedirectPage title="Documentation" href="/docs/:sdk:/test" sdks={["react","nextjs"]} />`)
 

--- a/scripts/build-docs.test.ts
+++ b/scripts/build-docs.test.ts
@@ -1323,6 +1323,7 @@ availableSdks: react,nextjs
 notAvailableSdks: ""
 search:
   exclude: true
+canonical: /docs/:sdk:/sdk-document
 ---
 <SDKDocRedirectPage title="SDK Document" description="This document is available for React and Next.js." href="/docs/:sdk:/sdk-document" sdks={["react","nextjs"]} />`,
     )
@@ -5141,6 +5142,7 @@ availableSdks: nextjs,remix,react
 notAvailableSdks: ""
 search:
   exclude: true
+canonical: /docs/:sdk:/api-doc
 ---
 <SDKDocRedirectPage title="API Documentation" description="x" href="/docs/:sdk:/api-doc" sdks={["nextjs","remix","react"]} />`)
 
@@ -5236,6 +5238,7 @@ availableSdks: react,nextjs
 notAvailableSdks: ""
 search:
   exclude: true
+canonical: /docs/:sdk:/test
 ---
 <SDKDocRedirectPage title="Documentation" href="/docs/:sdk:/test" sdks={["react","nextjs"]} />`)
 

--- a/scripts/build-docs.test.ts
+++ b/scripts/build-docs.test.ts
@@ -225,6 +225,8 @@ Testing with a simple page.`,
 title: Simple Test
 description: This is a simple test page
 lastUpdated: ${initialCommitDate.toISOString()}
+sdkScoped: "false"
+canonical: /docs/simple-test
 ---
 
 # Simple Test Page
@@ -5026,6 +5028,8 @@ description: Generated API docs
     expect(await readFile('./dist/llms-full.txt')).toEqual(`---
 title: API Documentation
 description: Generated API docs
+sdkScoped: "false"
+canonical: /docs/api-doc
 ---
 
 # API Documentation
@@ -5292,6 +5296,8 @@ description: x
     expect(await readFile('./dist/overview.mdx')).toBe(`---
 title: Overview
 description: x
+sdkScoped: "false"
+canonical: /docs/overview
 ---
 
 <SDKLink href="/docs/:sdk:/api-doc" sdks={["nextjs","remix","react"]}>API Doc</SDKLink>
@@ -5394,4 +5400,43 @@ activeSdk: react
 Updated Documentation specific to React.js
 `)
   })
+})
+
+test('x', async () => {
+  const { tempDir, readFile, writeFile, pathJoin } = await createTempFiles([
+    {
+      path: './docs/manifest.json',
+      content: JSON.stringify({
+        navigation: [[{ title: 'API Doc', href: '/docs/api-doc' }]],
+      }),
+    },
+    {
+      path: './docs/api-doc.mdx',
+      content: `---
+title: API Documentation
+description: x
+---
+
+# API Documentation
+`,
+    },
+  ])
+
+  await build(
+    await createConfig({
+      ...baseConfig,
+      basePath: tempDir,
+      validSdks: ['react'],
+    }),
+  )
+
+  expect(await readFile('./dist/api-doc.mdx')).toBe(`---
+title: API Documentation
+description: x
+sdkScoped: "false"
+canonical: /docs/api-doc
+---
+
+# API Documentation
+`)
 })

--- a/scripts/build-docs.ts
+++ b/scripts/build-docs.ts
@@ -885,6 +885,17 @@ export async function build(config: BuildConfig, store: Store = createBlankStore
 
         if (needsRedirectPage) {
           // This is a sdk specific doc with multiple options, so we want to put a landing page here to redirect the user to a doc customized to their sdk.
+
+          // get the same canonical value as the doc
+          const hrefSegments = doc.file.href.split('/')
+          const hrefAlreadyContainsSdk = sdks.some((sdk) => hrefSegments.includes(sdk))
+          const isSingleSdkDocument = sdks.length === 1
+
+          const canonical =
+            hrefAlreadyContainsSdk || isSingleSdkDocument
+              ? doc.file.href
+              : scopeHrefToSDK(config)(doc.file.href, ':sdk:')
+
           await writeFile(
             doc.file.filePathInDocsFolder,
             `---
@@ -894,6 +905,7 @@ ${yaml.stringify({
   availableSdks: sdks.join(','),
   notAvailableSdks: config.validSdks.filter((sdk) => !sdks?.includes(sdk)).join(','),
   search: { exclude: true },
+  canonical: canonical,
 })}---
 <SDKDocRedirectPage title="${doc.frontmatter.title}"${doc.frontmatter.description ? ` description="${doc.frontmatter.description}" ` : ' '}href="${scopeHrefToSDK(config)(doc.file.href, ':sdk:')}" sdks={${JSON.stringify(sdks)}} />`,
           )

--- a/scripts/build-docs.ts
+++ b/scripts/build-docs.ts
@@ -827,6 +827,8 @@ export async function build(config: BuildConfig, store: Store = createBlankStore
           .use(
             insertFrontmatter({
               lastUpdated: (await getCommitDate(doc.file.fullFilePath))?.toISOString() ?? undefined,
+              sdkScoped: 'false',
+              canonical: doc.file.href,
             }),
           )
           .process(doc.vfile),

--- a/scripts/build-docs.ts
+++ b/scripts/build-docs.ts
@@ -893,6 +893,7 @@ ${yaml.stringify({
   redirectPage: 'true',
   availableSdks: sdks.join(','),
   notAvailableSdks: config.validSdks.filter((sdk) => !sdks?.includes(sdk)).join(','),
+  search: { exclude: true },
 })}---
 <SDKDocRedirectPage title="${doc.frontmatter.title}"${doc.frontmatter.description ? ` description="${doc.frontmatter.description}" ` : ' '}href="${scopeHrefToSDK(config)(doc.file.href, ':sdk:')}" sdks={${JSON.stringify(sdks)}} />`,
           )


### PR DESCRIPTION
### What does this solve?

Need to make changes to the frontmatter so the site can include information in the meta tags for Algolia to pick up, so we can improve our in-site search.

### What changed?

- Adds `sdkScoped: "false"` to non sdk scoped pages
- Adds `canonical: ...` to non sdk scoped pages to be consistent with sdk scoped pages
- Adds `search: exclude: true` for redirect pages to stop them being indexed

### Checklist

- [x] I have clicked on "Files changed" and performed a thorough self-review
- [x] All existing checks pass
