### PR TITLE
Add removed step for metamask plugin download

### DIFF
--- a/docs/guides/configure/auth-strategies/web3/metamask.mdx
+++ b/docs/guides/configure/auth-strategies/web3/metamask.mdx
@@ -5,12 +5,12 @@ description: Learn how to set up Web3 authentication with MetaMask.
 
 <TutorialHero
   beforeYouStart={[
-    {
-      title: "A Clerk application is required.",
-      link: "/docs/getting-started/quickstart/setup-clerk",
-      icon: "clerk",
-    },
-  ]}
+{
+  title: "A Clerk application is required.",
+  link: "/docs/getting-started/quickstart/setup-clerk",
+  icon: "clerk",
+},
+]}
 />
 
 Enabling [MetaMask](https://metamask.io/) as a Web3 provider allows your users to sign in and  up to your Clerk application with their MetaMask wallet.
@@ -22,6 +22,7 @@ Enabling [MetaMask](https://metamask.io/) as a Web3 provider allows your users t
 
 1. In the Clerk Dashboard, navigate to the [**Web3**](https://dashboard.clerk.com/last-active?path=user-authentication/web3) page.
 1. From the list of web3 providers, enable **MetaMask**.
+1. Download the [Metamask plugin](https://metamask.io/download/) and install it on your browser to ensure a seamless login flow.
 
 ## Test authentication
 


### PR DESCRIPTION
### 🔎 Previews:

-

### What does this solve?

Linear: https://linear.app/clerk/issue/DOCS-11030/re-add-metamask-callout-to-documentation-for-user-guidance
Slack thread: https://clerkinc.slack.com/archives/C01QFRQNHSN/p1759505563513379

A crucial step was missing from the Web3 metamask docs. This PR re-adds that step.

### What changed?

Re-added the step of downloading the Metamask plugin. Made it into a step, but open to suggestions if we prefer it as a callout for e.g. 

### Checklist

- [ ] I have clicked on "Files changed" and performed a thorough self-review
- [ ] All existing checks pass
