### PR TITLE
Expo web SSO - Only attempt browser warm up on android

### DIFF
--- a/docs/custom-flows/oauth-connections.mdx
+++ b/docs/custom-flows/oauth-connections.mdx
@@ -90,6 +90,7 @@ You must configure your application instance through the Clerk Dashboard for the
       useEffect(() => {
         // Preloads the browser for Android devices to reduce authentication load time
         // See: https://docs.expo.dev/guides/authentication/#improving-user-experience
+        if (Platform.OS !== "android") return;
         void WebBrowser.warmUpAsync()
         return () => {
           // Cleanup: closes browser when component unmounts


### PR DESCRIPTION
### 🔎 Previews:

-

### What does this solve?

Getting this error when attempting to use the Expo SSO example code in Expo web.
<img width="1391" height="1550" alt="Screenshot 2025-09-24 at 1 02 22 PM" src="https://github.com/user-attachments/assets/70bddbde-d857-44e1-89d6-5f4ec546e7d7" />

### What changed?

Added a check for the platform so this warm up only happens on the platform its needed, android.

### Checklist

- [ ] I have clicked on "Files changed" and performed a thorough self-review
- [x] All existing checks pass
