### PR TITLE
Document missing createInvitationBulk method on JS Backend SDK 

### DIFF
--- a/docs/manifest.json
+++ b/docs/manifest.json
@@ -2445,6 +2445,10 @@
                                 "href": "/docs/reference/backend/invitations/create-invitation"
                               },
                               {
+                                "title": "`createInvitationBulk()`",
+                                "href": "/docs/reference/backend/invitations/create-invitation-bulk"
+                              },
+                              {
                                 "title": "`revokeInvitation()`",
                                 "href": "/docs/reference/backend/invitations/revoke-invitation"
                               }

--- a/docs/reference/backend/invitations/create-invitation-bulk.mdx
+++ b/docs/reference/backend/invitations/create-invitation-bulk.mdx
@@ -1,20 +1,29 @@
 ---
-title: '`createInvitation()`'
-description: Use Clerk's JS Backend SDK to create a new invitation for the given email address, and send the invitation email.
+title: '`createInvitationBulk()`'
+description: Use Clerk's JS Backend SDK to create multiple invitations for the given email addresses, and send the invitation emails.
 sdk: js-backend
 ---
 
-{/* clerk/javascript file: https://github.com/clerk/javascript/blob/main/packages/backend/src/api/endpoints/InvitationApi.ts#L42 */}
+{/* clerk/javascript file: https://github.com/clerk/javascript/blob/main/packages/backend/src/api/endpoints/InvitationApi.ts#L69 */}
 
-Creates a new [`Invitation`](/docs/reference/backend/types/backend-invitation) for the given email address and sends the invitation email.
+Creates multiple [`Invitation`](/docs/reference/backend/types/backend-invitation)s in bulk for the given email addresses and sends the invitation emails.
 
 If an email address has already been invited or already exists in your application, trying to create a new invitation will return an error. To bypass this error and create a new invitation anyways, set `ignoreExisting` to `true`.
 
 ```ts
-function createInvitation(params: CreateParams): Promise<Invitation>
+function createInvitationBulk(params: CreateBulkParams): Promise<Invitation[]>
 ```
 
-## `CreateParams`
+## Parameters
+
+<Properties>
+  - `params`
+  - [`CreateBulkParams[]`](#create-bulk-params)
+
+  An array of objects, each representing a single invitation.
+</Properties>
+
+## `CreateBulkParams`
 
 <Properties>
   - `emailAddress`
@@ -49,7 +58,7 @@ function createInvitation(params: CreateParams): Promise<Invitation>
   - `boolean`
 
   Whether an invitation should be created if there is already an existing invitation for this email address, or if the email address already exists in the application. Defaults to `false`.
-  
+
   ---
 
   - `expiresInDays?`
@@ -62,7 +71,7 @@ function createInvitation(params: CreateParams): Promise<Invitation>
   - `templateSlug?`
   - `'invitation' | 'waitlist_invitation'`
 
-  The slug of the email template to use for the invitation email. Defaults to `invitation`. 
+  The slug of the email template to use for the invitation email. Defaults to `invitation`.
 </Properties>
 
 ## Example
@@ -70,18 +79,33 @@ function createInvitation(params: CreateParams): Promise<Invitation>
 <Include src="_partials/backend/usage" />
 
 ```tsx
-const response = await clerkClient.invitations.createInvitation({
-  emailAddress: 'invite@example.com',
-  redirectUrl: 'https://www.example.com/my-sign-up',
-  publicMetadata: {
-    example: 'metadata',
-    example_nested: {
-      nested: 'metadata',
+// Each object in the array represents a single invitation
+const params = [
+  {
+    emailAddress: 'invite@example.com',
+    redirectUrl: 'https://www.example.com/my-sign-up',
+    publicMetadata: {
+      example: 'metadata',
+      example_nested: {
+        nested: 'metadata',
+      },
     },
   },
-})
+  {
+    emailAddress: 'invite2@example.com',
+    redirectUrl: 'https://www.example.com/my-sign-up',
+    publicMetadata: {
+      example: 'metadata',
+      example_nested: {
+        nested: 'metadata',
+      },
+    },
+  },
+]
+
+const response = await clerkClient.invitations.createInvitationBulk(params)
 ```
 
 ## Backend API (BAPI) endpoint
 
-This method in the SDK is a wrapper around the BAPI endpoint `POST/invitations`. See the [BAPI reference](/docs/reference/backend-api/tag/invitations/post/invitations){{ target: '_blank' }} for more information.
+This method in the SDK is a wrapper around the BAPI endpoint `POST/invitations/bulk`. See the [BAPI reference](/docs/reference/backend-api/tag/invitations/post/invitations/bulk){{ target: '_blank' }} for more information.

--- a/docs/reference/backend/invitations/create-invitation.mdx
+++ b/docs/reference/backend/invitations/create-invitation.mdx
@@ -49,7 +49,7 @@ function createInvitation(params: CreateParams): Promise<Invitation>
   - `boolean`
 
   Whether an invitation should be created if there is already an existing invitation for this email address, or if the email address already exists in the application. Defaults to `false`.
-  
+
   ---
 
   - `expiresInDays?`
@@ -62,7 +62,7 @@ function createInvitation(params: CreateParams): Promise<Invitation>
   - `templateSlug?`
   - `'invitation' | 'waitlist_invitation'`
 
-  The slug of the email template to use for the invitation email. Defaults to `invitation`. 
+  The slug of the email template to use for the invitation email. Defaults to `invitation`.
 </Properties>
 
 ## Example


### PR DESCRIPTION
### 🔎 Previews:

- https://clerk.com/docs/pr/ss-docs-10973/reference/backend/invitations/create-invitation-bulk

### What does this solve?

In the Clerk Backend API Reference, there is a route to create multiple invitations in bulk, and the wrapper method (`createInvitationBulk`) for that route is also being documented in the `javascript` repo [here](https://github.com/clerk/javascript/blob/main/packages/backend/src/api/endpoints/InvitationApi.ts). However, we do not have it in our docs - this PR documents the missing method within our JS Backend SDK. 

### What changed?

- Adds the `createInvitationBulk` method in JS Backend SDK. 

**Note:** While doing this work, @manovotny and I noticed the `templateSlug` and `expiresInDays` properties were missing from the `createInvitation` method while being documents in both the `javascript` repo and the Backend API reference docs. So we added them there too as part of this PR. 

### Checklist

- [ ] I have clicked on "Files changed" and performed a thorough self-review
- [ ] All existing checks pass
