### PR TITLE
Fixes domain in sync host code block

### DIFF
--- a/docs/guides/sessions/sync-host.mdx
+++ b/docs/guides/sessions/sync-host.mdx
@@ -37,8 +37,8 @@ Clerk allows you to sync the authentication state from your web app to your Chro
 
       ```env {{ filename: '.env.production', mark: [3] }}
       PLASMO_PUBLIC_CLERK_PUBLISHABLE_KEY=pk_live_123
-      CLERK_FRONTEND_API=https://yourdomain.com
-      PLASMO_PUBLIC_CLERK_SYNC_HOST=https://yourdomain.com
+      CLERK_FRONTEND_API=https://clerk.yourwebsite.com
+      PLASMO_PUBLIC_CLERK_SYNC_HOST=https://yourwebsite.com
       ```
     </Tab>
   </Tabs>


### PR DESCRIPTION
### 🔎 Previews:

-

### What does this solve?

Fixes incorrect domain for *Production* `CLERK_FRONTEND_API` environment var value.

### What changed?

`https://yourdomain.com` → https://clerk.yourwebsite.com

Switched to using `yourwebsite.com` instead of `yourdomain.com` as well, since the text above also references `yourwebsite.com`

### Checklist

- [x] I have clicked on "Files changed" and performed a thorough self-review
- [x] All existing checks pass
