### PR TITLE
Bring consistency to Secured by Clerk branding message

### DIFF
--- a/docs/reference/components/overview.mdx
+++ b/docs/reference/components/overview.mdx
@@ -58,11 +58,13 @@ Control components manage authentication-related behaviors in your application. 
 - [Add pages to the `<UserProfile />` component](/docs/guides/customizing-clerk/adding-items/user-profile)
 - [Add pages to the `<OrganizationProfile />` component](/docs/guides/customizing-clerk/adding-items/organization-profile)
 
-## Secured by Clerk branding
+### Secured by Clerk branding
+
+<Include src="_partials/feature-not-free-callout" />
 
 By default, Clerk displays a **Secured by Clerk** badge on Clerk components. You can remove this branding by following these steps:
 
 1. In the Clerk Dashboard, navigate to your application's [**Settings**](https://dashboard.clerk.com/last-active?path=settings).
-1. Under **Branding**, toggle on the **Remove "Secured by Clerk" branding** option. Please note that this setting requires a [paid plan](/pricing){{ target: '_blank' }} for production use, but all features are free to use in development mode so that you can try out what works for you. See the [pricing](/pricing){{ target: '_blank' }} page for more information.
+1. Under **Branding**, toggle on the **Remove "Secured by Clerk" branding** option.
 
 <Include src="_partials/help" />


### PR DESCRIPTION
### 🔎 Previews:

-

### What does this solve?

This [PR](https://github.com/clerk/clerk-docs/pull/2633) made a change to the Secured by Clerk section of the iOS components overview. But that section also exists in the Components overview page. This PR is to make the same changes to the section. 

### What changed?

Copy / pasted the section. 

### Checklist

- [ ] I have clicked on "Files changed" and performed a thorough self-review
- [ ] All existing checks pass
