### PR TITLE
Move enable native API callout as step

### DIFF
--- a/docs/_partials/native-api-callout.mdx
+++ b/docs/_partials/native-api-callout.mdx
@@ -1,2 +1,3 @@
-> [!IMPORTANT]
-> Ensure that the Native API is enabled to integrate Clerk in your native application. In the Clerk Dashboard, navigate to the [**Native Applications**](https://dashboard.clerk.com/last-active?path=/native-applications) page.
+## Enable Native API
+
+In the Clerk Dashboard, navigate to the [**Native Applications**](https://dashboard.clerk.com/last-active?path=/native-applications) page and ensure that the Native API is enabled. This is required to integrate Clerk in your native application.

--- a/docs/getting-started/quickstart.android.mdx
+++ b/docs/getting-started/quickstart.android.mdx
@@ -20,9 +20,9 @@ sdk: android
   ]}
 />
 
-<Include src="_partials/native-api-callout" />
-
 <Steps>
+  <Include src="_partials/native-api-callout" />
+
   ## Create an Android Project
 
   1. Create a new Android project in Android Studio using the **Empty Activity** template. This tutorial uses `MyClerkApp` as the app name. If you choose a different name, be sure to update any code examples accordingly to match your app's name.

--- a/docs/getting-started/quickstart.chrome-extension.mdx
+++ b/docs/getting-started/quickstart.chrome-extension.mdx
@@ -20,9 +20,9 @@ sdk: chrome-extension
   ]}
 />
 
-<Include src="_partials/native-api-callout" />
-
 <Steps>
+  <Include src="_partials/native-api-callout" />
+
   ## Configure your authentication options
 
   When creating your Clerk application in the Clerk Dashboard, your authentication options will depend on how you configure your Chrome Extension. Chrome Extensions can be used as a popup, a side panel, or in conjunction with a web app. Popups and side panels have limited authentication options. [Learn more about what options are available.](/docs/reference/chrome-extension/overview#authentication-options)

--- a/docs/getting-started/quickstart.expo.mdx
+++ b/docs/getting-started/quickstart.expo.mdx
@@ -25,9 +25,9 @@ sdk: expo
   ]}
 />
 
-<Include src="_partials/native-api-callout" />
-
 <Steps>
+  <Include src="_partials/native-api-callout" />
+
   ## Install `@clerk/clerk-expo`
 
   The [Clerk Expo SDK](/docs/reference/expo/overview) gives you access to prebuilt components, hooks, and helpers to make user authentication easier.

--- a/docs/getting-started/quickstart.ios.mdx
+++ b/docs/getting-started/quickstart.ios.mdx
@@ -14,9 +14,9 @@ icon: "clerk",
 ]}
 />
 
-<Include src="_partials/native-api-callout" />
-
 <Steps>
+  <Include src="_partials/native-api-callout" />
+
   ## Create an iOS Project
 
   To get started using Clerk with iOS, create a new project in Xcode. Select SwiftUI as your interface and Swift as your language.
@@ -29,7 +29,7 @@ icon: "clerk",
 
   ## Add your Native Application
 
-  Add your iOS application to the [**Native Applications**](https://dashboard.clerk.com/last-active?path=/native-applications) page in the Clerk dashboard. You will need your iOS app's **App ID Prefix** and **Bundle ID**.
+  Add your iOS application to the [**Native Applications**](https://dashboard.clerk.com/last-active?path=/native-applications) page in the Clerk Dashboard. You will need your iOS app's **App ID Prefix** and **Bundle ID**.
 
   ## Add associated domain capability
 


### PR DESCRIPTION
### 🔎 Previews:

-

### What does this solve?

It was reported that the Expo quickstart doesn't mention the need to enable Native API. However, we have a callout at the top of the file stating that need, which is the case for the other Native SDK quickstarts. 

We thought moving it as an actual step might help in not missing the callout. 

### What changed?

- Moved Native API from a callout to an actual step

### Checklist

- [ ] I have clicked on "Files changed" and performed a thorough self-review
- [ ] All existing checks pass
