### PR TITLE
Fix 404 links on Inngest guide

### DIFF
--- a/docs/guides/development/webhooks/inngest.mdx
+++ b/docs/guides/development/webhooks/inngest.mdx
@@ -7,8 +7,8 @@ Webhooks allow you to [synchronize data](/docs/guides/development/webhooks/synci
 
 - [Limiting concurrency](https://www.inngest.com/docs/guides/concurrency) to handle spikes in events without overwhelming your API or database.
 - Triggering multiple functions from a single event ([fan-out jobs](https://www.inngest.com/docs/guides/fan-out-jobs)).
-- [Delaying code](https://www.inngest.com/docs/functions/multi-step) to run after a period of time.
-- [Debouncing events](https://www.inngest.com/docs/references/functions/debounce) to reduce duplicate processing.
+- [Delaying code](https://www.inngest.com/docs/guides/multi-step-functions) to run after a period of time.
+- [Debouncing events](https://www.inngest.com/docs/guides/debounce) to reduce duplicate processing.
 
 In this guide, you'll learn how to set up Inngest to receive Clerk webhook events and how to define Inngest functions in your application using Clerk events including synchronizing data and sending welcome emails.
 
@@ -101,7 +101,7 @@ Now, you have a function that utilizes the same Clerk webhook event for another 
 
 ### Sending a delayed follow-up email
 
-Every Inngest function handler has an additional `step` object which provides tools to create more complex functions. Using `step.run` allows you to encapsulate specific code that will be automatically retried ensuring that issues with one part of your function don't force the entire function to re-run. Additionally, [other tools like `step.sleep`](https://www.inngest.com/docs/references/functions/step-sleep), are available to extend functionality.
+Every Inngest function handler has an additional `step` object which provides tools to create more complex functions. Using `step.run` allows you to encapsulate specific code that will be automatically retried ensuring that issues with one part of your function don't force the entire function to re-run. Additionally, [other tools like `step.sleep`](https://www.inngest.com/docs/reference/functions/step-sleep), are available to extend functionality.
 
 The code below sends a welcome email, then uses `step.sleep` to wait for three days before sending another email offering a free trial:
 


### PR DESCRIPTION
### 🔎 Previews:

-

### What does this solve?

With the new restructure, the Inngest guide isn't on the sidebar, as there are plans to revamp/ restructure it. However, while working on other things, I noticed some links were broken in the guide, and we probably want those fixed for any users stumbling upon the guide. 

### What changed?

Fixed the links leading to 404.

### Checklist

- [ ] I have clicked on "Files changed" and performed a thorough self-review
- [ ] All existing checks pass
