### PR TITLE
docs(express): add platform limitation warning for organizationSyncOptions

### DIFF
--- a/docs/reference/express/clerk-middleware.mdx
+++ b/docs/reference/express/clerk-middleware.mdx
@@ -120,4 +120,16 @@ app.use(
 
 #### `OrganizationSyncOptions`
 
+> [!WARNING]
+> `organizationSyncOptions` is designed for standard HTTP requests in browser contexts and works best with Next.js middleware. It does **not** currently work in the following contexts:
+> 
+> - WebSocket connections
+> - Cloudflare Workers and other serverless environments
+> - Any request where the `Sec-Fetch-Mode` header is empty
+> - When using `authenticateRequest()` directly outside of `clerkMiddleware()`
+> 
+> If you need to sync organization context in these environments, consider manually calling `clerk.setActive()` before establishing connections or API calls. See [GitHub Issue #7178](https://github.com/clerk/javascript/issues/7178) for details and workarounds.
+> 
+> For the fully supported version of this feature, see the [Next.js `clerkMiddleware()` documentation](/docs/reference/nextjs/clerk-middleware).
+
 <Include src="_partials/organization-sync-options" />


### PR DESCRIPTION
### 🔎 Previews:

<!-- Please use these bullet points to add the Vercel preview link for pages that you've updated -->

- `docs/reference/express/clerk-middleware.mdx` - Added platform limitation warning for `organizationSyncOptions`

---

### What does this solve? What changed?

**Problem:**

The Express SDK documentation currently presents `organizationSyncOptions` as a standard, fully functional feature without any indication of platform-specific limitations. However, developers using this option in real-world applications are hitting a critical blocker:

- `organizationSyncOptions` does **not** work with WebSocket connections, Cloudflare Workers, or any context where the `Sec-Fetch-Mode` header is empty
- The underlying `authenticateRequest()` function includes a `Sec-Fetch-Mode` header check in `isRequestEligibleForHandshake()` that prevents the handshake from completing in these environments
- Developers discover this limitation only after extensive debugging in production

**Evidence:**

- **[GitHub Issue #7178](https://github.com/clerk/javascript/issues/7178)**: A developer encountered this exact issue while using Cloudflare Workers with WebSockets. They provided detailed analysis showing the `Sec-Fetch-Mode` header check failure and had to implement a workaround using `clerk.setActive()` before establishing connections.
- **[PR #3977](https://github.com/clerk/javascript/pull/3977)**: Clerk added dedicated `organizationSyncOptions` support to Next.js middleware, confirming that the feature is primarily designed for browser HTTP contexts and Next.js provides the fully supported implementation.

**What changed:**

Added a prominent warning callout box to the Express `clerkMiddleware()` documentation right before the `OrganizationSyncOptions` section that:

1. **Clearly states the limitation**: Explains that `organizationSyncOptions` is designed for standard HTTP requests in browser contexts and works best with Next.js middleware
2. **Lists unsupported contexts**: WebSocket connections, Cloudflare Workers, serverless environments, and any request where `Sec-Fetch-Mode` is empty
3. **Provides the workaround**: Directs developers to manually call `clerk.setActive()` before establishing connections or API calls
4. **Links to the GitHub issue**: References Issue #7178 for developers to track progress and see detailed workarounds
5. **Points to the fully supported solution**: Links to Next.js `clerkMiddleware()` documentation

**Impact:**

- Prevents developers from spending hours debugging an option that doesn't work in their specific environment
- Provides a clear, actionable workaround with proven evidence
- Aligns documentation with actual SDK behavior
- Small, focused change with high developer value

---

### Deadline

No rush.

---

### Other resources

- **[GitHub Issue #7178](https://github.com/clerk/javascript/issues/7178)** - Developer encounter with `organizationSyncOptions` in Cloudflare Workers/WebSockets
- **[PR #3977](https://github.com/clerk/javascript/pull/3977)** - Next.js support for `organizationSyncOptions` confirming Express limitation
- **Related discussion**: The issue author noted that `isRequestEligibleForHandshake()` prevents the handshake due to `Sec-Fetch-Mode` header being empty, and their workaround involved `clerk.setActive()` calls before establishing connections