### PR TITLE
docs: remove duplicated word in OAuth custom consent page

### DIFF
--- a/docs/guides/configure/auth-strategies/oauth/custom-consent-page.mdx
+++ b/docs/guides/configure/auth-strategies/oauth/custom-consent-page.mdx
@@ -130,7 +130,7 @@ After you create and deploy your custom consent route, configure Clerk to send u
 
   ### Set the OAuth consent location
 
-  Under **Component paths**, locate the the **OAuth consent** section and choose your custom location:
+  Under **Component paths**, locate the **OAuth consent** section and choose your custom location:
 
   - For a development instance, enter a path on the development host, such as `/oauth-consent`.
   - For a production instance, enter an `https://` URL on your application domain, such as `https://example.com/oauth-consent`. Clerk only accepts production OAuth consent URLs that use HTTPS and belong to the same registrable domain as your instance domain, such as `example.com` or a subdomain of `example.com`.


### PR DESCRIPTION
## Summary

Remove duplicated word in OAuth custom consent page documentation.

| File | Fix |
|------|-----|
| docs/guides/configure/auth-strategies/oauth/custom-consent-page.mdx | "the the" → "the" |

## Test plan

- [x] Verified typo present before editing
- [x] Residual scan clean on changed file
