### PR TITLE
docs(organizations): add Role Sets integration and System Permissions table

### DIFF
--- a/docs/guides/organizations/control-access/roles-and-permissions.mdx
+++ b/docs/guides/organizations/control-access/roles-and-permissions.mdx
@@ -106,6 +106,40 @@ You cannot delete a Role that is still assigned to members of an Organization. C
 > [!NOTE]
 > You cannot delete any Roles currently assigned to one or more Organization members. If any Organization members currently have this Role, you'll need to reassign them first. Refer to [Role Sets](/docs/guides/organizations/control-access/role-sets) for more information.
 
+## Role Sets
+
+Role Sets are collections of Roles that define which Roles can be assigned to members of an Organization. Each Organization is assigned exactly one Role Set, and members can only be assigned Roles that exist within that Organization's assigned Role Set.
+
+Role Sets enable powerful multi-tenant authorization patterns:
+
+- **Subscription tiers**: Free plan organizations get a Role Set with only `admin` and `member` roles, while Pro plan organizations get additional `moderator`, `analyst`, and `manager` roles
+- **Customer cohorts**: Different customer segments (e.g., small practices vs. large hospitals) can have different Role Sets with different role structures
+- **Complex org structures**: Large organizations can have custom Role Sets tailored to their specific departmental needs
+
+### Managing Role Sets
+
+1. In the Clerk Dashboard, navigate to [**Roles & Permissions**](https://dashboard.clerk.com/~/organizations-settings/roles)
+2. Select the **Role Sets** tab
+3. From here you can:
+   - View existing Role Sets and the Roles they contain
+   - Create new Role Sets by selecting from available Roles
+   - Edit existing Role Sets to add or remove Roles
+   - Assign Role Sets to Organizations
+
+### Assigning Role Sets to Organizations
+
+When an Organization is created, it is automatically assigned the **Default Role Set**. To change an Organization's assigned Role Set:
+
+1. In the Clerk Dashboard, navigate to [**Organizations**](https://dashboard.clerk.com/~/organizations)
+2. Select the Organization you want to modify
+3. In the Organization settings, find the Role Set selector
+4. Choose the desired Role Set from the dropdown
+
+> [!NOTE]
+> Changing an Organization's Role Set affects the available Roles for all members. Members with Roles that are removed from the new Role Set will not lose their current assignments, but those Roles will no longer be available for new assignments or future updates.
+
+For more information, see the [Role Sets guide](/docs/guides/organizations/control-access/role-sets).
+
 ## Permissions
 
 Permissions grant users privileged access to resources and operations, like creating and deleting. Clerk supports two types of Permissions: **System Permissions** and **Custom Permissions**.
@@ -116,15 +150,17 @@ Clerk provides a set of System Permissions that power [Clerk's Frontend API](/do
 
 Clerk's System Permissions consist of the following:
 
-- Manage Organization (`org:sys_profile:manage`)
-- Delete Organization (`org:sys_profile:delete`)
-- Read members (`org:sys_memberships:read`)
-- Manage members (`org:sys_memberships:manage`)
-- Read domains (`org:sys_domains:read`)
-- Manage domains (`org:sys_domains:manage`)
-- Read billing (`org:sys_billing:read`)
-- Manage billing (`org:sys_billing:manage`)
-- Manage self-serve SSO (enterprise connections) (`org:sys_entconns:manage`)
+| Permission | Key | Description |
+|------------|-----|-------------|
+| Manage Organization | `org:sys_profile:manage` | Update Organization name, logo, and other profile information |
+| Delete Organization | `org:sys_profile:delete` | Permanently delete the Organization |
+| Read members | `org:sys_memberships:read` | View member list and member details |
+| Manage members | `org:sys_memberships:manage` | Invite, remove, and update member Roles |
+| Read domains | `org:sys_domains:read` | View Organization domains and verification status |
+| Manage domains | `org:sys_domains:manage` | Add, verify, and remove Organization domains |
+| Read billing | `org:sys_billing:read` | View billing information and subscription details |
+| Manage billing | `org:sys_billing:manage` | Update billing settings and payment methods |
+| Manage self-serve SSO | `org:sys_entconns:manage` | Configure and manage Enterprise SSO connections |
 
 You can assign these System Permissions to any Role.
 


### PR DESCRIPTION
### 🔎 Previews:

<!-- Please use these bullet points to add the Vercel preview link for pages that you've updated -->

- `docs/guides/organizations/control-access/roles-and-permissions.mdx` - Added Role Sets section and System Permissions table

---

### What does this solve? What changed?

**Problem:**

The current Roles and Permissions documentation has a significant gap around Role Sets, a major feature launched in January 2026. While the page mentions Role Sets in 5 different places, it never properly explains what they are or how they work:

1. **Fragmented references without definition**: The page says "select the Role Set you wish to edit," "You must add the Role to a Role Set," and "The Roles available in the dropdown are limited to those included in the Organization's assigned Role Set" — but never explains what Role Sets actually are

2. **Missing conceptual foundation**: A developer reading this page would encounter "Role Set" multiple times without understanding:
   - What a Role Set is
   - Why Role Sets exist
   - How Role Sets relate to Roles
   - How to create or manage Role Sets

3. **System Permissions listed in prose**: The System Permissions are shown as a bulleted list, making them difficult to scan and reference compared to a structured table format

**Evidence:**

- The changelog shows Role Sets were launched in January 2026 as a major feature enabling tiered access and cohort-based permissions
- The current page references Role Sets 5+ times but only through notes and procedural steps
- The page states "Roles are made available to Organizations through Role Sets" but never explains what that means
- The Next steps section has a card for "Configure and assign Role Sets" but the main page lacks the foundational explanation
- The System Permissions list in the community documentation has been shown as a cleaner table format

**What changed:**

1. **Added a dedicated "Role Sets" section** after the "Roles" section that:
   - Defines what Role Sets are: "collections of Roles that define which Roles can be assigned to members of an Organization"
   - Explains the core concept: "Each Organization is assigned exactly one Role Set"
   - Provides use cases: subscription tiers (Free vs Pro), customer cohorts, complex org structures
   - Shows how to manage Role Sets in the Dashboard
   - Explains how to assign Role Sets to Organizations
   - Includes a warning about the impact of changing an Organization's Role Set
   - Links to the full Role Sets guide for detailed management

2. **Replaced the System Permissions bulleted list with a table** that includes:
   - Permission name
   - Key (the actual permission string)
   - Description of what the permission allows

**Impact:**

- Developers now understand the complete picture: Roles → Role Sets → Permissions
- No more confusion when encountering "Role Set" references throughout the page
- System Permissions are now scannable and referenceable
- Aligns documentation with the January 2026 Role Sets feature launch
- Small, focused change with high developer value

---

### Deadline

No rush.

---

### Other resources

- **[Role Sets Guide]**- The separate guide for detailed Role Sets management.
- **[Role Sets Launch (January 2026)]** - Official changelog announcement for the Role Sets feature.
- **Related discussion**: Role Sets enable controlling which roles are available per organization, solving multi-tenant authorization patterns.