### PR TITLE
Missing Examples heading to be consistent with other billing components structure

### DIFF
--- a/docs/components/billing/subscription-details-button.mdx
+++ b/docs/components/billing/subscription-details-button.mdx
@@ -70,6 +70,8 @@ All props are optional.
 </>
 ```
 
+### Examples
+
 <Tabs items={["Next.js", "React", "Vue"]}>
   <Tab>
     ```tsx {{ filename: 'app/billing/page.tsx' }}


### PR DESCRIPTION
### 🔎 Previews:

-

### What does this solve?

Noticed the `SubscriptionDetailsButton` component was missing an **Examples** heading after the **Usage** section to be consistent with the structure of the other billing components.

### What changed?

Added an **Examples** heading.

### Checklist

- [ ] I have clicked on "Files changed" and performed a thorough self-review
- [ ] All existing checks pass
