### PR TITLE
Remove experimental from vercel mcp adapter since its stable now

### DIFF
--- a/docs/guides/development/mcp/build-mcp-server.mdx
+++ b/docs/guides/development/mcp/build-mcp-server.mdx
@@ -120,7 +120,7 @@ sdk: nextjs, expressjs
 
     ```ts {{ filename: 'app/[transport]/route.ts' }}
     import { verifyClerkToken } from '@clerk/mcp-tools/next'
-    import { createMcpHandler, experimental_withMcpAuth as withMcpAuth } from '@vercel/mcp-adapter'
+    import { createMcpHandler, withMcpAuth } from '@vercel/mcp-adapter'
     import { auth, clerkClient } from '@clerk/nextjs/server'
 
     const clerk = await clerkClient()
@@ -172,7 +172,7 @@ sdk: nextjs, expressjs
   <If sdk="nextjs">
     ```ts {{ filename: 'app/[transport]/route.ts', mark: [[7, 25]] }}
     import { verifyClerkToken } from '@clerk/mcp-tools/next'
-    import { createMcpHandler, experimental_withMcpAuth as withMcpAuth } from '@vercel/mcp-adapter'
+    import { createMcpHandler, withMcpAuth } from '@vercel/mcp-adapter'
     import { auth, clerkClient } from '@clerk/nextjs/server'
 
     const clerk = await clerkClient()


### PR DESCRIPTION
### 🔎 Previews:

-

### What changed?

Vercel moved the mcp auth handler to stable in their adapter, this updates the docs to reflect this

### Checklist

- [ ] I have clicked on "Files changed" and performed a thorough self-review
- [ ] All existing checks pass
