### PR TITLE
Add beta tags to billing hooks

### DIFF
--- a/docs/manifest.json
+++ b/docs/manifest.json
@@ -2919,31 +2919,38 @@
                         },
                         {
                           "title": "`useCheckout()`",
-                          "href": "/docs/reference/hooks/use-checkout"
+                          "href": "/docs/reference/hooks/use-checkout",
+                          "tag": "(Beta)"
                         },
                         {
                           "title": "`usePaymentElement()`",
-                          "href": "/docs/reference/hooks/use-payment-element"
+                          "href": "/docs/reference/hooks/use-payment-element",
+                          "tag": "(Beta)"
                         },
                         {
                           "title": "`usePaymentMethods()`",
-                          "href": "/docs/reference/hooks/use-payment-methods"
+                          "href": "/docs/reference/hooks/use-payment-methods",
+                          "tag": "(Beta)"
                         },
                         {
                           "title": "`usePlans()`",
-                          "href": "/docs/reference/hooks/use-plans"
+                          "href": "/docs/reference/hooks/use-plans",
+                          "tag": "(Beta)"
                         },
                         {
                           "title": "`useSubscription()`",
-                          "href": "/docs/reference/hooks/use-subscription"
+                          "href": "/docs/reference/hooks/use-subscription",
+                          "tag": "(Beta)"
                         },
                         {
                           "title": "`usePaymentAttempts()`",
-                          "href": "/docs/reference/hooks/use-payment-attempts"
+                          "href": "/docs/reference/hooks/use-payment-attempts",
+                          "tag": "(Beta)"
                         },
                         {
                           "title": "`useStatements()`",
-                          "href": "/docs/reference/hooks/use-statements"
+                          "href": "/docs/reference/hooks/use-statements",
+                          "tag": "(Beta)"
                         }
                       ]
                     ]


### PR DESCRIPTION
### 🔎 Previews:

- https://clerk.com/docs/pr/ss-docs-10978/reference/nextjs/overview

### What does this solve?

Linear: https://linear.app/clerk/issue/DOCS-10978/missing-beta-tags-on-billing-hooks

The billing hooks that are in beta don't have beta tags next to them. This PR adds them. 

### What changed?

- Adds beta tags to billing hooks

Before:

<img width="242" height="227" alt="Screenshot 2025-09-22 at 3 43 47 pm" src="https://github.com/user-attachments/assets/76eb3ca4-2bdb-4e50-8f02-73222e2c87d0" />

After:

<img width="228" height="230" alt="Screenshot 2025-09-30 at 1 43 43 pm" src="https://github.com/user-attachments/assets/64c5c4f8-1900-4740-b35b-fc835c0f4622" />

### Checklist

- [ ] I have clicked on "Files changed" and performed a thorough self-review
- [ ] All existing checks pass
