### PR TITLE
Fix TypeScript errors in the sign-in-or-up custom flow samples

### DIFF
--- a/docs/guides/development/custom-flows/authentication/sign-in-or-up.mdx
+++ b/docs/guides/development/custom-flows/authentication/sign-in-or-up.mdx
@@ -62,6 +62,7 @@ To blend a sign-up and sign-in flow into a single flow, you must **treat it as a
   'use client'
 
   import { useSignIn, useSignUp } from '@clerk/nextjs'
+  import { isClerkAPIResponseError } from '@clerk/nextjs/errors'
   import { useRouter } from 'next/navigation'
   import React from 'react'
 
@@ -89,7 +90,7 @@ To blend a sign-up and sign-in flow into a single flow, you must **treat it as a
 
         // If the identifier is not found, the user is not signed up yet
         // So swap to the sign-up flow
-        if (error.errors[0].code === 'form_identifier_not_found') {
+        if (isClerkAPIResponseError(error) && error.errors[0].code === 'form_identifier_not_found') {
           try {
             const { error } = await signUp.password({
               emailAddress,
@@ -298,7 +299,7 @@ To blend a sign-up and sign-in flow into a single flow, you must **treat it as a
   ```tsx {{ filename: 'src/app/sign-in/page.tsx', collapsible: true }}
   import { ThemedText } from '@/components/themed-text'
   import { ThemedView } from '@/components/themed-view'
-  import { useSignIn, useSignUp } from '@clerk/expo'
+  import { isClerkAPIResponseError, useSignIn, useSignUp } from '@clerk/expo'
   import { type Href, Link, useRouter } from 'expo-router'
   import * as React from 'react'
   import { Pressable, ScrollView, StyleSheet, TextInput, View } from 'react-native'
@@ -344,7 +345,7 @@ To blend a sign-up and sign-in flow into a single flow, you must **treat it as a
       })
       if (error) {
         // If the identifier is not found, the user is not signed up yet — swap to the sign-up flow
-        if (error.errors[0].code === 'form_identifier_not_found') {
+        if (isClerkAPIResponseError(error) && error.errors[0].code === 'form_identifier_not_found') {
           try {
             const { error: signUpError } = await signUp.password({
               emailAddress,
@@ -1276,6 +1277,7 @@ To blend a sign-up and sign-in flow into a single flow, you must **treat it as a
     'use client'
 
     import { useSignIn, useSignUp } from '@clerk/nextjs'
+    import { isClerkAPIResponseError } from '@clerk/nextjs/errors'
     import { useRouter } from 'next/navigation'
     import React from 'react'
 
@@ -1368,7 +1370,7 @@ To blend a sign-up and sign-in flow into a single flow, you must **treat it as a
         // the code 'sign_up_if_missing_transfer'. Check for this error
         // to determine if we need to transfer to sign-up.
         if (error) {
-          if (error.errors[0]?.code === 'sign_up_if_missing_transfer') {
+          if (isClerkAPIResponseError(error) && error.errors[0]?.code === 'sign_up_if_missing_transfer') {
             // The user doesn't exist - transfer to sign-up
             await handleTransfer()
             return
@@ -1532,7 +1534,7 @@ To blend a sign-up and sign-in flow into a single flow, you must **treat it as a
     ```tsx {{ filename: 'src/app/sign-in/page.tsx', collapsible: true }}
     import { ThemedText } from '@/components/themed-text'
     import { ThemedView } from '@/components/themed-view'
-    import { useSignIn, useSignUp } from '@clerk/expo'
+    import { isClerkAPIResponseError, useSignIn, useSignUp } from '@clerk/expo'
     import { type Href, Link, useRouter } from 'expo-router'
     import React from 'react'
     import { Pressable, StyleSheet, Switch, TextInput, View } from 'react-native'
@@ -1623,7 +1625,7 @@ To blend a sign-up and sign-in flow into a single flow, you must **treat it as a
         // the code 'sign_up_if_missing_transfer'. Check for this error
         // to determine if we need to transfer to sign-up.
         if (error) {
-          if (error.errors[0]?.code === 'sign_up_if_missing_transfer') {
+          if (isClerkAPIResponseError(error) && error.errors[0]?.code === 'sign_up_if_missing_transfer') {
             // The user doesn't exist - transfer to sign-up
             await handleTransfer()
             return


### PR DESCRIPTION
### 🔎 Previews:

- [Sign-in-or-up custom flow](https://clerk.com/docs/guides/development/custom-flows/authentication/sign-in-or-up)

### What does this solve? What changed?

**The problem:** none of the four TSX samples on this page compile.

All four read `error.errors` off the value returned by `signIn.password()` or `signIn.emailCode.verifyCode()`. Both of those return `{ error: ClerkError | null }`, and `ClerkError` declares only `code`, `message`, `longMessage`, `docsUrl` and `cause` — the `errors` array exists solely on its `ClerkAPIResponseError` subclass. So copying any of these samples into a TypeScript project fails the build:

```
Property 'errors' does not exist on type 'ClerkError'. (TS2339)
```

Reproduced against `@clerk/nextjs@7.8.4` / `@clerk/shared@4.30.2`. This is not a regression from a later SDK change — `@clerk/shared@4.3.1`, published 2026-03-17, six days before this page landed in #3202, already typed the return as `ClerkError | null`.

It goes unnoticed easily because `next dev` doesn't typecheck; the flow runs fine while you follow the guide and only fails at `next build`.

**The change:** guard with `isClerkAPIResponseError` before reading `error.errors`, at all four sites (password swap and `signUpIfMissing` transfer, each in its web and Expo variant).

Worth noting for reviewers, since it's the more obvious fix and it does not work: reading `error.code` directly instead of narrowing looks equivalent, but `ClerkAPIResponseError`'s constructor hardcodes `code: "api_response_error"`. The per-error codes (`form_identifier_not_found`, `sign_up_if_missing_transfer`) are reachable only through the `errors` array, so narrowing is required.

Import sources differ by SDK: `@clerk/nextjs/errors` for the web samples, and the package root for Expo — `@clerk/expo` re-exports `isClerkAPIResponseError` and has no `./errors` subpath in its `exports` map.

Verified by deriving the types from the SDK itself (`Awaited<ReturnType<typeof signIn.emailCode.verifyCode>>['error']`) and typechecking the patched expressions against `@clerk/nextjs@7.8.4` — clean. I wasn't able to preview the Expo samples in a running app, so that variant is the piece most worth a second look.

The `legacy/` pages on this same page's sibling routes are unaffected: they use `catch (err)` with an implicit `any`, so they typecheck as-is.

### Deadline

- No rush.

### Other resources

- Page source: `docs/guides/development/custom-flows/authentication/sign-in-or-up.mdx`
- Introduced in #3202
