### PR TITLE
Document reverification window configuration

### DIFF
--- a/docs/guides/secure/reverification.mdx
+++ b/docs/guides/secure/reverification.mdx
@@ -29,13 +29,13 @@ The following table shows the sensitive actions that require reverification alon
 
 ## Customize the reverification window
 
-By default, a successful sign-in or reverification remains valid for Clerk-protected sensitive actions for 10 minutes. You can set the reverification window to any whole number from 1 through 10 minutes. A shorter window requires a more recent sign-in or reverification and can prompt users to verify their credentials more often.
+By default, a successful sign-in or reverification remains valid for Clerk-protected sensitive actions for 10 minutes. You can set the reverification window to any whole number between 1 and 10 minutes. A shorter window requires a more recent sign-in or reverification and can prompt users to verify their credentials more often.
 
 1. In the Clerk Dashboard, navigate to the [**Sessions**](https://dashboard.clerk.com/~/sessions) page.
 1. Under **Session lifetime**, set **Reverification window** to the number of minutes you want.
 1. Select **Save**.
 
-The new window applies to the next Clerk-protected sensitive action. Reverification can't be disabled for these actions, and the minimum window is 1 minute.
+Changes can take a short time to propagate. The new window applies to Clerk-protected sensitive actions after propagation. Reverification can't be disabled for these actions, and the minimum window is 1 minute.
 
 This setting applies only to the Clerk-protected sensitive actions listed above. For sensitive actions unique to your application, define the required time period in your application. See [How to require reverification](#how-to-require-reverification).
 

--- a/docs/guides/secure/reverification.mdx
+++ b/docs/guides/secure/reverification.mdx
@@ -11,9 +11,9 @@ Clerk's prebuilt components handle reverification for certain [sensitive actions
 
 ## Sensitive actions that require reverification
 
-The following table shows the sensitive actions that require reverification along with the required strategy and timeframe for each action. When using Clerk's prebuilt components, reverification is automatically handled for these actions.
+The following table shows the sensitive actions that require reverification along with the required strategy and default reverification window for each action. When using Clerk's prebuilt components, reverification is automatically handled for these actions.
 
-| Action | Strategy | Timeframe |
+| Action | Strategy | Reverification window |
 | - | - | - |
 | Update username | Strongest available | 10m |
 | Set/update password | Strongest available | 10m |
@@ -26,6 +26,18 @@ The following table shows the sensitive actions that require reverification alon
 | Add/remove MFA (TOTP, phone number, backup codes) | Strongest available | 10m |
 | Revoke session | Strongest available | 10m |
 | Delete account | Strongest available | 10m |
+
+## Customize the reverification window
+
+By default, a successful sign-in or reverification remains valid for Clerk-protected sensitive actions for 10 minutes. You can set the reverification window to any whole number from 1 through 10 minutes. A shorter window requires a more recent sign-in or reverification and can prompt users to verify their credentials more often.
+
+1. In the Clerk Dashboard, navigate to the [**Sessions**](https://dashboard.clerk.com/~/sessions) page.
+1. Under **Session lifetime**, set **Reverification window** to the number of minutes you want.
+1. Select **Save**.
+
+The new window applies to the next Clerk-protected sensitive action. Reverification can't be disabled for these actions, and the minimum window is 1 minute.
+
+This setting applies only to the Clerk-protected sensitive actions listed above. For sensitive actions unique to your application, define the required time period in your application. See [How to require reverification](#how-to-require-reverification).
 
 ## Caveats
 


### PR DESCRIPTION
### 🔎 Previews:

- Generated by Vercel after this draft is opened.

### What does this solve? What changed?

- Explain how to configure the reverification window for Clerk-protected sensitive actions.
- Document the 10-minute default, the supported 1 through 10 minute range, and when a new value takes effect.
- Clarify that applications define their own time periods for custom sensitive actions.

### Deadline

- No rush.

### Other resources

- [Reverification guide](https://clerk.com/docs/guides/secure/reverification)
