### PR TITLE
removed duplicate class

### DIFF
--- a/docs/getting-started/quickstart.chrome-extension.mdx
+++ b/docs/getting-started/quickstart.chrome-extension.mdx
@@ -133,7 +133,7 @@ sdk: chrome-extension
   function IndexPopup() {
     return (
       <ClerkProvider publishableKey={PUBLISHABLE_KEY}>
-        <div className="plasmo-flex plasmo-items-center plasmo-justify-center plasmo-h-[600px] plasmo-w-[800px] plasmo-flex plasmo-flex-col">
+        <div className="plasmo-flex plasmo-items-center plasmo-justify-center plasmo-h-[600px] plasmo-w-[800px] plasmo-flex-col">
           <header className="plasmo-w-full">
             <SignedOut>
               <SignInButton mode="modal" />


### PR DESCRIPTION
### 🔎 Previews:

- Fixes duplicate CSS class in Chrome extension documentation example

### What does this solve?

- Removes duplicate plasmo-flex class from the Chrome extension code example
- Improves code quality and follows CSS best practices by eliminating redundant classes
- Makes the documentation example cleaner and more professional

### What changed?

- Removed the duplicate plasmo-flex class from the div element in the Chrome extension popup example
- The element now has only one plasmo-flex class instead of two identical ones
- The functionality remains exactly the same since duplicate classes don't affect rendering but are considered poor practice

## Before
```
<div className="plasmo-flex plasmo-items-center plasmo-justify-center plasmo-h-[600px] plasmo-w-[800px] plasmo-flex plasmo-flex-col">
```
## After 
```
<div className="plasmo-flex plasmo-items-center plasmo-justify-center plasmo-h-[600px] plasmo-w-[800px] plasmo-flex-col">
```
### Checklist

- [ ] I have clicked on "Files changed" and performed a thorough self-review
- [ ] All existing checks pass
